### PR TITLE
Lowercase the 'state', 'scope' and 'users' before comparison

### DIFF
--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -369,7 +369,7 @@ function createChannelConfiguration (requestObject) {
     deferred = q.defer(),
     channel = {};
 
-  if (requestObject.state && ['all', 'done', 'pending'].indexOf(requestObject.state) === -1) {
+  if (requestObject.state && ['all', 'done', 'pending'].indexOf(requestObject.state.toLowerCase()) === -1) {
     deferred.reject(new BadRequestError('Incorrect value for the "state" parameter. Expected: all, done or pending. Got: ' + requestObject.state));
     return deferred.promise;
   } else if (!requestObject.state) {
@@ -378,7 +378,7 @@ function createChannelConfiguration (requestObject) {
     channel.state = requestObject.state;
   }
 
-  if (requestObject.scope && ['all', 'in', 'out', 'none'].indexOf(requestObject.scope) === -1) {
+  if (requestObject.scope && ['all', 'in', 'out', 'none'].indexOf(requestObject.scope.toLowerCase()) === -1) {
     deferred.reject(new BadRequestError('Incorrect value for the "scope" parameter. Expected: all, in, out or none. Got: ' + requestObject.scope));
     return deferred.promise;
   } else if (!requestObject.scope) {
@@ -387,7 +387,7 @@ function createChannelConfiguration (requestObject) {
     channel.scope = requestObject.scope;
   }
 
-  if (requestObject.users && ['all', 'in', 'out', 'none'].indexOf(requestObject.users) === -1) {
+  if (requestObject.users && ['all', 'in', 'out', 'none'].indexOf(requestObject.users.toLowerCase()) === -1) {
     deferred.reject(new BadRequestError('Incorrect value for the "users" parameter. Expected: all, in, out or none. Got: ' + requestObject.users));
     return deferred.promise;
   } else if (!requestObject.users) {

--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -369,7 +369,7 @@ function createChannelConfiguration (requestObject) {
     deferred = q.defer(),
     channel = {};
 
-  if (requestObject.state && ['all', 'done', 'pending'].indexOf(requestObject.state.toLowerCase()) === -1) {
+  if (requestObject.state && ['all', 'done', 'pending'].indexOf(requestObject.state) === -1) {
     deferred.reject(new BadRequestError('Incorrect value for the "state" parameter. Expected: all, done or pending. Got: ' + requestObject.state));
     return deferred.promise;
   } else if (!requestObject.state) {
@@ -378,7 +378,7 @@ function createChannelConfiguration (requestObject) {
     channel.state = requestObject.state;
   }
 
-  if (requestObject.scope && ['all', 'in', 'out', 'none'].indexOf(requestObject.scope.toLowerCase()) === -1) {
+  if (requestObject.scope && ['all', 'in', 'out', 'none'].indexOf(requestObject.scope) === -1) {
     deferred.reject(new BadRequestError('Incorrect value for the "scope" parameter. Expected: all, in, out or none. Got: ' + requestObject.scope));
     return deferred.promise;
   } else if (!requestObject.scope) {
@@ -387,7 +387,7 @@ function createChannelConfiguration (requestObject) {
     channel.scope = requestObject.scope;
   }
 
-  if (requestObject.users && ['all', 'in', 'out', 'none'].indexOf(requestObject.users.toLowerCase()) === -1) {
+  if (requestObject.users && ['all', 'in', 'out', 'none'].indexOf(requestObject.users) === -1) {
     deferred.reject(new BadRequestError('Incorrect value for the "users" parameter. Expected: all, in, out or none. Got: ' + requestObject.users));
     return deferred.promise;
   } else if (!requestObject.users) {

--- a/lib/api/core/models/requestObject.js
+++ b/lib/api/core/models/requestObject.js
@@ -28,8 +28,12 @@ function construct (object, additionalData, protocol) {
     additionalData = {};
   }
 
-  ['action', 'controller', 'collection', 'state', 'scope', 'users'].forEach(attr => {
+  ['action', 'controller', 'collection'].forEach(attr => {
     this[attr] = object[attr] || additionalData[attr];
+  });
+
+  ['state', 'scope', 'users'].forEach(attr => {
+    this[attr] = (object[attr] ? object[attr].toLowerCase() : object[attr]) || (additionalData[attr] ? additionalData[attr].toLowerCase() : additionalData[attr]);
   });
 
   // the user can define the _id either in body or directly in object

--- a/test/api/core/models/requestObject.test.js
+++ b/test/api/core/models/requestObject.test.js
@@ -18,12 +18,15 @@ describe('Test: requestObject', function () {
 
   beforeEach(function () {
     request = {
-      action: 'fakeaction',
-      controller: 'fakecontroller',
-      collection: 'fakecollection',
+      action: 'fakeAction',
+      controller: 'fakeController',
+      collection: 'fakeCollection',
       protocol: protocol,
       requestId: 'fakerequestId',
-      body: { _id: 'fakeid', foo: 'bar' }
+      body: { _id: 'fakeid', foo: 'bar' },
+      state: 'fakeState',
+      scope: 'fakeScope',
+      users: 'fakeUsers'
     };
   });
 
@@ -48,6 +51,10 @@ describe('Test: requestObject', function () {
     should(requestObject.protocol).be.exactly(protocol);
     should(requestObject.controller).be.exactly(request.controller);
     should(requestObject.collection).be.exactly(request.collection);
+    should(requestObject.controller).be.exactly(request.controller);
+    should(requestObject.state).be.exactly(request.state.toLowerCase());
+    should(requestObject.scope).be.exactly(request.scope.toLowerCase());
+    should(requestObject.users).be.exactly(request.users.toLowerCase());
     should(requestObject.requestId).be.exactly(request.requestId);
     should(requestObject.timestamp).be.a.Number().and.be.within(timestampStart, timestampEnd);
   });


### PR DESCRIPTION
I added a toLowerCase before comparison of requestObject.state, requestObject.scope and requestObject.users to allow devs to use, for example, enums (Scope.OPEN ...)