### PR TITLE
Added code coverage for the elasticsearch service

### DIFF
--- a/features/support/apiWebsocket.js
+++ b/features/support/apiWebsocket.js
@@ -5,8 +5,6 @@ var
   io = require('socket.io-client');
 
 module.exports = {
-
-  socket: null,
   world: null,
   responses: null,
   subscribedRooms: {},
@@ -19,10 +17,10 @@ module.exports = {
   },
 
   disconnect: function () {
-    if (this.socket) {
-      this.socket.destroy();
-      this.socket = null;
-    }
+    Object.keys(this.listSockets).forEach(function (socket) {
+      this.listSockets[socket].destroy();
+      delete this.listSockets[socket];
+    }.bind(this));
   },
 
   get: function (id) {
@@ -264,7 +262,6 @@ var initSocket = function (socketName) {
 
   if (!this.listSockets[socketName]) {
     socket = io(config.url, { 'force new connection': true });
-
     this.listSockets[socketName] = socket;
 
     // the default socket is the socket with name 'client1'

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -22,11 +22,7 @@ module.exports = function (kuzzle, options) {
    */
   this.init = function () {
     if (this.client) {
-      return this.client;
-    }
-
-    if (this.kuzzleConfig[this.engineType].hosts.indexOf(',') !== -1) {
-      this.kuzzleConfig[this.engineType].hosts = this.kuzzleConfig[this.engineType].hosts.split(',');
+      return this;
     }
 
     this.client = new es.Client({
@@ -234,7 +230,6 @@ module.exports = function (kuzzle, options) {
       // override index
       async.eachLimit(data.body, 20, function (item) {
         var action = Object.keys(item)[0];
-
         if (nameActions.indexOf(action) !== -1) {
           if (data.type && data.type.length > 0) {
             item[action]._type = data.type;
@@ -247,9 +242,11 @@ module.exports = function (kuzzle, options) {
           item[action]._index = this.kuzzleConfig[this.engineType].index;
         }
       }.bind(this));
+      return this.client.bulk(data);
     }
-
-    return this.client.bulk(data);
+    else {
+      return Promise.reject(new Error('Bulk import: Parse error: document <body> is missing'));
+    }
   };
 
   /**

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -1,0 +1,532 @@
+var
+  should = require('should'),
+  rewire = require('rewire'),
+  params = require('rc')('kuzzle'),
+  Config = require('root-require')('lib/config'),
+  RequestObject = require('root-require')('lib/api/core/models/requestObject'),
+  ES = rewire('../../../lib/services/elasticsearch');
+
+require('should-promised');
+
+describe('Test: ElasticSearch service', function () {
+  var
+    kuzzle = {},
+    collection = 'unit-tests-elasticsearch',
+    createdDocumentId,
+    elasticsearch,
+    requestObject,
+    documentAda = {
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      city: 'London',
+      hobby: 'computer'
+    },
+    filter = {
+      filter: {
+        and: [
+          {
+            term: {
+              city: 'NYC'
+            }
+          },
+          {
+            term: {
+              hobby: 'computer'
+            }
+          }
+        ]
+      }
+    };
+
+  before(function () {
+    kuzzle.config = new Config(params);
+  });
+
+  beforeEach(function () {
+    requestObject = new RequestObject({
+        controller: 'write',
+        action: 'create',
+        requestId: 'foo',
+        collection: collection,
+        body: documentAda
+      });
+
+    elasticsearch = new ES(kuzzle, {service: 'readEngine'});
+    should(elasticsearch.init()).be.exactly(elasticsearch);
+  });
+
+  after(function (done) {
+    /*
+    We catch a rejected promise because one should be thrown if all tests succeed,
+    has there isn't any collection left to delete.
+
+    This hook is here only to ensure we clean up after tests if a test fails.
+     */
+    elasticsearch.deleteCollection(requestObject)
+      .then(function () {
+        done();
+      })
+      .catch(function () {
+        done();
+      });
+  });
+
+  it('should initialize properly', function () {
+    should(elasticsearch.init()).be.exactly(elasticsearch);
+    should(elasticsearch.client).not.be.null();
+  });
+
+  it('should prepare the data for elasticsearch', function () {
+    var
+      cleanData = ES.__get__('cleanData'),
+      preparedData;
+
+    requestObject.data._id = 'foobar';
+    preparedData = cleanData.call(elasticsearch, requestObject);
+
+    should(preparedData.type).be.exactly(requestObject.collection);
+    should(preparedData.id).be.exactly(requestObject.data._id);
+    should(preparedData._id).be.undefined();
+    should(preparedData.index).be.exactly(kuzzle.config.readEngine.index);
+
+    // we expect all properties expect _id to be carried over the new data object
+    Object.keys(requestObject.data).forEach(function (member) {
+      if (member !== '_id') {
+        should(preparedData[member]).be.exactly(requestObject.data[member]);
+      }
+    });
+  });
+
+  it('should be able to search documents', function (done) {
+    var ret;
+
+    requestObject.data.body = filter;
+    ret = elasticsearch.search(requestObject);
+    should(ret).be.a.Promise();
+
+    ret
+      .then(function(result) {
+        should(result.error).not.be.undefined().and.be.null();
+        should(result.data).not.be.undefined().and.not.be.null();
+        should(result.data.hits).not.be.undefined();
+        should(result.data.hits.total).be.exactly(0);
+        should(result.data.hits.hits).be.an.Array();
+        done();
+      })
+      .catch(function (error) {
+        done(error);
+      });
+  });
+
+  it('should return a rejected promise if a search fails', function () {
+    return should(elasticsearch.search(requestObject)).be.rejected();
+  });
+
+  it('should allow creating documents', function (done) {
+    var ret = elasticsearch.create(requestObject);
+
+    should(ret).be.a.Promise();
+
+    ret
+      .then(function (result) {
+        should(result._type).be.exactly(collection);
+        should(result._id).not.be.undefined().and.be.a.String();
+        should(result.created).be.true();
+        createdDocumentId = result._id;
+        done();
+      })
+      .catch(function (error) {
+        done(error);
+      });
+  });
+
+
+  it('should allow getting a single document', function (done) {
+    var ret;
+
+    delete requestObject.data.body;
+    requestObject.data._id = createdDocumentId;
+
+    ret = elasticsearch.get(requestObject);
+
+    should(ret).be.a.Promise();
+
+    ret
+      .then(function (result) {
+        should(result.data).not.be.undefined().and.be.an.Object();
+        should(result.data._id).be.exactly(createdDocumentId);
+        should(result.data.found).be.true();
+        should(result.data._source).match(documentAda);
+        done();
+      })
+      .catch(function (error) {
+        done(error);
+      });
+  });
+
+  it('should return a rejected promise if getting a single document fails', function () {
+    return should(elasticsearch.get(requestObject)).be.rejected();
+  });
+
+  it('should allow counting documents using a provided filter', function (done) {
+    var ret;
+
+    requestObject.data.body = {};
+    ret = elasticsearch.count(requestObject);
+    should(ret).be.a.Promise();
+
+    ret
+      .then(function(result) {
+        should(result.data).not.be.undefined();
+        should(result.data.body).be.an.Object().and.match({});
+        should(result.data.count).be.a.Number();
+        done();
+      })
+      .catch(function (error) {
+        done(error);
+      });
+  });
+
+  it('should allow counting objects using a query', function (done) {
+    var ret;
+
+    delete requestObject.data.body;
+    requestObject.data.query = { match: {firstName: 'Ada'}};
+    ret = elasticsearch.count(requestObject);
+    should(ret).be.a.Promise();
+
+    ret
+      .then(function(result) {
+        should(result.data).not.be.undefined();
+        should(result.data.query).be.an.Object().and.match({});
+        should(result.data.count).be.a.Number();
+        done();
+      })
+      .catch(function (error) {
+        done(error);
+      });
+  });
+
+  it('should return a rejected promise if the count fails', function () {
+    return should(elasticsearch.count(requestObject)).be.rejected();
+  });
+
+  it('should allow to update a document', function () {
+    requestObject.data._id = createdDocumentId;
+    return should(elasticsearch.update(requestObject)).be.fulfilled();
+  });
+
+  it('should return a rejected promise if an update fails', function () {
+    return should(elasticsearch.update(requestObject)).be.rejected();
+  });
+
+  it('should allow to delete a document', function () {
+    delete requestObject.data.body;
+    requestObject.data._id = createdDocumentId;
+    return should(elasticsearch.delete(requestObject)).be.fulfilled();
+  });
+
+  it('should return a rejected promise if a delete fails', function () {
+    return should(elasticsearch.delete(requestObject)).be.rejected();
+  });
+
+  it('should return an empty result array when no document has been deleted using a filter', function (done) {
+    requestObject.data.body = {};
+    elasticsearch.deleteByQuery(requestObject)
+      .then(function (result) {
+        should(result.ids).not.be.undefined().and.be.an.Array();
+        should(result.ids.length).be.exactly(0);
+        done();
+      })
+      .catch(function (error) {
+        done(error);
+      });
+  });
+
+  it('should allow to delete documents using a provided filter', function (done) {
+    var createdDocuments = [];
+
+    this.slow(5000);
+
+    elasticsearch.create(requestObject)
+      .then(function (result) {
+        createdDocuments.push(result._id);
+        return elasticsearch.create(requestObject);
+      })
+      .then(function (result) {
+        createdDocuments.push(result._id);
+        return elasticsearch.create(requestObject);
+      })
+      .then(function (result) {
+        createdDocuments.push(result._id);
+
+        setTimeout(function () {
+          var ret;
+
+          requestObject.data.body = {};
+          ret = elasticsearch.deleteByQuery(requestObject);
+          should(ret).be.a.Promise();
+
+          ret
+            .then(function (result) {
+              try {
+                should(result.ids).not.be.undefined().and.be.an.Array();
+                should(result.ids.length).be.exactly(3);
+                should(result.ids.sort()).match(createdDocuments.sort());
+                done();
+              }
+              catch (e) {
+                done(e);
+              }
+            })
+            .catch(function (error) {
+              done(error);
+            });
+        }, 1200);
+      })
+      .catch(function (error) {
+        done(error);
+      });
+  });
+
+  it('should return a rejected promise if the delete by query fails because of a bad filter', function () {
+    return should(elasticsearch.deleteByQuery(requestObject)).be.rejected();
+  });
+
+  it('should return a rejected promise if the delete by query fails because of a bulk failure', function () {
+    elasticsearch.client.bulk = function () { return Promise.reject(new Error('rejected')); };
+    requestObject.data.body = {};
+
+    return should(elasticsearch.deleteByQuery(requestObject)).be.rejected();
+  });
+
+  it('should support bulk data import', function () {
+    requestObject.data.body = [
+        { index:  {_id: 1, _type: collection } },
+        { firstName: 'foo' },
+        { index:  {_id: 2, _type: collection } },
+        { firstName: 'bar' },
+        { update: {_id: 1, _type: collection } },
+        { doc: { firstName: 'foobar' } },
+        { delete: {_id: 2, _type: collection } }
+      ];
+
+    return should(elasticsearch.import(requestObject)).be.fulfilled();
+  });
+
+  it('should override the type with the collection if one has been specified in the document', function () {
+    requestObject.data.body = [
+      { index:  {_id: 1} },
+      { firstName: 'foo' },
+      { index:  {_id: 2} },
+      { firstName: 'bar' },
+      { update: {_id: 1} },
+      { doc: { firstName: 'foobar' } },
+      { delete: {_id: 2} }
+    ];
+
+    return should(elasticsearch.import(requestObject)).be.fulfilled();
+  });
+
+  it('should return a rejected promise if no body is provided', function () {
+    delete requestObject.data.body;
+    return should(elasticsearch.import(requestObject)).be.rejected();
+  });
+
+  it('should return a rejected promise if no type has been provided, locally or globally', function () {
+    delete requestObject.collection;
+    requestObject.data.body = [
+      { index:  {_id: 1, _type: collection } },
+      { firstName: 'foo' },
+      { index:  {_id: 2, _type: collection } },
+      { firstName: 'bar' },
+      { update: {_id: 1} },
+      { doc: { firstName: 'foobar' } },
+      { delete: {_id: 2, _type: collection } }
+    ];
+
+    return should(elasticsearch.import(requestObject)).be.rejected();
+  });
+
+  it('should have mapping capabilities', function () {
+    requestObject.data.body =  {
+      properties: {
+        city: {type: 'string'}
+      }
+    };
+
+    return should(elasticsearch.putMapping(requestObject)).be.fulfilled();
+  });
+
+  it('should reject bad mapping input', function () {
+    return should(elasticsearch.putMapping(requestObject)).be.rejected();
+  });
+
+  it('should allow users to retrieve a mapping', function (done) {
+    elasticsearch.getMapping(requestObject)
+      .then(function (result) {
+        should(result.data).not.be.undefined();
+        should(result.data.mainindex).not.be.undefined();
+        should(result.data.mainindex.mappings).not.be.undefined();
+        done();
+      })
+      .catch(function (error) {
+        done(error);
+      });
+  });
+
+  it('should return a rejected promise if there is no mapping found', function () {
+    requestObject.collection = 'foobar';
+    return should(elasticsearch.getMapping(requestObject)).be.rejected();
+  });
+
+  it('should allow deleting an entire collection', function () {
+    delete requestObject.data.body;
+    return should(elasticsearch.deleteCollection(requestObject)).be.fulfilled();
+  });
+
+  it('should return a rejected promise if the delete mapping function fails', function () {
+    // because we already deleted the collection in the previous test, it should naturally fail
+    delete requestObject.data.body;
+    return should(elasticsearch.deleteCollection(requestObject)).be.rejected();
+  });
+
+  it('should allow resetting the database', function (done) {
+    var
+      ret,
+      deletedAll = false,
+      mainindexCreated = false;
+
+    elasticsearch.client.indices.delete = function (param) {
+      try {
+        should(param).be.an.Object().and.match({index: '_all'});
+        deletedAll = true;
+        return Promise.resolve({});
+      }
+      catch (error) {
+        done(error);
+      }
+    };
+
+    elasticsearch.client.indices.create = function (param) {
+      try {
+        should(param).be.an.Object().and.match({index: 'mainindex'});
+        mainindexCreated = true;
+        return Promise.resolve({});
+      }
+      catch (error) {
+        done(error);
+      }
+    };
+
+    ret = elasticsearch.reset();
+    should(ret).be.a.Promise();
+
+    ret
+      .then(function () {
+        should(deletedAll).be.true();
+        should(mainindexCreated).be.true();
+        done();
+      })
+      .catch(function (error) {
+        done(error);
+      });
+  });
+
+  it('should return a rejected promise if the reset fails while creating the main index', function () {
+    elasticsearch.client.indices.delete = function () { return Promise.resolve({}); };
+    elasticsearch.client.indices.create = function () { return Promise.reject(new Error('rejected')); };
+
+    return should(elasticsearch.reset()).be.rejected();
+  });
+
+  it('should return a rejected promise if the reset fails while deleting the database', function () {
+    elasticsearch.client.indices.delete = function () { return Promise.reject(new Error('rejected')); };
+
+    return should(elasticsearch.reset()).be.rejected();
+  });
+
+  it('should be able to get every ids matching a query', function (done) {
+    var
+      ret,
+      getAllIdsFromQuery = ES.__get__('getAllIdsFromQuery'),
+      ids = ['foo', 'bar'];
+
+    elasticsearch.client.search = function (data, callback) {
+      var response = {
+        hits: {
+          hits: [
+            {_id: 'foo'},
+            {_id: 'bar'}
+          ],
+          total: 2
+        }
+      };
+      callback(null, response);
+    };
+
+    ret = getAllIdsFromQuery.call(elasticsearch, requestObject);
+    should(ret).be.a.Promise();
+
+    ret
+      .then(function (result) {
+        should(result).be.an.Array().and.match(ids);
+        should(result.length).be.exactly(2);
+        done();
+      })
+      .catch(function (error) {
+        done(error);
+      });
+  });
+
+  it('should return a rejected promise if the search fails', function () {
+    var getAllIdsFromQuery = ES.__get__('getAllIdsFromQuery');
+
+    elasticsearch.client.search = function (data, callback) {
+      callback(new Error('rejected'));
+    };
+
+    return should(getAllIdsFromQuery.call(elasticsearch, requestObject)).be.rejectedWith('rejected');
+  });
+
+  it('should scroll through result pages until getting all ids', function (done) {
+    var
+      getAllIdsFromQuery = ES.__get__('getAllIdsFromQuery'),
+      ids = ['foo', 'bar'];
+
+    elasticsearch.client.search = function (data, callback) {
+      var response = {
+        hits: {
+          hits: [
+            {_id: 'foo'}
+          ],
+          total: 2
+        }
+      };
+      callback(null, response);
+    };
+
+
+    elasticsearch.client.scroll = function (data, callback) {
+      var response = {
+        hits: {
+          hits: [
+            {_id: 'bar'}
+          ],
+          total: 2
+        }
+      };
+      callback(null, response);
+    };
+
+    getAllIdsFromQuery.call(elasticsearch, requestObject)
+      .then(function (result) {
+        should(result).be.an.Array().and.match(ids);
+        should(result.length).be.exactly(2);
+        done();
+      })
+      .catch(function (error) {
+        done(error);
+      });
+  });
+});

--- a/test/services/init.test.js
+++ b/test/services/init.test.js
@@ -45,6 +45,7 @@ describe('Test service initialization function', function () {
     kuzzle.start(params, {dummy: true});
 
     should(kuzzle.services.list.readEngine).be.an.Object();
+    should(kuzzle.services.list.readEngine.init).be.a.Function();
     should(kuzzle.services.list.readEngine.search).be.a.Function();
     should(kuzzle.services.list.readEngine.get).be.a.Function();
   });
@@ -53,6 +54,7 @@ describe('Test service initialization function', function () {
     kuzzle.start(params, {dummy: true});
 
     should(kuzzle.services.list.writeEngine).be.an.Object();
+    should(kuzzle.services.list.writeEngine.init).be.a.Function();
     should(kuzzle.services.list.writeEngine.create).be.a.Function();
     should(kuzzle.services.list.writeEngine.update).be.a.Function();
     should(kuzzle.services.list.writeEngine.deleteByQuery).be.a.Function();


### PR DESCRIPTION
Added code coverage for the elasticsearch service:

* made the init() function return this in all cases
* made the import() function exit immediatly if the requestObject.body object is missing

Unrelated: fixed the disconnect() function in the websocket functional tests. 
Functional tests crashed during websocket tests, making cucumber think everything went fine.
