### PR TITLE
Issue #51: install node dependencies at build time

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lib": "lib"
   },
   "dependencies": {
-    "amqplib": "0.3.2",
+    "amqplib": "0.4.0",
     "async": "1.4.2",
     "big.js": "3.1.3",
     "body-parser": "1.13.3",
@@ -41,7 +41,7 @@
     "redis": "2.2.5",
     "request-promise": "0.4.3",
     "router": "1.1.3",
-    "socket.io": "1.3.6",
+    "socket.io": "1.3.7",
     "winston": "^1.0.2",
     "ws": "0.8.0"
   },


### PR DESCRIPTION
This pull request synchronizes the kuzzle project with the kuzzle-containers one. Now Kuzzle dependencies are installed at build time, instead of being installed at run time.

* added a .dockerignore file to avoid copying the node_modules directory, as it is now pre-installed
* updated some dependencies to avoid some node4 compatibility errors