### PR TITLE
Fix #1 'not exists' issue and subscribe whole collection

### DIFF
--- a/docs/API.AMQP.md
+++ b/docs/API.AMQP.md
@@ -132,6 +132,8 @@ How subscription works:
 }
 ```
 
+**Note:** If an empty body is provided, the subscription is performed on the whole collection
+
 **Response:**
 
 ```javascript

--- a/docs/API.MQTT.md
+++ b/docs/API.MQTT.md
@@ -132,6 +132,8 @@ How subscription works:
 }
 ```
 
+**Note:** If an empty body is provided, the subscription is performed on the whole collection
+
 **Response:**
 
 ```javascript

--- a/docs/API.STOMP.md
+++ b/docs/API.STOMP.md
@@ -131,6 +131,8 @@ How subscription works:
 }
 ```
 
+**Note:** If an empty body is provided, the subscription is performed on the whole collection
+
 **Response:**
 
 ```javascript

--- a/docs/API.WebSocket.md
+++ b/docs/API.WebSocket.md
@@ -122,6 +122,8 @@ How subscription works:
 }
 ```
 
+**Note:** If an empty body is provided, the subscription is performed on the whole collection
+
 **Response:**
 
 ```javascript

--- a/features/AMQP.feature
+++ b/features/AMQP.feature
@@ -89,6 +89,20 @@ Feature: Test AMQP API
     And The notification should not have a "_source" member
 
   @usingAMQP @unsubscribe
+  Scenario: Document creation notifications with not exists
+    Given A room subscription listening field "toto" doesn't exists
+    When I write the document "documentGrace"
+    Then I should receive a "create" notification
+    And The notification should have a "_source" member
+
+  @usingAMQP @unsubscribe
+  Scenario: Subscribe to a collection
+    Given A room subscription listening to the whole collection
+    When I write the document "documentGrace"
+    Then I should receive a "create" notification
+    And The notification should have a "_source" member
+
+  @usingAMQP @unsubscribe
   Scenario: Delete a document with a query
     Given A room subscription listening to "lastName" having value "Hopper"
     When I write the document "documentGrace"

--- a/features/MQTT.feature
+++ b/features/MQTT.feature
@@ -88,6 +88,20 @@ Feature: Test MQTT API
     And The notification should not have a "_source" member
 
   @usingMQTT @unsubscribe
+  Scenario: Document creation notifications with not exists
+    Given A room subscription listening field "toto" doesn't exists
+    When I write the document "documentGrace"
+    Then I should receive a "create" notification
+    And The notification should have a "_source" member
+
+  @usingMQTT @unsubscribe
+  Scenario: Subscribe to a collection
+    Given A room subscription listening to the whole collection
+    When I write the document "documentGrace"
+    Then I should receive a "create" notification
+    And The notification should have a "_source" member
+
+  @usingMQTT @unsubscribe
   Scenario: Delete a document with a query
     Given A room subscription listening to "lastName" having value "Hopper"
     When I write the document "documentGrace"

--- a/features/STOMP.feature
+++ b/features/STOMP.feature
@@ -88,6 +88,20 @@ Feature: Test STOMP API
     And The notification should not have a "_source" member
 
   @usingSTOMP @unsubscribe
+  Scenario: Document creation notifications with not exists
+    Given A room subscription listening field "toto" doesn't exists
+    When I write the document "documentGrace"
+    Then I should receive a "create" notification
+    And The notification should have a "_source" member
+
+  @usingSTOMP @unsubscribe
+  Scenario: Subscribe to a collection
+    Given A room subscription listening to the whole collection
+    When I write the document "documentGrace"
+    Then I should receive a "create" notification
+    And The notification should have a "_source" member
+
+  @usingSTOMP @unsubscribe
   Scenario: Delete a document with a query
     Given A room subscription listening to "lastName" having value "Hopper"
     When I write the document "documentGrace"

--- a/features/Websocket.feature
+++ b/features/Websocket.feature
@@ -64,6 +64,13 @@ Feature: Test websocket API
     And The notification should have a "_source" member
 
   @usingWebsocket @unsubscribe
+  Scenario: Document creation notifications with not exists
+    Given A room subscription listening field "toto" doesn't exists
+    When I write the document "documentGrace"
+    Then I should receive a "create" notification
+    And The notification should have a "_source" member
+
+  @usingWebsocket @unsubscribe
   Scenario: Document delete notifications
     Given A room subscription listening to "lastName" having value "Hopper"
     When I write the document "documentGrace"
@@ -86,6 +93,13 @@ Feature: Test websocket API
     Then I update the document with value "Foo" in field "lastName"
     Then I should receive a "update" notification
     And The notification should not have a "_source" member
+
+  @usingWebsocket @unsubscribe
+  Scenario: Subscribe to a collection
+    Given A room subscription listening to the whole collection
+    When I write the document "documentGrace"
+    Then I should receive a "create" notification
+    And The notification should have a "_source" member
 
   @usingWebsocket @unsubscribe
   Scenario: Delete a document with a query

--- a/features/step_definitions/api.js
+++ b/features/step_definitions/api.js
@@ -20,6 +20,39 @@ var apiSteps = function () {
       });
   });
 
+  this.Given(/^A room subscription listening to the whole collection$/, function (callback) {
+    this.api.subscribe()
+      .then(function (body) {
+        if (body.error !== null) {
+          callback.fail(new Error(body.error));
+          return false;
+        }
+
+        callback();
+      }.bind(this))
+      .catch(function (error) {
+        callback.fail(new Error(error));
+      });
+  });
+
+  this.Given(/^A room subscription listening field "([^"]*)" doesn't exists$/, function (key, callback) {
+    var filter = {not: {exists: {field : null}}};
+
+    filter.not.exists.field = key;
+    this.api.subscribe(filter)
+      .then(function (body) {
+        if (body.error !== null) {
+          callback.fail(new Error(body.error));
+          return false;
+        }
+
+        callback();
+      }.bind(this))
+      .catch(function (error) {
+        callback.fail(new Error(error));
+      });
+  });
+
   /**
    * Unsubscribes from one of the subscribed rooms
    */

--- a/features/support/apiAMQP.js
+++ b/features/support/apiAMQP.js
@@ -143,8 +143,12 @@ module.exports = {
     var
       topic = ['subscribe', this.world.fakeCollection, 'on'].join('.'),
       msg = {
-        body: filters
+        body: null
       };
+
+    if (filters) {
+      msg.body = filters;
+    }
 
     return publishAndListen.call(this, topic, msg);
   },

--- a/features/support/apiMQTT.js
+++ b/features/support/apiMQTT.js
@@ -132,8 +132,12 @@ module.exports = {
     var
       topic = ['subscribe', this.world.fakeCollection, 'on'].join('.'),
       msg = {
-        body: filters
+        body: null
       };
+
+    if (filters) {
+      msg.body = filters;
+    }
 
     return publishAndListen.call(this, topic, msg);
   },

--- a/features/support/apiSTOMP.js
+++ b/features/support/apiSTOMP.js
@@ -142,8 +142,12 @@ module.exports = {
     var
       topic = ['subscribe', this.world.fakeCollection, 'on'].join('.'),
       msg = {
-        body: filters
+        body: null
       };
+
+    if (filters) {
+      msg.body = filters;
+    }
 
     return publishAndListen.call(this, topic, msg);
   },

