### PR TITLE
add deferred.reject() to not yet implemented methods

### DIFF
--- a/lib/api/dsl/methods.js
+++ b/lib/api/dsl/methods.js
@@ -3,6 +3,7 @@ var
   async = require('async'),
   operators = require('./operators'),
   BadRequestError = require('../core/errors/badRequestError'),
+  KuzzleError = require('../core/errors/kuzzleError'),
   q = require('q'),
   util = require('util'),
   geohash = require('ngeohash'),
@@ -499,35 +500,50 @@ module.exports = methods = {
    * Return true only if the point in field is in a specific distance from a geo point
    */
   geoDistance: function () {
+    var deferred = q.defer();
 
+    deferred.reject(new KuzzleError('geoDistance is not implemented yet.'));
+    return deferred.promise;
   },
 
   /**
    * Return true only if the point in field is in a range from a specific point
    */
   geoDistanceRange: function () {
+    var deferred = q.defer();
 
+    deferred.reject(new KuzzleError('geoDistanceRange is not implemented yet.'));
+    return deferred.promise;
   },
 
   /**
    * Return true only if the point in field is in a polygon of points
    */
   geoPolygon: function () {
+    var deferred = q.defer();
 
+    deferred.reject(new KuzzleError('geoPolygon is not implemented yet.'));
+    return deferred.promise;
   },
 
   /**
    * Return true only if the point in field is in the square
    */
   geoShape: function() {
+    var deferred = q.defer();
 
+    deferred.reject(new KuzzleError('geoShape is not implemented yet.'));
+    return deferred.promise;
   },
 
   /**
    * Return true only if the value in field pass the regexp test
    */
   regexp: function () {
+    var deferred = q.defer();
 
+    deferred.reject(new KuzzleError('regexp is not implemented yet.'));
+    return deferred.promise;
   }
 };
 

--- a/test/api/dsl/methods/unimplemented.test.js
+++ b/test/api/dsl/methods/unimplemented.test.js
@@ -1,0 +1,25 @@
+var
+  should = require('should'),
+  rewire = require('rewire'),
+  methods = rewire('../../../../lib/api/dsl/methods'),
+  KuzzleError = require.main.require('lib/api/core/errors/kuzzleError');
+
+require('should-promised');
+
+describe('Test unimplemented methods', function () {
+  it('geoDistance call should return a rejected promise', function () {
+    should(methods.geoDistance()).be.rejectedWith(KuzzleError, {message: 'geoDistance is not implemented yet.'});
+  });
+  it('geoDistanceRange call should return a rejected promise', function () {
+    should(methods.geoDistanceRange()).be.rejectedWith(KuzzleError, {message: 'geoDistanceRange is not implemented yet.'});
+  });
+  it('geoPolygon call should return a rejected promise', function () {
+    should(methods.geoPolygon()).be.rejectedWith(KuzzleError, {message: 'geoPolygon is not implemented yet.'});
+  });
+  it('geoShape call should return a rejected promise', function () {
+    should(methods.geoShape()).be.rejectedWith(KuzzleError, {message: 'geoShape is not implemented yet.'});
+  });
+  it('regexp call should return a rejected promise', function () {
+    should(methods.regexp()).be.rejectedWith(KuzzleError, {message: 'regexp is not implemented yet.'});
+  });
+});


### PR DESCRIPTION
Some DSL methods are present and not yet implemented.
This adds a reject() method so that a clear error is returned instead of ```Cannot read property 'then' of undefined```