### PR TITLE
Check rest request

### DIFF
--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -303,7 +303,7 @@ function executeFromRest(params, request, response) {
     return false;
   }
 
-  if (request._body && request.headers['content-type'] !== 'application/json') {
+  if (request.headers['content-type'] && request.headers['content-type'] !== 'application/json') {
     response.writeHead(400, {'Content-Type': 'application/json'});
     response.end(stringify({error: 'Invalid request content-type. Expected "application/json", got: "' + request.headers['content-type'] +'"', result: null}));
     return false;

--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -303,7 +303,7 @@ function executeFromRest(params, request, response) {
     return false;
   }
 
-  if (request.headers['content-type'] !== 'application/json') {
+  if (request._body && request.headers['content-type'] !== 'application/json') {
     response.writeHead(400, {'Content-Type': 'application/json'});
     response.end(stringify({error: 'Invalid request content-type. Expected "application/json", got: "' + request.headers['content-type'] +'"', result: null}));
     return false;

--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -303,6 +303,12 @@ function executeFromRest(params, request, response) {
     return false;
   }
 
+  if (request.headers['content-type'] !== 'application/json') {
+    response.writeHead(400, {'Content-Type': 'application/json'});
+    response.end(stringify({error: 'Invalid request content-type. Expected "application/json", got: "' + request.headers['content-type'] +'"', result: null}));
+    return false;
+  }
+
   data = {
     controller: params.controller,
     action: params.action || request.params.action,

--- a/test/api/controllers/routerController/executeFromRest.test.js
+++ b/test/api/controllers/routerController/executeFromRest.test.js
@@ -29,173 +29,188 @@ describe('Test: routerController.executeFromRest', function () {
     },
     executeFromRest;
 
-    before(function (done) {
-      var
-        mockupFunnel = function (requestObject) {
-          var forwardedObject = new ResponseObject(requestObject, {});
+  before(function (done) {
+    var
+      mockupFunnel = function (requestObject) {
+        var forwardedObject = new ResponseObject(requestObject, {});
 
-          if (requestObject.data.body.resolve) {
-            if (requestObject.data.body.empty) {
-              return Promise.resolve({});
-            }
-            else {
-              return Promise.resolve(forwardedObject);
-            }
+        if (requestObject.data.body.resolve) {
+          if (requestObject.data.body.empty) {
+            return Promise.resolve({});
           }
           else {
-            return Promise.reject(new Error('rejected'));
+            return Promise.resolve(forwardedObject);
           }
-        },
-        mockupRouterListener = {
-          listener: {
-            add: function () { return true; }
-          }
-        };
-
-      kuzzle = new Kuzzle();
-      kuzzle.log = new (winston.Logger)({transports: [new (winston.transports.Console)({level: 'silent'})]});
-
-      kuzzle.start(params, {dummy: true})
-        .then(function () {
-          kuzzle.funnel.execute = mockupFunnel;
-          RouterController.router = mockupRouterListener;
-
-          executeFromRest = RouterController.__get__('executeFromRest');
-          done();
-        });
-    });
-
-    it('should reject requests when the controller is not provided', function () {
-      var params = { action: 'create', collection: 'foobar' };
-
-      mockupResponse.init();
-      executeFromRest.call(kuzzle, params, {}, mockupResponse);
-
-      should(mockupResponse.statusCode).be.exactly(400);
-      should(mockupResponse.header['Content-Type']).not.be.undefined();
-      should(mockupResponse.header['Content-Type']).be.exactly('application/json');
-      should(mockupResponse.response.result).be.null();
-      should(mockupResponse.response.error).not.be.null();
-      should(mockupResponse.response.error).be.exactly('The "controller" argument is missing');
-    });
-
-    it('should respond with a HTTP 200 message in case of success', function (done) {
-      var
-        params = { action: 'create', controller: 'write' },
-        data = {body: {resolve: true}, params: {collection: 'foobar'}};
-
-      mockupResponse.init();
-      executeFromRest.call(kuzzle, params, data, mockupResponse);
-
-      setTimeout(function () {
-        try {
-          should(mockupResponse.statusCode).be.exactly(200);
-          should(mockupResponse.header['Content-Type']).not.be.undefined();
-          should(mockupResponse.header['Content-Type']).be.exactly('application/json');
-          should(mockupResponse.response.error).be.null();
-          should(mockupResponse.response.result).be.not.null();
-          should(mockupResponse.response.result._source).match(data.body);
-          should(mockupResponse.response.result.action).be.exactly('create');
-          should(mockupResponse.response.result.controller).be.exactly('write');
-          done();
         }
-        catch (e) {
-          done(e);
+        else {
+          return Promise.reject(new Error('rejected'));
         }
-      }, 20);
-    });
-
-    it('should not respond if the response is empty', function (done) {
-      var
-        params = { action: 'create', controller: 'write' },
-        data = {body: {resolve: true, empty: true}, params: {collection: 'foobar'}};
-
-      mockupResponse.init();
-      executeFromRest.call(kuzzle, params, data, mockupResponse);
-
-      setTimeout(function () {
-        try {
-          should(mockupResponse.ended).be.false();
-          done();
+      },
+      mockupRouterListener = {
+        listener: {
+          add: function () { return true; }
         }
-        catch (e) {
-          done(e);
-        }
-      }, 20);
-    });
+      };
 
-    it('should respond with a HTTP 400 message in case of error', function (done) {
-      var
-        params = { action: 'create', controller: 'write' },
-        data = {body: {resolve: false}, params: {collection: 'foobar'}};
+    kuzzle = new Kuzzle();
+    kuzzle.log = new (winston.Logger)({transports: [new (winston.transports.Console)({level: 'silent'})]});
 
-      mockupResponse.init();
-      executeFromRest.call(kuzzle, params, data, mockupResponse);
+    kuzzle.start(params, {dummy: true})
+      .then(function () {
+        kuzzle.funnel.execute = mockupFunnel;
+        RouterController.router = mockupRouterListener;
 
-      setTimeout(function () {
-        try {
-          should(mockupResponse.statusCode).be.exactly(400);
-          should(mockupResponse.header['Content-Type']).not.be.undefined();
-          should(mockupResponse.header['Content-Type']).be.exactly('application/json');
-          should(mockupResponse.response.error).not.be.null();
-          should(mockupResponse.response.error).be.exactly('rejected');
-          should(mockupResponse.response.result).be.null();
-          done();
-        }
-        catch (e) {
-          done(e);
-        }
-      }, 20);
-    });
+        executeFromRest = RouterController.__get__('executeFromRest');
+        done();
+      });
+  });
 
-    it('should use the request content instead of the metadata to complete missing information', function (done) {
-      var
-        params = {controller: 'write' },
-        data = {body: {resolve: true}, params: {collection: 'foobar',  action: 'create'}};
+  it('should reject requests when the controller is not provided', function () {
+    var params = { action: 'create', collection: 'foobar' };
 
-      mockupResponse.init();
-      executeFromRest.call(kuzzle, params, data, mockupResponse);
+    mockupResponse.init();
+    executeFromRest.call(kuzzle, params, {headers: {'content-type': 'application/json'}}, mockupResponse);
 
-      setTimeout(function () {
-        try {
-          should(mockupResponse.statusCode).be.exactly(200);
-          should(mockupResponse.header['Content-Type']).not.be.undefined();
-          should(mockupResponse.header['Content-Type']).be.exactly('application/json');
-          should(mockupResponse.response.error).be.null();
-          should(mockupResponse.response.result).be.not.null();
-          should(mockupResponse.response.result.action).be.exactly('create');
-          should(mockupResponse.response.result.controller).be.exactly('write');
-          done();
-        }
-        catch (e) {
-          done(e);
-        }
-      }, 20);
-    });
+    should(mockupResponse.statusCode).be.exactly(400);
+    should(mockupResponse.header['Content-Type']).not.be.undefined();
+    should(mockupResponse.header['Content-Type']).be.exactly('application/json');
+    should(mockupResponse.response.result).be.null();
+    should(mockupResponse.response.error).not.be.null();
+    should(mockupResponse.response.error).be.exactly('The "controller" argument is missing');
+  });
 
-    it('should copy any found "id" identifier', function (done) {
-      var
-        params = {controller: 'write' },
-        data = {body: {resolve: true}, params: {collection: 'foobar',  action: 'create', id: 'fakeid'}};
+  it('should reject requests when the content-type is not application/json', function () {
+    var
+      params = { action: 'create', controller: 'write' },
+      data = {headers: {'content-type': '"application/x-www-form-urlencoded'}, body: {resolve: true}, params: {collection: 'foobar'}};
 
-      mockupResponse.init();
-      executeFromRest.call(kuzzle, params, data, mockupResponse);
+    mockupResponse.init();
+    executeFromRest.call(kuzzle, params, data, mockupResponse);
+    should(mockupResponse.statusCode).be.exactly(400);
+    should(mockupResponse.header['Content-Type']).not.be.undefined();
+    should(mockupResponse.header['Content-Type']).be.exactly('application/json');
+    should(mockupResponse.response.result).be.null();
+    should(mockupResponse.response.error).not.be.null();
+    should(mockupResponse.response.error).startWith('Invalid request content-type');
+  });
 
-      setTimeout(function () {
-        try {
-          should(mockupResponse.statusCode).be.exactly(200);
-          should(mockupResponse.header['Content-Type']).not.be.undefined();
-          should(mockupResponse.header['Content-Type']).be.exactly('application/json');
-          should(mockupResponse.response.error).be.null();
-          should(mockupResponse.response.result).be.not.null();
-          should(mockupResponse.response.result.action).be.exactly('create');
-          should(mockupResponse.response.result.controller).be.exactly('write');
-          should(mockupResponse.response.result._id).be.exactly('fakeid');
-          done();
-        }
-        catch (e) {
-          done(e);
-        }
-      }, 20);
-    });
+  it('should respond with a HTTP 200 message in case of success', function (done) {
+    var
+      params = { action: 'create', controller: 'write' },
+      data = {headers: {'content-type': 'application/json'}, body: {resolve: true}, params: {collection: 'foobar'}};
+
+    mockupResponse.init();
+    executeFromRest.call(kuzzle, params, data, mockupResponse);
+
+    setTimeout(function () {
+      try {
+        should(mockupResponse.statusCode).be.exactly(200);
+        should(mockupResponse.header['Content-Type']).not.be.undefined();
+        should(mockupResponse.header['Content-Type']).be.exactly('application/json');
+        should(mockupResponse.response.error).be.null();
+        should(mockupResponse.response.result).be.not.null();
+        should(mockupResponse.response.result._source).match(data.body);
+        should(mockupResponse.response.result.action).be.exactly('create');
+        should(mockupResponse.response.result.controller).be.exactly('write');
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    }, 20);
+  });
+
+  it('should not respond if the response is empty', function (done) {
+    var
+      params = { action: 'create', controller: 'write' },
+      data = {headers: {'content-type': 'application/json'}, body: {resolve: true, empty: true}, params: {collection: 'foobar'}};
+
+    mockupResponse.init();
+    executeFromRest.call(kuzzle, params, data, mockupResponse);
+
+    setTimeout(function () {
+      try {
+        should(mockupResponse.ended).be.false();
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    }, 20);
+  });
+
+  it('should respond with a HTTP 400 message in case of error', function (done) {
+    var
+      params = { action: 'create', controller: 'write' },
+      data = {headers: {'content-type': 'application/json'}, body: {resolve: false}, params: {collection: 'foobar'}};
+
+    mockupResponse.init();
+    executeFromRest.call(kuzzle, params, data, mockupResponse);
+
+    setTimeout(function () {
+      try {
+        should(mockupResponse.statusCode).be.exactly(400);
+        should(mockupResponse.header['Content-Type']).not.be.undefined();
+        should(mockupResponse.header['Content-Type']).be.exactly('application/json');
+        should(mockupResponse.response.error).not.be.null();
+        should(mockupResponse.response.error).be.exactly('rejected');
+        should(mockupResponse.response.result).be.null();
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    }, 20);
+  });
+
+  it('should use the request content instead of the metadata to complete missing information', function (done) {
+    var
+      params = {controller: 'write' },
+      data = {headers: {'content-type': 'application/json'}, body: {resolve: true}, params: {collection: 'foobar',  action: 'create'}};
+
+    mockupResponse.init();
+    executeFromRest.call(kuzzle, params, data, mockupResponse);
+
+    setTimeout(function () {
+      try {
+        should(mockupResponse.statusCode).be.exactly(200);
+        should(mockupResponse.header['Content-Type']).not.be.undefined();
+        should(mockupResponse.header['Content-Type']).be.exactly('application/json');
+        should(mockupResponse.response.error).be.null();
+        should(mockupResponse.response.result).be.not.null();
+        should(mockupResponse.response.result.action).be.exactly('create');
+        should(mockupResponse.response.result.controller).be.exactly('write');
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    }, 20);
+  });
+
+  it('should copy any found "id" identifier', function (done) {
+    var
+      params = {controller: 'write' },
+      data = {headers: {'content-type': 'application/json'}, body: {resolve: true}, params: {collection: 'foobar',  action: 'create', id: 'fakeid'}};
+
+    mockupResponse.init();
+    executeFromRest.call(kuzzle, params, data, mockupResponse);
+
+    setTimeout(function () {
+      try {
+        should(mockupResponse.statusCode).be.exactly(200);
+        should(mockupResponse.header['Content-Type']).not.be.undefined();
+        should(mockupResponse.header['Content-Type']).be.exactly('application/json');
+        should(mockupResponse.response.error).be.null();
+        should(mockupResponse.response.result).be.not.null();
+        should(mockupResponse.response.result.action).be.exactly('create');
+        should(mockupResponse.response.result.controller).be.exactly('write');
+        should(mockupResponse.response.result._id).be.exactly('fakeid');
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    }, 20);
+  });
 });

--- a/test/api/controllers/routerController/executeFromRest.test.js
+++ b/test/api/controllers/routerController/executeFromRest.test.js
@@ -82,7 +82,7 @@ describe('Test: routerController.executeFromRest', function () {
   it('should reject requests when the content-type is not application/json', function () {
     var
       params = { action: 'create', controller: 'write' },
-      data = {headers: {'content-type': '"application/x-www-form-urlencoded'}, body: {resolve: true}, params: {collection: 'foobar'}};
+      data = {_body: true, headers: {'content-type': '"application/x-www-form-urlencoded'}, body: {resolve: true}, params: {collection: 'foobar'}};
 
     mockupResponse.init();
     executeFromRest.call(kuzzle, params, data, mockupResponse);


### PR DESCRIPTION
When transmitting a REST query with an invalid content encoding, the user receive a "The body can't be empty" response, instead of a more explicit error. This PR fixes that.