### PR TITLE
Normalize realtime responses

### DIFF
--- a/docs/API.AMQP.md
+++ b/docs/API.AMQP.md
@@ -233,7 +233,11 @@ How subscription works:
   status: 200,                      // Assuming everything went well
   error: null,                      // Assuming everything went well
   result: {
-    roomId: 'unique Kuzzle room ID'
+    roomId: 'unique Kuzzle room ID',
+    requestId: <Unique ID>,
+    controller: 'subscribe',
+    action: 'on',
+    metadata: {}                   // subscription metadata
   }
 }
 ```
@@ -406,7 +410,13 @@ It works with the room unique ID Kuzzle returns to you when you make a subscript
 {
   status: 200,                        // Assuming everything went well
   error: null,                        // Assuming everything went well
-  result: <number of subscriptions>
+  result: {
+    roomId: 'unique Kuzzle room ID',
+    count: <number of subscriptions>
+    requestId: <Unique ID>,
+    controller: 'subscribe',
+    action: 'count',
+  }
 }
 ```
 
@@ -444,7 +454,11 @@ Makes Kuzzle remove you from its subscribers on this room.
   status: 200,                        // Assuming everything went well
   error: null,                        // Assuming everything went well
   result: {
-    roomId: 'unique Kuzzle room ID'
+    roomId: 'unique Kuzzle room ID',
+    requestId: <Unique ID>,
+    controller: 'subscribe',
+    action: 'off',
+    metadata: {}                      // subscription metadata
   }
 }
 ```

--- a/docs/API.MQTT.md
+++ b/docs/API.MQTT.md
@@ -38,7 +38,7 @@ The current implementation of our MQ Broker service uses [RabbitMQ](https://www.
   * [Getting all stored statistics](#getting-all-stored-statistics)
   * [Listing all known data collections](#listing-all-known-data-collections)
   * [Getting the current Kuzzle timestamp](#getting-the-current-kuzzle-timestamp)
-  
+
 ##  How to connect to Kuzzle
 
 To establish communication with Kuzzle using MQTT, simply connect your application to the Kuzzle's MQTT port.
@@ -235,7 +235,11 @@ How subscription works:
   status: 200,                      // Assuming everything went well
   error: null,                      // Assuming everything went well
   result: {
-    roomId: 'unique Kuzzle room ID'
+    roomId: 'unique Kuzzle room ID',
+    requestId: <Unique ID>,
+    controller: 'subscribe',
+    action: 'on',
+    metadata: {}                   // subscription metadata
   }
 }
 ```
@@ -406,7 +410,13 @@ It works with the room unique ID Kuzzle returns to you when you make a subscript
 {
   status: 200,                       // Assuming everything went well
   error: null,                        // Assuming everything went well
-  result: <number of subscriptions>
+  result: {
+    roomId: 'unique Kuzzle room ID',
+    count: <number of subscriptions>,
+    requestId: <Unique ID>,
+    controller: 'subscribe',
+    action: 'count'
+  }
 }
 ```
 
@@ -440,7 +450,11 @@ Makes Kuzzle remove you from its subscribers on this room.
   status: 200,                       // Assuming everything went well
   error: null,                        // Assuming everything went well
   result: {
-    roomId: 'unique Kuzzle room ID'
+    roomId: 'unique Kuzzle room ID',
+    requestId: <Unique ID>,
+    controller: 'subscribe',
+    action: 'off',
+    metadata: {}                   // subscription metadata
   }
 }
 ```

--- a/docs/API.STOMP.md
+++ b/docs/API.STOMP.md
@@ -234,7 +234,11 @@ How subscription works:
   status: 200,                      // Assuming everything went well
   error: null,                      // Assuming everything went well
   result: {
-    roomId: 'unique Kuzzle room ID'
+    roomId: 'unique Kuzzle room ID',
+    requestId: <Unique ID>,
+    controller: 'subscribe',
+    action: 'on',
+    metadata: {}                   // subscription metadata
   }
 }
 ```
@@ -405,7 +409,13 @@ It works with the room unique ID Kuzzle returns to you when you make a subscript
 {
   status: 200,                       // Assuming everything went well
   error: null,                        // Assuming everything went well
-  result: <number of subscriptions>
+  result: {
+    roomId: 'unique Kuzzle room ID',
+    count: <number of subscriptions>,
+    requestId: <Unique ID>,
+    controller: 'subscribe',
+    action: 'count'
+  }
 }
 ```
 
@@ -441,7 +451,11 @@ Makes Kuzzle remove you of its subscribers on this room.
   status: 200,                       // Assuming everything went well
   error: null,                        // Assuming everything went well
   result: {
-    roomId: 'unique Kuzzle room ID'
+    roomId: 'unique Kuzzle room ID',
+    requestId: <Unique ID>,
+    controller: 'subscribe',
+    action: 'off',
+    metadata: {}                   // subscription metadata
   }
 }
 ```

--- a/docs/API.WebSocket.md
+++ b/docs/API.WebSocket.md
@@ -228,7 +228,11 @@ How subscription works:
   status: 200,                      // Assuming everything went well
   error: null,                      // Assuming everything went well
   result: {
-    roomId: 'unique Kuzzle room ID'
+    roomId: 'unique Kuzzle room ID',
+    requestId: <Unique ID>,
+    controller: 'subscribe',
+    action: 'on',
+    metadata: {}                   // subscription metadata
   }
 }
 ```
