### PR TITLE
reinit response buffer between each test scenario

### DIFF
--- a/docs/API.REST.md
+++ b/docs/API.REST.md
@@ -724,7 +724,6 @@ These statistics include:
 {
   error: null,                      // Assuming everything went well
   result: {
-    count: <number of found documents>
     _source: {                      // Your original count query
       ...
     },

--- a/features/AMQP.feature
+++ b/features/AMQP.feature
@@ -62,7 +62,7 @@ Feature: Test AMQP API
     When I write the document "documentGrace"
     Then I don't find a document with "Grace" in field "firstName"
     Then I remove the collection and schema
-    Then I wait 2s
+    Then I wait 1s
     Then I change the schema
     When I write the document "documentGrace"
     Then I find a document with "Grace" in field "firstName"

--- a/features/MQTT.feature
+++ b/features/MQTT.feature
@@ -62,7 +62,7 @@ Feature: Test MQTT API
     When I write the document "documentGrace"
     Then I don't find a document with "Grace" in field "firstName"
     Then I remove the collection and schema
-    Then I wait 2s
+    Then I wait 1s
     Then I change the schema
     When I write the document "documentGrace"
     Then I find a document with "Grace" in field "firstName"

--- a/features/REST.feature
+++ b/features/REST.feature
@@ -62,7 +62,7 @@ Feature: Test REST API
     When I write the document "documentGrace"
     Then I don't find a document with "Grace" in field "firstName"
     Then I remove the collection and schema
-    Then I wait 2s
+    Then I wait 1s
     Then I change the schema
     When I write the document "documentGrace"
     Then I find a document with "Grace" in field "firstName"

--- a/features/STOMP.feature
+++ b/features/STOMP.feature
@@ -63,7 +63,7 @@ Feature: Test STOMP API
     When I write the document "documentGrace"
     Then I don't find a document with "Grace" in field "firstName"
     Then I remove the collection and schema
-    Then I wait 2s
+    Then I wait 1s
     Then I change the schema
     When I write the document "documentGrace"
     Then I find a document with "Grace" in field "firstName"

--- a/features/STOMP.feature
+++ b/features/STOMP.feature
@@ -138,7 +138,6 @@ Feature: Test STOMP API
     And I should receive a "off" notification
 
   @usingSTOMP
-<<<<<<< HEAD
   Scenario: Getting the last statistics frame
     When I get the last statistics frame
     Then I get at least 1 statistic frame
@@ -148,9 +147,8 @@ Feature: Test STOMP API
     When I get all statistics frames
     Then I get at least 1 statistic frame
 
-=======
+  @usingSTOMP
   Scenario: list known collections
     When I write the document "documentGrace"
     And I list data collections
     Then I can find a collection "kuzzle-collection-test"
->>>>>>> origin/master

--- a/features/Websocket.feature
+++ b/features/Websocket.feature
@@ -62,7 +62,7 @@ Feature: Test websocket API
     When I write the document "documentGrace"
     Then I don't find a document with "Grace" in field "firstName"
     Then I remove the collection and schema
-    Then I wait 2s
+    Then I wait 1s
     Then I change the schema
     When I write the document "documentGrace"
     Then I find a document with "Grace" in field "firstName"

--- a/features/step_definitions/api.js
+++ b/features/step_definitions/api.js
@@ -121,7 +121,7 @@ var apiSteps = function () {
 
             callbackAsync(error);
           });
-      }.bind(this), 500); // end setTimeout
+      }.bind(this), 20); // end setTimeout
     };
 
 
