### PR TITLE
Refactor WS/MQ controllers : use only one listenning topic for ALL controllers

### DIFF
--- a/docs/API.AMQP.md
+++ b/docs/API.AMQP.md
@@ -13,6 +13,7 @@ The current implementation of our MQ Broker service uses [RabbitMQ](https://www.
 ## Index
 
 * [How to connect to Kuzzle](#how-to-connect-to-kuzzle)
+* [Query syntax](#query-syntax)
 * [What are response objects](#what-are-response-objects)
 * [Sending metadata](#sending-metadata)
 * [Performing queries](#performing-queries)
@@ -39,10 +40,56 @@ The current implementation of our MQ Broker service uses [RabbitMQ](https://www.
   * [Listing all known data collections](#listing-all-known-data-collections)
   * [Getting the current Kuzzle timestamp](#getting-the-current-kuzzle-timestamp)
 
-##  How to connect to Kuzzle
+## How to connect to Kuzzle
 
 To establish communication with Kuzzle using AMQP, simply connect your application to Kuzzle's AMQP port.
 By default, the MQ Broker listens to the port 5672 for AMQP applications.
+
+## Query syntax
+
+The MQ Broker layer listens to a specific topic in order to forward your queries to the right Kuzzle controller.
+
+**Exchange name:** ``amq.topic``
+
+**Topic name:** ``kuzzle``
+
+**Query body syntax (JSON data):**
+```javascript
+{
+  /*
+  Optional
+  */
+  clientId: <Unique connection ID>,
+
+  /*
+  Optional: Kuzzle will create a unique ID if you don't provide one,
+    and forward this field in its response, allowing you
+    to easily identify which query generated the response you got.
+  */
+  requestId: <Unique ID>,
+
+  /*
+  Required: Controller and Action to call:
+  */
+  controller: '<controller>',
+  action: '<action>',
+
+  /*
+  Collection on which the action is handled (empty for actions that do not manage a unique collection)
+  */
+  collection: '<data collection>',
+
+  /*
+  A set of filters matching documents you want to listen to
+  */
+  body: {
+
+  }
+}
+```
+
+What that means is that you ask a Kuzzle ``controller`` to perform an ``action`` on a ``data collection``.
+
 
 ##  What are ``response`` objects
 
@@ -66,7 +113,7 @@ A ``response`` is a JSON object with the following structure:
   Complex object, depending on your query
   */
   result: {
-    requestId: <unique ID>  // Your query unique identifier. See below.
+    requestId: <unique ID>  // Your query unique identifier. See above.
     ...
   }
 }
@@ -74,16 +121,16 @@ A ``response`` is a JSON object with the following structure:
 
 _NB: For more details about status code and error object, see [status-codes.md](status-codes.md)_
 
-In order to get responses from Kuzzle, you have to provide a ``replyTo`` queue name in your message metadata. If you don't, Kuzzle will have no way to reply to you and may even discard your queries if a response is necessary.
+In order to get responses from Kuzzle, you have to provide a ``replyTo`` queue name in your message headers. If you don't, Kuzzle will have no way to reply to you and may even discard your queries if a response is necessary.
 
-To get responses from Kuzzle, simply subscribe to the queue you provided in the ``replyTo`` metadata.
+To get responses from Kuzzle, simply subscribe to the queue you provided in the ``replyTo`` header.
 
 Once you subscribed to your response topic, you may want to send multiple queries asynchronously to Kuzzle, and make a distinction between which response refers to which query.  
 To do that, simply add a unique ``requestId`` field to your queries. Kuzzle will send it back in its response!
 
 ## Sending metadata
 
-In every request you send to Kuzzle, you can include a ``metadata`` object. This object content will be ignored by Kuzzle, but it will also be forwarded back in ``responses`` and in ``notifications`` (see below).  
+In every request you send to Kuzzle, you can include a ``metadata`` object. This object content will be ignored by Kuzzle, but it will also be forwarded back in ``responses`` and in ``notifications`` (see below).
 
 You can also include metadata information to a subscription request. These metadata information will be forwarded to other subscribers at the moment of the subscription, and when you leave the room. Please note that when leaving the room, the forwarded metadata are those provided in the **subscription** request.
 
@@ -94,6 +141,9 @@ For example, if you update a document:
 ```javascript
 {
   clientId: 'myVeryUniqueClientID',
+  action: 'update',
+  collection: '<data collection>',
+  controller: 'write',
   _id: 'a document ID',
   body: {
     somefield: 'now has a new value'
@@ -134,6 +184,9 @@ Or if you subscribe:
 ```javascript
 {
   clientId: 'myVeryUniqueClientID',
+  controller: 'subscribe',
+  collection: '<data collection>',
+  action: 'on',
   body: {
     // subscription filters
   },
@@ -150,7 +203,7 @@ And then if you leave this room, other subscribers will receive this notificatio
   status: 200,
   error: null,
   result: {
-    roomId: 'unique Kuzzle room ID',
+    roomId: 'uniqueKuzzleRoomID',
     controller: 'subscribe',
     action: 'off',
     count: <the new user count on that room>,
@@ -161,22 +214,13 @@ And then if you leave this room, other subscribers will receive this notificatio
 }
 ```
 
-##  Performing queries
+## Performing queries
 
 This section details every query you can send to Kuzzle, and the ``response`` object Kuzzle will send you back, if any.
 
-The MQ Broker layer listens to specific topics in order to forward your queries to the right Kuzzle controller.
-
-Kuzzle topics are named like this: ``<controller>.<data collection>.<action>``  
-What that means is that you ask a Kuzzle ``controller`` to perform an ``action`` on a ``data collection``.
-
-This documentation will tell you to which topic your queries need to be sent. The only thing you need to know is what a ``data collection`` is.  
-Simply put, a ``data collection`` is a set of data managed internally by Kuzzle. It acts like a data table for persistent documents, or like a room for pub/sub messages.  
-
-
 ---
 
-###  Subscribing to documents
+### Subscribing to documents
 
 Subscription works differently in Kuzzle than with a regular publish/subscribe protocol.  
 In Kuzzle, you don't exactly subscribe to a room or to a topic but, instead, you subscribe to documents.
@@ -192,34 +236,28 @@ The matching criteria you pass on to Kuzzle are [filters](./filters.md).
 How subscription works:  
 :arrow_right: You send a subscription query to Kuzzle  
 :arrow_left: Kuzzle responds to you with a room unique ID  
-:arrow_right: You subscribe to the queue you provided in the ``replyTo`` metadata
+:arrow_right: You subscribe to the queue you provided in the ``replyTo`` header
 :arrow_left: When a document matches your room criteria, Kuzzle sends you a ``response``
 
-**Topic:** ``subscribe.<data collection>.on``
-
-**Exchange name:** ``amq.topic``
-
-**replyTo queue metadata:** Required
+**replyTo queue header:** Required
 
 **Query:**
 
 ```javascript
 {
   /*
-  Optional
+  Required. Allow Kuzzle to know which client wants to subscribe.
   */
-  clientId: <Unique connection ID>,
+  clientId: '<your unique client ID>',
 
-  /*
-  Optional: Kuzzle will create a unique ID if you don't provide one.
-  */
-  requestId: <Unique ID>,
-
-  /*
-  A set of filters matching documents you want to listen to
-  */
+  controller: 'subscribe',
+  action: 'on',
+  collection: '<data collection>',
   body: {
-
+    // subscription filters
+  },
+  metadata: {
+    // query metadata
   }
 }
 ```
@@ -242,7 +280,7 @@ How subscription works:
 }
 ```
 
-####  Notifications
+#### Notifications
 
 Once you receive this ``response``, all you have to do is to subscribe to the ``roomId`` channel on the ``amq.topic`` exchange to receive notifications.
 
@@ -325,7 +363,7 @@ There are 4 types of notifications you can receive:
     action: 'delete',
     collection: '<data collection>',
     controller: 'write',
-    requestId: '<unique request ID>',  // The query updating the document
+    requestId: '<unique request ID>',  // The query deleting the document
     metadata: {
       // metadata embedded in the modifying request
     }
@@ -371,35 +409,26 @@ There are 4 types of notifications you can receive:
 
 ---
 
-###  Counting the number of subscriptions on a given room
+### Counting the number of subscriptions on a given room
 
 Return the number of people/applications who have subscribed to the same documents as you.
 
 It works with the room unique ID Kuzzle returns to you when you make a subscription.
 
-**Topic:** ``subscribe.<data collection>.count``
-
-**Exchange name:** ``amq.topic``
-
-**replyTo queue metadata:** Required.
+**replyTo queue header:** Required.
 
 **Query:**
 
 ```javascript
 {
-  /*
-   Optional
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optional: Kuzzle will forward this field in its response, allowing you
-  to easily identify which query generated the response you got.
-  */
-  requestId: <Unique query ID>,
-
+  controller: 'subscribe',
+  action: 'count'
+  collection: '<data collection>'
   body: {
     roomId: 'unique room ID'
+  }
+  metadata: {
+    // query metadata
   }
 }
 ```
@@ -426,11 +455,7 @@ It works with the room unique ID Kuzzle returns to you when you make a subscript
 
 Makes Kuzzle remove you from its subscribers on this room.
 
-**Topic:** ``subscribe.<data collection>.off``
-
-**Exchange name:** ``amq.topic``
-
-**replyTo queue metadata:** Optional
+**replyTo queue header:** Optional
 
 **Query:**
 
@@ -441,8 +466,15 @@ Makes Kuzzle remove you from its subscribers on this room.
   */
   clientId: '<your unique client ID>',
 
+  controller: 'subscribe',
+  action: 'off',
+  collection: '<data collection>',
+
   body: {
     roomId: 'unique room ID'
+  },
+  metadata: {
+    // query metadata
   }
 }
 ```
@@ -465,18 +497,18 @@ Makes Kuzzle remove you from its subscribers on this room.
 
 ---
 
-###  Sending a non persistent message
+### Sending a non persistent message
 
-**Topic:** ``write.<data collection>.create``
-
-**Exchange name:** ``amq.topic``
-
-**replyTo queue metadata:** Ignored by Kuzzle
+**replyTo queue header:** Ignored by Kuzzle
 
 **Query:**
 
 ```javascript
 {
+  controller: 'write',
+  action: 'create',
+  collection: '<data collection>',
+
   // Tells Kuzzle to send a non persistent message
   persist: false,
 
@@ -493,33 +525,22 @@ Makes Kuzzle remove you from its subscribers on this room.
 
 ---
 
-###  Creating a new document
+### Creating a new document
 
 Creates a new document in the persistent data storage. Returns an error if the document already exists.
 
-**Topic:** ``write.<data collection>.create``
-
-**Exchange name:** ``amq.topic``
-
-**replyTo queue metadata:** Optional
+**replyTo queue header:** Optional
 
 **Query:**
 
 ```javascript
 {
+  controller: 'write',
+  action: 'create',
+  collection: '<data collection>',
+
   // Tells Kuzzle to store your document
   persist: true,
-
-  /*
-  Optional
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optional: Kuzzle will forward this field in its response, allowing you
-  to easily identify which query generated the response you got.
-  */
-  requestId: <Unique query ID>,
 
   /*
   The document itself
@@ -544,7 +565,7 @@ Creates a new document in the persistent data storage. Returns an error if the d
     collection: '<data collection>',
     action: 'create',
     controller: 'write',
-    requestId, '<unique request identifier>',
+    requestId: '<unique request identifier>',
     _version: 1                     // The version of the document in the persistent data storage
   }
 }
@@ -556,26 +577,15 @@ Creates a new document in the persistent data storage. Returns an error if the d
 
 Creates a new document in the persistent data storage, or update it if it already exists.
 
-**Topic:** ``write.<data collection>.createOrUpdate``
-
-**Exchange name:** ``amq.topic``
-
-**replyTo queue metadata:** Optional
+**replyTo queue header:** Optional
 
 **Query:**
 
 ```javascript
 {
-  /*
-  Optional
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optional: Kuzzle will forward this field in its response, allowing you
-  to easily identify which query generated the response you got.
-  */
-  requestId: <Unique query ID>,
+  controller: 'write',
+  action: 'createOrUpdate',
+  collection: '<data collection>',
 
   /*
   The document itself
@@ -609,30 +619,19 @@ Creates a new document in the persistent data storage, or update it if it alread
 
 ---
 
-###  Retrieving a document
+### Retrieving a document
 
 Only documents in the persistent data storage layer can be retrieved.
 
-**Topic:** ``read.<data collection>.get``
-
-**Exchange name:** ``amq.topic``
-
-**replyTo queue metadata:** Required.
+**replyTo queue header:** Required.
 
 **Query:**
 
 ```javascript
 {
-  /*
-  Optional
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optional: Kuzzle will forward this field in its response, allowing you
-  to easily identify which query generated the response you got.
-  */
-  requestId: <Unique query ID>,
+  controller: 'read',
+  action: 'get',
+  collection: '<data collection>',
 
   /*
   The document unique identifier. It's the same one that Kuzzle sends you
@@ -663,32 +662,22 @@ Only documents in the persistent data storage layer can be retrieved.
 
 ---
 
-###  Searching for documents
+### Searching for documents
 
 Only documents in the persistent data storage layer can be searched.
 
 Kuzzle uses the [ElasticSearch Query DSL ](https://www.elastic.co/guide/en/elasticsearch/reference/1.3/query-dsl.html) syntax.
 
-**Topic:** ``read.<data collection>.search``
 
-**Exchange name:** ``amq.topic``
-
-**replyTo queue metadata:** Required.
+**replyTo queue header:** Required.
 
 **Query:**
 
 ```javascript
 {
-  /*
-  Optional
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optional: Kuzzle will forward this field in its response, allowing you
-  to easily identify which query generated the response you got.
-  */
-  requestId: <Unique query ID>,
+  controller: 'read',
+  action: 'search',
+  collection: '<data collection>',
 
   /*
   A set of filters or queries matching documents you're looking for.
@@ -737,30 +726,19 @@ Kuzzle uses the [ElasticSearch Query DSL ](https://www.elastic.co/guide/en/elast
 
 ---
 
-###  Updating a document
+### Updating a document
 
 Only documents in the persistent data storage layer can be updated.
 
-**Topic:** ``write.<data collection>.update``
-
-**Exchange name:** ``amq.topic``
-
-**replyTo queue metadata:** Optional.
+**replyTo queue header:** Optional.
 
 **Query:**
 
 ```javascript
 {
-  /*
-  Optional
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optional: Kuzzle will forward this field in its response, allowing you
-  to easily identify which query generated the response you got.
-  */
-  requestId: <Unique query ID>,
+  controller: 'write',
+  action: 'update',
+  collection: '<data collection>',
 
   /*
   The document unique identifier. It's the same one that Kuzzle sends you
@@ -800,33 +778,22 @@ Only documents in the persistent data storage layer can be updated.
 
 ---
 
-###  Counting documents
+### Counting documents
 
 Only documents in the persistent data storage layer can be counted.
 
 Kuzzle uses the [ElasticSearch Query DSL ](https://www.elastic.co/guide/en/elasticsearch/reference/1.3/query-dsl.html) syntax.
 
 
-**Topic:** ``read.<data collection>.count``
-
-**Exchange name:** ``amq.topic``
-
-**replyTo queue metadata:** Required.
+**replyTo queue header:** Required.
 
 **Query:**
 
 ```javascript
 {
-  /*
-  Optional
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optional: Kuzzle will forward this field in its response, allowing you
-  to easily identify which query generated the response you got.
-  */
-  requestId: <Unique query ID>,
+  controller: 'read',
+  action: 'count',
+  collection: '<data collection>',
 
   /*
   A set of filters or queries matching documents you're looking for.
@@ -861,30 +828,19 @@ Kuzzle uses the [ElasticSearch Query DSL ](https://www.elastic.co/guide/en/elast
 
 ---
 
-###  Deleting a document using a document unique ID
+### Deleting a document using a document unique ID
 
 Only documents in the persistent data storage layer can be deleted.
 
-**Topic:** ``write.<data collection>.delete``
-
-**Exchange name:** ``amq.topic``
-
-**replyTo queue metadata:** Optional.
+**replyTo queue header:** Optional.
 
 **Query:**
 
 ```javascript
 {
-  /*
-  Optional
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optional: Kuzzle will forward this field in its response, allowing you
-  to easily identify which query generated the response you got.
-  */
-  requestId: <Unique query ID>,
+  controller: 'write',
+  action: 'delete',
+  collection: '<data collection>',
 
   /*
   The document unique identifier. It's the same one that Kuzzle sends you
@@ -917,33 +873,22 @@ Only documents in the persistent data storage layer can be deleted.
 
 ---
 
-###  Deleting documents using a query
+### Deleting documents using a query
 
 Only documents in the persistent data storage layer can be deleted.
 
 Kuzzle uses the [ElasticSearch Query DSL ](https://www.elastic.co/guide/en/elasticsearch/reference/1.3/query-dsl.html) syntax.
 
 
-**Topic:** ``write.<data collection>.deleteByQuery``
-
-**Exchange name:** ``amq.topic``
-
-**replyTo queue metadata:** Optional.
+**replyTo queue header:** Optional.
 
 **Query:**
 
 ```javascript
 {
-  /*
-  Optional
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optional: Kuzzle will forward this field in its response, allowing you
-  to easily identify which query generated the response you got.
-  */
-  requestId: <Unique query ID>,
+  controller: 'write',
+  action: 'deleteByQuery',
+  collection: '<data collection>',
 
   /*
   A set of filters or queries matching documents you're looking for.
@@ -982,31 +927,20 @@ Kuzzle uses the [ElasticSearch Query DSL ](https://www.elastic.co/guide/en/elast
 
 ---
 
-###  Deleting an entire data collection
+### Deleting an entire data collection
 
 This removes an entire data collection in the persistent data storage layer.  
 This action is handled by the **administration** controller.
 
-**Topic:** ``admin.<data collection>.deleteCollection``
-
-**Exchange name:** ``amq.topic``
-
-**replyTo queue metadata:** Optional.
+**replyTo queue header:** Optional.
 
 **Query:**
 
 ```javascript
 {
-  /*
-  Optional
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optional: Kuzzle will forward this field in its response, allowing you
-  to easily identify which query generated the response you got.
-  */
-  requestId: <Unique query ID>,
+  controller: 'admin',
+  action: 'deleteCollection',
+  collection: '<data collection>'
 }
 ```
 
@@ -1032,7 +966,7 @@ This action is handled by the **administration** controller.
 
 ---
 
-###  Setting up a data mapping in a collection
+### Setting up a data mapping in a collection
 
 When creating a new data collection in the persistent data storage layer, Kuzzle uses a default mapping.  
 It means that, by default, you won't be able to exploit the full capabilities of our persistent data storage layer (currently handled by [ElasticSearch](https://www.elastic.co/products/elasticsearch)), and your searches may suffer from below-average performances, depending on the amount of data you stored in a collection and the complexity of your database.
@@ -1041,26 +975,15 @@ To solve this matter, Kuzzle's API offers a way to create data mapping and to ex
 
 This action is handled by the **administration** controller.
 
-**Topic:** ``admin.<data collection>.putMapping``
-
-**Exchange name:** ``amq.topic``
-
-**replyTo queue metadata:** Optional.
+**replyTo queue header:** Optional.
 
 **Query:**
 
 ```javascript
 {
-  /*
-  Optional
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optional: Kuzzle will forward this field in its response, allowing you
-  to easily identify which query generated the response you got.
-  */
-  requestId: <Unique query ID>,
+  controller: 'admin',
+  action: 'putMapping',
+  collection: '<data collection>',
 
   /*
   Data mapping using ElasticSearch mapping syntax
@@ -1096,30 +1019,19 @@ This action is handled by the **administration** controller.
 
 ---
 
-###  Retrieving the data mapping of a collection
+### Retrieving the data mapping of a collection
 
 Get data mapping of a collection previously defined
 
-**Topic:** ``admin.<data collection>.getMapping``
-
-**Exchange name:** ``amq.topic``
-
-**replyTo queue metadata:** Required.
+**replyTo queue header:** Required.
 
 **Query:**
 
 ```javascript
 {
-  /*
-  Optional: allow Kuzzle to send a response to your application
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optional: Kuzzle will forward this field in its response, allowing you
-  to easily identify which query generated the response you got.
-  */
-  requestId: <Unique query ID>,
+  controller: 'admin',
+  action: 'getMapping',
+  collection: '<data collection>'
 }
 ```
 
@@ -1134,7 +1046,7 @@ Get data mapping of a collection previously defined
     action: 'getMapping',
     collection: '<data collection>',
     controller: 'admin',
-    requestId, '<unique request identifier>',
+    requestId: '<unique request identifier>',
 
     mainindex: {
       mappings: {
@@ -1165,26 +1077,15 @@ For other queries, the syntax for bulk imports closely resembles the [ElasticSea
 
 Bulk import only works on documents in our persistent data storage layer.
 
-**Topic:** ``bulk.<data collection>.import``
-
-**Exchange name:** ``amq.topic``
-
-**replyTo queue metadata:** Optional.
+**replyTo queue header:** Optional.
 
 **Query:**
 
 ```javascript
 {
-  /*
-  Optional
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optional: Kuzzle will forward this field in its response, allowing you
-  to easily identify which query generated the response you got.
-  */
-  requestId: <Unique query ID>,
+  controller: 'bulk',
+  action: 'import',
+  collection: '<data collection>',
 
   /*
   Data mapping using ElasticSearch bulk syntax.
@@ -1215,7 +1116,7 @@ Bulk import only works on documents in our persistent data storage layer.
     requestId, '<unique request identifier>',
 
     /*
-    The list of executed queries with their status
+    The list of executed queries, with their status
     */
     items: [
       { create: {
@@ -1248,26 +1149,15 @@ To do that, refer to the [ElasticSearch Bulk API](https://www.elastic.co/guide/e
 
 Bulk import only works on documents in our persistent data storage layer.
 
-**Topic:** ``bulk..import``
-
-**Exchange name:** ``amq.topic``
-
-**replyTo queue metadata:** Optionnal.
+**replyTo queue header:** Optionnal.
 
 **Query:**
 
 ```javascript
 {
-  /*
-  Optionnal: allow Kuzzle to send a response to your application
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optionnal: Kuzzle will forward this field in its response, allowing you
-  to easily identify what query generated the response you got.
-  */
-  requestId: <Unique query ID>,
+  controller: 'bulk',
+  action: 'import',
+  collection: '',
 
   /*
   Data mapping using ElasticSearch bulk syntax.
@@ -1319,7 +1209,7 @@ Bulk import only works on documents in our persistent data storage layer.
     /*
     The requestId field you provided.
     */
-    requestId, '<unique request identifier>'
+    requestId: '<unique request identifier>'
   }
 }
 ```
@@ -1328,7 +1218,8 @@ Bulk import only works on documents in our persistent data storage layer.
 
 ### Getting the last statistics frame
 
-Kuzzle monitors its internal activities and make snapshots of them. This command allows getting the last stored statistics frame.
+Kuzzle monitors its internal activities and make snapshots regularly. This command allows getting the last stored statistics frame.  
+By default, snapshots are made every 10s.
 
 These statistics include:
 
@@ -1337,26 +1228,15 @@ These statistics include:
 * the number of completed requests since the last frame
 * the number of failed requests since the last frame
 
-**Topic:** ``admin..getStats``
-
-**Exchange name:** ``amq.topic``
-
-**replyTo queue metadata:** Required.
+**replyTo queue header:** Required.
 
 **Query:**
 
 ```javascript
 {
-  /*
-  Optional
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optional: Kuzzle will forward this field in its response, allowing you
-  to easily identify which query generated the response you got.
-  */
-  requestId: <Unique query ID>
+  controller: 'admin',
+  action: 'getStats',
+  collection: ''
 }
 ```
 
@@ -1367,7 +1247,9 @@ These statistics include:
   status: 200,                      // Assuming everything went well
   error: null,                      // Assuming everything went well
   result: {
-    _source: {}                     // Your original query
+    _source: {                      // Your original query
+      ...
+    },
     action: 'getStats',
     controller: 'admin',
     statistics: {
@@ -1413,27 +1295,15 @@ These statistics include:
 
 Statistics are returned as a JSON-object with each key being the snapshot's timestamp.
 
-
-**Topic:** ``admin..getAllStats``
-
-**Exchange name:** ``amq.topic``
-
-**replyTo queue metadata:** Required.
+**replyTo queue header:** Required.
 
 **Query:**
 
 ```javascript
 {
-  /*
-  Optional
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optional: Kuzzle will forward this field in its response, allowing you
-  to easily identify which query generated the response you got.
-  */
-  requestId: <Unique query ID>
+  controller: 'admin',
+  action: 'getAllStats',
+  collection: ''
 }
 ```
 
@@ -1489,26 +1359,15 @@ Statistics are returned as a JSON-object with each key being the snapshot's time
 
 Return the complete list of persisted data collections.
 
-**Topic:** ``read..listCollections``
-
-**Exchange name:** ``amq.topic``
-
-**replyTo queue metadata:** Required.
+**replyTo queue header:** Required.
 
 **Query:**
 
 ```javascript
 {
-  /*
-  Optional
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optional: Kuzzle will forward this field in its response, allowing you
-  to easily identify which query generated the response you got.
-  */
-  requestId: <Unique query ID>
+  controller: 'read',
+  action: 'listCollections',
+  collection: ''
 }
 ```
 
@@ -1538,26 +1397,15 @@ Return the complete list of persisted data collections.
 
 Return the the current Kuzzle UTC timestamp as Epoch time (number of milliseconds elapsed since 1 January 1970 00:00:00)
 
-**Topic:** ``read..now``
-
-**Exchange name:** ``amq.topic``
-
-**replyTo queue metadata:** Required.
+**replyTo queue header:** Required.
 
 **Query:**
 
 ```javascript
 {
-  /*
-  Optional
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optional: Kuzzle will forward this field in its response, allowing you
-  to easily identify which query generated the response you got.
-  */
-  requestId: <Unique query ID>
+  controller: 'read',
+  action: 'now',
+  collection: ''
 }
 ```
 

--- a/docs/API.AMQP.md
+++ b/docs/API.AMQP.md
@@ -1157,7 +1157,6 @@ Bulk import only works on documents in our persistent data storage layer.
 {
   controller: 'bulk',
   action: 'import',
-  collection: '',
 
   /*
   Data mapping using ElasticSearch bulk syntax.
@@ -1235,8 +1234,7 @@ These statistics include:
 ```javascript
 {
   controller: 'admin',
-  action: 'getStats',
-  collection: ''
+  action: 'getStats'
 }
 ```
 
@@ -1302,8 +1300,7 @@ Statistics are returned as a JSON-object with each key being the snapshot's time
 ```javascript
 {
   controller: 'admin',
-  action: 'getAllStats',
-  collection: ''
+  action: 'getAllStats'
 }
 ```
 
@@ -1366,8 +1363,7 @@ Return the complete list of persisted data collections.
 ```javascript
 {
   controller: 'read',
-  action: 'listCollections',
-  collection: ''
+  action: 'listCollections'
 }
 ```
 
@@ -1404,8 +1400,7 @@ Return the the current Kuzzle UTC timestamp as Epoch time (number of millisecond
 ```javascript
 {
   controller: 'read',
-  action: 'now',
-  collection: ''
+  action: 'now'
 }
 ```
 

--- a/docs/API.MQTT.md
+++ b/docs/API.MQTT.md
@@ -13,6 +13,7 @@ The current implementation of our MQ Broker service uses [RabbitMQ](https://www.
 ## Index
 
 * [How to connect to Kuzzle](#how-to-connect-to-kuzzle)
+* [Query syntax](#query-syntax)
 * [What are response objects](#what-are-response-objects)
 * [Sending metadata](#sending-metadata)
 * [Performing queries](#performing-queries)
@@ -39,15 +40,58 @@ The current implementation of our MQ Broker service uses [RabbitMQ](https://www.
   * [Listing all known data collections](#listing-all-known-data-collections)
   * [Getting the current Kuzzle timestamp](#getting-the-current-kuzzle-timestamp)
 
-##  How to connect to Kuzzle
+## How to connect to Kuzzle
 
 To establish communication with Kuzzle using MQTT, simply connect your application to the Kuzzle's MQTT port.
 By default, the MQ Broker listens to the port 1883 for MQTT applications.
 
+## Query syntax
+
+The MQ Broker layer listens to a specific topic in order to forward your queries to the right Kuzzle controller.
+
+**Topic name:** ``kuzzle``
+
+**Query body syntax (JSON data):**
+```javascript
+{
+  /*
+  Required for queries that need a feedback (see details below):
+  */
+  clientId: <Unique connection ID>,
+
+  /*
+  Optional: Kuzzle will create a unique ID if you don't provide one,
+    and forward this field in its response, allowing you
+    to easily identify which query generated the response you got.
+  */
+  requestId: <Unique ID>,
+
+  /*
+  Required: Controller and Action to call:
+  */
+  controller: '<controller>',
+  action: '<action>',
+
+  /*
+  Collection on which the action is handled (empty for actions that do not manage a unique collection)
+  */
+  collection: '<data collection>',
+
+  /*
+  A set of filters matching documents you want to listen to
+  */
+  body: {
+
+  }
+}
+```
+
+What that means is that you ask a Kuzzle ``controller`` to perform an ``action`` on a ``data collection``.
+
 ##  What are ``response`` objects
 
 A ``response`` is the result of a query you send to Kuzzle. It may be the results of a search query, an acknowledgement of a created action, and so on.  
-And when you subscribe to a room, Kuzzle also sends notifications to your application in the form of a ``response`` object.
+When you subscribe to a room, Kuzzle also sends a notification to your application in the form of a ``response`` object.
 
 A ``response`` is a JSON object with the following structure:
 
@@ -67,7 +111,7 @@ A ``response`` is a JSON object with the following structure:
   Complex object, depending on your query
   */
   result: {
-    requestId: <unique ID>  // Your query unique identifier. See below.
+    requestId: <unique ID>  // Your query unique identifier. See above.
     ...
   }
 }
@@ -97,6 +141,9 @@ For example, if you update a document:
 ```javascript
 {
   clientId: 'myVeryUniqueClientID',
+  action: 'update',
+  collection: '<data collection>',
+  controller: 'write',
   _id: 'a document ID',
   body: {
     somefield: 'now has a new value'
@@ -137,6 +184,9 @@ Or if you subscribe:
 ```javascript
 {
   clientId: 'myVeryUniqueClientID',
+  controller: 'subscribe',
+  collection: '<data collection>',
+  action: 'on',
   body: {
     // subscription filters
   },
@@ -153,7 +203,7 @@ And then if you leave this room, other subscribers will receive this notificatio
   status: 200,
   error: null,
   result: {
-    roomId: 'unique Kuzzle room ID',
+    roomId: 'uniqueKuzzleRoomID',
     controller: 'subscribe',
     action: 'off',
     count: <the new user count on that room>,
@@ -164,25 +214,18 @@ And then if you leave this room, other subscribers will receive this notificatio
 }
 ```
 
-##  Performing queries
+## Performing queries
 
 This section details every query you can send to Kuzzle, and the ``response`` object Kuzzle will send you back, if any.
 
-The MQ Broker layer listens to specific topics in order to forward your queries to the right Kuzzle controller.
-
-Kuzzle topics are named like this: ``<controller>.<data collection>.<action>``  
-What that means is that you ask a Kuzzle ``controller`` to perform an ``action`` on a ``data collection``.
-
-This documentation will tell you to what topic your queries need to be sent. The only thing you need to know is what a ``data collection`` is.  
-Simply put, a ``data collection`` is a set of data managed internally by Kuzzle. It acts like a data table for persistent documents, or like a room for pub/sub messages.  
 
 
 ---
 
-###  Subscribing to documents
+### Subscribing to documents
 
 Subscription works differently in Kuzzle than with a regular publish/subscribe protocol.  
-In Kuzzle, you don't exactly subscribe to a room or a topic but, instead, you subscribe to documents.
+In Kuzzle, you don't exactly subscribe to a room or to a topic but, instead, you subscribe to documents.
 
 What it means is that, along with your subscription query, you also give to Kuzzle a set of matching criteria.  
 Once you have subscribed to a room, if a pub/sub message is published matching your criteria, or if a matching stored document changes (because it is created, updated or deleted), then you'll receive a notification about it.  
@@ -198,8 +241,6 @@ How subscription works:
 :arrow_right: You subscribe to the topic ``mqtt.<room name>``
 :arrow_left: When a document matches your room criteria, Kuzzle sends you a ``response``
 
-**Topic:** ``subscribe.<data collection>.on``
-
 **Query:**
 
 ```javascript
@@ -209,19 +250,18 @@ How subscription works:
   will discard your query, because it doesn't have any mean to send you
   the resulting room ID.
   */
-  clientId: <Unique session ID>,
+  clientId: '<your unique client ID>',
 
-  /*
-  Optionnal: Kuzzle will create an unique ID if you don't provide one.
-  If you do, the requestId will be treated by Kuzzle as a room name.
-  */
-  requestId: <room name>,
+  controller: 'subscribe',
+  action: 'on',
+  collection: '<data collection>',
 
-  /*
-  A set of filters matching documents you want to listen to
-  */
   body: {
 
+    // subscription filters
+  },
+  metadata: {
+    // query metadata
   }
 }
 ```
@@ -244,7 +284,7 @@ How subscription works:
 }
 ```
 
-####  Notifications
+#### Notifications
 
 Once you receive this ``response``, all you have to do is to subscribe to the ``<provided room name>`` topic to receive notifications.
 
@@ -254,7 +294,7 @@ There are 4 types of notifications you can receive:
 
 ```javascript
 {
-  status: 200,                       // Assuming everything went well
+  status: 200,                        // Assuming everything went well
   error: null,                        // Assuming everything went well
   result: {
     _id: 'unique document ID',
@@ -264,7 +304,7 @@ There are 4 types of notifications you can receive:
     action: 'create',
     collection: '<data collection>',
     controller: 'write',
-    requestId: '<unique request ID>',  // The query updating the document document
+    requestId: '<unique request ID>',  // The query updating the document
     metadata: {
       // metadata embedded in the modifying request
     }
@@ -277,7 +317,7 @@ There are 4 types of notifications you can receive:
 
 ```javascript
 {
-  status: 200,                       // Assuming everything went well
+  status: 200,                        // Assuming everything went well
   error: null,                        // Assuming everything went well
   result: {
     _id: 'unique document ID',
@@ -299,7 +339,7 @@ There are 4 types of notifications you can receive:
 
 ```javascript
 {
-  status: 200,                       // Assuming everything went well
+  status: 200,                        // Assuming everything went well
   error: null,                        // Assuming everything went well
   result: {
     _id: 'unique document ID',
@@ -320,14 +360,14 @@ There are 4 types of notifications you can receive:
 
 ```javascript
 {
-  status: 200,                       // Assuming everything went well
+  status: 200,                        // Assuming everything went well
   error: null,                        // Assuming everything went well
   result: {
     _id: 'unique document ID',
     action: 'delete',
     collection: '<data collection>',
     controller: 'write',
-    requestId: '<unique request ID>',  // The query updating the document
+    requestId: '<unique request ID>',  // The query deleting the document
     metadata: {
       // metadata embedded in the modifying request
     }
@@ -340,7 +380,7 @@ There are 4 types of notifications you can receive:
 
 ```javascript
 {
-  status: 200,                       // Assuming everything went well
+  status: 200,                        // Assuming everything went well
   error: null,                        // Assuming everything went well
   result: {
     roomId: 'unique Kuzzle room ID',
@@ -357,7 +397,7 @@ There are 4 types of notifications you can receive:
 
 ```javascript
 {
-  status: 200,                       // Assuming everything went well
+  status: 200,                        // Assuming everything went well
   error: null,                        // Assuming everything went well
   result: {
     roomId: 'unique Kuzzle room ID',
@@ -373,13 +413,11 @@ There are 4 types of notifications you can receive:
 
 ---
 
-###  Counting the number of subscriptions on a given room
+### Counting the number of subscriptions on a given room
 
 Return the number of people/applications who have subscribed to the same documents as you.
 
 It works with the room unique ID Kuzzle returns to you when you make a subscription.
-
-**Topic:** ``subscribe.<data collection>.count``
 
 **Query:**
 
@@ -392,14 +430,14 @@ It works with the room unique ID Kuzzle returns to you when you make a subscript
   */
   clientId: <Unique session ID>,
 
-  /*
-  Optionnal: Kuzzle will forward this field in its response, allowing you
-  to easily identify what query generated the response you got.
-  */
-  requestId: <Unique query ID>,
-
+  controller: 'subscribe',
+  action: 'count'
+  collection: '<data collection>'
   body: {
-    roomId: 'internal Kuzzle room ID'
+    roomId: 'unique room ID'
+  }
+  metadata: {
+    // query metadata
   }
 }
 ```
@@ -408,7 +446,7 @@ It works with the room unique ID Kuzzle returns to you when you make a subscript
 
 ```javascript
 {
-  status: 200,                       // Assuming everything went well
+  status: 200,                        // Assuming everything went well
   error: null,                        // Assuming everything went well
   result: {
     roomId: 'unique Kuzzle room ID',
@@ -426,19 +464,23 @@ It works with the room unique ID Kuzzle returns to you when you make a subscript
 
 Makes Kuzzle remove you from its subscribers on this room.
 
-**Topic:** ``subscribe.<data collection>.off``
-
 **Query:**
 
 ```javascript
 {
   /*
-  Required. Allow Kuzzle to know which client want to unsubscribe.
+  Required. Allow Kuzzle to know which client wants to unsubscribe.
   */
   clientId: '<your unique client ID>',
+  controller: 'subscribe',
+  action: 'off',
+  collection: '<data collection>',
 
   body: {
-    roomId: 'internal Kuzzle room ID'
+    roomId: 'unique room ID'
+  },
+  metadata: {
+    // query metadata
   }
 }
 ```
@@ -447,7 +489,7 @@ Makes Kuzzle remove you from its subscribers on this room.
 
 ```javascript
 {
-  status: 200,                       // Assuming everything went well
+  status: 200,                        // Assuming everything went well
   error: null,                        // Assuming everything went well
   result: {
     roomId: 'unique Kuzzle room ID',
@@ -461,14 +503,16 @@ Makes Kuzzle remove you from its subscribers on this room.
 
 ---
 
-###  Sending a non persistent message
-
-**Topic:** ``write.<data collection>.create``
+### Sending a non persistent message
 
 **Query:**
 
 ```javascript
 {
+  controller: 'write',
+  action: 'create',
+  collection: '<data collection>',
+
   // Tells Kuzzle to send a non persistent message
   persist: false,
 
@@ -481,33 +525,24 @@ Makes Kuzzle remove you from its subscribers on this room.
 }
 ```
 
-**Response:** Kuzzle doesn't send a response when sending non persistent message.
+**Response:** Kuzzle doesn't send a response when sending a non persistent message.
 
 ---
 
-###  Creating a new document
+### Creating a new document
 
 Creates a new document in the persistent data storage. Returns an error if the document already exists.
-
-**Topic:** ``write.<data collection>.create``
 
 **Query:**
 
 ```javascript
 {
+  controller: 'write',
+  action: 'create',
+  collection: '<data collection>',
+
   // Tells Kuzzle to store your document
   persist: true,
-
-  /*
-  Optionnal: allow Kuzzle to send a response to your application
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optionnal: Kuzzle will forward this field in its response, allowing you
-  to easily identify what query generated the response you got.
-  */
-  requestId: <Unique query ID>,
 
   /*
   The document itself
@@ -532,7 +567,7 @@ Creates a new document in the persistent data storage. Returns an error if the d
     collection: '<data collection>',
     action: 'create',
     controller: 'write',
-    requestId, '<unique request identifier>',
+    requestId: '<unique request identifier>',
     _version: 1                     // The version of the document in the persistent data storage
   }
 }
@@ -544,22 +579,13 @@ Creates a new document in the persistent data storage. Returns an error if the d
 
 Creates a new document in the persistent data storage, or update it if it already exists.
 
-**Topic:** ``write.<data collection>.createOrUpdate``
-
 **Query:**
 
 ```javascript
 {
-  /*
-  Optionnal: allow Kuzzle to send a response to your application
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optionnal: Kuzzle will forward this field in its response, allowing you
-  to easily identify what query generated the response you got.
-  */
-  requestId: <Unique query ID>,
+  controller: 'write',
+  action: 'createOrUpdate',
+  collection: '<data collection>',
 
   /*
   The document itself
@@ -593,11 +619,9 @@ Creates a new document in the persistent data storage, or update it if it alread
 
 ---
 
-###  Retrieving a document
+### Retrieving a document
 
 Only documents in the persistent data storage layer can be retrieved.
-
-**Topic:** ``read.<data collection>.get``
 
 **Query:**
 
@@ -610,11 +634,9 @@ Only documents in the persistent data storage layer can be retrieved.
   */
   clientId: <Unique session ID>,
 
-  /*
-  Optionnal: Kuzzle will forward this field in its response, allowing you
-  to easily identify what query generated the response you got.
-  */
-  requestId: <Unique query ID>,
+  controller: 'read',
+  action: 'get',
+  collection: '<data collection>',
 
   /*
   The document unique identifier. It's the same one that Kuzzle sends you
@@ -645,13 +667,11 @@ Only documents in the persistent data storage layer can be retrieved.
 
 ---
 
-###  Searching for documents
+### Searching for documents
 
 Only documents in the persistent data storage layer can be searched.
 
 Kuzzle uses the [ElasticSearch Query DSL ](https://www.elastic.co/guide/en/elasticsearch/reference/1.3/query-dsl.html) syntax.
-
-**Topic:** ``read.<data collection>.search``
 
 **Query:**
 
@@ -664,11 +684,9 @@ Kuzzle uses the [ElasticSearch Query DSL ](https://www.elastic.co/guide/en/elast
   */
   clientId: <Unique session ID>,
 
-  /*
-  Optionnal: Kuzzle will forward this field in its response, allowing you
-  to easily identify what query generated the response you got.
-  */
-  requestId: <Unique query ID>,
+  controller: 'read',
+  action: 'search',
+  collection: '<data collection>',
 
   /*
   A set of filters or queries matching documents you're looking for.
@@ -717,26 +735,17 @@ Kuzzle uses the [ElasticSearch Query DSL ](https://www.elastic.co/guide/en/elast
 
 ---
 
-###  Updating a document
+### Updating a document
 
 Only documents in the persistent data storage layer can be updated.
-
-**Topic:** ``write.<data collection>.update``
 
 **Query:**
 
 ```javascript
 {
-  /*
-  Optionnal: allow Kuzzle to send a response to your application
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optionnal: Kuzzle will forward this field in its response, allowing you
-  to easily identify what query generated the response you got.
-  */
-  requestId: <Unique query ID>,
+  controller: 'write',
+  action: 'update',
+  collection: '<data collection>',
 
   /*
   The document unique identifier. It's the same one that Kuzzle sends you
@@ -776,31 +785,20 @@ Only documents in the persistent data storage layer can be updated.
 
 ---
 
-###  Counting documents
+### Counting documents
 
 Only documents in the persistent data storage layer can be counted.
 
 Kuzzle uses the [ElasticSearch Query DSL ](https://www.elastic.co/guide/en/elasticsearch/reference/1.3/query-dsl.html) syntax.
 
 
-**Topic:** ``read.<data collection>.count``
-
 **Query:**
 
 ```javascript
 {
-  /*
-  Required. If your query doesn't include a clientId field, Kuzzle
-  will discard your query, because it doesn't have any mean to send you
-  the result.
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optionnal: Kuzzle will forward this field in its response, allowing you
-  to easily identify what query generated the response you got.
-  */
-  requestId: <Unique query ID>,
+  controller: 'read',
+  action: 'count',
+  collection: '<data collection>',
 
   /*
   A set of filters or queries matching documents you're looking for.
@@ -835,30 +833,21 @@ Kuzzle uses the [ElasticSearch Query DSL ](https://www.elastic.co/guide/en/elast
 
 ---
 
-###  Deleting a document using a document unique ID
+### Deleting a document using a document unique ID
 
 Only documents in the persistent data storage layer can be deleted.
-
-**Topic:** ``write.<data collection>.delete``
 
 **Query:**
 
 ```javascript
 {
-  /*
-  Optionnal: allow Kuzzle to send a response to your application
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optionnal: Kuzzle will forward this field in its response, allowing you
-  to easily identify what query generated the response you got.
-  */
-  requestId: <Unique query ID>,
+  controller: 'write',
+  action: 'delete',
+  collection: '<data collection>',
 
   /*
   The document unique identifier. It's the same one that Kuzzle sends you
-  in its responses when you create a document, or when you do a search query.
+  in its response when you create a document, or when you do a search query.
   */
   _id: '<document ID>'
 }
@@ -887,29 +876,20 @@ Only documents in the persistent data storage layer can be deleted.
 
 ---
 
-###  Deleting documents using a query
+### Deleting documents using a query
 
 Only documents in the persistent data storage layer can be deleted.
 
 Kuzzle uses the [ElasticSearch Query DSL ](https://www.elastic.co/guide/en/elasticsearch/reference/1.3/query-dsl.html) syntax.
 
 
-**Topic:** ``write.<data collection>.deleteByQuery``
-
 **Query:**
 
 ```javascript
 {
-  /*
-  Optionnal: allow Kuzzle to send a response to your application
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optionnal: Kuzzle will forward this field in its response, allowing you
-  to easily identify what query generated the response you got.
-  */
-  requestId: <Unique query ID>,
+  controller: 'write',
+  action: 'deleteByQuery',
+  collection: '<data collection>',
 
   /*
   A set of filters or queries matching documents you're looking for.
@@ -948,27 +928,18 @@ Kuzzle uses the [ElasticSearch Query DSL ](https://www.elastic.co/guide/en/elast
 
 ---
 
-###  Deleting an entire data collection
+### Deleting an entire data collection
 
 This removes an entire data collection in the persistent data storage layer.  
 This action is handled by the **administration** controller.
-
-**Topic:** ``admin.<data collection>.deleteCollection``
 
 **Query:**
 
 ```javascript
 {
-  /*
-  Optionnal: allow Kuzzle to send a response to your application
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optionnal: Kuzzle will forward this field in its response, allowing you
-  to easily identify what query generated the response you got.
-  */
-  requestId: <Unique query ID>,
+  controller: 'admin',
+  action: 'deleteCollection',
+  collection: '<data collection>'
 }
 ```
 
@@ -994,31 +965,22 @@ This action is handled by the **administration** controller.
 
 ---
 
-###  Setting up a data mapping in a collection
+### Setting up a data mapping in a collection
 
 When creating a new data collection in the persistent data storage layer, Kuzzle uses a default mapping.  
 It means that, by default, you won't be able to exploit the full capabilities of our persistent data storage layer (currently handled by [ElasticSearch](https://www.elastic.co/products/elasticsearch)), and your searches may suffer from below-average performances, depending on the amount of data you stored in a collection and the complexity of your database.
 
-To solve this matter, Kuzzle's API offer a way to create data mapping and expose the entire [mapping capabilities of ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/1.3/mapping.html).
+To solve this matter, Kuzzle's API offers a way to create data mapping and to expose the entire [mapping capabilities of ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/1.3/mapping.html).
 
 This action is handled by the **administration** controller.
-
-**Topic:** ``admin.<data collection>.putMapping``
 
 **Query:**
 
 ```javascript
 {
-  /*
-  Optionnal: allow Kuzzle to send a response to your application
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optionnal: Kuzzle will forward this field in its response, allowing you
-  to easily identify what query generated the response you got.
-  */
-  requestId: <Unique query ID>,
+  controller: 'admin',
+  action: 'putMapping',
+  collection: '<data collection>',
 
   /*
   Data mapping using ElasticSearch mapping syntax
@@ -1054,11 +1016,9 @@ This action is handled by the **administration** controller.
 
 ---
 
-###  Retrieving the data mapping of a collection
+### Retrieving the data mapping of a collection
 
 Get data mapping of a collection previously defined
-
-**Topic:** ``admin.<data collection>.getMapping``
 
 **Query:**
 
@@ -1071,11 +1031,9 @@ Get data mapping of a collection previously defined
   */
   clientId: <Unique session ID>,
 
-  /*
-  Optionnal: Kuzzle will forward this field in its response, allowing you
-  to easily identify what query generated the response you got.
-  */
-  requestId: <Unique query ID>,
+  controller: 'admin',
+  action: 'getMapping',
+  collection: '<data collection>'
 }
 ```
 
@@ -1116,27 +1074,18 @@ Get data mapping of a collection previously defined
 
 ### Performing a bulk import on a data collection
 
-A bulk import allows your application to perform multiple writing operations thanks to a single query. This is especially useful if you want to create a large number of documents, as a bulk import will be a lot faster compared to creating them individually using ``create`` queries.  
-As with other queries, the syntax for bulk imports closely resembles the [ElasticSearch Bulk API](https://www.elastic.co/guide/en/elasticsearch/reference/1.3/docs-bulk.html?q=bulk).
+A bulk import allows your application to perform multiple writing operations thanks to a single query. This is especially useful if you want to create a large number of documents. A bulk import will be a lot faster compared to creating them individually using ``create`` queries.  
+For other queries, the syntax for bulk imports closely resembles the [ElasticSearch Bulk API](https://www.elastic.co/guide/en/elasticsearch/reference/1.3/docs-bulk.html?q=bulk).
 
 Bulk import only works on documents in our persistent data storage layer.
-
-**Topic:** ``bulk.<data collection>.import``
 
 **Query:**
 
 ```javascript
 {
-  /*
-  Optionnal: allow Kuzzle to send a response to your application
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optionnal: Kuzzle will forward this field in its response, allowing you
-  to easily identify what query generated the response you got.
-  */
-  requestId: <Unique query ID>,
+  controller: 'bulk',
+  action: 'import',
+  collection: '<data collection>',
 
   /*
   Data mapping using ElasticSearch bulk syntax.
@@ -1200,22 +1149,13 @@ To do that, refer to the [ElasticSearch Bulk API](https://www.elastic.co/guide/e
 
 Bulk import only works on documents in our persistent data storage layer.
 
-**Topic:** ``bulk..import``
-
 **Query:**
 
 ```javascript
 {
-  /*
-  Optionnal: allow Kuzzle to send a response to your application
-  */
-  clientId: <Unique session ID>,
-
-  /*
-  Optionnal: Kuzzle will forward this field in its response, allowing you
-  to easily identify what query generated the response you got.
-  */
-  requestId: <Unique query ID>,
+  controller: 'bulk',
+  action: 'import',
+  collection: '',
 
   /*
   Data mapping using ElasticSearch bulk syntax.
@@ -1267,7 +1207,7 @@ Bulk import only works on documents in our persistent data storage layer.
     /*
     The requestId field you provided.
     */
-    requestId, '<unique request identifier>'
+    requestId: '<unique request identifier>'
   }
 }
 ```
@@ -1285,8 +1225,6 @@ These statistics include:
 * the number of completed requests since the last frame
 * the number of failed requests since the last frame
 
-**Topic:** ``admin..getStats``
-
 **Query:**
 
 ```javascript
@@ -1298,11 +1236,9 @@ These statistics include:
   */
   clientId: <Unique session ID>,
 
-  /*
-  Optionnal: Kuzzle will forward this field in its response, allowing you
-  to easily identify what query generated the response you got.
-  */
-  requestId: <Unique query ID>
+  controller: 'admin',
+  action: 'getStats',
+  collection: ''
 }
 ```
 
@@ -1361,8 +1297,6 @@ These statistics include:
 
 Statistics are returned as a JSON-object with each key being the snapshot's timestamp.
 
-**Topic:** ``admin..getStats``
-
 **Query:**
 
 ```javascript
@@ -1374,11 +1308,9 @@ Statistics are returned as a JSON-object with each key being the snapshot's time
   */
   clientId: <Unique session ID>,
 
-  /*
-  Optionnal: Kuzzle will forward this field in its response, allowing you
-  to easily identify what query generated the response you got.
-  */
-  requestId: <Unique query ID>
+  controller: 'admin',
+  action: 'getAllStats',
+  collection: ''
 }
 ```
 
@@ -1434,8 +1366,6 @@ Statistics are returned as a JSON-object with each key being the snapshot's time
 
 Return the complete list of persisted data collections.
 
-**Topic:** ``read..listCollections``
-
 **Query:**
 
 ```javascript
@@ -1447,11 +1377,9 @@ Return the complete list of persisted data collections.
   */
   clientId: <Unique session ID>,
 
-  /*
-  Optionnal: Kuzzle will forward this field in its response, allowing you
-  to easily identify what query generated the response you got.
-  */
-  requestId: <Unique query ID>
+  controller: 'read',
+  action: 'listCollections',
+  collection: ''
 }
 ```
 
@@ -1481,8 +1409,6 @@ Return the complete list of persisted data collections.
 
 Return the the current Kuzzle UTC timestamp as Epoch time (number of milliseconds elapsed since 1 January 1970 00:00:00)
 
-**Topic:** ``read..now``
-
 **Query:**
 
 ```javascript
@@ -1494,11 +1420,9 @@ Return the the current Kuzzle UTC timestamp as Epoch time (number of millisecond
   */
   clientId: <Unique session ID>,
 
-  /*
-  Optionnal: Kuzzle will forward this field in its response, allowing you
-  to easily identify what query generated the response you got.
-  */
-  requestId: <Unique query ID>
+  controller: 'read',
+  action: 'now',
+  collection: ''
 }
 ```
 

--- a/docs/API.MQTT.md
+++ b/docs/API.MQTT.md
@@ -1155,7 +1155,6 @@ Bulk import only works on documents in our persistent data storage layer.
 {
   controller: 'bulk',
   action: 'import',
-  collection: '',
 
   /*
   Data mapping using ElasticSearch bulk syntax.
@@ -1237,8 +1236,7 @@ These statistics include:
   clientId: <Unique session ID>,
 
   controller: 'admin',
-  action: 'getStats',
-  collection: ''
+  action: 'getStats'
 }
 ```
 
@@ -1309,8 +1307,7 @@ Statistics are returned as a JSON-object with each key being the snapshot's time
   clientId: <Unique session ID>,
 
   controller: 'admin',
-  action: 'getAllStats',
-  collection: ''
+  action: 'getAllStats'
 }
 ```
 
@@ -1378,8 +1375,7 @@ Return the complete list of persisted data collections.
   clientId: <Unique session ID>,
 
   controller: 'read',
-  action: 'listCollections',
-  collection: ''
+  action: 'listCollections'
 }
 ```
 
@@ -1421,8 +1417,7 @@ Return the the current Kuzzle UTC timestamp as Epoch time (number of millisecond
   clientId: <Unique session ID>,
 
   controller: 'read',
-  action: 'now',
-  collection: ''
+  action: 'now'
 }
 ```
 

--- a/docs/API.STOMP.md
+++ b/docs/API.STOMP.md
@@ -1154,7 +1154,6 @@ Bulk import only works on documents in our persistent data storage layer.
 {
   controller: 'bulk',
   action: 'import',
-  collection: '',
 
   /*
   Data mapping using ElasticSearch bulk syntax.
@@ -1231,8 +1230,7 @@ These statistics include:
 ```javascript
 {
   controller: 'admin',
-  action: 'getStats',
-  collection: ''
+  action: 'getStats'
 }
 ```
 
@@ -1298,8 +1296,7 @@ Statistics are returned as a JSON-object with each key being the snapshot's time
 ```javascript
 {
   controller: 'admin',
-  action: 'getAllStats',
-  collection: ''
+  action: 'getAllStats'
 }
 ```
 
@@ -1362,8 +1359,7 @@ Return the complete list of persisted data collections.
 ```javascript
 {
   controller: 'read',
-  action: 'listCollections',
-  collection: ''
+  action: 'listCollections'
 }
 ```
 
@@ -1400,8 +1396,7 @@ Return the the current Kuzzle UTC timestamp as Epoch time (number of millisecond
 ```javascript
 {
   controller: 'read',
-  action: 'now',
-  collection: ''
+  action: 'now'
 }
 ```
 

--- a/docs/API.WebSocket.md
+++ b/docs/API.WebSocket.md
@@ -1130,7 +1130,6 @@ Bulk import only works on documents in our persistent data storage layer.
 {
   controller: 'bulk',
   action: 'import',
-  collection: '',
 
   /*
   Data mapping using ElasticSearch bulk syntax.
@@ -1213,8 +1212,7 @@ These statistics include:
   requestId: <Unique query ID>,
 
   controller: 'admin',
-  action: 'getStats',
-  collection: ''
+  action: 'getStats'
 }
 ```
 
@@ -1284,8 +1282,7 @@ Statistics are returned as a JSON-object with each key being the snapshot's time
   requestId: <Unique query ID>,
 
   controller: 'admin',
-  action: 'getAllStats',
-  collection: ''
+  action: 'getAllStats'
 }
 ```
 
@@ -1352,8 +1349,7 @@ Return the complete list of persisted data collections.
   requestId: <Unique query ID>,
 
   controller: 'read',
-  action: 'listCollections',
-  collection: ''
+  action: 'listCollections'
 }
 ```
 
@@ -1394,8 +1390,7 @@ Return the the current Kuzzle UTC timestamp as Epoch time (number of millisecond
   requestId: <Unique query ID>,
 
   controller: 'read',
-  action: 'now',
-  collection: ''
+  action: 'now'
 }
 ```
 

--- a/docs/API.WebSocket.md
+++ b/docs/API.WebSocket.md
@@ -10,6 +10,7 @@ This will give you a direct access to Kuzzle's router controller, dispatching yo
 ## Index
 
 * [How to connect to Kuzzle](#how-to-connect-to-kuzzle)
+* [Query syntax](#query-syntax)
 * [What are response objects](#what-are-response-objects)
 * [Sending metadata](#sending-metadata)
 * [Performing queries](#performing-queries)
@@ -36,15 +37,52 @@ This will give you a direct access to Kuzzle's router controller, dispatching yo
   * [Listing all known data collections](#listing-all-known-data-collections)
   * [Getting the current Kuzzle timestamp](#getting-the-current-kuzzle-timestamp)
 
-##  How to connect to Kuzzle
+## How to connect to Kuzzle
 
 To establish communication with Kuzzle using WebSockets, simply connect your application to Kuzzle's WebSocket port.
 By default, the router controller listens to the port 7512 for WebSocket applications.
 
+## Query syntax
+
+The Websocket layer listens to a specific socket room in order to forward your queries to the right Kuzzle controller.
+
+**Room name:** ``kuzzle``
+
+**Query body syntax (JSON data):**
+```javascript
+{
+  /*
+  Required for queries that need a feedback (see details below):
+  */
+  requestId: <Unique ID>,
+
+  /*
+  Required: Controller and Action to call:
+  */
+  controller: '<controller>',
+  action: '<action>',
+
+  /*
+  Collection on which the action is handled (empty for actions that do not manage a unique collection)
+  */
+  collection: '<data collection>',
+
+  /*
+  A set of filters matching documents you want to listen to
+  */
+  body: {
+
+  }
+}
+```
+
+What that means is that you ask a Kuzzle ``controller`` to perform an ``action`` on a ``data collection``.
+
+
 ##  What are ``response`` objects
 
 A ``response`` is the result of a query you send to Kuzzle. It may be the results of a search query, an acknowledgement of a created action, and so on.  
-And when you subscribe to a room, Kuzzle also sends notifications to your application in the form of a ``response`` object.
+When you subscribe to a room, Kuzzle also sends a notification to your application in the form of a ``response`` object.
 
 A ``response`` is a JSON object with the following structure:
 
@@ -64,7 +102,7 @@ A ``response`` is a JSON object with the following structure:
   Complex object, depending on your query
   */
   result: {
-    requestId: <unique ID>  // Your query unique identifier. See below.
+    requestId: <unique ID>  // Your query unique identifier. See above.
     ...
   }
 }
@@ -89,7 +127,8 @@ For example, if you update a document:
 ```javascript
 {
   action: 'update',
-  collection: 'some data collection',
+  collection: '<data collection>',
+  controller: 'write',
   _id: 'a document ID',
   body: {
     somefield: 'now has a new value'
@@ -129,8 +168,9 @@ Or if you subscribe:
 
 ```javascript
 {
+  controller: 'subscribe',
+  collection: '<data collection>',
   action: 'on',
-  collection: 'some data collection',
   body: {
     // subscription filters
   },
@@ -158,27 +198,16 @@ And then if you leave this room, other subscribers will receive this notificatio
 }
 ```
 
-##  Performing queries
+## Performing queries
 
 This section details every query you can send to Kuzzle, and the ``response`` object Kuzzle will send you back, if any.
 
-Each query you make needs to specify:
-
-* what ``action`` you want to perform,
-* and the ``data collection`` you want to query
-
-Moreover, you need to emit to Kuzzle a ``controller`` message, where ``controller`` is the Kuzzle component that will execute your query.
-
-This documentation will tell you the corresponding ``controller`` and ``action``. The only thing you need to know is what a ``data collection`` is.  
-Simply put, a ``data collection`` is a set of data managed internally by Kuzzle. It acts like a data table for persistent documents, or like a room for pub/sub messages.  
-
-
 ---
 
-###  Subscribing to documents
+### Subscribing to documents
 
 Subscription works differently in Kuzzle than with a regular publish/subscribe protocol.  
-In Kuzzle, you don't exactly subscribe to a room or a topic but, instead, you subscribe to documents.
+In Kuzzle, you don't exactly subscribe to a room or to a topic but, instead, you subscribe to documents.
 
 What it means is that, along with your subscription query, you also give to Kuzzle a set of matching criteria.  
 Once you have subscribed to a room, if a pub/sub message is published matching your criteria, or if a matching stored document changes (because it is created, updated or deleted), then you'll receive a notification about it.  
@@ -194,15 +223,10 @@ How subscription works:
 :arrow_right: You listen to ``requestId`` messages on your websocket
 :arrow_left: When a document matches your room criteria, Kuzzle sends you a ``response``
 
-**Message type:** ``subscribe``
-
 **Query:**
 
 ```javascript
 {
-  action: 'on',
-  collection: '<data collection>',
-
   /*
   Required. If your query doesn't include a requestId field, Kuzzle
   will discard your query, because it doesn't have any means to send you
@@ -210,11 +234,15 @@ How subscription works:
   */
   requestId: <room name>,
 
-  /*
-  A set of filters matching documents you want to listen to
-  */
-  body: {
+  controller: 'subscribe',
+  action: 'on',
+  collection: '<data collection>',
 
+  body: {
+    // subscription filters
+  },
+  metadata: {
+    // query metadata
   }
 }
 ```
@@ -237,7 +265,7 @@ How subscription works:
 }
 ```
 
-####  Notifications
+#### Notifications
 
 Once you receive this ``response``, all you have to do is to listen to ``requestId`` messages on your websocket to receive notifications.
 
@@ -247,7 +275,7 @@ There are 4 types of notifications you can receive:
 
 ```javascript
 {
-  status: 200,                       // Assuming everything went well
+  status: 200,                        // Assuming everything went well
   error: null,                        // Assuming everything went well
   result: {
     _id: 'unique document ID',
@@ -257,10 +285,11 @@ There are 4 types of notifications you can receive:
     action: 'create',
     collection: '<data collection>',
     controller: 'write',
-    requestId: '<unique request ID>',  // The query updating the document document
+    requestId: '<unique request ID>',  // The query updating the document
     metadata: {
       // metadata embedded in the modifying request
     }
+    // there is no document source in this notification
   }
 }
 ```
@@ -269,7 +298,7 @@ There are 4 types of notifications you can receive:
 
 ```javascript
 {
-  status: 200,                       // Assuming everything went well
+  status: 200,                        // Assuming everything went well
   error: null,                        // Assuming everything went well
   result: {
     _id: 'unique document ID',
@@ -291,7 +320,7 @@ There are 4 types of notifications you can receive:
 
 ```javascript
 {
-  status: 200,                       // Assuming everything went well
+  status: 200,                        // Assuming everything went well
   error: null,                        // Assuming everything went well
   result: {
     _id: 'unique document ID',
@@ -312,7 +341,7 @@ There are 4 types of notifications you can receive:
 
 ```javascript
 {
-  status: 200,                       // Assuming everything went well
+  status: 200,                        // Assuming everything went well
   error: null,                        // Assuming everything went well
   result: {
     _id: 'unique document ID',
@@ -332,7 +361,7 @@ There are 4 types of notifications you can receive:
 
 ```javascript
 {
-  status: 200,                       // Assuming everything went well
+  status: 200,                        // Assuming everything went well
   error: null,                        // Assuming everything went well
   result: {
     roomId: 'unique Kuzzle room ID',
@@ -349,7 +378,7 @@ There are 4 types of notifications you can receive:
 
 ```javascript
 {
-  status: 200,                       // Assuming everything went well
+  status: 200,                        // Assuming everything went well
   error: null,                        // Assuming everything went well
   result: {
     roomId: 'unique Kuzzle room ID',
@@ -365,28 +394,30 @@ There are 4 types of notifications you can receive:
 
 ---
 
-###  Counting the number of subscriptions on a given room
+### Counting the number of subscriptions on a given room
 
 Return the number of people/applications who have subscribed to the same documents as you.
 
 It works with the room unique ID Kuzzle returns to you when you make a subscription.
 
-**Message type:** ``subscribe``
-
 **Query:**
 
 ```javascript
 {
-  action: 'count',
-
   /*
   Required: if your query doesn't include a requestId field, Kuzzle will
   discard it, as it doesn't have any means to provide you with the result
   */
   requestId: <Unique query ID>,
 
+  controller: 'subscribe',
+  action: 'count'
+  collection: '<data collection>'
   body: {
-    roomId: 'unique Kuzzle room ID'
+    roomId: 'unique room ID'
+  }
+  metadata: {
+    // query metadata
   }
 }
 ```
@@ -395,7 +426,7 @@ It works with the room unique ID Kuzzle returns to you when you make a subscript
 
 ```javascript
 {
-  status: 200,                       // Assuming everything went well
+  status: 200,                        // Assuming everything went well
   error: null,                        // Assuming everything went well
   result: {
     roomId: 'unique Kuzzle room ID',
@@ -413,17 +444,19 @@ It works with the room unique ID Kuzzle returns to you when you make a subscript
 
 Makes Kuzzle remove you from its subscribers on this room.
 
-**Message type:** ``subscribe``
-
 **Query:**
 
 ```javascript
 {
+  controller: 'subscribe',
   action: 'off',
   collection: '<data collection>',
 
   body: {
-    roomId: 'unique Kuzzle room ID'
+    roomId: 'unique room ID'
+  },
+  metadata: {
+    // query metadata
   }
 }
 ```
@@ -432,7 +465,7 @@ Makes Kuzzle remove you from its subscribers on this room.
 
 ```javascript
 {
-  status: 200,                       // Assuming everything went well
+  status: 200,                        // Assuming everything went well
   error: null,                        // Assuming everything went well
   result: {
     roomId: 'unique Kuzzle room ID',
@@ -446,14 +479,13 @@ Makes Kuzzle remove you from its subscribers on this room.
 
 ---
 
-###  Sending a non persistent message
-
-**Message type:** ``write``
+### Sending a non persistent message
 
 **Query:**
 
 ```javascript
 {
+  controller: 'write',
   action: 'create',
   collection: '<data collection>',
 
@@ -469,30 +501,24 @@ Makes Kuzzle remove you from its subscribers on this room.
 }
 ```
 
-**Response:** Kuzzle doesn't send a response when sending non persistent message.
+**Response:** Kuzzle doesn't send a response when sending a non persistent message.
 
 ---
 
-###  Creating a new document
+### Creating a new document
 
 Creates a new document in the persistent data storage. Returns an error if the document already exists.
-
-**Message type:** ``write``
 
 **Query:**
 
 ```javascript
 {
+  controller: 'write',
   action: 'create',
   collection: '<data collection>',
 
   // Tells Kuzzle to store your document
   persist: true,
-
-  /*
-  Optional: allow Kuzzle to send a response to your application
-  */
-  requestId: <Unique query ID>,
 
   /*
   The document itself
@@ -529,19 +555,13 @@ Creates a new document in the persistent data storage. Returns an error if the d
 
 Creates a new document in the persistent data storage, or update it if it already exists.
 
-**Message type:** ``write``
-
 **Query:**
 
 ```javascript
 {
+  controller: 'write',
   action: 'createOrUpdate',
   collection: '<data collection>',
-
-  /*
-  Optional: allow Kuzzle to send a response to your application
-  */
-  requestId: <Unique query ID>,
 
   /*
   The document itself
@@ -575,24 +595,24 @@ Creates a new document in the persistent data storage, or update it if it alread
 
 ---
 
-###  Retrieving a document
+### Retrieving a document
 
 Only documents in the persistent data storage layer can be retrieved.
-
-**Message type:** ``read``
 
 **Query:**
 
 ```javascript
 {
-  action: 'get',
-  collection: '<data collection>',
-
   /*
   Required: if your query doesn't include a requestId field, Kuzzle will
   discard it, as it doesn't have any means to provide you with the result
   */
   requestId: <Unique query ID>,
+
+  controller: 'read',
+  action: 'get',
+  collection: '<data collection>',
+
 
   /*
   The document unique identifier. It's the same one that Kuzzle sends you
@@ -623,26 +643,25 @@ Only documents in the persistent data storage layer can be retrieved.
 
 ---
 
-###  Searching for documents
+### Searching for documents
 
 Only documents in the persistent data storage layer can be searched.
 
 Kuzzle uses the [ElasticSearch Query DSL ](https://www.elastic.co/guide/en/elasticsearch/reference/1.3/query-dsl.html) syntax.
 
-**Message type:** ``read``
-
 **Query:**
 
 ```javascript
 {
-  action: 'search',
-  collection: '<data collection>',
-
   /*
   Required: if your query doesn't include a requestId field, Kuzzle will
   discard it, as it doesn't have any means to provide you with the result
   */
   requestId: <Unique query ID>,
+
+  controller: 'read',
+  action: 'search',
+  collection: '<data collection>',
 
   /*
   A set of filters or queries matching documents you're looking for.
@@ -691,23 +710,17 @@ Kuzzle uses the [ElasticSearch Query DSL ](https://www.elastic.co/guide/en/elast
 
 ---
 
-###  Updating a document
+### Updating a document
 
 Only documents in the persistent data storage layer can be updated.
-
-**Message type:** ``write``
 
 **Query:**
 
 ```javascript
 {
+  controller: 'write',
   action: 'update',
   collection: '<data collection>',
-
-  /*
-  Optional: allow Kuzzle to send a response to your application
-  */
-  requestId: <Unique query ID>,
 
   /*
   The document unique identifier. It's the same one that Kuzzle sends you
@@ -747,27 +760,20 @@ Only documents in the persistent data storage layer can be updated.
 
 ---
 
-###  Counting documents
+### Counting documents
 
 Only documents in the persistent data storage layer can be counted.
 
 Kuzzle uses the [ElasticSearch Query DSL ](https://www.elastic.co/guide/en/elasticsearch/reference/1.3/query-dsl.html) syntax.
 
 
-**Message type:** ``read``
-
 **Query:**
 
 ```javascript
 {
+  controller: 'read',
   action: 'count',
   collection: '<data collection>',
-
-  /*
-  Required: if your query doesn't include a requestId field, Kuzzle will
-  discard it, as it doesn't have any means to provide you with the result
-  */
-  requestId: <Unique query ID>,
 
   /*
   A set of filters or queries matching documents you're looking for.
@@ -802,27 +808,21 @@ Kuzzle uses the [ElasticSearch Query DSL ](https://www.elastic.co/guide/en/elast
 
 ---
 
-###  Deleting a document using a document unique ID
+### Deleting a document using a document unique ID
 
 Only documents in the persistent data storage layer can be deleted.
-
-**Message type:** ``write``
 
 **Query:**
 
 ```javascript
 {
+  controller: 'write',
   action: 'delete',
   collection: '<data collection>',
 
   /*
-  Optional: allow Kuzzle to send a response to your application
-  */
-  requestId: <Unique query ID>,
-
-  /*
   The document unique identifier. It's the same one that Kuzzle sends you
-  in its responses when you create a document, or when you do a search query.
+  in its response when you create a document, or when you do a search query.
   */
   _id: '<document ID>'
 }
@@ -851,26 +851,20 @@ Only documents in the persistent data storage layer can be deleted.
 
 ---
 
-###  Deleting documents using a query
+### Deleting documents using a query
 
 Only documents in the persistent data storage layer can be deleted.
 
 Kuzzle uses the [ElasticSearch Query DSL ](https://www.elastic.co/guide/en/elasticsearch/reference/1.3/query-dsl.html) syntax.
 
 
-**Message type:** ``write``
-
 **Query:**
 
 ```javascript
 {
+  controller: 'write',
   action: 'deleteByQuery',
   collection: '<data collection>',
-
-  /*
-  Optional: allow Kuzzle to send a response to your application
-  */
-  requestId: <Unique query ID>,
 
   /*
   A set of filters or queries matching documents you're looking for.
@@ -909,24 +903,18 @@ Kuzzle uses the [ElasticSearch Query DSL ](https://www.elastic.co/guide/en/elast
 
 ---
 
-###  Deleting an entire data collection
+### Deleting an entire data collection
 
 This removes an entire data collection in the persistent data storage layer.  
 This action is handled by the **administration** controller.
-
-**Message type:** ``admin``
 
 **Query:**
 
 ```javascript
 {
+  controller: 'admin',
   action: 'deleteCollection',
-  collection: '<data collection>',
-
-  /*
-  Optional: allow Kuzzle to send a response to your application
-  */
-  requestId: <Unique query ID>,
+  collection: '<data collection>'
 }
 ```
 
@@ -952,28 +940,22 @@ This action is handled by the **administration** controller.
 
 ---
 
-###  Setting up a data mapping in a collection
+### Setting up a data mapping in a collection
 
 When creating a new data collection in the persistent data storage layer, Kuzzle uses a default mapping.  
 It means that, by default, you won't be able to exploit the full capabilities of our persistent data storage layer (currently handled by [ElasticSearch](https://www.elastic.co/products/elasticsearch)), and your searches may suffer from below-average performances, depending on the amount of data you stored in a collection and the complexity of your database.
 
-To solve this matter, Kuzzle's API offer a way to create data mapping and expose the entire [mapping capabilities of ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/1.3/mapping.html).
+To solve this matter, Kuzzle's API offers a way to create data mapping and to expose the entire [mapping capabilities of ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/1.3/mapping.html).
 
 This action is handled by the **administration** controller.
-
-**Message type:** ``admin``
 
 **Query:**
 
 ```javascript
 {
+  controller: 'admin',
   action: 'putMapping',
   collection: '<data collection>',
-
-  /*
-  Optional: allow Kuzzle to send a response to your application
-  */
-  requestId: <Unique query ID>,
 
   /*
   Data mapping using ElasticSearch mapping syntax
@@ -1009,24 +991,23 @@ This action is handled by the **administration** controller.
 
 ---
 
-###  Retrieving the data mapping of a collection
+### Retrieving the data mapping of a collection
 
 Get data mapping of a collection previously defined
-
-**Message type:** ``admin``
 
 **Query:**
 
 ```javascript
 {
-  action: 'getMapping',
-  collection: '<data collection>',
-
   /*
   Required: if your query doesn't include a requestId field, Kuzzle will
   discard it, as it doesn't have any means to provide you with the result
   */
   requestId: <Unique query ID>,
+
+  controller: 'admin',
+  action: 'getMapping',
+  collection: '<data collection>'
 }
 ```
 
@@ -1068,24 +1049,18 @@ Get data mapping of a collection previously defined
 
 ### Performing a bulk import on a data collection
 
-A bulk import allows your application to perform multiple writing operations thanks to a single query. This is especially useful if you want to create a large number of documents, as a bulk import will be a lot faster compared to creating them individually using ``create`` queries.  
-As with other queries, the syntax for bulk imports closely resembles the [ElasticSearch Bulk API](https://www.elastic.co/guide/en/elasticsearch/reference/1.3/docs-bulk.html?q=bulk).
+A bulk import allows your application to perform multiple writing operations thanks to a single query. This is especially useful if you want to create a large number of documents. A bulk import will be a lot faster compared to creating them individually using ``create`` queries.  
+For other queries, the syntax for bulk imports closely resembles the [ElasticSearch Bulk API](https://www.elastic.co/guide/en/elasticsearch/reference/1.3/docs-bulk.html?q=bulk).
 
 Bulk import only works on documents in our persistent data storage layer.
-
-**Message type:** ``bulk``
 
 **Query:**
 
 ```javascript
 {
+  controller: 'bulk',
   action: 'import',
   collection: '<data collection>',
-
-  /*
-  Optional: allow Kuzzle to send a response to your application
-  */
-  requestId: <Unique query ID>,
 
   /*
   Data mapping using ElasticSearch bulk syntax.
@@ -1149,18 +1124,13 @@ To do that, refer to the [ElasticSearch Bulk API](https://www.elastic.co/guide/e
 
 Bulk import only works on documents in our persistent data storage layer.
 
-**Message type:** ``bulk``
-
 **Query:**
 
 ```javascript
 {
+  controller: 'bulk',
   action: 'import',
-
-  /*
-  Optionnal: allow Kuzzle to send a response to your application
-  */
-  requestId: <Unique query ID>,
+  collection: '',
 
   /*
   Data mapping using ElasticSearch bulk syntax.
@@ -1232,19 +1202,19 @@ These statistics include:
 * the number of completed requests since the last frame
 * the number of failed requests since the last frame
 
-**Message type:** ``admin``
-
 **Query:**
 
 ```javascript
 {
-  action: 'getStats',
-
   /*
   Required: if your query doesn't include a requestId field, Kuzzle will
   discard it, as it doesn't have any means to provide you with the result
   */
-  requestId: <Unique query ID>
+  requestId: <Unique query ID>,
+
+  controller: 'admin',
+  action: 'getStats',
+  collection: ''
 }
 ```
 
@@ -1303,19 +1273,19 @@ These statistics include:
 
 Statistics are returned as a JSON-object with each key being the snapshot's timestamp.
 
-**Message type:** ``admin``
-
 **Query:**
 
 ```javascript
 {
-  action: 'getAllStats',
-
   /*
   Required: if your query doesn't include a requestId field, Kuzzle will
   discard it, as it doesn't have any means to provide you with the result
   */
-  requestId: <Unique query ID>
+  requestId: <Unique query ID>,
+
+  controller: 'admin',
+  action: 'getAllStats',
+  collection: ''
 }
 ```
 
@@ -1371,19 +1341,19 @@ Statistics are returned as a JSON-object with each key being the snapshot's time
 
 Return the complete list of persisted data collections.
 
-**Message type:** ``read``
-
 **Query:**
 
 ```javascript
 {
-  action: 'listCollections',
-
   /*
   Required: if your query doesn't include a requestId field, Kuzzle will
   discard it, as it doesn't have any means to provide you with the result
   */
-  requestId: <Unique query ID>
+  requestId: <Unique query ID>,
+
+  controller: 'read',
+  action: 'listCollections',
+  collection: ''
 }
 ```
 
@@ -1413,19 +1383,19 @@ Return the complete list of persisted data collections.
 
 Return the the current Kuzzle UTC timestamp as Epoch time (number of milliseconds elapsed since 1 January 1970 00:00:00)
 
-**Message type:** ``read``
-
 **Query:**
 
 ```javascript
 {
-  action: 'now',
-
   /*
   Required: if your query doesn't include a requestId field, Kuzzle will
   discard it, as it doesn't have any means to provide you with the result
   */
-  requestId: <Unique query ID>
+  requestId: <Unique query ID>,
+
+  controller: 'read',
+  action: 'now',
+  collection: ''
 }
 ```
 

--- a/features/support/apiAMQP.js
+++ b/features/support/apiAMQP.js
@@ -176,7 +176,6 @@ module.exports = {
     var
       msg = {
         controller: 'bulk',
-        collection: '',
         action: 'import',
         body: bulk
       };
@@ -236,8 +235,7 @@ module.exports = {
     var
       msg = {
         controller: 'admin',
-        collection: '',
-        action: 'getStats',
+        action: 'getStats'
       };
 
     return publish.call(this, msg);
@@ -247,8 +245,7 @@ module.exports = {
     var
       msg = {
         controller: 'admin',
-        collection: '',
-        action: 'getStats',
+        action: 'getStats'
       };
 
     return publish.call(this, msg);
@@ -258,8 +255,7 @@ module.exports = {
     var
       msg = {
         controller: 'read',
-        collection: '',
-        action: 'listCollections',
+        action: 'listCollections'
       };
 
     return publish.call(this, msg);
@@ -269,8 +265,7 @@ module.exports = {
     var
       msg = {
         controller: 'read',
-        collection: '',
-        action: 'now',
+        action: 'now'
       };
 
     return publish.call(this, msg);

--- a/features/support/apiAMQP.js
+++ b/features/support/apiAMQP.js
@@ -41,128 +41,155 @@ module.exports = {
 
   create: function (body, persist) {
     var
-      topic = ['write', this.world.fakeCollection, 'create'].join('.'),
       msg = {
+        controller: 'write',
+        collection: this.world.fakeCollection,
+        action: 'create',
         persist: persist,
         body: body
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   createOrUpdate: function (body) {
     var
-      topic = ['write', this.world.fakeCollection, 'createOrUpdate'].join('.'),
       msg = {
+        controller: 'write',
+        collection: this.world.fakeCollection,
+        action: 'createOrUpdate',
         body: body
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   get: function (id) {
     var
-      topic = ['read', this.world.fakeCollection, 'get'].join('.'),
       msg = {
+        controller: 'read',
+        collection: this.world.fakeCollection,
+        action: 'get',
         _id: id
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   search: function (filters) {
     var
-      topic = ['read', this.world.fakeCollection, 'search'].join('.'),
       msg = {
+        controller: 'read',
+        collection: this.world.fakeCollection,
+        action: 'search',
         body: filters
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   count: function (filters) {
     var
-      topic = ['read', this.world.fakeCollection, 'count'].join('.'),
       msg = {
+        controller: 'read',
+        collection: this.world.fakeCollection,
+        action: 'count',
         body: filters
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   update: function (id, body) {
     var
-      topic = ['write', this.world.fakeCollection, 'update'].join('.'),
       msg = {
+        controller: 'write',
+        collection: this.world.fakeCollection,
+        action: 'update',
         _id: id,
         body: body
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   deleteById: function (id) {
     var
-      topic = ['write', this.world.fakeCollection, 'delete'].join('.'),
       msg = {
+        controller: 'write',
+        collection: this.world.fakeCollection,
+        action: 'delete',
         _id: id
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   deleteByQuery: function (filters) {
     var
-      topic = ['write', this.world.fakeCollection, 'deleteByQuery'].join('.'),
       msg = {
+        controller: 'write',
+        collection: this.world.fakeCollection,
+        action: 'deleteByQuery',
         body: filters
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   deleteCollection: function () {
     var
-      topic = ['admin', this.world.fakeCollection, 'deleteCollection'].join('.'),
-      msg = {};
+      msg = {
+        controller: 'admin',
+        collection: this.world.fakeCollection,
+        action: 'deleteCollection',
+      };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   putMapping: function () {
     var
-      topic = ['admin', this.world.fakeCollection, 'putMapping'].join('.'),
       msg = {
+        controller: 'admin',
+        collection: this.world.fakeCollection,
+        action: 'putMapping',
         body: this.world.schema
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   bulkImport: function (bulk) {
     var
-      topic = ['bulk', this.world.fakeCollection, 'import'].join('.'),
       msg = {
+        controller: 'bulk',
+        collection: this.world.fakeCollection,
+        action: 'import',
         body: bulk
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   globalBulkImport: function (bulk) {
     var
-      topic = ['bulk', '', 'import'].join('.'),
       msg = {
+        controller: 'bulk',
+        collection: '',
+        action: 'import',
         body: bulk
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   subscribe: function (filters) {
     var
-      topic = ['subscribe', this.world.fakeCollection, 'on'].join('.'),
       msg = {
+        controller: 'subscribe',
+        collection: this.world.fakeCollection,
+        action: 'on',
         body: null
       };
 
@@ -170,76 +197,93 @@ module.exports = {
       msg.body = filters;
     }
 
-    return publishAndListen.call(this, topic, msg);
+    return publishAndListen.call(this, msg);
   },
 
   unsubscribe: function (room, clientId) {
     var
-      topic = ['subscribe', this.world.fakeCollection, 'off'].join('.'),
       msg = {
         clientId: clientId,
+        controller: 'subscribe',
+        collection: this.world.fakeCollection,
+        action: 'off',
         body: { roomId: room }
       };
 
     this.subscribedRooms[clientId][room].close();
     delete this.subscribedRooms[clientId];
 
-    return publish.call(this, topic, msg, false);
+    return publish.call(this, msg, false);
   },
 
   countSubscription: function () {
     var
-      topic = ['subscribe', this.world.fakeCollection, 'count'].join('.'),
       clients = Object.keys(this.subscribedRooms),
       rooms = Object.keys(this.subscribedRooms[clients[0]]),
       msg = {
+        controller: 'subscribe',
+        collection: this.world.fakeCollection,
+        action: 'count',
         body: {
           roomId: rooms[0]
         }
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   getStats: function () {
     var
-      topic = ['admin', '', 'getStats'].join('.'),
-      msg = {};
+      msg = {
+        controller: 'admin',
+        collection: '',
+        action: 'getStats',
+      };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   getAllStats: function () {
     var
-      topic = ['admin', '', 'getAllStats'].join('.'),
-      msg = {};
+      msg = {
+        controller: 'admin',
+        collection: '',
+        action: 'getStats',
+      };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   listCollections: function () {
     var
-      topic = ['read', '', 'listCollections'].join('.'),
-      msg = {};
+      msg = {
+        controller: 'read',
+        collection: '',
+        action: 'listCollections',
+      };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   now: function () {
     var
-      topic = ['read', '', 'now'].join('.'),
-      msg = {};
+      msg = {
+        controller: 'read',
+        collection: '',
+        action: 'now',
+      };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   }
 };
 
-var publish = function (topic, message, waitForAnswer) {
+var publish = function (message, waitForAnswer) {
   var
     deferred = q.defer(),
+    topic = 'kuzzle',
     listen = (waitForAnswer !== undefined) ? waitForAnswer : true;
 
-  if ( !message.clientId ) {
+  if (!message.clientId) {
     message.clientId = this.clientId;
   }
 
@@ -277,14 +321,14 @@ var publish = function (topic, message, waitForAnswer) {
   return deferred.promise;
 };
 
-var publishAndListen = function (topic, message) {
+var publishAndListen = function (message) {
   var
     deferred = q.defer();
 
   message.clientId = uuid.v1();
   this.subscribedRooms[message.clientId] = {};
 
-  publish.call(this, topic, message)
+  publish.call(this, message)
     .then(response => {
       this.amqpClient.then(connection => { return connection.createChannel(); })
       .then(channel => {

--- a/features/support/apiMQTT.js
+++ b/features/support/apiMQTT.js
@@ -32,128 +32,155 @@ module.exports = {
 
   create: function (body, persist) {
     var
-      topic = ['write', this.world.fakeCollection, 'create'].join('.'),
       msg = {
+        controller: 'write',
+        collection: this.world.fakeCollection,
+        action: 'create',
         persist: persist,
         body: body
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   createOrUpdate: function (body) {
     var
-      topic = ['write', this.world.fakeCollection, 'createOrUpdate'].join('.'),
       msg = {
+        controller: 'write',
+        collection: this.world.fakeCollection,
+        action: 'createOrUpdate',
         body: body
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   get: function (id) {
     var
-      topic = ['read', this.world.fakeCollection, 'get'].join('.'),
       msg = {
+        controller: 'read',
+        collection: this.world.fakeCollection,
+        action: 'get',
         _id: id
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   search: function (filters) {
     var
-      topic = ['read', this.world.fakeCollection, 'search'].join('.'),
       msg = {
+        controller: 'read',
+        collection: this.world.fakeCollection,
+        action: 'search',
         body: filters
       };
 
-    return publish.call(this, topic, msg);
-  },
-
-  update: function (id, body) {
-    var
-      topic = ['write', this.world.fakeCollection, 'update'].join('.'),
-      msg = {
-        _id: id,
-        body: body
-      };
-
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   count: function (filters) {
     var
-      topic = ['read', this.world.fakeCollection, 'count'].join('.'),
       msg = {
+        controller: 'read',
+        collection: this.world.fakeCollection,
+        action: 'count',
         body: filters
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
+  },
+
+  update: function (id, body) {
+    var
+      msg = {
+        controller: 'write',
+        collection: this.world.fakeCollection,
+        action: 'update',
+        _id: id,
+        body: body
+      };
+
+    return publish.call(this, msg);
   },
 
   deleteById: function (id) {
     var
-      topic = ['write', this.world.fakeCollection, 'delete'].join('.'),
       msg = {
+        controller: 'write',
+        collection: this.world.fakeCollection,
+        action: 'delete',
         _id: id
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   deleteByQuery: function (filters) {
     var
-      topic = ['write', this.world.fakeCollection, 'deleteByQuery'].join('.'),
       msg = {
+        controller: 'write',
+        collection: this.world.fakeCollection,
+        action: 'deleteByQuery',
         body: filters
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   deleteCollection: function () {
     var
-      topic = ['admin', this.world.fakeCollection, 'deleteCollection'].join('.'),
-      msg = {};
+      msg = {
+        controller: 'admin',
+        collection: this.world.fakeCollection,
+        action: 'deleteCollection',
+      };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   putMapping: function () {
     var
-      topic = ['admin', this.world.fakeCollection, 'putMapping'].join('.'),
       msg = {
+        controller: 'admin',
+        collection: this.world.fakeCollection,
+        action: 'putMapping',
         body: this.world.schema
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   bulkImport: function (bulk) {
     var
-      topic = ['bulk', this.world.fakeCollection, 'import'].join('.'),
       msg = {
+        controller: 'bulk',
+        collection: this.world.fakeCollection,
+        action: 'import',
         body: bulk
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   globalBulkImport: function (bulk) {
     var
-      topic = ['bulk', '', 'import'].join('.'),
       msg = {
+        controller: 'bulk',
+        collection: '',
+        action: 'import',
         body: bulk
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   subscribe: function (filters) {
     var
-      topic = ['subscribe', this.world.fakeCollection, 'on'].join('.'),
       msg = {
+        controller: 'subscribe',
+        collection: this.world.fakeCollection,
+        action: 'on',
         body: null
       };
 
@@ -161,73 +188,90 @@ module.exports = {
       msg.body = filters;
     }
 
-    return publishAndListen.call(this, topic, msg);
+    return publishAndListen.call(this, msg);
   },
 
   unsubscribe: function (room, clientId) {
     var
-      topic = ['subscribe', this.world.fakeCollection, 'off'].join('.'),
       msg = {
         clientId: clientId,
+        controller: 'subscribe',
+        collection: this.world.fakeCollection,
+        action: 'off',
         body: { roomId: room }
       };
 
     this.subscribedRooms[clientId][room].end(true);
     delete this.subscribedRooms[clientId];
-    return publish.call(this, topic, msg, false);
+    return publish.call(this, msg, false);
   },
 
   countSubscription: function () {
     var
-      topic = ['subscribe', this.world.fakeCollection, 'count'].join('.'),
       clients = Object.keys(this.subscribedRooms),
       rooms = Object.keys(this.subscribedRooms[clients[0]]),
       msg = {
+        controller: 'subscribe',
+        collection: this.world.fakeCollection,
+        action: 'count',
         body: {
           roomId: rooms[0]
         }
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   getStats: function () {
     var
-      topic = ['admin', '', 'getStats'].join('.'),
-      msg = {};
+      msg = {
+        controller: 'admin',
+        collection: '',
+        action: 'getStats',
+      };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   getAllStats: function () {
     var
-      topic = ['admin', '', 'getAllStats'].join('.'),
-      msg = {};
+      msg = {
+        controller: 'admin',
+        collection: '',
+        action: 'getStats',
+      };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   listCollections: function () {
     var
-      topic = ['read', '', 'listCollections'].join('.'),
-      msg = {};
+      msg = {
+        controller: 'read',
+        collection: '',
+        action: 'listCollections',
+      };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   now: function () {
     var
-      topic = ['read', '', 'now'].join('.'),
-      msg = {};
+      msg = {
+        controller: 'read',
+        collection: '',
+        action: 'now',
+      };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   }
 };
 
-var publish = function (topic, message, waitForAnswer) {
+var publish = function (message, waitForAnswer) {
   var
     deferred = q.defer(),
-    listen = (waitForAnswer === undefined) ? true : waitForAnswer;
+    topic = 'kuzzle',
+    listen = (waitForAnswer !== undefined) ? waitForAnswer : true;
 
   if (!message.clientId) {
     message.clientId = this.mqttClient.options.clientId;
@@ -256,9 +300,10 @@ var publish = function (topic, message, waitForAnswer) {
   return deferred.promise;
 };
 
-var publishAndListen = function (topic, message) {
+var publishAndListen = function (message) {
   var
     deferred = q.defer(),
+    topic = 'kuzzle',
     mqttListener = mqtt.connect(config.mqttUrl);
 
   message.clientId = mqttListener.options.clientId;

--- a/features/support/apiMQTT.js
+++ b/features/support/apiMQTT.js
@@ -167,7 +167,6 @@ module.exports = {
     var
       msg = {
         controller: 'bulk',
-        collection: '',
         action: 'import',
         body: bulk
       };
@@ -226,8 +225,7 @@ module.exports = {
     var
       msg = {
         controller: 'admin',
-        collection: '',
-        action: 'getStats',
+        action: 'getStats'
       };
 
     return publish.call(this, msg);
@@ -237,8 +235,7 @@ module.exports = {
     var
       msg = {
         controller: 'admin',
-        collection: '',
-        action: 'getStats',
+        action: 'getStats'
       };
 
     return publish.call(this, msg);
@@ -248,8 +245,7 @@ module.exports = {
     var
       msg = {
         controller: 'read',
-        collection: '',
-        action: 'listCollections',
+        action: 'listCollections'
       };
 
     return publish.call(this, msg);
@@ -259,8 +255,7 @@ module.exports = {
     var
       msg = {
         controller: 'read',
-        collection: '',
-        action: 'now',
+        action: 'now'
       };
 
     return publish.call(this, msg);

--- a/features/support/apiSTOMP.js
+++ b/features/support/apiSTOMP.js
@@ -177,7 +177,6 @@ module.exports = {
     var
       msg = {
         controller: 'bulk',
-        collection: '',
         action: 'import',
         body: bulk
       };
@@ -237,8 +236,7 @@ module.exports = {
     var
       msg = {
         controller: 'admin',
-        collection: '',
-        action: 'getStats',
+        action: 'getStats'
       };
 
     return publish.call(this, msg);
@@ -248,8 +246,7 @@ module.exports = {
     var
       msg = {
         controller: 'admin',
-        collection: '',
-        action: 'getStats',
+        action: 'getStats'
       };
 
     return publish.call(this, msg);
@@ -259,8 +256,7 @@ module.exports = {
     var
       msg = {
         controller: 'read',
-        collection: '',
-        action: 'listCollections',
+        action: 'listCollections'
       };
 
     return publish.call(this, msg);
@@ -270,8 +266,7 @@ module.exports = {
     var
       msg = {
         controller: 'read',
-        collection: '',
-        action: 'now',
+        action: 'now'
       };
 
     return publish.call(this, msg);

--- a/features/support/apiSTOMP.js
+++ b/features/support/apiSTOMP.js
@@ -42,128 +42,155 @@ module.exports = {
 
   create: function (body, persist) {
     var
-      topic = ['write', this.world.fakeCollection, 'create'].join('.'),
       msg = {
+        controller: 'write',
+        collection: this.world.fakeCollection,
+        action: 'create',
         persist: persist,
         body: body
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   createOrUpdate: function (body) {
     var
-      topic = ['write', this.world.fakeCollection, 'createOrUpdate'].join('.'),
       msg = {
+        controller: 'write',
+        collection: this.world.fakeCollection,
+        action: 'createOrUpdate',
         body: body
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   get: function (id) {
     var
-      topic = ['read', this.world.fakeCollection, 'get'].join('.'),
       msg = {
+        controller: 'read',
+        collection: this.world.fakeCollection,
+        action: 'get',
         _id: id
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   search: function (filters) {
     var
-      topic = ['read', this.world.fakeCollection, 'search'].join('.'),
       msg = {
+        controller: 'read',
+        collection: this.world.fakeCollection,
+        action: 'search',
         body: filters
       };
 
-    return publish.call(this, topic, msg);
-  },
-
-  update: function (id, body) {
-    var
-      topic = ['write', this.world.fakeCollection, 'update'].join('.'),
-      msg = {
-        _id: id,
-        body: body
-      };
-
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   count: function (filters) {
     var
-      topic = ['read', this.world.fakeCollection, 'count'].join('.'),
       msg = {
+        controller: 'read',
+        collection: this.world.fakeCollection,
+        action: 'count',
         body: filters
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
+  },
+
+  update: function (id, body) {
+    var
+      msg = {
+        controller: 'write',
+        collection: this.world.fakeCollection,
+        action: 'update',
+        _id: id,
+        body: body
+      };
+
+    return publish.call(this, msg);
   },
 
   deleteById: function (id) {
     var
-      topic = ['write', this.world.fakeCollection, 'delete'].join('.'),
       msg = {
+        controller: 'write',
+        collection: this.world.fakeCollection,
+        action: 'delete',
         _id: id
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   deleteByQuery: function (filters) {
     var
-      topic = ['write', this.world.fakeCollection, 'deleteByQuery'].join('.'),
       msg = {
+        controller: 'write',
+        collection: this.world.fakeCollection,
+        action: 'deleteByQuery',
         body: filters
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   deleteCollection: function () {
     var
-      topic = ['admin', this.world.fakeCollection, 'deleteCollection'].join('.'),
-      msg = {};
+      msg = {
+        controller: 'admin',
+        collection: this.world.fakeCollection,
+        action: 'deleteCollection',
+      };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   putMapping: function () {
     var
-      topic = ['admin', this.world.fakeCollection, 'putMapping'].join('.'),
       msg = {
+        controller: 'admin',
+        collection: this.world.fakeCollection,
+        action: 'putMapping',
         body: this.world.schema
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   bulkImport: function (bulk) {
     var
-      topic = ['bulk', this.world.fakeCollection, 'import'].join('.'),
       msg = {
+        controller: 'bulk',
+        collection: this.world.fakeCollection,
+        action: 'import',
         body: bulk
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   globalBulkImport: function (bulk) {
     var
-      topic = ['bulk', '', 'import'].join('.'),
       msg = {
+        controller: 'bulk',
+        collection: '',
+        action: 'import',
         body: bulk
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   subscribe: function (filters) {
     var
-      topic = ['subscribe', this.world.fakeCollection, 'on'].join('.'),
       msg = {
+        controller: 'subscribe',
+        collection: this.world.fakeCollection,
+        action: 'on',
         body: null
       };
 
@@ -171,73 +198,91 @@ module.exports = {
       msg.body = filters;
     }
 
-    return publishAndListen.call(this, topic, msg);
+    return publishAndListen.call(this, msg);
   },
 
   unsubscribe: function (room, clientId) {
     var
-      topic = ['subscribe', this.world.fakeCollection, 'off'].join('.'),
       msg = {
-        body: { roomId: room },
-        clientId: clientId
+        clientId: clientId,
+        controller: 'subscribe',
+        collection: this.world.fakeCollection,
+        action: 'off',
+        body: { roomId: room }
       };
 
     this.subscribedRooms[clientId][room].disconnect();
     delete this.subscribedRooms[clientId][room];
-    return publish.call(this, topic, msg, false);
+
+    return publish.call(this, msg, false);
   },
 
   countSubscription: function () {
     var
-      topic = ['subscribe', this.world.fakeCollection, 'count'].join('.'),
       clients = Object.keys(this.subscribedRooms),
       rooms = Object.keys(this.subscribedRooms[clients[0]]),
       msg = {
+        controller: 'subscribe',
+        collection: this.world.fakeCollection,
+        action: 'count',
         body: {
           roomId: rooms[0]
         }
       };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   getStats: function () {
     var
-      topic = ['admin', '', 'getStats'].join('.'),
-      msg = {};
+      msg = {
+        controller: 'admin',
+        collection: '',
+        action: 'getStats',
+      };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   getAllStats: function () {
     var
-      topic = ['admin', '', 'getAllStats'].join('.'),
-      msg = {};
+      msg = {
+        controller: 'admin',
+        collection: '',
+        action: 'getStats',
+      };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   listCollections: function () {
     var
-      topic = ['read', '', 'listCollections'].join('.'),
-      msg = {};
+      msg = {
+        controller: 'read',
+        collection: '',
+        action: 'listCollections',
+      };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   },
 
   now: function () {
     var
-      topic = ['read', '', 'now'].join('.'),
-      msg = {};
+      msg = {
+        controller: 'read',
+        collection: '',
+        action: 'now',
+      };
 
-    return publish.call(this, topic, msg);
+    return publish.call(this, msg);
   }
 };
 
-var publish = function (topic, message, waitForAnswer) {
+var publish = function (message, waitForAnswer) {
   var
     deferred = q.defer(),
-    listen = (waitForAnswer === undefined) ? true : waitForAnswer,
+    topic = 'kuzzle',
+    listen = (waitForAnswer !== undefined) ? waitForAnswer : true,
     destination = ['/exchange', KUZZLE_EXCHANGE, topic].join('/'),
     messageHeader = {
       'content-type': 'application/json'
@@ -279,7 +324,7 @@ var publish = function (topic, message, waitForAnswer) {
   return deferred.promise;
 };
 
-var publishAndListen = function (topic, message) {
+var publishAndListen = function (message) {
   var
     roomClient = new stomp(this.stompUrl[0], this.stompUrl[1], 'guest', 'guest', '1.0', '/'),
     deferred = q.defer(),
@@ -288,7 +333,7 @@ var publishAndListen = function (topic, message) {
   message.clientId = uuid.v1();
   self.subscribedRooms[message.clientId] = {};
 
-  publish.call(self, topic, message)
+  publish.call(this, message)
     .then(function (response) {
       roomClient.connect(function () {
         var topic = '/topic/' + response.result.roomId;

--- a/features/support/apiWebsocket.js
+++ b/features/support/apiWebsocket.js
@@ -27,138 +27,151 @@ module.exports = {
   get: function (id) {
     var
       msg = {
+        controller: 'read',
         action: 'get',
         collection: this.world.fakeCollection,
         _id: id
       };
 
-    return emit.call(this, 'read', msg);
+    return emit.call(this, msg);
   },
 
   search: function (filters) {
     var
       msg = {
+        controller: 'read',
         action: 'search',
         collection: this.world.fakeCollection,
         body: filters
       };
 
-    return emit.call(this, 'read', msg);
+    return emit.call(this, msg);
   },
 
   count: function (filters) {
     var
       msg = {
+        controller: 'read',
         action: 'count',
         collection: this.world.fakeCollection,
         body: filters
       };
 
-    return emit.call(this, 'read', msg);
+    return emit.call(this, msg);
   },
 
   create: function (body, persist) {
     var
       msg = {
+        controller: 'write',
         persist: persist,
         action: 'create',
         collection: this.world.fakeCollection,
         body: body
       };
 
-    return emit.call(this, 'write', msg);
+    return emit.call(this, msg);
   },
 
   createOrUpdate: function (body) {
     var
       msg = {
+        controller: 'write',
         action: 'createOrUpdate',
         collection: this.world.fakeCollection,
         body: body
       };
 
-    return emit.call(this, 'write', msg);
+    return emit.call(this, msg);
   },
 
   update: function (id, body) {
     var
       msg = {
+        controller: 'write',
         action: 'update',
         collection: this.world.fakeCollection,
         _id: id,
         body: body
       };
 
-    return emit.call(this, 'write', msg);
+    return emit.call(this, msg);
   },
 
   deleteById: function (id) {
     var
       msg = {
+        controller: 'write',
         action: 'delete',
         collection: this.world.fakeCollection,
         _id: id
       };
 
-    return emit.call(this, 'write', msg);
+    return emit.call(this, msg);
   },
 
   deleteByQuery: function (filters) {
     var
       msg = {
+        controller: 'write',
         action: 'deleteByQuery',
         collection: this.world.fakeCollection,
         body: filters
       };
 
-    return emit.call(this, 'write', msg);
+    return emit.call(this, msg);
   },
 
   deleteCollection: function () {
     var
       msg = {
+        controller: 'admin',
         action: 'deleteCollection',
         collection: this.world.fakeCollection
       };
 
-    return emit.call(this, 'admin', msg);
+    return emit.call(this, msg);
   },
 
   bulkImport: function (bulk) {
     var
       msg = {
+        controller: 'bulk',
         action: 'import',
         collection: this.world.fakeCollection,
         body: bulk
       };
 
-    return emit.call(this, 'bulk', msg );
+    return emit.call(this, msg );
   },
 
   globalBulkImport: function (bulk) {
     var
       msg = {
+        controller: 'bulk',
         action: 'import',
         body: bulk
       };
 
-    return emit.call(this, 'bulk', msg );
+    return emit.call(this, msg );
   },
 
   putMapping: function () {
     var
       msg = {
+        controller: 'admin',
         action: 'putMapping',
         collection: this.world.fakeCollection,
         body: this.world.schema
       };
 
-    return emit.call(this, 'admin', msg );
+    return emit.call(this, msg );
   },
 
   subscribe: function (filters, socketName) {
     var
       msg = {
+        controller: 'subscribe',
         action: 'on',
         collection: this.world.fakeCollection,
         body: null
@@ -168,12 +181,13 @@ module.exports = {
       msg.body = filters;
     }
 
-    return emitAndListen.call(this, 'subscribe', msg, socketName);
+    return emitAndListen.call(this, msg, socketName);
 
   },
   unsubscribe: function (room, socketName) {
     var
       msg = {
+        controller: 'subscribe',
         action: 'off',
         collection: this.world.fakeCollection,
         body: { roomId: room }
@@ -183,7 +197,7 @@ module.exports = {
 
     this.listSockets[socketName].removeListener(room, this.subscribedRooms[socketName][room]);
     delete this.subscribedRooms[socketName][room];
-    return emit.call(this, 'subscribe', msg, false, socketName);
+    return emit.call(this, msg, false, socketName);
   },
 
   countSubscription: function (socketName) {
@@ -192,49 +206,59 @@ module.exports = {
     var
       rooms = Object.keys(this.subscribedRooms[socketName]),
       msg = {
+        controller: 'subscribe',
         action: 'count',
         body: {
           roomId: rooms[0]
         }
       };
 
-    return emit.call(this, 'subscribe', msg);
+    return emit.call(this, msg);
   },
 
   getStats: function () {
     var
       msg = {
+        controller: 'admin',
         action: 'getStats'
       };
 
-    return emit.call(this, 'admin', msg);
+    return emit.call(this, msg);
   },
 
   getAllStats: function () {
     var
       msg = {
+        controller: 'admin',
         action: 'getAllStats'
       };
 
-    return emit.call(this, 'admin', msg);
+    return emit.call(this, msg);
   },
 
   listCollections: function () {
-    var msg = {action: 'listCollections'};
+    var msg = {
+      controller: 'read',
+      action: 'listCollections'
+    };
 
-    return emit.call(this, 'read', msg );
+    return emit.call(this, msg );
   },
 
   now: function () {
-    var msg = {action: 'now'};
+    var msg = {
+      controller: 'read',
+      action: 'now'
+    };
 
-    return emit.call(this, 'read', msg );
+    return emit.call(this, msg );
   }
 };
 
-var emit = function (controller, msg, getAnswer, socketName) {
+var emit = function (msg, getAnswer, socketName) {
   var
     deferred = q.defer(),
+    routename = 'kuzzle',
     listen = (getAnswer !== undefined) ? getAnswer : true;
 
   if (!msg.requestId) {
@@ -259,14 +283,15 @@ var emit = function (controller, msg, getAnswer, socketName) {
     deferred.resolve({});
   }
 
-  this.listSockets[socketName].emit(controller, msg);
+  this.listSockets[socketName].emit(routename, msg);
 
   return deferred.promise;
 };
 
-var emitAndListen = function (controller, msg, socketName) {
+var emitAndListen = function (msg, socketName) {
   var
-    deferred = q.defer();
+    deferred = q.defer(),
+    routename = 'kuzzle';
 
   if (!msg.requestId) {
     msg.requestId = uuid.v1();
@@ -294,7 +319,7 @@ var emitAndListen = function (controller, msg, socketName) {
     deferred.resolve(response);
   });
 
-  this.listSockets[socketName].emit(controller, msg);
+  this.listSockets[socketName].emit(routename, msg);
 
   return deferred.promise;
 };

--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -1,5 +1,4 @@
 var
-  async = require('async'),
   _ = require('lodash'),
   stringify = require('json-stable-stringify'),
   Router = require('router'),
@@ -12,7 +11,7 @@ var
 
 module.exports = function RouterController (kuzzle) {
   this.router = null;
-  this.controllers = ['write', 'read', 'subscribe', 'admin', 'bulk'];
+  this.routename = 'kuzzle';
   this.kuzzle = kuzzle;
   this.listener = new ResponseListener(this.kuzzle, this.kuzzle.config.queues.workerWriteResponseQueue);
 
@@ -228,35 +227,33 @@ module.exports = function RouterController (kuzzle) {
 
     kuzzle.statistics.newConnection(context.connection);
 
-    async.each(routerCtrl.controllers, function recordSocketListener (controller) {
-      socket.on(controller, function (data) {
-        var
-          requestObject;
+    socket.on(routerCtrl.routename, function (data) {
+      var
+        requestObject;
 
-        requestObject = new RequestObject(data, {controller: controller}, 'websocket');
+      requestObject = new RequestObject(data, {}, 'websocket');
 
-        kuzzle.pluginsManager.trigger('log:silly', 'Handle Websocket for controller ' + controller);
-        kuzzle.router.listener.add(requestObject, context.connection);
+      kuzzle.pluginsManager.trigger('log:silly', 'Handle Websocket for controller ' + data.controller);
+      kuzzle.router.listener.add(requestObject, context.connection);
 
-        // Execute the funnel. Forward any non-empty response to the user.
-        kuzzle.repositories.user.loadFromToken(getBearerTokenFromHeaders(data.headers))
-          .then(function (user) {
-            context.user = user;
+      // Execute the funnel. Forward any non-empty response to the user.
+      kuzzle.repositories.user.loadFromToken(getBearerTokenFromHeaders(data.headers))
+        .then(function (user) {
+          context.user = user;
 
-            return kuzzle.funnel.execute(requestObject, context);
-          })
-          .then(function onExecuteSuccess (responseObject) {
-            if (!_.isEmpty(responseObject)) {
-              kuzzle.notifier.notify(requestObject.requestId, responseObject.toJson(), context.connection);
-            }
-          })
-          .catch(function onExecuteError(error) {
-            var errorObject = new ResponseObject({}, error);
-            kuzzle.emit(requestObject.controller + ':websocket:funnel:reject', error);
-            kuzzle.pluginsManager.trigger('log:error', error);
-            kuzzle.notifier.notify(requestObject.requestId, errorObject.toJson(), context.connection);
-          });
-      });
+          return kuzzle.funnel.execute(requestObject, context);
+        })
+        .then(function onExecuteSuccess (responseObject) {
+          if (!_.isEmpty(responseObject)) {
+            kuzzle.notifier.notify(requestObject.requestId, responseObject.toJson(), context.connection);
+          }
+        })
+        .catch(function onExecuteError(error) {
+          var errorObject = new ResponseObject({}, error);
+          kuzzle.emit(requestObject.controller + ':websocket:funnel:reject', error);
+          kuzzle.pluginsManager.trigger('log:error', error);
+          kuzzle.notifier.notify(requestObject.requestId, errorObject.toJson(), context.connection);
+        });
     });
 
     // handles socket disconnections
@@ -279,69 +276,63 @@ module.exports = function RouterController (kuzzle) {
    *
    */
   this.routeMQListener = function () {
-    async.each(this.controllers, function recordMQListener (controller) {
-      kuzzle.services.list.mqBroker.listenExchange(controller+'.*.*', function handleMQMessage(msg) {
-        var
-          context = {
-            connection: null,
-            user: null
-          },
-          data,
-          requestObject,
-          rawContent,
-          routingArray = msg.fields.routingKey.split('.'),
-          // routingArray[0] is the controller, which we already have in the 'controller' variable
-          collection = routingArray[1],
-          action = routingArray[2];
+    kuzzle.services.list.mqBroker.listenExchange(this.routename, function handleMQMessage(msg) {
+      var
+        context = {
+          connection: null,
+          user: null
+        },
+        data,
+        requestObject,
+        rawContent;
 
-        if (!(msg.content instanceof Buffer)) {
-          rawContent = msg.content.toString();
-        }
-        else {
-          rawContent = (new Buffer(msg.content)).toString();
-        }
+      if (!(msg.content instanceof Buffer)) {
+        rawContent = msg.content.toString();
+      }
+      else {
+        rawContent = (new Buffer(msg.content)).toString();
+      }
 
-        try {
-          data = JSON.parse(rawContent);
-        }
-        catch (e) {
-          kuzzle.pluginsManager.trigger('log:error', {message: 'Parse error', error: e});
-          return false;
-        }
+      try {
+        data = JSON.parse(rawContent);
+      }
+      catch (e) {
+        kuzzle.pluginsManager.trigger('log:error', {message: 'Parse error', error: e});
+        return false;
+      }
 
-        kuzzle.pluginsManager.trigger('log:silly', 'Handle MQ input' + msg.fields.routingKey);
+      kuzzle.pluginsManager.trigger('log:silly', 'Handle MQ input' + msg.fields.routingKey);
 
-        // For MQTT messages, we do not have a replyTo header like with AMQP or STOMP
-        // => MQTT client has to send its mqtt client id and subscribe to the topic exchange mqtt.<clientId>
-        //    to get feedback from Kuzzle.
-        if (msg.properties && msg.properties.replyTo) {
-          context.connection = {type: 'amq', id: data.clientId, replyTo: msg.properties.replyTo};
-        }
-        else {
-          context.connection = {type: 'mqtt', id: data.clientId, replyTo: 'mqtt.' + data.clientId};
-        }
+      // For MQTT messages, we do not have a replyTo header like with AMQP or STOMP
+      // => MQTT client has to send its mqtt client id and subscribe to the topic exchange mqtt.<clientId>
+      //    to get feedback from Kuzzle.
+      if (msg.properties && msg.properties.replyTo) {
+        context.connection = {type: 'amq', id: data.clientId, replyTo: msg.properties.replyTo};
+      }
+      else {
+        context.connection = {type: 'mqtt', id: data.clientId, replyTo: 'mqtt.' + data.clientId};
+      }
 
-        requestObject = new RequestObject(data, {controller: controller, collection: collection, action: action}, 'mq');
+      requestObject = new RequestObject(data, {}, 'mq');
 
-        kuzzle.router.listener.add(requestObject, context.connection);
-        kuzzle.repositories.user.loadFromToken(getBearerTokenFromHeaders(data.headers))
-          .then(function (user) {
-            context.user = user;
-            return kuzzle.funnel.execute(requestObject, context);
-          })
-          .then(function (responseObject) {
-            if (!_.isEmpty(responseObject)) {
-              kuzzle.notifier.notify(requestObject.requestId, responseObject.toJson(), context.connection);
-            }
-          })
-          .catch(function (error) {
-            var errorObject = new ResponseObject({}, error);
-            kuzzle.emit(requestObject.controller + ':mq:funnel:reject', error);
-            kuzzle.pluginsManager.trigger('log:error', error);
-            kuzzle.notifier.notify(requestObject.requestId, errorObject.toJson(), context.connection);
-          });
-      }); // end listenExchange
-    }); // end async
+      kuzzle.router.listener.add(requestObject, context.connection);
+      kuzzle.repositories.user.loadFromToken(getBearerTokenFromHeaders(data.headers))
+        .then(function (user) {
+          context.user = user;
+          return kuzzle.funnel.execute(requestObject, context);
+        })
+        .then(function (responseObject) {
+          if (!_.isEmpty(responseObject)) {
+            kuzzle.notifier.notify(requestObject.requestId, responseObject.toJson(), context.connection);
+          }
+        })
+        .catch(function (error) {
+          var errorObject = new ResponseObject({}, error);
+          kuzzle.emit(requestObject.controller + ':mq:funnel:reject', error);
+          kuzzle.pluginsManager.trigger('log:error', error);
+          kuzzle.notifier.notify(requestObject.requestId, errorObject.toJson(), context.connection);
+        });
+    }); // end listenExchange
   };
 };
 

--- a/test/api/controllers/routerController/routeMQListener.test.js
+++ b/test/api/controllers/routerController/routeMQListener.test.js
@@ -87,19 +87,17 @@ describe('Test: routerController.routeMQListener', function () {
       });
   });
 
-  it('should register a listener for each known controller', function () {
-    router.controllers.forEach(function (controller) {
-      var listener = kuzzle.services.list.mqBroker.listeners[controller + '.*.*'];
+  it('should register a global listener', function () {
+    var listener = kuzzle.services.list.mqBroker.listeners[router.routename];
 
-      should(listener).not.be.undefined();
-      should(listener.type).be.exactly('listenExchange');
-    });
+    should(listener).not.be.undefined();
+    should(listener.type).be.exactly('listenExchange');
   });
 
   it('should be able to manage JSON-based messages content', function (done) {
     var
-      listener = kuzzle.services.list.mqBroker.listeners['write.*.*'].callback,
-      body = { body: { resolve: true }};
+      listener = kuzzle.services.list.mqBroker.listeners[router.routename].callback,
+      body = { controller: 'write', collection: 'foobar', action: 'create', body: { resolve: true }};
 
     mqMessage.content = JSON.stringify(body);
     notifyStatus = '';
@@ -139,8 +137,8 @@ describe('Test: routerController.routeMQListener', function () {
 
   it('should be able to manage Buffer-based messages content', function (done) {
     var
-      listener = kuzzle.services.list.mqBroker.listeners['write.*.*'].callback,
-      body = { body: { resolve: true }};
+      listener = kuzzle.services.list.mqBroker.listeners[router.routename].callback,
+      body = { controller: 'write', collection: 'foobar', action: 'create', body: { resolve: true }};
 
     mqMessage.content = new Buffer(JSON.stringify(body));
     notifyStatus = 'pending';
@@ -179,7 +177,7 @@ describe('Test: routerController.routeMQListener', function () {
 
   it('should fail cleanly with incorrect messages', function (done) {
     var
-      listener = kuzzle.services.list.mqBroker.listeners['write.*.*'].callback;
+      listener = kuzzle.services.list.mqBroker.listeners[router.routename].callback;
 
     kuzzle.once('log:error', function (error) {
       should(error).be.an.Object();
@@ -196,8 +194,8 @@ describe('Test: routerController.routeMQListener', function () {
   it('should notify with an error object in case of rejection', function (done) {
     var
       eventReceived = false,
-      listener = kuzzle.services.list.mqBroker.listeners['write.*.*'].callback,
-      body = { body: { resolve: false }, clientId: 'foobar'};
+      listener = kuzzle.services.list.mqBroker.listeners[router.routename].callback,
+      body = {controller: 'write', collection: 'foobar', action: 'create', body: { resolve: false }, clientId: 'foobar'};
 
     mqMessage.content = JSON.stringify(body);
     notifyStatus = 'pending';
@@ -237,7 +235,7 @@ describe('Test: routerController.routeMQListener', function () {
 
   it('should not notify if the response is empty', function (done) {
     var
-      listener = kuzzle.services.list.mqBroker.listeners['write.*.*'].callback,
+      listener = kuzzle.services.list.mqBroker.listeners[router.routename].callback,
       body = { body: { resolve: true, empty: true }, clientId: 'foobar'};
 
     mqMessage.content = JSON.stringify(body);
@@ -258,7 +256,7 @@ describe('Test: routerController.routeMQListener', function () {
 
   it('should initialize an AMQ connection type for AMQP/STOMP messages', function (done) {
     var
-      listener = kuzzle.services.list.mqBroker.listeners['write.*.*'].callback,
+      listener = kuzzle.services.list.mqBroker.listeners[router.routename].callback,
       body = { body: { resolve: true }, clientId: 'foobar'};
 
     mqMessage.content = JSON.stringify(body);
@@ -296,7 +294,7 @@ describe('Test: routerController.routeMQListener', function () {
 
   it('should initialize an MQTT connection type for MQTT messages', function (done) {
     var
-      listener = kuzzle.services.list.mqBroker.listeners['write.*.*'].callback,
+      listener = kuzzle.services.list.mqBroker.listeners[router.routename].callback,
       body = { body: { resolve: true }, clientId: 'foobar'};
 
     mqMessage.content = JSON.stringify(body);

--- a/test/api/controllers/routerController/routeWebsocket.test.js
+++ b/test/api/controllers/routerController/routeWebsocket.test.js
@@ -73,17 +73,15 @@ describe('Test: routerController.routeWebsocket', function () {
         });
     });
 
-    it('should have registered a listener for each known controller', function () {
-      router.controllers.forEach(function (controller) {
-        should(emitter.listeners(controller).length).be.exactly(1);
-      });
+    it('should have registered a global listener', function () {
+      should(emitter.listeners(router.routename).length).be.exactly(1);
     });
 
     it('should embed incoming requests into a well-formed request object', function (done) {
-      var emittedObject = {body: {resolve: true}, action: 'get'};
+      var emittedObject = {body: {resolve: true}, controller: 'read', action: 'get'};
 
       forwardedObject = false;
-      emitter.emit('read', emittedObject);
+      emitter.emit(router.routename, emittedObject);
 
       timer = setInterval(function () {
         if (forwardedObject === false) {
@@ -115,10 +113,10 @@ describe('Test: routerController.routeWebsocket', function () {
     });
 
     it('should notify with the returned document in case of success', function (done) {
-      var emittedObject = {body: {resolve: true}, action: 'get'};
+      var emittedObject = {body: {resolve: true}, controller: 'read', action: 'get'};
 
       notifyStatus = 'pending';
-      emitter.emit('read', emittedObject);
+      emitter.emit(router.routename, emittedObject);
 
       timer = setInterval(function () {
         if (notifyStatus === 'pending') {
@@ -148,7 +146,7 @@ describe('Test: routerController.routeWebsocket', function () {
 
     it('should notify with an error object in case of rejection', function (done) {
       var
-        emittedObject = {body: {resolve: false}, action: 'get'},
+        emittedObject = {body: {resolve: false}, controller: 'read', action: 'get'},
         eventReceived = false;
 
       notifyStatus = 'pending';
@@ -157,7 +155,7 @@ describe('Test: routerController.routeWebsocket', function () {
         eventReceived = true;
       });
 
-      emitter.emit('read', emittedObject);
+      emitter.emit(router.routename, emittedObject);
 
       timer = setInterval(function () {
         if (notifyStatus === 'pending') {
@@ -187,11 +185,11 @@ describe('Test: routerController.routeWebsocket', function () {
 
     it('should not notify if the response is empty', function (done) {
       var
-        emittedObject = {body: {resolve: true, empty: true}, action: 'get'};
+        emittedObject = {body: {resolve: true, empty: true}, controller: 'read', action: 'get'};
 
       notifyStatus = 'pending';
       forwardedObject = false;
-      emitter.emit('read', emittedObject);
+      emitter.emit(router.routename, emittedObject);
 
       timer = setInterval(function () {
         if (forwardedObject === false) {

--- a/test/api/core/responseListener.test.js
+++ b/test/api/core/responseListener.test.js
@@ -19,6 +19,7 @@ describe('Test: responseListener', function () {
     kuzzle,
     registered,
     listenCallback,
+    controllers = ['write', 'subscribe', 'read', 'admin', 'bulk'],
     requestObject = new RequestObject({
       controller: '',
       action: 'update',
@@ -46,7 +47,7 @@ describe('Test: responseListener', function () {
 
     requestObject.persist = false;
 
-    kuzzle.router.controllers.forEach(function (controller) {
+    controllers.forEach(function (controller) {
       requestObject.controller = controller;
       requestObject.requestId = uuid.v1();
       responseListener.add(requestObject, {});
@@ -60,7 +61,7 @@ describe('Test: responseListener', function () {
 
     requestObject.persist = true;
 
-    kuzzle.router.controllers.forEach(function (controller) {
+    controllers.forEach(function (controller) {
       requestObject.controller = controller;
       requestObject.requestId = uuid.v1();
       responseListener.add(requestObject, {});
@@ -76,7 +77,7 @@ describe('Test: responseListener', function () {
     requestObject.persist = true;
 
     responseListener = new ResponseListener(kuzzle, kuzzle.config.queues.workerWriteResponseQueue);
-    kuzzle.router.controllers.forEach(function (controller) {
+    controllers.forEach(function (controller) {
       requestObject.controller = controller;
       requestObject.requestId = uuid.v1();
       responseListener.add(requestObject, {});


### PR DESCRIPTION
/!\ WARNING - This PR involves refactoring into the SDK implementation, that need to be done before merging  /!\

Use only one listening topic for both every controllers, to simplifiy controllers code maintenance and facilitate the next implementation of plugin controllers.