--- a/features/support/apiWebsocket.js
+++ b/features/support/apiWebsocket.js
@@ -142,8 +142,12 @@ module.exports = {
       msg = {
         action: 'on',
         collection: this.world.fakeCollection,
-        body: filters
+        body: null
       };
+
+    if (filters) {
+      msg.body = filters;
+    }
 
     return emitAndListen.call(this, 'subscribe', msg);
 

--- a/lib/api/controllers/writeController.js
+++ b/lib/api/controllers/writeController.js
@@ -17,16 +17,18 @@ module.exports = function WriteController (kuzzle) {
     requestObject.isValid()
       .then(function () {
         kuzzle.emit('data:create', requestObject);
-        deferred.resolve({});
 
         if (!requestObject.isPersistent()) {
           return kuzzle.dsl.testFilters(requestObject);
         }
+
+        deferred.resolve({});
       })
       .then(function (rooms) {
         kuzzle.notifier.notify(rooms, new ResponseObject(requestObject).toJson());
       })
       .catch(function (error) {
+        kuzzle.log.error(error);
         deferred.reject(error);
       });
 

--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -20,6 +20,7 @@ module.exports = function HotelClerk (kuzzle) {
    *    'f45de4d8ef4f3ze4ffzer85d4fgkzm41' : { // -> the room id (according to filters and collection)
    *      names: [ 'chat-room-kuzzle' ], // -> real room name list to notify
    *      count: 100 // -> how many users have subscribed to this room
+   *      collection: 'message', // -> the collection name
    *      filters: {
    *        and : {
    *          'message.subject.termSubjectKuzzle': filtersTree.message.subject.termSubjectKuzzle.fn
@@ -248,8 +249,13 @@ var createRoom = function (room, collection, filters) {
             id: roomId,
             names: [],
             count: 0,
-            filters: formattedFilters
+            collection: collection
           };
+
+          // In case the user subscribe on the whole collection, there is no formattedFilters
+          if (formattedFilters) {
+            this.rooms[roomId].filters = formattedFilters;
+          }
         }
 
         deferred.resolve(roomId);
@@ -302,6 +308,9 @@ var cleanUpRooms = function (roomId) {
       .then(function () {
         delete this.rooms[roomId];
         deferred.resolve(roomId);
+      }.bind(this))
+      .catch(function (error) {
+        this.kuzzle.log.error(error);
       }.bind(this));
   }
   else {
@@ -380,6 +389,10 @@ var cleanUpCustomers = function (connectionId) {
  * @return {promise} promise. Resolve a list of path that points to filtersTree object
  */
 var addRoomAndFilters = function (roomId, collection, filters) {
+  if (!filters || _.isEmpty(filters)) {
+    return this.kuzzle.dsl.addCollectionSubscription(roomId, collection);
+  }
+
   return this.kuzzle.dsl.addCurriedFunction(roomId, collection, filters);
 };
 

--- a/lib/api/dsl/README.md
+++ b/lib/api/dsl/README.md
@@ -57,6 +57,7 @@ Eventually, we want to store this subscription in the hotelClerkController rooms
 rooms = {
     'f45de4d8ef4f3ze4ffzer85d4fgkzm41' : { // -> computed room id
         id: "f45de4d8ef4f3ze4ffzer85d4fgkzm41",
+        collection: 'members'
         names: [ 'my-custom-subscription' ], // -> customer
         count: 7 // -> how many users have subscribed to this room
         filters: {

--- a/lib/api/dsl/index.js
+++ b/lib/api/dsl/index.js
@@ -4,7 +4,6 @@ var
   async = require('async'),
   _ = require('lodash'),
   stringify = require('json-stable-stringify'),
-  crypto = require('crypto'),
   q = require('q');
 
 
@@ -22,10 +21,13 @@ module.exports = function Dsl (kuzzle) {
    * Example for chat-room-kuzzle (see above)
    *  filtersTree = {
    *    message : { // -> collection name
-   *      subject : { // -> attribute where a filter exists
-   *        termSubjectKuzzle : {
-   *          rooms: [ 'f45de4d8ef4f3ze4ffzer85d4fgkzm41'], // -> room id that match this filter
-   *          fn: function () {} // -> function to execute on collection message, on field subject
+   *      rooms: [] // -> room to test each time (for a a subscribe on a whole collection, or if 'not exist' filter (see issue #1 on github)
+   *      fields: {
+   *        subject : { // -> attribute where a filter exists
+   *          termSubjectKuzzle : {
+   *            rooms: [ 'f45de4d8ef4f3ze4ffzer85d4fgkzm41'], // -> room id that match this filter
+   *            fn: function () {} // -> function to execute on collection message, on field subject
+   *          }
    *        }
    *      }
    *    }
@@ -35,9 +37,10 @@ module.exports = function Dsl (kuzzle) {
 
   this.methods = require('./methods');
   this.methods.dsl = this;
+  this.kuzzle = kuzzle;
 
   /**
-   *
+   * Create a currified function with methods and operators. Will create a new filter on a specific field for a collection
    * @param {string} roomId
    * @param {string} collection
    * @param {Object} filters
@@ -72,6 +75,30 @@ module.exports = function Dsl (kuzzle) {
   };
 
   /**
+   * Subscribe a roomId on the whole collection
+   *
+   * @param roomId
+   * @param collection
+   */
+  this.addCollectionSubscription = function (roomId, collection) {
+    var
+      deferred = q.defer();
+
+    if (!this.filtersTree[collection]) {
+      this.filtersTree[collection] = {};
+    }
+
+    if (!this.filtersTree[collection].rooms) {
+      this.filtersTree[collection].rooms = [];
+    }
+
+    this.filtersTree[collection].rooms.push(roomId);
+
+    deferred.resolve();
+    return deferred.promise;
+  };
+
+  /**
    * Test all filters in filtersTree to get the rooms to notify
    *
    * @param {RequestObject|ResponseObject} modelObject
@@ -81,9 +108,9 @@ module.exports = function Dsl (kuzzle) {
     var
       deferred = q.defer(),
       cachedResults = {},
-      documentKeys =[],
-      flattenBody = {},
-      rooms = [];
+      rooms = [],
+      // trick to easily parse nested document
+      flattenBody = flattenObject(modelObject.data.body);
 
     if (!modelObject.collection) {
       deferred.reject('The data doesn\'t contain a collection');
@@ -96,109 +123,232 @@ module.exports = function Dsl (kuzzle) {
       return deferred.promise;
     }
 
-    // trick to easily parse nested document
-    flattenBody = flattenObject(modelObject.data.body);
-
-    // we still need to get the real field keys
-    Object.keys(flattenBody).forEach(function(compoundField){
-      var key;
-
-      compoundField.split('.').forEach(function(attr){
-        if (key) {
-          key += '.' + attr;
-        }
-        else {
-          key = attr;
-        }
-        documentKeys.push(key);
-      });
-    });
-
-    async.each(documentKeys, function (field, callbackField) {
-      var fieldFilters = this.filtersTree[modelObject.collection][field];
-
-      if (!fieldFilters) {
-        callbackField();
-        return false;
-      }
-
-      async.each(Object.keys(fieldFilters), function (functionName, callbackFilter) {
-        var
-          // Clean function name of potential '.' characters
-          cleanFunctionName = functionName.split('.').join(''),
-          filter = fieldFilters[functionName],
-          cachePath = modelObject.collection + '.' + field + '.' + cleanFunctionName;
-
-        if (cachedResults[cachePath] === undefined) {
-          cachedResults[cachePath] = filter.fn(flattenBody);
-        }
-
-        if (!cachedResults[cachePath]) {
-          callbackFilter();
-          return false;
-        }
-
-        async.each(
-          filter.rooms,
-          function (roomId, callbackRoom) {
-            var
-              room = kuzzle.hotelClerk.rooms[roomId],
-              passAllFilters;
-
-            if (!room) {
-              callbackRoom('Room not found '+roomId);
-              return false;
-            }
-
-            passAllFilters = testFilterRecursively(flattenBody, room.filters, cachedResults, 'and');
-
-            if (passAllFilters) {
-              rooms = _.uniq(rooms.concat(room.id));
-            }
-
-            callbackRoom();
-          }.bind(this),
-          function (error) {
-            callbackFilter(error);
+    var that = this;
+    async.parallel({
+      // Will try filters on field in document
+      onFields: function (callback) {
+        testFieldFilters.call(that, modelObject, flattenBody, cachedResults)
+          .then(function (rooms) {
+            callback(null, rooms);
+          })
+          .catch(function (error) {
+            callback(error);
           });
-      }.bind(this),
-        function (error) {
-          callbackField(error);
-        });
-    }.bind(this), function (error) {
-
+      },
+      // Will try global filters and add rooms which subscribed on the whole collection
+      onGlobals: function (callback) {
+        testGlobalsFilters.call(that, modelObject, flattenBody, cachedResults)
+          .then(function (rooms) {
+            callback(null, rooms);
+          })
+          .catch(function (error) {
+            callback(error);
+          });
+      }
+    }, function (error, rooms) {
       if (error) {
-        kuzzle.emit('filter:error', error);
+        this.kuzzle.emit('filter:error', error);
         deferred.reject(error);
         return false;
       }
-      deferred.resolve(rooms);
-    });
+
+      deferred.resolve(_.uniq(rooms.onFields.concat(rooms.onGlobals)));
+    }.bind(this));
 
     return deferred.promise;
   };
-
 
   /**
    * Removes all references to a given room
    *
    * @param room the room to remove
-   * @returns {promise}
+   * @returns {Promise}
    */
   this.removeRoom = function (room) {
-    var deferred = q.defer();
-
-    async.each(getFiltersPathsRecursively(room.filters), function (filterPath, callback) {
-      removeFilterPath.call(this, room, filterPath);
-      callback();
-    }.bind(this), function (error) {
-        deferred.resolve();
-      }
-    );
-
-    return deferred.promise;
+    removeRoomFromGlobal.call(this, room);
+    return removeRoomFromFields(room);
   };
 
+};
+
+/**
+ * Remove the room id from filtersTree for the corresponding global room of this collection
+ *
+ * @param {Object} room room to remove
+ */
+var removeRoomFromGlobal = function (room) {
+  if (!this.filtersTree[room.collection].rooms || _.isEmpty(this.filtersTree[room.collection].rooms)) {
+    return false;
+  }
+
+  var index = this.filtersTree[room.collection].rooms.indexOf(room.id);
+  if (index !== -1) {
+    this.filtersTree[room.collection].rooms.splice(index, 1);
+  }
+};
+
+/**
+ * Remove room from each array in fields in corresponding collection
+ *
+ * @param room room to remove
+ * @returns {Promise}
+ */
+var removeRoomFromFields = function (room) {
+  var deferred = q.defer();
+
+  if (!room.filters) {
+    deferred.resolve();
+    return deferred.promise;
+  }
+
+  async.each(getFiltersPathsRecursively(room.filters), function (filterPath, callback) {
+      removeFilterPath.call(this, room, filterPath);
+      callback();
+    }.bind(this), function () {
+      deferred.resolve();
+    }
+  );
+
+  return deferred.promise;
+};
+
+var testFieldFilters = function (modelObject, flattenBody, cachedResults) {
+  var
+    deferred = q.defer(),
+    rooms = [],
+    documentKeys = [];
+
+  // we still need to get the real field keys
+  Object.keys(flattenBody).forEach(function(compoundField){
+    var key;
+
+    compoundField.split('.').forEach(function(attr){
+      if (key) {
+        key += '.' + attr;
+      }
+      else {
+        key = attr;
+      }
+      documentKeys.push(key);
+    });
+  });
+
+  async.each(documentKeys, function (field, callbackField) {
+    var fieldFilters = this.filtersTree[modelObject.collection][field];
+
+    if (!fieldFilters) {
+      callbackField();
+      return false;
+    }
+
+    async.each(Object.keys(fieldFilters), function (functionName, callbackFilter) {
+      var
+      // Clean function name of potential '.' characters
+        cleanFunctionName = functionName.split('.').join(''),
+        filter = fieldFilters[functionName],
+        cachePath = modelObject.collection + '.' + field + '.' + cleanFunctionName;
+
+      if (cachedResults[cachePath] === undefined) {
+        cachedResults[cachePath] = filter.fn(flattenBody);
+      }
+
+      if (!cachedResults[cachePath]) {
+        callbackFilter();
+        return false;
+      }
+
+      // For each rooms of this filter we'll test which one must be notified
+      testRooms.call(this, filter.rooms, flattenBody, cachedResults)
+        .then(function (roomsToNotify) {
+          rooms = _.uniq(rooms.concat(roomsToNotify));
+          callbackFilter();
+        })
+        .catch(function (error) {
+          callbackFilter(error);
+        });
+
+    }.bind(this), function (error) {
+      callbackField(error);
+    });
+
+  }.bind(this), function (error) {
+    if (error) {
+      return deferred.reject(error);
+    }
+
+    deferred.resolve(rooms);
+  });
+
+  return deferred.promise;
+};
+
+/**
+ * For a given room array and document, will test which room pass filters
+ *
+ * @param {Array} roomsToTest
+ * @param {Object} flattenBody
+ * @param {Object} cachedResults
+ * @returns {Promise}
+ */
+var testRooms = function (roomsToTest, flattenBody, cachedResults) {
+  var
+    deferred = q.defer(),
+    roomsToNotify = [];
+
+  async.each(roomsToTest, function (roomId, callback) {
+    var
+      room = this.kuzzle.hotelClerk.rooms[roomId],
+      passAllFilters;
+
+    if (!room) {
+      callback('Room not found '+roomId);
+      return false;
+    }
+
+    if (!room.filters) {
+      // Filters can be null if the room is subscribed on the whole collection
+      passAllFilters = true;
+    }
+    else {
+      passAllFilters = testFilterRecursively(flattenBody, room.filters, cachedResults, 'and');
+    }
+
+    if (passAllFilters) {
+      roomsToNotify = _.uniq(roomsToNotify.concat(room.id));
+    }
+
+    callback();
+  }.bind(this), function (error) {
+    if (error) {
+      return deferred.reject(error);
+    }
+
+    return deferred.resolve(roomsToNotify);
+  });
+
+  return deferred.promise;
+};
+
+/**
+ * Test room related to a collection and not to a specific filter
+ *
+ * @param {RequestObject|ResponseObject} modelObject
+ * @param {Object} flattenBody
+ * @param {Object} cachedResults
+ * @returns {Promise}
+ */
+var testGlobalsFilters = function (modelObject, flattenBody, cachedResults) {
+  var
+    deferred = q.defer(),
+    collection = modelObject.collection;
+
+  // If the entry "rooms" doesn't exist or is an empty array, we don't have a filter to test on every document of this collection
+  if (!this.filtersTree[collection].rooms || _.isEmpty(this.filtersTree[collection].rooms)) {
+    deferred.resolve([]);
+    return deferred.promise;
+  }
+
+  return testRooms.call(this, this.filtersTree[collection].rooms, flattenBody, cachedResults);
 };
 
 /**
@@ -327,6 +477,7 @@ var removeFilterPath = function (room, filterPath) {
       parent[subPath].rooms.splice(index, 1);
     }
 
+    // If there is another rooms that use this filter, we have nothing to do more on this filter
     if (parent[subPath].rooms.length > 0) {
       return false;
     }
@@ -336,6 +487,7 @@ var removeFilterPath = function (room, filterPath) {
     return false;
   }
 
+  // If there is no another rooms that use this filter, we can remove the filter
   delete parent[subPath];
   pathArray.pop();
 

--- a/lib/api/dsl/index.js
+++ b/lib/api/dsl/index.js
@@ -21,7 +21,7 @@ module.exports = function Dsl (kuzzle) {
    * Example for chat-room-kuzzle (see above)
    *  filtersTree = {
    *    message : { // -> collection name
-   *      rooms: [] // -> room to test each time (for a a subscribe on a whole collection, or if 'not exist' filter (see issue #1 on github)
+   *      rooms: [] // -> global room to test each time (for a a subscribe on a whole collection, or if 'not exists' filter (see issue #1 on github)
    *      fields: {
    *        subject : { // -> attribute where a filter exists
    *          termSubjectKuzzle : {
@@ -165,8 +165,34 @@ module.exports = function Dsl (kuzzle) {
    * @returns {Promise}
    */
   this.removeRoom = function (room) {
-    removeRoomFromGlobal.call(this, room);
-    return removeRoomFromFields(room);
+    var
+      deferred = q.defer(),
+      that = this;
+
+    // Remove roomId reference from both in global room for collection and room with filter on attribute
+    async.parallel([
+      function (callback) {
+        removeRoomFromGlobal.call(that, room);
+        callback();
+      },
+      function (callback) {
+        removeRoomFromFields(room)
+          .then(function () {
+            callback();
+          })
+          .catch(function (error) {
+            callback(error);
+          });
+      }
+    ], function (error) {
+      if (error) {
+        return deferred.reject(error);
+      }
+
+      deferred.resolve();
+    });
+
+    return deferred.promise;
   };
 
 };
@@ -212,6 +238,14 @@ var removeRoomFromFields = function (room) {
   return deferred.promise;
 };
 
+/**
+ * For a specific document sent by the user, will try saved filter on each attribute in order to retrieve roomId to notify
+ *
+ * @param {RequestObject|ResponseObject} modelObject
+ * @param {Object} flattenBody
+ * @param {Object} cachedResults
+ * @returns {Promise}
+ */
 var testFieldFilters = function (modelObject, flattenBody, cachedResults) {
   var
     deferred = q.defer(),
@@ -233,6 +267,7 @@ var testFieldFilters = function (modelObject, flattenBody, cachedResults) {
     });
   });
 
+  // Loop on all document attributes
   async.each(documentKeys, function (field, callbackField) {
     var fieldFilters = this.filtersTree[modelObject.collection][field];
 
@@ -241,6 +276,7 @@ var testFieldFilters = function (modelObject, flattenBody, cachedResults) {
       return false;
     }
 
+    // For each attribute, loop on all saved filters
     async.each(Object.keys(fieldFilters), function (functionName, callbackFilter) {
       var
       // Clean function name of potential '.' characters

--- a/lib/api/dsl/index.js
+++ b/lib/api/dsl/index.js
@@ -176,7 +176,7 @@ module.exports = function Dsl (kuzzle) {
         callback();
       },
       function (callback) {
-        removeRoomFromFields(room)
+        removeRoomFromFields.call(that, room)
           .then(function () {
             callback();
           })
@@ -269,12 +269,15 @@ var testFieldFilters = function (modelObject, flattenBody, cachedResults) {
 
   // Loop on all document attributes
   async.each(documentKeys, function (field, callbackField) {
-    var fieldFilters = this.filtersTree[modelObject.collection][field];
+    var fieldFilters;
 
-    if (!fieldFilters) {
+    if (!this.filtersTree[modelObject.collection].fields || !this.filtersTree[modelObject.collection].fields[field]) {
       callbackField();
       return false;
     }
+
+    fieldFilters = this.filtersTree[modelObject.collection].fields[field];
+
 
     // For each attribute, loop on all saved filters
     async.each(Object.keys(fieldFilters), function (functionName, callbackFilter) {
@@ -503,11 +506,16 @@ var removeFilterPath = function (room, filterPath) {
     index;
 
   for(i = 0; i < pathArray.length-1; i++) {
-    parent = parent[pathArray[i]];
+    if (parent.fields) {
+      parent = parent.fields[pathArray[i]];
+    }
+    else {
+      parent = parent[pathArray[i]];
+    }
   }
 
   // If the current entry is the curried function (that contains the room list and the function definition)
-  if (parent[subPath].rooms !== undefined) {
+  if (parent[subPath] && parent[subPath].rooms) {
     index = parent[subPath].rooms.indexOf(room.id);
     if (index > -1) {
       parent[subPath].rooms.splice(index, 1);
@@ -519,12 +527,21 @@ var removeFilterPath = function (room, filterPath) {
     }
   }
   // If it's not a function, test if the entry is not empty
-  else if (!_.isEmpty(parent[subPath])) {
+  else if (parent.fields && !_.isEmpty(parent.fields[subPath])) {
+    return false;
+  }
+  else if (parent[subPath] && parent[subPath].fields && !_.isEmpty(parent[subPath].fields)) {
     return false;
   }
 
   // If there is no another rooms that use this filter, we can remove the filter
-  delete parent[subPath];
+  if (parent.fields) {
+    delete parent.fields[subPath];
+  }
+  else {
+    delete parent[subPath];
+  }
+
   pathArray.pop();
 
   if (_.isEmpty(pathArray)) {

--- a/lib/api/dsl/methods.js
+++ b/lib/api/dsl/methods.js
@@ -554,30 +554,34 @@ var buildCurriedFunction = function (collection, field, operatorName, value, cur
     this.dsl.filtersTree[collection] = {};
   }
 
-  if (!this.dsl.filtersTree[collection][field]) {
-    this.dsl.filtersTree[collection][field] = {};
+  if (!this.dsl.filtersTree[collection].fields) {
+    this.dsl.filtersTree[collection].fields = {};
   }
 
-  if (!this.dsl.filtersTree[collection][field][curriedFunctionName]) {
+  if (!this.dsl.filtersTree[collection].fields[field]) {
+    this.dsl.filtersTree[collection].fields[field] = {};
+  }
+
+  if (!this.dsl.filtersTree[collection].fields[field][curriedFunctionName]) {
     curriedFunction  = _.curry(operators[operatorName]);
     curriedFunction = _.curry(curriedFunction(field, value));
     if (not) {
       curriedFunction = _.negate(curriedFunction);
     }
 
-    this.dsl.filtersTree[collection][field][curriedFunctionName] = {
+    this.dsl.filtersTree[collection].fields[field][curriedFunctionName] = {
       rooms: [],
       fn: curriedFunction
     };
   }
 
-  if (this.dsl.filtersTree[collection][field][curriedFunctionName].rooms.indexOf(roomId) === -1) {
-    this.dsl.filtersTree[collection][field][curriedFunctionName].rooms.push(roomId);
+  if (this.dsl.filtersTree[collection].fields[field][curriedFunctionName].rooms.indexOf(roomId) === -1) {
+    this.dsl.filtersTree[collection].fields[field][curriedFunctionName].rooms.push(roomId);
   }
 
   return {
     path: path,
-    filter: this.dsl.filtersTree[collection][field][curriedFunctionName]
+    filter: this.dsl.filtersTree[collection].fields[field][curriedFunctionName]
   };
 }.bind(methods);
 

--- a/lib/api/dsl/methods.js
+++ b/lib/api/dsl/methods.js
@@ -292,7 +292,8 @@ module.exports = methods = {
       deferred = q.defer(),
       fieldName,
       formattedFilters,
-      curriedFunctionName = '';
+      curriedFunctionName = '',
+      inGlobals = false;
 
     if (_.isEmpty(filter)) {
       deferred.reject('A filter can\'t be empty');
@@ -310,11 +311,12 @@ module.exports = methods = {
 
     if (not) {
       curriedFunctionName += 'not';
+      inGlobals = true;
     }
     // Clean the field in function name because can contains '.' and we don't want it in the function name
     curriedFunctionName += 'exists' + fieldName.split('.').join('');
 
-    var result = buildCurriedFunction(collection, fieldName, 'exists', fieldName, curriedFunctionName, roomId, not);
+    var result = buildCurriedFunction(collection, fieldName, 'exists', fieldName, curriedFunctionName, roomId, not, inGlobals);
     if (result.error) {
       deferred.reject(result.error);
       return deferred.promise;
@@ -539,9 +541,10 @@ module.exports = methods = {
  * @param {String} curriedFunctionName
  * @param {String} roomId
  * @param {Boolean} not
+ * @param {Boolean} inGlobals true if the roomId must be added in global room for the collection (eg, for 'not exists' filter)
  * @returns {Object} an object with the path and the new filter
  */
-var buildCurriedFunction = function (collection, field, operatorName, value, curriedFunctionName, roomId, not) {
+var buildCurriedFunction = function (collection, field, operatorName, value, curriedFunctionName, roomId, not, inGlobals) {
   if (operators[operatorName] === undefined) {
     return {error: 'Operator ' + operatorName + ' doesn\'t exist'};
   }
@@ -577,6 +580,14 @@ var buildCurriedFunction = function (collection, field, operatorName, value, cur
 
   if (this.dsl.filtersTree[collection].fields[field][curriedFunctionName].rooms.indexOf(roomId) === -1) {
     this.dsl.filtersTree[collection].fields[field][curriedFunctionName].rooms.push(roomId);
+  }
+
+  if (inGlobals) {
+    if (!this.dsl.filtersTree[collection].rooms) {
+      this.dsl.filtersTree[collection].rooms = [];
+    }
+
+    this.dsl.filtersTree[collection].rooms.push(roomId);
   }
 
   return {

--- a/test/api/dsl/methods/and.test.js
+++ b/test/api/dsl/methods/and.test.js
@@ -41,24 +41,25 @@ describe('Test and method', function () {
   it('should construct the filterTree object for the correct attribute', function () {
     should(methods.dsl.filtersTree).not.be.empty();
     should(methods.dsl.filtersTree[collection]).not.be.empty();
-    should(methods.dsl.filtersTree[collection].city).not.be.empty();
-    should(methods.dsl.filtersTree[collection].hobby).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.city).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.hobby).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
-    should(methods.dsl.filtersTree[collection].city.termcityNYC).not.be.empty();
-    should(methods.dsl.filtersTree[collection].hobby.termhobbycomputer).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.city.termcityNYC).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.hobby.termhobbycomputer).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var rooms;
 
-    rooms = methods.dsl.filtersTree[collection].city.termcityNYC.rooms;
+    rooms = methods.dsl.filtersTree[collection].fields.city.termcityNYC.rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[collection].hobby.termhobbycomputer.rooms;
+    rooms = methods.dsl.filtersTree[collection].fields.hobby.termhobbycomputer.rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
@@ -67,14 +68,14 @@ describe('Test and method', function () {
   it('should construct the filterTree with correct functions', function () {
     var result;
 
-    result = methods.dsl.filtersTree[collection].city.termcityNYC.fn(documentGrace);
+    result = methods.dsl.filtersTree[collection].fields.city.termcityNYC.fn(documentGrace);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[collection].city.termcityNYC.fn(documentAda);
+    result = methods.dsl.filtersTree[collection].fields.city.termcityNYC.fn(documentAda);
     should(result).be.exactly(false);
 
-    result = methods.dsl.filtersTree[collection].hobby.termhobbycomputer.fn(documentGrace);
+    result = methods.dsl.filtersTree[collection].fields.hobby.termhobbycomputer.fn(documentGrace);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[collection].hobby.termhobbycomputer.fn(documentAda);
+    result = methods.dsl.filtersTree[collection].fields.hobby.termhobbycomputer.fn(documentAda);
     should(result).be.exactly(true);
   });
 

--- a/test/api/dsl/methods/bool.test.js
+++ b/test/api/dsl/methods/bool.test.js
@@ -67,53 +67,54 @@ describe('Test bool method', function () {
   it('should construct the filterTree object for the correct attribute', function () {
     should(methods.dsl.filtersTree).not.be.empty();
     should(methods.dsl.filtersTree[collection]).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields).not.be.empty();
 
-    should(methods.dsl.filtersTree[collection].firstName).not.be.empty();
-    should(methods.dsl.filtersTree[collection].age).not.be.empty();
-    should(methods.dsl.filtersTree[collection].city).not.be.empty();
-    should(methods.dsl.filtersTree[collection].hobby).not.be.empty();
-    should(methods.dsl.filtersTree[collection].lastName).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.firstName).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.age).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.city).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.hobby).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.lastName).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
-    should(methods.dsl.filtersTree[collection].firstName['termsfirstNameGrace,Ada']).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.firstName['termsfirstNameGrace,Ada']).not.be.empty();
 
-    should(methods.dsl.filtersTree[collection].age.rangeagegte36).not.be.empty();
-    should(methods.dsl.filtersTree[collection].age.rangeagelt85).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.age.rangeagegte36).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.age.rangeagelt85).not.be.empty();
 
-    should(methods.dsl.filtersTree[collection].city.nottermcityNYC).not.be.empty();
-    should(methods.dsl.filtersTree[collection].hobby.termhobbycomputer).not.be.empty();
-    should(methods.dsl.filtersTree[collection].lastName.existslastName).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.city.nottermcityNYC).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.hobby.termhobbycomputer).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.lastName.existslastName).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var rooms;
 
-    rooms = methods.dsl.filtersTree[collection].firstName['termsfirstNameGrace,Ada'].rooms;
+    rooms = methods.dsl.filtersTree[collection].fields.firstName['termsfirstNameGrace,Ada'].rooms;
     should(rooms).be.an.Array;
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[collection].age.rangeagegte36.rooms;
+    rooms = methods.dsl.filtersTree[collection].fields.age.rangeagegte36.rooms;
     should(rooms).be.an.Array;
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
-    rooms = methods.dsl.filtersTree[collection].age.rangeagelt85.rooms;
-    should(rooms).be.an.Array;
-    should(rooms).have.length(1);
-    should(rooms[0]).be.exactly(roomId);
-
-    rooms = methods.dsl.filtersTree[collection].city.nottermcityNYC.rooms;
+    rooms = methods.dsl.filtersTree[collection].fields.age.rangeagelt85.rooms;
     should(rooms).be.an.Array;
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[collection].hobby.termhobbycomputer.rooms;
+    rooms = methods.dsl.filtersTree[collection].fields.city.nottermcityNYC.rooms;
     should(rooms).be.an.Array;
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[collection].lastName.existslastName.rooms;
+    rooms = methods.dsl.filtersTree[collection].fields.hobby.termhobbycomputer.rooms;
+    should(rooms).be.an.Array;
+    should(rooms).have.length(1);
+    should(rooms[0]).be.exactly(roomId);
+
+    rooms = methods.dsl.filtersTree[collection].fields.lastName.existslastName.rooms;
     should(rooms).be.an.Array;
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
@@ -124,34 +125,34 @@ describe('Test bool method', function () {
   it('should construct the filterTree with correct functions', function () {
     var result;
 
-    result = methods.dsl.filtersTree[collection].firstName['termsfirstNameGrace,Ada'].fn(documentGrace);
+    result = methods.dsl.filtersTree[collection].fields.firstName['termsfirstNameGrace,Ada'].fn(documentGrace);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[collection].firstName['termsfirstNameGrace,Ada'].fn(documentAda);
-    should(result).be.exactly(true);
-
-    result = methods.dsl.filtersTree[collection].age.rangeagegte36.fn(documentGrace);
-    should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[collection].age.rangeagegte36.fn(documentAda);
+    result = methods.dsl.filtersTree[collection].fields.firstName['termsfirstNameGrace,Ada'].fn(documentAda);
     should(result).be.exactly(true);
 
-    result = methods.dsl.filtersTree[collection].age.rangeagelt85.fn(documentGrace);
+    result = methods.dsl.filtersTree[collection].fields.age.rangeagegte36.fn(documentGrace);
+    should(result).be.exactly(true);
+    result = methods.dsl.filtersTree[collection].fields.age.rangeagegte36.fn(documentAda);
+    should(result).be.exactly(true);
+
+    result = methods.dsl.filtersTree[collection].fields.age.rangeagelt85.fn(documentGrace);
     should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[collection].age.rangeagelt85.fn(documentAda);
+    result = methods.dsl.filtersTree[collection].fields.age.rangeagelt85.fn(documentAda);
     should(result).be.exactly(true);
 
-    result = methods.dsl.filtersTree[collection].city.nottermcityNYC.fn(documentGrace);
+    result = methods.dsl.filtersTree[collection].fields.city.nottermcityNYC.fn(documentGrace);
     should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[collection].city.nottermcityNYC.fn(documentAda);
+    result = methods.dsl.filtersTree[collection].fields.city.nottermcityNYC.fn(documentAda);
     should(result).be.exactly(true);
 
-    result = methods.dsl.filtersTree[collection].hobby.termhobbycomputer.fn(documentGrace);
+    result = methods.dsl.filtersTree[collection].fields.hobby.termhobbycomputer.fn(documentGrace);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[collection].hobby.termhobbycomputer.fn(documentAda);
+    result = methods.dsl.filtersTree[collection].fields.hobby.termhobbycomputer.fn(documentAda);
     should(result).be.exactly(true);
 
-    result = methods.dsl.filtersTree[collection].lastName.existslastName.fn(documentGrace);
+    result = methods.dsl.filtersTree[collection].fields.lastName.existslastName.fn(documentGrace);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[collection].lastName.existslastName.fn(documentAda);
+    result = methods.dsl.filtersTree[collection].fields.lastName.existslastName.fn(documentAda);
     should(result).be.exactly(true);
 
   });

--- a/test/api/dsl/methods/exists.test.js
+++ b/test/api/dsl/methods/exists.test.js
@@ -27,18 +27,19 @@ describe('Test exists method', function () {
   it('should construct the filterTree object for the correct attribute', function () {
     should(methods.dsl.filtersTree).not.be.empty();
     should(methods.dsl.filtersTree[collection]).not.be.empty();
-    should(methods.dsl.filtersTree[collection].lastName).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.lastName).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
-    should(methods.dsl.filtersTree[collection].lastName.existslastName).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.lastName.existslastName).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var rooms;
 
     // Test gt from filterGrace
-    rooms = methods.dsl.filtersTree[collection].lastName.existslastName.rooms;
+    rooms = methods.dsl.filtersTree[collection].fields.lastName.existslastName.rooms;
     should(rooms).be.an.Array;
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
@@ -47,9 +48,9 @@ describe('Test exists method', function () {
   it('should construct the filterTree with correct functions exists', function () {
     var result;
 
-    result = methods.dsl.filtersTree[collection].lastName.existslastName.fn(documentGrace);
+    result = methods.dsl.filtersTree[collection].fields.lastName.existslastName.fn(documentGrace);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[collection].lastName.existslastName.fn(documentAda);
+    result = methods.dsl.filtersTree[collection].fields.lastName.existslastName.fn(documentAda);
     should(result).be.exactly(false);
   });
 

--- a/test/api/dsl/methods/geoBoundingBox.test.js
+++ b/test/api/dsl/methods/geoBoundingBox.test.js
@@ -81,7 +81,9 @@ describe('Test geoboundingbox method', function () {
   it('should construct the filterTree object for the correct attribute', function () {
     should(methods.dsl.filtersTree).not.be.empty();
     should(methods.dsl.filtersTree[collection]).not.be.empty();
-    should(methods.dsl.filtersTree[collection].location).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields).not.be.empty();
+
+    should(methods.dsl.filtersTree[collection].fields.location).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
@@ -89,26 +91,26 @@ describe('Test geoboundingbox method', function () {
     // because we have many times the same coord in filters,
     // we must have only three functions (one for filterEngland, and two for filterUSA)
 
-    should(Object.keys(methods.dsl.filtersTree[collection].location)).have.length(3);
-    should(methods.dsl.filtersTree[collection].location.locationgeoBoundingBoxgcmfj457fu10ffy7m4).not.be.empty();
-    should(methods.dsl.filtersTree[collection].location.locationgeoBoundingBoxc0x5cc73fds7jwb737).not.be.empty();
-    should(methods.dsl.filtersTree[collection].location.locationgeoBoundingBoxc0x5c7zzzds7jw7zzz).not.be.empty();
+    should(Object.keys(methods.dsl.filtersTree[collection].fields.location)).have.length(3);
+    should(methods.dsl.filtersTree[collection].fields.location.locationgeoBoundingBoxgcmfj457fu10ffy7m4).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.location.locationgeoBoundingBoxc0x5cc73fds7jwb737).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.location.locationgeoBoundingBoxc0x5c7zzzds7jw7zzz).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var rooms;
 
-    rooms = methods.dsl.filtersTree[collection].location.locationgeoBoundingBoxgcmfj457fu10ffy7m4.rooms;
+    rooms = methods.dsl.filtersTree[collection].fields.location.locationgeoBoundingBoxgcmfj457fu10ffy7m4.rooms;
     should(rooms).be.an.Array;
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[collection].location.locationgeoBoundingBoxc0x5cc73fds7jwb737.rooms;
+    rooms = methods.dsl.filtersTree[collection].fields.location.locationgeoBoundingBoxc0x5cc73fds7jwb737.rooms;
     should(rooms).be.an.Array;
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[collection].location.locationgeoBoundingBoxc0x5c7zzzds7jw7zzz.rooms;
+    rooms = methods.dsl.filtersTree[collection].fields.location.locationgeoBoundingBoxc0x5c7zzzds7jw7zzz.rooms;
     should(rooms).be.an.Array;
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
@@ -118,21 +120,21 @@ describe('Test geoboundingbox method', function () {
     var result;
 
     // test filterEngland
-    result = methods.dsl.filtersTree[collection].location.locationgeoBoundingBoxgcmfj457fu10ffy7m4.fn(documentGrace);
+    result = methods.dsl.filtersTree[collection].fields.location.locationgeoBoundingBoxgcmfj457fu10ffy7m4.fn(documentGrace);
     should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[collection].location.locationgeoBoundingBoxgcmfj457fu10ffy7m4.fn(documentAda);
+    result = methods.dsl.filtersTree[collection].fields.location.locationgeoBoundingBoxgcmfj457fu10ffy7m4.fn(documentAda);
     should(result).be.exactly(true);
 
     // test filterUSA
-    result = methods.dsl.filtersTree[collection].location.locationgeoBoundingBoxc0x5cc73fds7jwb737.fn(documentGrace);
+    result = methods.dsl.filtersTree[collection].fields.location.locationgeoBoundingBoxc0x5cc73fds7jwb737.fn(documentGrace);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[collection].location.locationgeoBoundingBoxc0x5cc73fds7jwb737.fn(documentAda);
+    result = methods.dsl.filtersTree[collection].fields.location.locationgeoBoundingBoxc0x5cc73fds7jwb737.fn(documentAda);
     should(result).be.exactly(false);
 
     // test filterUSA2
-    result = methods.dsl.filtersTree[collection].location.locationgeoBoundingBoxc0x5c7zzzds7jw7zzz.fn(documentGrace);
+    result = methods.dsl.filtersTree[collection].fields.location.locationgeoBoundingBoxc0x5c7zzzds7jw7zzz.fn(documentGrace);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[collection].location.locationgeoBoundingBoxc0x5c7zzzds7jw7zzz.fn(documentAda);
+    result = methods.dsl.filtersTree[collection].fields.location.locationgeoBoundingBoxc0x5c7zzzds7jw7zzz.fn(documentAda);
     should(result).be.exactly(false);
   });
 

--- a/test/api/dsl/methods/not.test.js
+++ b/test/api/dsl/methods/not.test.js
@@ -32,18 +32,20 @@ describe('Test not method', function () {
   it('should construct the filterTree object for the correct attribute', function () {
     should(methods.dsl.filtersTree).not.be.empty();
     should(methods.dsl.filtersTree[collection]).not.be.empty();
-    should(methods.dsl.filtersTree[collection].city).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields).not.be.empty();
+
+    should(methods.dsl.filtersTree[collection].fields.city).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
-    should(methods.dsl.filtersTree[collection].city.nottermcityLondon).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.city.nottermcityLondon).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var rooms;
 
     // Test gt from filterGrace
-    rooms = methods.dsl.filtersTree[collection].city.nottermcityLondon.rooms;
+    rooms = methods.dsl.filtersTree[collection].fields.city.nottermcityLondon.rooms;
     should(rooms).be.an.Array;
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
@@ -52,9 +54,9 @@ describe('Test not method', function () {
   it('should construct the filterTree with correct functions', function () {
     var result;
 
-    result = methods.dsl.filtersTree[collection].city.nottermcityLondon.fn(documentGrace);
+    result = methods.dsl.filtersTree[collection].fields.city.nottermcityLondon.fn(documentGrace);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[collection].city.nottermcityLondon.fn(documentAda);
+    result = methods.dsl.filtersTree[collection].fields.city.nottermcityLondon.fn(documentAda);
     should(result).be.exactly(false);
   });
 

--- a/test/api/dsl/methods/or.test.js
+++ b/test/api/dsl/methods/or.test.js
@@ -44,35 +44,37 @@ describe('Test or method', function () {
   it('should construct the filterTree object for the correct attribute', function () {
     should(methods.dsl.filtersTree).not.be.empty();
     should(methods.dsl.filtersTree[collection]).not.be.empty();
-    should(methods.dsl.filtersTree[collection].city).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields).not.be.empty();
+
+    should(methods.dsl.filtersTree[collection].fields.city).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
-    should(methods.dsl.filtersTree[collection].city.termcityNYC).not.be.empty();
-    should(methods.dsl.filtersTree[collection].city.termcityLondon).not.be.empty();
-    should(methods.dsl.filtersTree[collection].city.nottermcityNYC).not.be.empty();
-    should(methods.dsl.filtersTree[collection].city.nottermcityLondon).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.city.termcityNYC).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.city.termcityLondon).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.city.nottermcityNYC).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.city.nottermcityLondon).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var rooms;
 
-    rooms = methods.dsl.filtersTree[collection].city.termcityNYC.rooms;
+    rooms = methods.dsl.filtersTree[collection].fields.city.termcityNYC.rooms;
     should(rooms).be.an.Array;
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[collection].city.termcityLondon.rooms;
+    rooms = methods.dsl.filtersTree[collection].fields.city.termcityLondon.rooms;
     should(rooms).be.an.Array;
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[collection].city.nottermcityNYC.rooms;
+    rooms = methods.dsl.filtersTree[collection].fields.city.nottermcityNYC.rooms;
     should(rooms).be.an.Array;
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[collection].city.nottermcityLondon.rooms;
+    rooms = methods.dsl.filtersTree[collection].fields.city.nottermcityLondon.rooms;
     should(rooms).be.an.Array;
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
@@ -81,24 +83,24 @@ describe('Test or method', function () {
   it('should construct the filterTree with correct functions', function () {
     var result;
 
-    result = methods.dsl.filtersTree[collection].city.termcityNYC.fn(documentGrace);
+    result = methods.dsl.filtersTree[collection].fields.city.termcityNYC.fn(documentGrace);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[collection].city.termcityNYC.fn(documentAda);
+    result = methods.dsl.filtersTree[collection].fields.city.termcityNYC.fn(documentAda);
     should(result).be.exactly(false);
 
-    result = methods.dsl.filtersTree[collection].city.termcityLondon.fn(documentGrace);
+    result = methods.dsl.filtersTree[collection].fields.city.termcityLondon.fn(documentGrace);
     should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[collection].city.termcityLondon.fn(documentAda);
+    result = methods.dsl.filtersTree[collection].fields.city.termcityLondon.fn(documentAda);
     should(result).be.exactly(true);
 
-    result = methods.dsl.filtersTree[collection].city.nottermcityNYC.fn(documentGrace);
+    result = methods.dsl.filtersTree[collection].fields.city.nottermcityNYC.fn(documentGrace);
     should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[collection].city.nottermcityNYC.fn(documentAda);
+    result = methods.dsl.filtersTree[collection].fields.city.nottermcityNYC.fn(documentAda);
     should(result).be.exactly(true);
 
-    result = methods.dsl.filtersTree[collection].city.nottermcityLondon.fn(documentGrace);
+    result = methods.dsl.filtersTree[collection].fields.city.nottermcityLondon.fn(documentGrace);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[collection].city.nottermcityLondon.fn(documentAda);
+    result = methods.dsl.filtersTree[collection].fields.city.nottermcityLondon.fn(documentAda);
     should(result).be.exactly(false);
   });
 

--- a/test/api/dsl/methods/range.test.js
+++ b/test/api/dsl/methods/range.test.js
@@ -59,55 +59,57 @@ describe('Test range method', function () {
   it('should construct the filterTree object for the correct attribute', function () {
     should(methods.dsl.filtersTree).not.be.empty();
     should(methods.dsl.filtersTree[collection]).not.be.empty();
-    should(methods.dsl.filtersTree[collection].age).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields).not.be.empty();
+
+    should(methods.dsl.filtersTree[collection].fields.age).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
-    should(methods.dsl.filtersTree[collection].age.rangeagegt36).not.be.empty();
-    should(methods.dsl.filtersTree[collection].age.rangeagelte85).not.be.empty();
-    should(methods.dsl.filtersTree[collection].age.rangeagegte36).not.be.empty();
-    should(methods.dsl.filtersTree[collection].age.rangeagelt85).not.be.empty();
-    should(methods.dsl.filtersTree[collection].age.notrangeagegte36).not.be.empty();
-    should(methods.dsl.filtersTree[collection].age.notrangeagelte85).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.age.rangeagegt36).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.age.rangeagelte85).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.age.rangeagegte36).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.age.rangeagelt85).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.age.notrangeagegte36).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.age.notrangeagelte85).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var rooms;
 
     // Test gt from filterGrace
-    rooms = methods.dsl.filtersTree[collection].age.rangeagegt36.rooms;
+    rooms = methods.dsl.filtersTree[collection].fields.age.rangeagegt36.rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomIdFilterGrace);
 
     // Test lte from filterGrace and filterAll
-    rooms = methods.dsl.filtersTree[collection].age.rangeagelte85.rooms;
+    rooms = methods.dsl.filtersTree[collection].fields.age.rangeagelte85.rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(2);
     should(rooms).containEql(roomIdFilterGrace);
     should(rooms).containEql(roomIdFilterAll);
 
     // Test gte from filterAda and filterAll
-    rooms = methods.dsl.filtersTree[collection].age.rangeagegte36.rooms;
+    rooms = methods.dsl.filtersTree[collection].fields.age.rangeagegte36.rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(2);
     should(rooms).containEql(roomIdFilterAda);
     should(rooms).containEql(roomIdFilterAll);
 
     // Test lt from filterAda
-    rooms = methods.dsl.filtersTree[collection].age.rangeagelt85.rooms;
+    rooms = methods.dsl.filtersTree[collection].fields.age.rangeagelt85.rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomIdFilterAda);
 
     // Test not gte from negative filterAll
-    rooms = methods.dsl.filtersTree[collection].age.notrangeagegte36.rooms;
+    rooms = methods.dsl.filtersTree[collection].fields.age.notrangeagegte36.rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomIdFilterNobody);
 
     // Test not lte from negative filterAll
-    rooms = methods.dsl.filtersTree[collection].age.notrangeagelte85.rooms;
+    rooms = methods.dsl.filtersTree[collection].fields.age.notrangeagelte85.rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomIdFilterNobody);
@@ -116,34 +118,34 @@ describe('Test range method', function () {
   it('should construct the filterTree with correct functions range', function () {
     var result;
 
-    result = methods.dsl.filtersTree[collection].age.rangeagegt36.fn(documentGrace);
+    result = methods.dsl.filtersTree[collection].fields.age.rangeagegt36.fn(documentGrace);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[collection].age.rangeagegt36.fn(documentAda);
+    result = methods.dsl.filtersTree[collection].fields.age.rangeagegt36.fn(documentAda);
     should(result).be.exactly(false);
 
-    result = methods.dsl.filtersTree[collection].age.rangeagelte85.fn(documentGrace);
+    result = methods.dsl.filtersTree[collection].fields.age.rangeagelte85.fn(documentGrace);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[collection].age.rangeagelte85.fn(documentAda);
-    should(result).be.exactly(true);
-
-    result = methods.dsl.filtersTree[collection].age.rangeagegte36.fn(documentGrace);
-    should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[collection].age.rangeagegte36.fn(documentAda);
+    result = methods.dsl.filtersTree[collection].fields.age.rangeagelte85.fn(documentAda);
     should(result).be.exactly(true);
 
-    result = methods.dsl.filtersTree[collection].age.rangeagelt85.fn(documentGrace);
-    should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[collection].age.rangeagelt85.fn(documentAda);
+    result = methods.dsl.filtersTree[collection].fields.age.rangeagegte36.fn(documentGrace);
+    should(result).be.exactly(true);
+    result = methods.dsl.filtersTree[collection].fields.age.rangeagegte36.fn(documentAda);
     should(result).be.exactly(true);
 
-    result = methods.dsl.filtersTree[collection].age.notrangeagegte36.fn(documentGrace);
+    result = methods.dsl.filtersTree[collection].fields.age.rangeagelt85.fn(documentGrace);
     should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[collection].age.notrangeagegte36.fn(documentAda);
+    result = methods.dsl.filtersTree[collection].fields.age.rangeagelt85.fn(documentAda);
+    should(result).be.exactly(true);
+
+    result = methods.dsl.filtersTree[collection].fields.age.notrangeagegte36.fn(documentGrace);
+    should(result).be.exactly(false);
+    result = methods.dsl.filtersTree[collection].fields.age.notrangeagegte36.fn(documentAda);
     should(result).be.exactly(false);
 
-    result = methods.dsl.filtersTree[collection].age.notrangeagelte85.fn(documentGrace);
+    result = methods.dsl.filtersTree[collection].fields.age.notrangeagelte85.fn(documentGrace);
     should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[collection].age.notrangeagelte85.fn(documentAda);
+    result = methods.dsl.filtersTree[collection].fields.age.notrangeagelte85.fn(documentAda);
     should(result).be.exactly(false);
   });
 

--- a/test/api/dsl/methods/term.test.js
+++ b/test/api/dsl/methods/term.test.js
@@ -32,18 +32,20 @@ describe('Test term method', function () {
   it('should construct the filterTree object for the correct attribute', function () {
     should(methods.dsl.filtersTree).not.be.empty();
     should(methods.dsl.filtersTree[collection]).not.be.empty();
-    should(methods.dsl.filtersTree[collection].firstName).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields).not.be.empty();
+
+    should(methods.dsl.filtersTree[collection].fields.firstName).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
-    should(methods.dsl.filtersTree[collection].firstName.termfirstNameGrace).not.be.empty();
-    should(methods.dsl.filtersTree[collection].firstName.nottermfirstNameGrace).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.firstName.termfirstNameGrace).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.firstName.nottermfirstNameGrace).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var
-      rooms = methods.dsl.filtersTree[collection].firstName.termfirstNameGrace.rooms,
-      roomsNot = methods.dsl.filtersTree[collection].firstName.nottermfirstNameGrace.rooms;
+      rooms = methods.dsl.filtersTree[collection].fields.firstName.termfirstNameGrace.rooms,
+      roomsNot = methods.dsl.filtersTree[collection].fields.firstName.nottermfirstNameGrace.rooms;
 
     should(rooms).be.an.Array();
     should(roomsNot).be.an.Array();
@@ -57,14 +59,14 @@ describe('Test term method', function () {
 
   it('should construct the filterTree with correct functions term', function () {
     var
-      resultMatch = methods.dsl.filtersTree[collection].firstName.termfirstNameGrace.fn(documentGrace),
-      resultNotMatch = methods.dsl.filtersTree[collection].firstName.termfirstNameGrace.fn(documentAda);
+      resultMatch = methods.dsl.filtersTree[collection].fields.firstName.termfirstNameGrace.fn(documentGrace),
+      resultNotMatch = methods.dsl.filtersTree[collection].fields.firstName.termfirstNameGrace.fn(documentAda);
 
     should(resultMatch).be.exactly(true);
     should(resultNotMatch).be.exactly(false);
 
-    resultMatch = methods.dsl.filtersTree[collection].firstName.nottermfirstNameGrace.fn(documentAda);
-    resultNotMatch = methods.dsl.filtersTree[collection].firstName.nottermfirstNameGrace.fn(documentGrace);
+    resultMatch = methods.dsl.filtersTree[collection].fields.firstName.nottermfirstNameGrace.fn(documentAda);
+    resultNotMatch = methods.dsl.filtersTree[collection].fields.firstName.nottermfirstNameGrace.fn(documentGrace);
 
     should(resultMatch).be.exactly(true);
     should(resultNotMatch).be.exactly(false);

--- a/test/api/dsl/methods/terms.test.js
+++ b/test/api/dsl/methods/terms.test.js
@@ -32,18 +32,20 @@ describe('Test terms method', function () {
   it('should construct the filterTree object for the correct attribute', function () {
     should(methods.dsl.filtersTree).not.be.empty();
     should(methods.dsl.filtersTree[collection]).not.be.empty();
-    should(methods.dsl.filtersTree[collection].firstName).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields).not.be.empty();
+
+    should(methods.dsl.filtersTree[collection].fields.firstName).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
-    should(methods.dsl.filtersTree[collection].firstName['termsfirstNameGrace,Jean']).not.be.empty();
-    should(methods.dsl.filtersTree[collection].firstName['nottermsfirstNameGrace,Jean']).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.firstName['termsfirstNameGrace,Jean']).not.be.empty();
+    should(methods.dsl.filtersTree[collection].fields.firstName['nottermsfirstNameGrace,Jean']).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var
-      rooms = methods.dsl.filtersTree[collection].firstName['termsfirstNameGrace,Jean'].rooms,
-      roomsNot = methods.dsl.filtersTree[collection].firstName['nottermsfirstNameGrace,Jean'].rooms;
+      rooms = methods.dsl.filtersTree[collection].fields.firstName['termsfirstNameGrace,Jean'].rooms,
+      roomsNot = methods.dsl.filtersTree[collection].fields.firstName['nottermsfirstNameGrace,Jean'].rooms;
 
     should(rooms).be.an.Array();
     should(roomsNot).be.an.Array();
@@ -57,14 +59,14 @@ describe('Test terms method', function () {
 
   it('should construct the filterTree with correct functions terms', function () {
     var
-      resultMatch = methods.dsl.filtersTree[collection].firstName['termsfirstNameGrace,Jean'].fn(documentGrace),
-      resultNotMatch = methods.dsl.filtersTree[collection].firstName['termsfirstNameGrace,Jean'].fn(documentAda);
+      resultMatch = methods.dsl.filtersTree[collection].fields.firstName['termsfirstNameGrace,Jean'].fn(documentGrace),
+      resultNotMatch = methods.dsl.filtersTree[collection].fields.firstName['termsfirstNameGrace,Jean'].fn(documentAda);
 
     should(resultMatch).be.exactly(true);
     should(resultNotMatch).be.exactly(false);
 
-    resultMatch = methods.dsl.filtersTree[collection].firstName['nottermsfirstNameGrace,Jean'].fn(documentAda);
-    resultNotMatch = methods.dsl.filtersTree[collection].firstName['nottermsfirstNameGrace,Jean'].fn(documentGrace);
+    resultMatch = methods.dsl.filtersTree[collection].fields.firstName['nottermsfirstNameGrace,Jean'].fn(documentAda);
+    resultNotMatch = methods.dsl.filtersTree[collection].fields.firstName['nottermsfirstNameGrace,Jean'].fn(documentGrace);
 
     should(resultMatch).be.exactly(true);
     should(resultNotMatch).be.exactly(false);


### PR DESCRIPTION
With this PR, we're now able to perfom a filter with just a filter 'not exists' like

```json
{
  "not":
    {
      "exists":
        {
          "field": "some field name"
        }
    }
}
```

We can also perform a subscribe on a whole collection by providing an empty object.
More information in issue #1 