### PR TITLE
added createCollection and truncate operations

### DIFF
--- a/docs/API.AMQP.md
+++ b/docs/API.AMQP.md
@@ -39,6 +39,7 @@ The current implementation of our MQ Broker service uses [RabbitMQ](https://www.
   * [Getting all stored statistics](#getting-all-stored-statistics)
   * [Listing all known data collections](#listing-all-known-data-collections)
   * [Getting the current Kuzzle timestamp](#getting-the-current-kuzzle-timestamp)
+  * [Creating an empty collection](#creating-an-empty-collection)
 
 ## How to connect to Kuzzle
 
@@ -1414,6 +1415,43 @@ Return the the current Kuzzle UTC timestamp as Epoch time (number of millisecond
     now: 1447151167622,             // Epoch time
     action: 'now',
     controller: 'read',
+    requestId: '<unique request identifier>'
+  }
+}
+```
+
+---
+
+### Creating an empty collection
+
+When creating a document, Kuzzle will automatically create a data collection if needed.  
+But in some cases, you may want to create an empty collection directly, prior to storing any document in it.
+
+This method does nothing if the collection already exists.
+
+**replyTo queue header:** Optionnal
+
+**Query:**
+
+```javascript
+{
+  controller: 'write',
+  action: 'createCollection',
+  collection: 'collection name'
+}
+```
+
+**Response:**
+
+```javascript
+{
+  status: 200,
+  error: null,
+  result: {
+    acknowledged: true,
+    action: 'createCollection',
+    controller: 'write',
+    collection: 'collection name',
     requestId: '<unique request identifier>'
   }
 }

--- a/docs/API.AMQP.md
+++ b/docs/API.AMQP.md
@@ -40,6 +40,7 @@ The current implementation of our MQ Broker service uses [RabbitMQ](https://www.
   * [Listing all known data collections](#listing-all-known-data-collections)
   * [Getting the current Kuzzle timestamp](#getting-the-current-kuzzle-timestamp)
   * [Creating an empty collection](#creating-an-empty-collection)
+  * [Deleting the entire content of a collection](#deleting-the-entire-content-of-a-collection)
 
 ## How to connect to Kuzzle
 
@@ -1451,6 +1452,42 @@ This method does nothing if the collection already exists.
     acknowledged: true,
     action: 'createCollection',
     controller: 'write',
+    collection: 'collection name',
+    requestId: '<unique request identifier>'
+  }
+}
+```
+
+
+---
+
+### Deleting the entire content of a collection
+
+This method empties a collection from all its documents, while keeping any associated mapping.  
+It is also way faster than deleting all documents from a collection using a query.
+
+**replyTo queue header:** Optionnal
+
+**Query:**
+
+```javascript
+{
+  controller: 'admin',
+  action: 'truncateCollection',
+  collection: 'collection name'
+}
+```
+
+**Response:**
+
+```javascript
+{
+  status: 200,
+  error: null,
+  result: {
+    acknowledged: true,
+    action: 'truncateCollection',
+    controller: 'admin',
     collection: 'collection name',
     requestId: '<unique request identifier>'
   }

--- a/docs/API.MQTT.md
+++ b/docs/API.MQTT.md
@@ -39,6 +39,7 @@ The current implementation of our MQ Broker service uses [RabbitMQ](https://www.
   * [Getting all stored statistics](#getting-all-stored-statistics)
   * [Listing all known data collections](#listing-all-known-data-collections)
   * [Getting the current Kuzzle timestamp](#getting-the-current-kuzzle-timestamp)
+  * [Creating an empty collection](#creating-an-empty-collection)
 
 ## How to connect to Kuzzle
 
@@ -1431,6 +1432,46 @@ Return the the current Kuzzle UTC timestamp as Epoch time (number of millisecond
     now: 1447151167622,             // Epoch time
     action: 'now',
     controller: 'read',
+    requestId: '<unique request identifier>'
+  }
+}
+```
+
+---
+
+### Creating an empty collection
+
+When creating a document, Kuzzle will automatically create a data collection if needed.  
+But in some cases, you may want to create an empty collection directly, prior to storing any document in it.
+
+This method does nothing if the collection already exists.
+
+**Query:**
+
+```javascript
+{
+  /* 
+    Optionnal
+   */
+  clientId: <Unique session ID>,
+  
+  controller: 'write',
+  action: 'createCollection',
+  collection: 'collection name'
+}
+```
+
+**Response:**
+
+```javascript
+{
+  status: 200,
+  error: null,
+  result: {
+    acknowledged: true,
+    action: 'createCollection',
+    controller: 'write',
+    collection: 'collection name',
     requestId: '<unique request identifier>'
   }
 }

--- a/docs/API.MQTT.md
+++ b/docs/API.MQTT.md
@@ -40,6 +40,7 @@ The current implementation of our MQ Broker service uses [RabbitMQ](https://www.
   * [Listing all known data collections](#listing-all-known-data-collections)
   * [Getting the current Kuzzle timestamp](#getting-the-current-kuzzle-timestamp)
   * [Creating an empty collection](#creating-an-empty-collection)
+  * [Deleting the entire content of a collection](#deleting-the-entire-content-of-a-collection)
 
 ## How to connect to Kuzzle
 
@@ -1450,11 +1451,6 @@ This method does nothing if the collection already exists.
 
 ```javascript
 {
-  /* 
-    Optionnal
-   */
-  clientId: <Unique session ID>,
-  
   controller: 'write',
   action: 'createCollection',
   collection: 'collection name'
@@ -1471,6 +1467,41 @@ This method does nothing if the collection already exists.
     acknowledged: true,
     action: 'createCollection',
     controller: 'write',
+    collection: 'collection name',
+    requestId: '<unique request identifier>'
+  }
+}
+```
+
+
+---
+
+### Deleting the entire content of a collection
+
+This method empties a collection from all its documents, while keeping any associated mapping.  
+It is also way faster than deleting all documents from a collection using a query.
+
+
+**Query:**
+
+```javascript
+{
+  controller: 'admin',
+  action: 'truncateCollection',
+  collection: 'collection name'
+}
+```
+
+**Response:**
+
+```javascript
+{
+  status: 200,
+  error: null,
+  result: {
+    acknowledged: true,
+    action: 'truncateCollection',
+    controller: 'admin',
     collection: 'collection name',
     requestId: '<unique request identifier>'
   }

--- a/docs/API.REST.md
+++ b/docs/API.REST.md
@@ -31,6 +31,7 @@ If you need such functionalities, please check our other supported protocols. Fo
   * [Getting all stored statistics](#getting-all-stored-statistics)
   * [Listing all known data collections](#listing-all-known-data-collections)
   * [Getting the current Kuzzle timestamp](#getting-the-current-kuzzle-timestamp)
+  * [Creating an empty collection](#creating-an-empty-collection)
 
 ## What are ``response`` objects
 
@@ -939,6 +940,36 @@ Return the the current Kuzzle UTC timestamp as Epoch time (number of millisecond
     now: 1447151167622,             // Epoch time
     action: 'now',
     controller: 'read',
+    requestId: '<unique request identifier>'
+  }
+}
+```
+
+
+---
+
+### Creating an empty collection
+
+When creating a document, Kuzzle will automatically create a data collection if needed.  
+But in some cases, you may want to create an empty collection directly, prior to storing any document in it.
+
+This method does nothing if the collection already exists.
+
+**URL:** ``http://kuzzle:7512/api/<collection name>``
+
+**Method:** ``PUT``
+
+**Response:**
+
+```javascript
+{
+  status: 200,
+  error: null,
+  result: {
+    acknowledged: true,
+    action: 'createCollection',
+    controller: 'write',
+    collection: 'collection name',
     requestId: '<unique request identifier>'
   }
 }

--- a/docs/API.REST.md
+++ b/docs/API.REST.md
@@ -32,6 +32,7 @@ If you need such functionalities, please check our other supported protocols. Fo
   * [Listing all known data collections](#listing-all-known-data-collections)
   * [Getting the current Kuzzle timestamp](#getting-the-current-kuzzle-timestamp)
   * [Creating an empty collection](#creating-an-empty-collection)
+  * [Deleting the entire content of a collection](#deleting-the-entire-content-of-a-collection)
 
 ## What are ``response`` objects
 
@@ -969,6 +970,36 @@ This method does nothing if the collection already exists.
     acknowledged: true,
     action: 'createCollection',
     controller: 'write',
+    collection: 'collection name',
+    requestId: '<unique request identifier>'
+  }
+}
+```
+
+
+---
+
+### Deleting the entire content of a collection
+
+This method empties a collection from all its documents, while keeping any associated mapping.  
+It is also way faster than deleting all documents from a collection using a query.
+
+**replyTo queue header:** Optionnal
+
+**URL:** ``http://kuzzle:7512/api/<collection name>/_truncate``
+
+**Method:** ``DELETE``
+
+**Response:**
+
+```javascript
+{
+  status: 200,
+  error: null,
+  result: {
+    acknowledged: true,
+    action: 'truncateCollection',
+    controller: 'admin',
     collection: 'collection name',
     requestId: '<unique request identifier>'
   }

--- a/docs/API.STOMP.md
+++ b/docs/API.STOMP.md
@@ -39,6 +39,7 @@ The current implementation of our MQ Broker service uses [RabbitMQ](https://www.
   * [Getting all stored statistics](#getting-all-stored-statistics)
   * [Listing all known data collections](#listing-all-known-data-collections)
   * [Getting the current Kuzzle timestamp](#getting-the-current-kuzzle-timestamp)
+  * [Creating an empty collection](#creating-an-empty-collection)
 
 ## How to connect to Kuzzle
 
@@ -1410,6 +1411,44 @@ Return the the current Kuzzle UTC timestamp as Epoch time (number of millisecond
     now: 1447151167622,             // Epoch time
     action: 'now',
     controller: 'read',
+    requestId: '<unique request identifier>'
+  }
+}
+```
+
+
+---
+
+### Creating an empty collection
+
+When creating a document, Kuzzle will automatically create a data collection if needed.  
+But in some cases, you may want to create an empty collection directly, prior to storing any document in it.
+
+This method does nothing if the collection already exists.
+
+**replyTo queue header:** Optionnal
+
+**Query:**
+
+```javascript
+{
+  controller: 'write',
+  action: 'createCollection',
+  collection: 'collection name'
+}
+```
+
+**Response:**
+
+```javascript
+{
+  status: 200,
+  error: null,
+  result: {
+    acknowledged: true,
+    action: 'createCollection',
+    controller: 'write',
+    collection: 'collection name',
     requestId: '<unique request identifier>'
   }
 }

--- a/docs/API.STOMP.md
+++ b/docs/API.STOMP.md
@@ -40,6 +40,7 @@ The current implementation of our MQ Broker service uses [RabbitMQ](https://www.
   * [Listing all known data collections](#listing-all-known-data-collections)
   * [Getting the current Kuzzle timestamp](#getting-the-current-kuzzle-timestamp)
   * [Creating an empty collection](#creating-an-empty-collection)
+  * [Deleting the entire content of a collection](#deleting-the-entire-content-of-a-collection)
 
 ## How to connect to Kuzzle
 
@@ -1448,6 +1449,42 @@ This method does nothing if the collection already exists.
     acknowledged: true,
     action: 'createCollection',
     controller: 'write',
+    collection: 'collection name',
+    requestId: '<unique request identifier>'
+  }
+}
+```
+
+
+---
+
+### Deleting the entire content of a collection
+
+This method empties a collection from all its documents, while keeping any associated mapping.  
+It is also way faster than deleting all documents from a collection using a query.
+
+**replyTo queue header:** Optionnal
+
+**Query:**
+
+```javascript
+{
+  controller: 'admin',
+  action: 'truncateCollection',
+  collection: 'collection name'
+}
+```
+
+**Response:**
+
+```javascript
+{
+  status: 200,
+  error: null,
+  result: {
+    acknowledged: true,
+    action: 'truncateCollection',
+    controller: 'admin',
     collection: 'collection name',
     requestId: '<unique request identifier>'
   }

--- a/docs/API.WebSocket.md
+++ b/docs/API.WebSocket.md
@@ -37,6 +37,7 @@ This will give you a direct access to Kuzzle's router controller, dispatching yo
   * [Listing all known data collections](#listing-all-known-data-collections)
   * [Getting the current Kuzzle timestamp](#getting-the-current-kuzzle-timestamp)
   * [Creating an empty collection](#creating-an-empty-collection)
+  * [Deleting the entire content of a collection](#deleting-the-entire-content-of-a-collection)
 
 ## How to connect to Kuzzle
 
@@ -1440,6 +1441,39 @@ This method does nothing if the collection already exists.
     acknowledged: true,
     action: 'createCollection',
     controller: 'write',
+    collection: 'collection name',
+    requestId: '<unique request identifier>'
+  }
+}
+```
+
+---
+
+### Deleting the entire content of a collection
+
+This method empties a collection from all its documents, while keeping any associated mapping.  
+It is also way faster than deleting all documents from a collection using a query.
+
+**Query:**
+
+```javascript
+{
+  controller: 'admin',
+  action: 'truncateCollection',
+  collection: 'collection name'
+}
+```
+
+**Response:**
+
+```javascript
+{
+  status: 200,
+  error: null,
+  result: {
+    acknowledged: true,
+    action: 'truncateCollection',
+    controller: 'admin',
     collection: 'collection name',
     requestId: '<unique request identifier>'
   }

--- a/docs/API.WebSocket.md
+++ b/docs/API.WebSocket.md
@@ -36,6 +36,7 @@ This will give you a direct access to Kuzzle's router controller, dispatching yo
   * [Getting all stored statistics](#getting-all-stored-statistics)
   * [Listing all known data collections](#listing-all-known-data-collections)
   * [Getting the current Kuzzle timestamp](#getting-the-current-kuzzle-timestamp)
+  * [Creating an empty collection](#creating-an-empty-collection)
 
 ## How to connect to Kuzzle
 
@@ -1404,6 +1405,42 @@ Return the the current Kuzzle UTC timestamp as Epoch time (number of millisecond
     now: 1447151167622,             // Epoch time
     action: 'now',
     controller: 'read',
+    requestId: '<unique request identifier>'
+  }
+}
+```
+
+
+---
+
+### Creating an empty collection
+
+When creating a document, Kuzzle will automatically create a data collection if needed.  
+But in some cases, you may want to create an empty collection directly, prior to storing any document in it.
+
+This method does nothing if the collection already exists.
+
+**Query:**
+
+```javascript
+{
+  controller: 'write',
+  action: 'createCollection',
+  collection: 'collection name'
+}
+```
+
+**Response:**
+
+```javascript
+{
+  status: 200,
+  error: null,
+  result: {
+    acknowledged: true,
+    action: 'createCollection',
+    controller: 'write',
+    collection: 'collection name',
     requestId: '<unique request identifier>'
   }
 }

--- a/features/AMQP.feature
+++ b/features/AMQP.feature
@@ -59,6 +59,8 @@ Feature: Test AMQP API
     When I write the document "documentAda"
     Then I count 4 documents
     And I count 2 documents with "NYC" in field "city"
+    Then I truncate the collection
+    And I count 0 documents
 
   @removeSchema @usingAMQP
   Scenario: Change mapping

--- a/features/MQTT.feature
+++ b/features/MQTT.feature
@@ -59,6 +59,8 @@ Feature: Test MQTT API
     When I write the document "documentAda"
     Then I count 4 documents
     And I count 2 documents with "NYC" in field "city"
+    Then I truncate the collection
+    And I count 0 documents
 
   @removeSchema @usingMQTT
   Scenario: Change mapping

--- a/features/REST.feature
+++ b/features/REST.feature
@@ -62,6 +62,8 @@ Feature: Test REST API
     When I write the document "documentAda"
     Then I count 4 documents
     And I count 2 documents with "NYC" in field "city"
+    Then I truncate the collection
+    And I count 0 documents
 
   @usingREST @removeSchema
   Scenario: Change mapping

--- a/features/STOMP.feature
+++ b/features/STOMP.feature
@@ -59,6 +59,8 @@ Feature: Test STOMP API
     When I write the document "documentAda"
     Then I count 4 documents
     And I count 2 documents with "NYC" in field "city"
+    Then I truncate the collection
+    And I count 0 documents
 
   @removeSchema @usingSTOMP
   Scenario: Change mapping

--- a/features/Websocket.feature
+++ b/features/Websocket.feature
@@ -59,6 +59,8 @@ Feature: Test websocket API
     When I write the document "documentAda"
     Then I count 4 documents
     And I count 2 documents with "NYC" in field "city"
+    Then I truncate the collection
+    And I count 0 documents
 
   @removeSchema @usingWebsocket
   Scenario: Change mapping

--- a/features/step_definitions/api.js
+++ b/features/step_definitions/api.js
@@ -800,8 +800,7 @@ var apiSteps = function () {
     this.api.deleteCollection()
       .then(function (body) {
         if (body.error !== null) {
-          callback(new Error(body.error.message));
-          return false;
+          return callback(new Error(body.error.message));
         }
 
         callback();
@@ -827,6 +826,17 @@ var apiSteps = function () {
       });
   });
 
+  this.Then(/^I truncate the collection$/, function (callback) {
+    this.api.truncateCollection()
+      .then(body => {
+        if (body.error !== null) {
+          return callback(new Error(body.error.message));
+        }
+
+        callback();
+      })
+      .catch(error => callback(error));
+  });
 
   /** TOOLS **/
   this.Then(/^I wait ([\d]*)s$/, function (time, callback) {

--- a/features/support/apiAMQP.js
+++ b/features/support/apiAMQP.js
@@ -269,6 +269,17 @@ module.exports = {
       };
 
     return publish.call(this, msg);
+  },
+
+  truncateCollection: function () {
+    var
+      msg = {
+        controller: 'admin',
+        collection: this.world.fakeCollection,
+        action: 'truncateCollection'
+      };
+
+    return publish.call(this, msg);
   }
 };
 

--- a/features/support/apiMQTT.js
+++ b/features/support/apiMQTT.js
@@ -259,6 +259,17 @@ module.exports = {
       };
 
     return publish.call(this, msg);
+  },
+
+  truncateCollection: function () {
+    var
+      msg = {
+        controller: 'admin',
+        collection: this.world.fakeCollection,
+        action: 'truncateCollection'
+      };
+
+    return publish.call(this, msg);
   }
 };
 

--- a/features/support/apiREST.js
+++ b/features/support/apiREST.js
@@ -179,5 +179,15 @@ module.exports = {
     };
 
     return this.callApi(options);
+  },
+
+  truncateCollection: function () {
+    var options = {
+      url: this.pathApi(this.world.fakeCollection + '/_truncate'),
+      method: 'DELETE',
+      json: true
+    };
+
+    return this.callApi(options);
   }
 };

--- a/features/support/apiSTOMP.js
+++ b/features/support/apiSTOMP.js
@@ -270,6 +270,17 @@ module.exports = {
       };
 
     return publish.call(this, msg);
+  },
+
+  truncateCollection: function () {
+    var
+      msg = {
+        controller: 'admin',
+        collection: this.world.fakeCollection,
+        action: 'truncateCollection'
+      };
+
+    return publish.call(this, msg);
   }
 };
 

--- a/features/support/apiWebsocket.js
+++ b/features/support/apiWebsocket.js
@@ -252,6 +252,18 @@ module.exports = {
     };
 
     return emit.call(this, msg );
+  },
+
+
+  truncateCollection: function () {
+    var
+      msg = {
+        controller: 'admin',
+        collection: this.world.fakeCollection,
+        action: 'truncateCollection'
+      };
+
+    return emit.call(this, msg);
   }
 };
 

--- a/lib/api/controllers/adminController.js
+++ b/lib/api/controllers/adminController.js
@@ -61,4 +61,19 @@ module.exports = function AdminController (kuzzle) {
     kuzzle.pluginsManager.trigger('data:getAllStats', requestObject);
     return kuzzle.statistics.getAllStats(requestObject);
   };
+
+  /**
+   * Reset a collection by removing all documents while keeping the existing mapping.
+   *
+   * @param {RequestObject} requestObject
+   * @returns {promise}
+   */
+  this.truncateCollection = function (requestObject) {
+    var deferred = q.defer();
+
+    kuzzle.pluginsManager.trigger('data:truncateCollection', requestObject);
+
+    deferred.resolve({});
+    return deferred.promise;
+  };
 };

--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -21,7 +21,28 @@ module.exports = function RouterController (kuzzle) {
   this.initRouterHttp = function () {
     var
       api = new Router(),
-      coverage;
+      coverage,
+      routes = [
+        {verb: 'get', url: '/_listCollections', controller: 'read', action: 'listCollections'},
+        {verb: 'get', url: '/_getStats', controller: 'admin', action: 'getStats'},
+        {verb: 'get', url: '/_getAllStats', controller: 'admin', action: 'getAllStats'},
+        {verb: 'get', url: '/_now', controller: 'read', action: 'now'},
+        {verb: 'get', url: '/:collection/_mapping', controller: 'admin', action: 'getMapping'},
+        {verb: 'get', url: '/:collection/:id', controller: 'read', action: 'get'},
+        {verb: 'post', url: '/_bulk', controller: 'bulk', action: 'import'},
+        {verb: 'post', url: '/:collection/_bulk', controller: 'bulk', action: 'import'},
+        {verb: 'post', url: '/:collection/_search', controller: 'read', action: 'search'},
+        {verb: 'post', url: '/:collection/_count', controller: 'read', action: 'count'},
+        {verb: 'post', url: '/:collection', controller: 'write', action: 'create'},
+        {verb: 'delete', url: '/:collection/_query', controller: 'write', action: 'deleteByQuery'},
+        {verb: 'delete', url: '/:collection/_truncate', controller: 'admin', action: 'truncateCollection'},
+        {verb: 'delete', url: '/:collection/:id', controller: 'write', action: 'delete'},
+        {verb: 'delete', url: '/:collection', controller: 'admin', action: 'deleteCollection'},
+        {verb: 'put', url: '/:collection', controller: 'write', action: 'createCollection'},
+        {verb: 'put', url: '/:collection/_mapping', controller: 'admin', action: 'putMapping'},
+        {verb: 'put', url: '/:collection/:id/_:action', controller: 'write'},
+        {verb: 'put', url: '/:collection/:id', controller: 'write', action: 'createOrUpdate'}
+      ];
 
     this.router = new Router();
 
@@ -45,158 +66,20 @@ module.exports = function RouterController (kuzzle) {
       response.end(stringify({status: 200, error: null, result: 'Hello from Kuzzle :)'}));
     });
 
-    api.post('/_bulk', function (request, response) {
-      var params = {
-        controller: 'bulk',
-        action: 'import'
-      };
+    // Register API routes
+    routes.forEach(route => {
+      api[route.verb](route.url, function (request, response) {
+        var params = {
+          controller: route.controller
+        };
 
-      executeFromRest.call(kuzzle, params, request, response);
+        if (route.action) {
+          params.action = route.action;
+        }
+
+        executeFromRest.call(kuzzle, params, request, response);
+      });
     });
-
-    api.get('/_getStats', function (request, response) {
-      var params = {
-        controller: 'admin',
-        action: 'getStats'
-      };
-
-      executeFromRest.call(kuzzle, params, request, response);
-    });
-
-    api.get('/_getAllStats', function (request, response) {
-      var params = {
-        controller: 'admin',
-        action: 'getAllStats'
-      };
-
-      executeFromRest.call(kuzzle, params, request, response);
-    });
-
-    api.get('/_listCollections', function (request, response) {
-      var params = {
-        controller: 'read',
-        action: 'listCollections'
-      };
-
-      executeFromRest.call(kuzzle, params, request, response);
-    });
-
-    api.get('/_now', function (request, response) {
-      var params = {
-        controller: 'read',
-        action: 'now'
-      };
-
-      executeFromRest.call(kuzzle, params, request, response);
-    });
-
-    api.post('/:collection/_bulk', function (request, response) {
-      var params = {
-        controller: 'bulk',
-        action: 'import'
-      };
-
-      executeFromRest.call(kuzzle, params, request, response);
-    });
-
-    api.put('/:collection/_mapping', function (request, response) {
-      var params = {
-        controller: 'admin',
-        action: 'putMapping'
-      };
-
-      executeFromRest.call(kuzzle, params, request, response);
-    });
-
-    api.get('/:collection/_mapping', function (request, response) {
-      var params = {
-        controller: 'admin',
-        action: 'getMapping'
-      };
-
-      executeFromRest.call(kuzzle, params, request, response);
-    });
-
-    api.post('/:collection/_search', function (request, response) {
-      var params = {
-        controller: 'read',
-        action: 'search'
-      };
-
-      executeFromRest.call(kuzzle, params, request, response);
-    });
-
-    api.delete('/:collection/_query', function (request, response) {
-      var params = {
-        controller: 'write',
-        action: 'deleteByQuery'
-      };
-
-      executeFromRest.call(kuzzle, params, request, response);
-    });
-
-    api.post('/:collection/_count', function (request, response) {
-      var params = {
-        controller: 'read',
-        action: 'count'
-      };
-
-      executeFromRest.call(kuzzle, params, request, response);
-    });
-
-    api.put('/:collection/:id/_:action', function (request, response) {
-      var params = {
-        controller: 'write'
-      };
-
-      executeFromRest.call(kuzzle, params, request, response);
-    });
-
-    api.put('/:collection/:id', function (request, response) {
-      var params = {
-        controller: 'write',
-        action: 'createOrUpdate'
-      };
-
-      executeFromRest.call(kuzzle, params, request, response);
-    });
-
-    api.post('/:collection', function (request, response) {
-      var params = {
-        controller: 'write',
-        action: 'create'
-      };
-
-      executeFromRest.call(kuzzle, params, request, response);
-    });
-
-    api.get('/:collection/:id', function (request, response) {
-      var params = {
-        controller: 'read',
-        action: 'get'
-      };
-
-      executeFromRest.call(kuzzle, params, request, response);
-    });
-
-    api.delete('/:collection/:id', function (request, response) {
-      var params = {
-        controller: 'write',
-        action: 'delete'
-      };
-
-      executeFromRest.call(kuzzle, params, request, response);
-    });
-
-    api.delete('/:collection', function (request, response) {
-      var params = {
-        controller: 'admin',
-        action: 'deleteCollection'
-      };
-
-      executeFromRest.call(kuzzle, params, request, response);
-    });
-
   };
 
   /**

--- a/lib/api/controllers/writeController.js
+++ b/lib/api/controllers/writeController.js
@@ -108,4 +108,20 @@ module.exports = function WriteController (kuzzle) {
 
     return deferred.promise;
   };
+
+
+  /**
+   * Creates a new collection. Does nothing if the collection already exists.
+   *
+   * @param {RequestObject} requestObject
+   * @returns {Promise} promise resolved as a ResponseObject
+   */
+  this.createCollection = function (requestObject) {
+    var deferred = q.defer();
+
+    kuzzle.pluginsManager.trigger('data:createCollection', requestObject);
+
+    deferred.resolve({});
+    return deferred.promise;
+  };
 };

--- a/lib/api/core/models/responseObject.js
+++ b/lib/api/core/models/responseObject.js
@@ -56,7 +56,7 @@ function construct (requestObject, response) {
   this.timestamp = requestObject.timestamp;
   this.metadata = requestObject.metadata;
 
-  this.data = _.extend(requestObject.data, response);
+  this.data = !util.isError(response) ? _.extend(requestObject.data, response) : requestObject.data;
 }
 
 /**
@@ -70,6 +70,7 @@ function formatError(error) {
     count: 1,
     stack: ''
   };
+
   if (error.message) {
     response.message = error.message;
   }

--- a/lib/config/hooks.js
+++ b/lib/config/hooks.js
@@ -8,6 +8,8 @@ module.exports = {
   'data:bulkImport': ['write:add'],
   'data:deleteCollection': ['write:add'],
   'data:putMapping': ['write:add'],
-  'data:reset': ['write:add']
+  'data:reset': ['write:add'],
+  'data:createCollection': ['write:add'],
+  'data:truncateCollection': ['write:add']
 };
 

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -255,6 +255,56 @@ module.exports = function (kuzzle, options) {
   };
 
   /**
+   * Create an empty collection with no mapping
+   *
+   * @param {RequestObject} requestObject
+   * @returns {Promise}
+   */
+  this.createCollection = function (requestObject) {
+    var data = cleanData.call(this, requestObject);
+
+    data.body = {};
+    data.body[data.type] = {};
+
+    return this.client.indices.putMapping(data);
+  };
+
+  /**
+   * Empty the content of a collection. Keep the existing mapping.
+   *
+   * @param {RequestObject} requestObject
+   * @returns {Promise}
+   */
+  this.truncateCollection = function (requestObject) {
+    var
+      deferred = q.defer(),
+      mappings,
+      data = cleanData.call(this, requestObject);
+
+    delete data.body;
+
+    this.client.indices.getMapping(data)
+      .then(mapping => {
+        if (!mapping[this.kuzzleConfig[this.engineType].index]) {
+          return Promise.reject(new NotFoundError('The collection "' + data.type + '" does not exist'));
+        }
+
+        mappings = mapping[this.kuzzleConfig[this.engineType].index].mappings[data.type];
+        return this.client.indices.deleteMapping(data);
+      })
+      .then(() => {
+        data.body = {};
+        data.body[data.type] = mappings;
+
+        return this.client.indices.putMapping(data);
+      })
+      .then(result => deferred.resolve(new ResponseObject(requestObject, result)))
+      .catch(error => deferred.reject(error));
+
+    return deferred.promise;
+  };
+
+  /**
    * Run several action and document
    * @param {RequestObject} requestObject
    * @returns {Promise}

--- a/lib/workers/write.js
+++ b/lib/workers/write.js
@@ -1,8 +1,7 @@
 var
   q = require('q'),
   ResponseObject = require('../api/core/models/responseObject'),
-  BadRequestError = require('../api/core/errors/badRequestError'),
-  InternalError = require('../api/core/errors/internalError');
+  BadRequestError = require('../api/core/errors/badRequestError');
 
 module.exports = function (kuzzle) {
   this.init = function () {
@@ -48,7 +47,7 @@ function onListenCB (serializedRequestObject) {
       this.services.list.broker.add(this.config.queues.coreNotifierTaskQueue, responseObject);
     }.bind(this))
     .catch(function (error) {
-      var responseObject = new ResponseObject(serializedRequestObject, new InternalError(error));
-      this.services.list.broker.add(this.config.queues.workerWriteResponseQueue, responseObject.toJson());
+      var responseObject = new ResponseObject(serializedRequestObject, error);
+      this.services.list.broker.add(this.config.queues.workerWriteResponseQueue, responseObject);
     }.bind(this));
 }

--- a/test/api/controllers/adminController.test.js
+++ b/test/api/controllers/adminController.test.js
@@ -112,4 +112,20 @@ describe('Test: admin controller', function () {
 
     kuzzle.funnel.admin.getAllStats(requestObject);
   });
+
+  it('should trigger a hook on a truncateCollection call', function (done) {
+    this.timeout(50);
+
+    kuzzle.once('data:truncateCollection', obj => {
+      try {
+        should(obj).be.exactly(requestObject);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+
+    kuzzle.funnel.admin.truncateCollection(requestObject);
+  });
 });

--- a/test/api/controllers/routerController/initRouterHttp.test.js
+++ b/test/api/controllers/routerController/initRouterHttp.test.js
@@ -584,4 +584,46 @@ describe('Test: routerController.initRouterHttp', function () {
         .catch(error => done(error));
     });
   });
+
+  it('should create a route for the createCollection command', done => {
+    var request;
+
+    options.method = 'PUT';
+    options.path= '/api/collection';
+
+    request = http.request(options, function (response) {
+      parseHttpResponse(response)
+        .then(result => {
+          should(response.statusCode).be.exactly(200);
+          should(result.controller).be.exactly('write');
+          should(result.action).be.exactly('createCollection');
+          done();
+        })
+        .catch(error => done(error));
+    });
+
+    request.write('foobar');
+    request.end();
+  });
+
+  it('should create a route for the truncateCollection command', done => {
+    var request;
+
+    options.method = 'DELETE';
+    options.path= '/api/collection/_truncate';
+
+    request = http.request(options, function (response) {
+      parseHttpResponse(response)
+        .then(result => {
+          should(response.statusCode).be.exactly(200);
+          should(result.controller).be.exactly('admin');
+          should(result.action).be.exactly('truncateCollection');
+          done();
+        })
+        .catch(error => done(error));
+    });
+
+    request.write('foobar');
+    request.end();
+  });
 });

--- a/test/api/controllers/writeController.test.js
+++ b/test/api/controllers/writeController.test.js
@@ -185,4 +185,23 @@ describe('Test: write controller', function () {
         done(error);
       });
   });
+
+
+  it('should trigger a hook on a createCollection call', function (done) {
+    var requestObject = new RequestObject({}, {}, 'unit-test');
+
+    this.timeout(50);
+
+    kuzzle.once('data:createCollection', obj => {
+      try {
+        should(obj).be.exactly(requestObject);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+
+    kuzzle.funnel.write.createCollection(requestObject);
+  });
 });

--- a/test/api/core/models/responseObject.test.js
+++ b/test/api/core/models/responseObject.test.js
@@ -8,7 +8,7 @@ var
   rewire = require('rewire'),
   uuid = require('node-uuid'),
   RequestObject = require.main.require('lib/api/core/models/requestObject'),
-  ResponseObject = require.main.require('lib/api/core/models/responseObject'),
+  ResponseObject = rewire('../../../../lib/api/core/models/responseObject'),
   BadRequestError = require.main.require('lib/api/core/errors/badRequestError'),
   ForbiddenError = require.main.require('lib/api/core/errors/forbiddenError'),
   NotFoundError = require.main.require('lib/api/core/errors/notFoundError'),
@@ -26,11 +26,11 @@ describe('Test: responseObject', function () {
       body: {_id: 'fakeid', foo: 'bar'}
     },
     errorItems = [
-      { name: 'BadRequestError', type: BadRequestError, status: 400 },
-      { name: 'ForbiddenError', type: ForbiddenError, status: 403 },
-      { name: 'NotFoundError', type: NotFoundError, status: 404 },
-      { name: 'InternalError', type: InternalError, status: 500 },
-      { name: 'ServiceUnavailableError', type: ServiceUnavailableError, status: 503 }
+      {name: 'BadRequestError', type: BadRequestError, status: 400},
+      {name: 'ForbiddenError', type: ForbiddenError, status: 403},
+      {name: 'NotFoundError', type: NotFoundError, status: 404},
+      {name: 'InternalError', type: InternalError, status: 500},
+      {name: 'ServiceUnavailableError', type: ServiceUnavailableError, status: 503}
     ],
     requestObject;
 
@@ -74,22 +74,22 @@ describe('Test: responseObject', function () {
     should(response.data).be.null();
   });
 
-  async.each(errorItems, function(item, callback) {
+  async.each(errorItems, function (item, callback) {
     it('should initialize a ' + item.name + ' response if such an error is provided', function () {
       var
         error = new item.type('foobar'),
         response = new ResponseObject(requestObject, error);
 
-        should(response.error.message).be.not.null();
-        should(response.error.message).be.exactly(error.message);
-        should(response.status).be.exactly(item.status);
-        should(response.protocol).be.exactly(requestObject.protocol);
-        should(response.action).be.exactly(requestObject.action);
-        should(response.collection).be.exactly(requestObject.collection);
-        should(response.controller).be.exactly(requestObject.controller);
-        should(response.requestId).be.exactly(requestObject.requestId);
-        should(response.timestamp).be.exactly(requestObject.timestamp);
-        should(response.data).match(requestObject.data);
+      should(response.error.message).be.not.null();
+      should(response.error.message).be.exactly(error.message);
+      should(response.status).be.exactly(item.status);
+      should(response.protocol).be.exactly(requestObject.protocol);
+      should(response.action).be.exactly(requestObject.action);
+      should(response.collection).be.exactly(requestObject.collection);
+      should(response.controller).be.exactly(requestObject.controller);
+      should(response.requestId).be.exactly(requestObject.requestId);
+      should(response.timestamp).be.exactly(requestObject.timestamp);
+      should(response.data).match(requestObject.data);
     });
   });
 
@@ -158,5 +158,45 @@ describe('Test: responseObject', function () {
 
     should(response.data._source).not.be.undefined();
     should(response.data.body).match(response.data._source);
+  });
+
+  describe('#formatError', function () {
+    it('should format a default error response', function () {
+      var
+        formatError = ResponseObject.__get__('formatError'),
+        result = formatError({});
+
+      should(result.message).be.exactly('Internal error');
+      should(result.count).be.exactly(1);
+      should(result.stack).be.exactly('');
+      should(result.errors).be.undefined();
+      should(result.details).be.undefined();
+    });
+
+    it('should copy the stack trace only if the status code is 500', function () {
+      var formatError = ResponseObject.__get__('formatError');
+
+      should(formatError({stack: 'foobar', status: 404}).stack).be.exactly('');
+      should(formatError({stack: 'foobar', status: 500}).stack).be.exactly('foobar');
+      should(formatError({body: 'foobar', status: 404}).stack).be.exactly('');
+      should(formatError({body: 'foobar', status: 500}).stack).be.exactly('foobar');
+      should(formatError({foo: 'bar', status: 404}).stack).be.exactly('');
+      should(formatError({foo: 'bar', status: 500}).stack).be.an.Object().and.containEql('foo');
+    });
+
+    it('should copy optional error values', function () {
+      var
+        formatError = ResponseObject.__get__('formatError'),
+        error = {
+          count: 123,
+          errors: 'oh noes!!1!',
+          details: { TheDevil: 'is here' }
+        },
+        result = formatError(error);
+
+      should(result.count).be.exactly(error.count);
+      should(result.errors).be.exactly(error.errors);
+      should(result.details).be.exactly(error.details);
+    });
   });
 });

--- a/test/api/core/notifier/checkNewRoutes.test.js
+++ b/test/api/core/notifier/checkNewRoutes.test.js
@@ -19,7 +19,21 @@ var
 describe('Test: notifier.checkNewRoutes', function () {
   var
     kuzzle,
-    blacklist = ['init', 'search', 'get', 'mget', 'count', 'deleteCollection', 'import', 'putMapping', 'getMapping', 'listCollections', 'reset'],
+    blacklist = [
+      'init',
+      'search',
+      'get',
+      'mget',
+      'count',
+      'deleteCollection',
+      'import',
+      'putMapping',
+      'getMapping',
+      'listCollections',
+      'reset',
+      'createCollection',
+      'truncateCollection'
+    ],
     requestObject = new RequestObject({
       controller: 'write',
       action: '',

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -620,4 +620,19 @@ describe('Test: ElasticSearch service', function () {
     delete requestObject.data.body;
     return should(elasticsearch.listCollections(requestObject)).be.rejected();
   });
+
+  // createCollection
+  it('should allow creating a new collection', function () {
+    return should(elasticsearch.createCollection(requestObject)).be.fulfilled();
+  });
+
+  // truncateCollection
+  it('should allow truncating an existing collection', function () {
+    return should(elasticsearch.truncateCollection(requestObject)).be.fulfilled();
+  });
+
+  it('should return an error if trying to truncate a non-existing collection', function () {
+    requestObject.collection = 'non existing collection';
+    return should(elasticsearch.truncateCollection(requestObject)).be.rejected();
+  });
 });


### PR DESCRIPTION
* added the createCollection API method: create a new empty collection 
* added the truncate API method: truncate an existing collection
* added unit tests and functional tests
* updated API documentation
* simplified the initialization of REST routes, eliminating a lot of repetition of code
* bugfix: errors from Elasticsearch coming from workers weren't correctly delivered to the users because of a formatting problem