@@ -393,7 +397,13 @@ It works with the room unique ID Kuzzle returns to you when you make a subscript
 {
   status: 200,                       // Assuming everything went well
   error: null,                        // Assuming everything went well
-  result: <number of subscriptions>
+  result: {
+    roomId: 'unique Kuzzle room ID',
+    count: <number of subscriptions>,
+    requestId: <Unique ID>,
+    controller: 'subscribe',
+    action: 'count'
+  }
 }
 ```
 
@@ -425,7 +435,11 @@ Makes Kuzzle remove you from its subscribers on this room.
   status: 200,                       // Assuming everything went well
   error: null,                        // Assuming everything went well
   result: {
-    roomId: 'unique Kuzzle room ID'
+    roomId: 'unique Kuzzle room ID',
+    requestId: <Unique ID>,
+    controller: 'subscribe',
+    action: 'off',
+    metadata: {}                   // subscription metadata
   }
 }
 ```

--- a/features/step_definitions/api.js
+++ b/features/step_definitions/api.js
@@ -472,7 +472,7 @@ var apiSteps = function () {
           return false;
         }
 
-        if (response.result !== parseInt(number)) {
+        if (!response.result.count || response.result.count !== parseInt(number)) {
           callback(new Error('No correct value for count. Expected ' + number + ', got ' + response.result));
           return false;
         }

--- a/lib/api/core/models/realTimeResponseObject.js
+++ b/lib/api/core/models/realTimeResponseObject.js
@@ -1,6 +1,7 @@
 function RealTimeResponseObject (roomId, requestObject, count) {
 
   this.roomId = roomId;
+  this.requestId = requestObject.requestId;
   this.controller = requestObject.controller;
   this.action = requestObject.action;
   this.protocol = requestObject.protocol;
@@ -11,15 +12,22 @@ function RealTimeResponseObject (roomId, requestObject, count) {
 }
 
 RealTimeResponseObject.prototype.toJson = function () {
-  var object = {error: null, status: 200};
+  var object = {
+    error: null,
+    status: 200,
+    result: {
+      roomId: this.roomId,
+      requestId: this.requestId,
+      controller: this.controller,
+      action: this.action,
+      protocol: this.protocol,
+      timestamp: this.timestamp,
+      metadata: this.metadata
+    }
+  };
 
   if (this.count) {
-    object.result = this.count;
-  }
-  else {
-    object.result = {
-      roomId: this.roomId
-    };
+    object.result.count = this.count;
   }
 
   return object;

--- a/test/api/core/models/realTimeResponseObject.test.js
+++ b/test/api/core/models/realTimeResponseObject.test.js
@@ -14,10 +14,10 @@ describe('Test: realTimeResponseObject', function () {
   var
     roomId = 'fakeroomid',
     requestObject = new RequestObject({
-      controller: 'write',
-      action: 'update',
-      requestId: 'fakerequestid',
+      controller: 'subscribe',
+      action: 'count',
       collection: 'fakecollection',
+      protocol: 'fakeprotocol',
       body: { foo: 'bar' }
     });
 
@@ -33,7 +33,15 @@ describe('Test: realTimeResponseObject', function () {
       response = responseObject.toJson();
 
     should(response.error).be.null();
-    should(response.result).not.be.null().and.be.exactly(42);
+    should(response.status).be.a.Number().and.be.eql(200);
+    should(response.result).not.be.null().and.be.an.Object();
+    should(response.result.action).be.exactly(requestObject.action);
+    should(response.result.controller).be.exactly(requestObject.controller);
+    should(response.result.metadata).match(requestObject.metadata);
+    should(response.result.protocol).be.exactly(requestObject.protocol);
+    should(response.result.requestId).be.exactly(requestObject.requestId);
+    should(response.result.timestamp).be.exactly(requestObject.timestamp);
+    should(response.result.count).be.exactly(42);
   });
 
   it('should return a normalized subscription response', function () {
@@ -43,6 +51,15 @@ describe('Test: realTimeResponseObject', function () {
 
     should(response.error).be.null();
     should(response.result).not.be.null();
-    should(response.result.roomId).not.be.undefined().and.be.exactly(roomId);
+    should(response.error).be.null();
+    should(response.status).be.a.Number().and.be.eql(200);
+    should(response.result).not.be.null().and.be.an.Object();
+    should(response.result.action).be.exactly(requestObject.action);
+    should(response.result.controller).be.exactly(requestObject.controller);
+    should(response.result.metadata).match(requestObject.metadata);
+    should(response.result.protocol).be.exactly(requestObject.protocol);
+    should(response.result.requestId).be.exactly(requestObject.requestId);
+    should(response.result.timestamp).be.exactly(requestObject.timestamp);
+    should(response.result.count).be.undefined();
   });
 });

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -262,7 +262,7 @@ describe('Test: ElasticSearch service', function () {
   // deleteByQuery
   it('should return an empty result array when no document has been deleted using a filter', function (done) {
     delete requestObject.data.body;
-    requestObject.data.query = { match: {firstName: 'foobar'}};
+    requestObject.data.query = { term: {firstName: 'no way any document can be returned with this filter'}};
 
     elasticsearch.deleteByQuery(requestObject)
       .then(function (result) {


### PR DESCRIPTION
Realtime response objects are expected to be different than regular response objects, mainly because of the 'roomId' key field.

But these responses weren't normalized, mainly when counting subscriptions:
```json
 {
  "error": null,
  "status": 200,
  "response": <number>
}
```

No roomId, and an integer ``result`` instead of an object like all other responses. This poses a problem when coding SDK in languages more strictly typed than JS, forcing developers to handle subscription count response differently than all other responses.

This PR fixes this by normalizing realtime responses:

* all RT responses return a ``roomId`` field 
* all RT responses are formatted the same way, with ``result`` being an object
* RT responses now return a ``requestId`` and a request ``timestamp``, like with regular responses
* RT responses now return the following technical fields: ``controller``, ``action``, ``protocol`` and ``metadata``
