### PR TITLE
Kuz-310 global repository load method

### DIFF
--- a/lib/api/core/models/repositories/repository.js
+++ b/lib/api/core/models/repositories/repository.js
@@ -169,9 +169,18 @@ Repository.prototype.load = function (id, opts) {
     error;
 
   try {
+
+    if (this.cacheEngine === null) {
+      return this.loadOneFromDatabase(id);
+    }
+
     this.loadFromCache(id, opts)
       .then(function (object) {
         if (object === null) {
+          if (this.readEngine === null) {
+            deferred.resolve(null);
+            return deferred.promise;
+          }
           this.loadOneFromDatabase(id)
             .then(function (objectFromDatabase) {
               if (objectFromDatabase !== null) {

--- a/lib/api/core/models/repositories/repository.js
+++ b/lib/api/core/models/repositories/repository.js
@@ -148,6 +148,59 @@ Repository.prototype.loadFromCache = function (id, opts) {
 };
 
 /**
+ * Loads an object from Cache or from the Database if not available in Cache.
+ * Returns a promise that resolves either to the
+ * retrieved object of null in case it is not found.
+ *
+ * If the object is not found in Cache and found in the Database,
+ * it will be written to cache also.
+ *
+ * The opts object currently accepts one optional parameter: key, which forces
+ * the cache key to fetch.
+ * In case the key is not provided, it defauls to <collection>/id, i.e.: _kuzzle/users/12
+ *
+ * @param {String} id The id of the object to get
+ * @param {Object} opts Optional options.
+ * @returns {Promise}
+ */
+Repository.prototype.load = function (id, opts) {
+  var
+    deferred = q.defer(),
+    error;
+
+  try {
+    this.loadFromCache(id, opts)
+      .then(function (object) {
+        if (object === null) {
+          this.loadOneFromDatabase(id)
+            .then(function (objectFromDatabase) {
+              if (objectFromDatabase !== null) {
+                this.persistToCache(objectFromDatabase);
+              }
+              deferred.resolve(objectFromDatabase);
+            }.bind(this))
+            .catch(function (err) {
+              deferred.reject(err);
+            });
+        }
+        else {
+          this.refreshCacheTTL(object);
+          deferred.resolve(object);
+        }
+      }.bind(this))
+      .catch(function (err) {
+        deferred.reject(err);
+      });
+  }
+  catch (err) {
+    error = new InternalError('Error loading Object');
+    error.details = err;
+    deferred.reject(error);
+  }
+  return deferred.promise;
+};
+
+/**
  * From a poco object, hydrate an ObjectConstructor one.
  *
  * @param {Object} object The Object to be hydrated

--- a/lib/api/core/models/repositories/repository.js
+++ b/lib/api/core/models/repositories/repository.js
@@ -164,48 +164,38 @@ Repository.prototype.loadFromCache = function (id, opts) {
  * @returns {Promise}
  */
 Repository.prototype.load = function (id, opts) {
-  var
-    deferred = q.defer(),
-    error;
+  var deferred = q.defer();
 
-  try {
-
-    if (this.cacheEngine === null) {
-      return this.loadOneFromDatabase(id);
-    }
-
-    this.loadFromCache(id, opts)
-      .then(function (object) {
-        if (object === null) {
-          if (this.readEngine === null) {
-            deferred.resolve(null);
-            return deferred.promise;
-          }
-          this.loadOneFromDatabase(id)
-            .then(function (objectFromDatabase) {
-              if (objectFromDatabase !== null) {
-                this.persistToCache(objectFromDatabase);
-              }
-              deferred.resolve(objectFromDatabase);
-            }.bind(this))
-            .catch(function (err) {
-              deferred.reject(err);
-            });
-        }
-        else {
-          this.refreshCacheTTL(object);
-          deferred.resolve(object);
-        }
-      }.bind(this))
-      .catch(function (err) {
-        deferred.reject(err);
-      });
+  if (this.cacheEngine === null) {
+    return this.loadOneFromDatabase(id);
   }
-  catch (err) {
-    error = new InternalError('Error loading Object');
-    error.details = err;
-    deferred.reject(error);
-  }
+
+  this.loadFromCache(id, opts)
+    .then(function (object) {
+      if (object === null) {
+        if (this.readEngine === null) {
+          deferred.resolve(null);
+          return deferred.promise;
+        }
+        this.loadOneFromDatabase(id)
+          .then(function (objectFromDatabase) {
+            if (objectFromDatabase !== null) {
+              this.persistToCache(objectFromDatabase);
+            }
+            deferred.resolve(objectFromDatabase);
+          }.bind(this))
+          .catch(function (err) {
+            deferred.reject(err);
+          });
+      }
+      else {
+        this.refreshCacheTTL(object);
+        deferred.resolve(object);
+      }
+    }.bind(this))
+    .catch(function (err) {
+      deferred.reject(err);
+    });
   return deferred.promise;
 };
 

--- a/lib/api/core/models/repositories/userRepository.js
+++ b/lib/api/core/models/repositories/userRepository.js
@@ -41,27 +41,12 @@ module.exports = function (kuzzle) {
         return this.admin();
       }
 
-      this.loadFromCache(decodedToken._id)
+      this.load(decodedToken._id)
         .then(function (user) {
           if (user === null) {
-            this.loadOneFromDatabase(decodedToken._id)
-              .then(function (userFromDatabase) {
-                if (userFromDatabase === null) {
-                  deferred.resolve(this.anonymous());
-                }
-                else {
-                  this.persistToCache(userFromDatabase);
-
-                  deferred.resolve(userFromDatabase);
-                }
-              }.bind(this))
-              .catch(function (err) {
-                deferred.reject(err);
-              });
+            deferred.resolve(this.anonymous());
           }
           else {
-            this.refreshCacheTTL(user);
-
             deferred.resolve(user);
           }
         }.bind(this))

--- a/test/api/core/models/repositories/repository.test.js
+++ b/test/api/core/models/repositories/repository.test.js
@@ -24,10 +24,21 @@ describe('Test: repositories/repository', function () {
   persistedObject._id = -1;
   persistedObject.name = 'persisted';
 
+  cachedObject = new ObjectConstructor();
+  cachedObject._id = -2;
+  cachedObject.name = 'cached';
+
+  uncachedObject = new ObjectConstructor();
+  uncachedObject._id = -3;
+  uncachedObject.name = 'uncached';
+
   mockCacheEngine = {
     get: function (key) {
       if (key === repository.collection + '/persisted') {
         return Promise.resolve(persistedObject);
+      }
+      if (key === repository.collection + '/cached') {
+        return Promise.resolve(cachedObject);
       }
       if (key === repository.collection + '/error') {
         return Promise.reject(new InternalError('Error'));
@@ -51,6 +62,12 @@ describe('Test: repositories/repository', function () {
       }
       if (requestObject.data._id === 'persisted') {
         return Promise.resolve(new ResponseObject(requestObject, persistedObject));
+      }
+      if (requestObject.data._id === 'uncached') {
+        return Promise.resolve(new ResponseObject(requestObject, uncachedObject));
+      }
+      if (requestObject.data._id === 'cached') {
+        return Promise.resolve(new ResponseObject(requestObject, uncachedObject));
       }
       if (requestObject.data._id === 'error') {
         return Promise.reject(new InternalError('Error'));
@@ -116,6 +133,10 @@ describe('Test: repositories/repository', function () {
 
   beforeEach(function () {
     forwardedObject = null;
+    repository.ObjectConstructor = ObjectConstructor;
+    repository.readEngine = mockReadEngine;
+    repository.writeEngine = mockWriteEngine;
+    repository.cacheEngine = mockCacheEngine;
   });
 
   describe('#loadOneFromDatabase', function () {
@@ -238,6 +259,94 @@ describe('Test: repositories/repository', function () {
           should(result._id).be.exactly(-1);
           should(result.name).be.exactly('persisted');
           should(result.type).be.exactly('testObject');
+          done();
+        })
+        .catch(function (error) {
+          done(error);
+        });
+    });
+  });
+
+  describe('#load', function () {
+    it('should return null for an non-existing id', function (done) {
+      repository.load(-999)
+        .then(function (result) {
+          should(result).be.null();
+          done();
+        })
+        .catch(function (error) {
+          done(error);
+        });
+    });
+
+    it('should reject the promise in case of error', done => {
+      should(repository.load('error')).be.rejectedWith(InternalError);
+      should(repository.load('string')).be.rejectedWith(InternalError);
+      done();
+    });
+
+    it('should return a valid ObjectConstructor instance if found', function (done) {
+      repository.load('persisted')
+        .then(function (result) {
+          should(result).be.an.instanceOf(ObjectConstructor);
+          should(result._id).be.exactly(-1);
+          should(result.name).be.exactly('persisted');
+          should(result.type).be.exactly('testObject');
+          done();
+        })
+        .catch(function (error) {
+          done(error);
+        });
+    });
+
+    it('should return a valid ObjectConstructor instance if found only in cache', function (done) {
+      repository.load('cached')
+        .then(function (result) {
+          should(result).be.an.instanceOf(ObjectConstructor);
+          should(result._id).be.exactly(-2);
+          should(result.name).be.exactly('cached');
+          should(result.type).be.exactly('testObject');
+          done();
+        })
+        .catch(function (error) {
+          done(error);
+        });
+    });
+
+    it('should return a valid ObjectConstructor instance if found only in readEngine', function (done) {
+      repository.load('uncached')
+        .then(function (result) {
+          should(result).be.an.instanceOf(ObjectConstructor);
+          should(result._id).be.exactly(-3);
+          should(result.name).be.exactly('uncached');
+          should(result.type).be.exactly('testObject');
+          done();
+        })
+        .catch(function (error) {
+          done(error);
+        });
+    });
+
+    it('should get content only from readEngine if cacheEngine is null', function (done) {
+      repository.cacheEngine = null;
+      repository.load('cached')
+        .then(function (result) {
+          should(result).be.an.instanceOf(ObjectConstructor);
+          should(result._id).be.exactly(-3);
+          should(result.name).be.exactly('uncached');
+          should(result.type).be.exactly('testObject');
+          done();
+        })
+        .catch(function (error) {
+          done(error);
+        });
+    });
+
+    it('should get content only from cacheEngine if readEngine is null', function (done) {
+      repository.readEngine = null;
+      repository.load('uncached')
+        .then(function (result) {
+          should(result).be.null();
           done();
         })
         .catch(function (error) {


### PR DESCRIPTION
Add a load() method to abstract Repository class that tries to retrieve a content from cacheEngine, and if not in cache, fallback to readEngine.