@@ -165,7 +165,7 @@ var apiSteps = function () {
           .catch(function (error) {
             callbackAsync(error);
           });
-      }.bind(this), 500); // end setTimeout
+      }.bind(this), 100); // end setTimeout
     };
 
     async.retry(20, main.bind(this), function (err) {
@@ -226,7 +226,7 @@ var apiSteps = function () {
 
             callbackAsync(error);
           });
-      }.bind(this), 500); // end setTimeout
+      }.bind(this), 20); // end setTimeout
     };
 
     async.retry(20, main.bind(this), function (err) {
@@ -296,7 +296,7 @@ var apiSteps = function () {
 
           callbackAsync();
         }.bind(this)); // end async.parallel
-      }.bind(this), 500); // end setTimeout
+      }.bind(this), 20); // end setTimeout
     }; // end method main
 
     async.retry(20, main.bind(this), function (err) {
@@ -333,7 +333,7 @@ var apiSteps = function () {
           .catch(function (error) {
             callbackAsync(error);
           });
-      }.bind(this), 500); // end setTimeout
+      }.bind(this), 100); // end setTimeout
     };
 
     async.retry(20, main.bind(this), function (err) {
@@ -378,7 +378,7 @@ var apiSteps = function () {
           .catch(function (error) {
             callbackAsync(new Error(error));
           });
-      }.bind(this), 500);
+      }.bind(this), 20);
     };
 
     async.retry(20, main.bind(this), function (error) {
@@ -394,6 +394,7 @@ var apiSteps = function () {
   this.Then(/^I should receive a "([^"]*)" notification$/, function (action, callback) {
     var main = function (callbackAsync) {
       setTimeout(function () {
+        console.log('trying...');
         if (this.api.responses) {
           if (this.api.responses.error) {
             callbackAsync('An error occurred ' + this.api.response.error.toString());
@@ -409,7 +410,7 @@ var apiSteps = function () {
         } else {
           callbackAsync('No notification received');
         }
-      }.bind(this), 500);
+      }.bind(this), 20);
     };
 
     async.retry(20, main.bind(this), function (err) {
@@ -636,7 +637,7 @@ var apiSteps = function () {
           .catch(function (error) {
             callbackAsync(error);
           });
-      }.bind(this), 500); // end setTimeout
+      }.bind(this), 20); // end setTimeout
     };
 
     async.retry(20, main.bind(this), function (err) {
@@ -689,7 +690,7 @@ var apiSteps = function () {
           .catch(function (error) {
             callbackAsync(error);
           });
-      }.bind(this), 500); // end setTimeout
+      }.bind(this), 20); // end setTimeout
     };
 
     async.retry(20, main.bind(this), function (err) {

--- a/features/step_definitions/api.js
+++ b/features/step_definitions/api.js
@@ -226,7 +226,7 @@ var apiSteps = function () {
 
             callbackAsync(error);
           });
-      }.bind(this), 20); // end setTimeout
+      }.bind(this), 100); // end setTimeout
     };
 
     async.retry(20, main.bind(this), function (err) {

--- a/features/step_definitions/api.js
+++ b/features/step_definitions/api.js
@@ -394,7 +394,6 @@ var apiSteps = function () {
   this.Then(/^I should receive a "([^"]*)" notification$/, function (action, callback) {
     var main = function (callbackAsync) {
       setTimeout(function () {
-        console.log('trying...');
         if (this.api.responses) {
           if (this.api.responses.error) {
             callbackAsync('An error occurred ' + this.api.response.error.toString());

--- a/features/support/apiAMQP.js
+++ b/features/support/apiAMQP.js
@@ -15,7 +15,7 @@ module.exports = {
 
   init: function (world) {
     this.world = world;
-
+    this.responses = null;
     this.clientId = uuid.v1();
 
     if (!this.amqpClient) {

--- a/features/support/apiMQTT.js
+++ b/features/support/apiMQTT.js
@@ -12,6 +12,7 @@ module.exports = {
 
   init: function (world) {
     this.world = world;
+    this.responses = null;
 
     if (this.mqttClient) {
       return false;

--- a/features/support/apiSTOMP.js
+++ b/features/support/apiSTOMP.js
@@ -29,6 +29,7 @@ module.exports = {
       });
     }
     this.world = world;
+    this.responses = null;
   },
 
   disconnect: function () {

--- a/features/support/apiSTOMP.js
+++ b/features/support/apiSTOMP.js
@@ -20,7 +20,6 @@ module.exports = {
     this.stompUrl = config.stompUrl.replace('stomp://', '').split(':');
 
     if (!this.stompClient) {
-      console.log('initializing new stomp client');
       this.stompClient = new stomp(this.stompUrl[0], this.stompUrl[1], 'guest', 'guest', '1.0', '/');
 
       deferredConnection = q.defer();
@@ -285,9 +284,6 @@ var publishAndListen = function (topic, message) {
 
         roomClient.subscribe(topic, function (body) { //, headers) {
           self.responses = JSON.parse(body);
-
-  console.log('===== NOTIFICATION RECEIVED');
-  console.log(self.responses);
         });
 
         deferred.resolve(response);

--- a/features/support/apiWebsocket.js
+++ b/features/support/apiWebsocket.js
@@ -12,6 +12,7 @@ module.exports = {
 
   init: function (world) {
     this.world = world;
+    this.responses = null;
 
     initSocket.call(this, 'client1');
   },


### PR DESCRIPTION
In functional tests, checking if a notification is received is done by reading the response buffer of the tested API.
Problem is, this buffer is not reinitialized between test scenarios, meaning that if a notification takes more time than usual to reach the test client (we're speaking of a few milliseconds), then the previous response is read instead, leading to a false "wrong notification received" error.

This PR aims to correct this behavior by reinitializing the response buffer between each test scenario.