### PR TITLE
updated plugin logger version

### DIFF
--- a/config/defaultPlugins.json
+++ b/config/defaultPlugins.json
@@ -1,6 +1,6 @@
 {
   "kuzzle-plugin-logger": {
-    "version": "1.0.3",
+    "version": "1.0.4",
     "activated": true,
     "defaultConfig": {
       "service": "winston",


### PR DESCRIPTION
Minor update on the logger plugin: it now handles error objects correctly.
This PR only updates this plugin version for the auto-installer.