### PR TITLE
bugfix: filter removal was not migrated to the new "or" filter format

### DIFF
--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -422,13 +422,13 @@ function cleanUpRooms (roomId) {
     this.kuzzle.dsl.removeRoom(this.rooms[roomId])
       .then(() => {
         this.kuzzle.pluginsManager.trigger('room:remove', roomId);
-        delete this.rooms[roomId];
         deferred.resolve(roomId);
       })
       .catch(error => {
         this.kuzzle.pluginsManager.trigger('log:error', error);
         deferred.reject(error);
-      });
+      })
+      .finally(() => delete this.rooms[roomId]);
   }
   else {
     deferred.resolve(roomId);

--- a/lib/api/dsl/index.js
+++ b/lib/api/dsl/index.js
@@ -573,7 +573,7 @@ function getFiltersPathsRecursively(filters) {
   }
 
   if (filters.or) {
-    paths = paths.concat(getFiltersPathsRecursively(filters.or));
+    filters.or.forEach(subfilter => { paths = paths.concat(getFiltersPathsRecursively(subfilter)); });
   }
 
   _.each(filters, function (value, key) {

--- a/lib/api/dsl/methods.js
+++ b/lib/api/dsl/methods.js
@@ -305,6 +305,11 @@ module.exports = methods = {
       return deferred.promise;
     }
 
+    if (typeof fieldName !== 'string') {
+      deferred.reject(new BadRequestError('Filter \'exists\' takes a string attribute. Found: ' + typeof fieldName));
+      return deferred.promise;
+    }
+
     formattedFilters = {};
 
     if (not) {

--- a/test/api/core/hotelClerck/removeCustomerFromAllRooms.test.js
+++ b/test/api/core/hotelClerck/removeCustomerFromAllRooms.test.js
@@ -91,7 +91,7 @@ describe('Test: hotelClerk.removeCustomerFromAllRooms', function () {
 
   it('should clean up customers, rooms and filtersTree object', function () {
     return kuzzle.hotelClerk.removeCustomerFromAllRooms(connection)
-      .then(function () {
+      .finally(function () {
         should(kuzzle.dsl.filtersTree).be.an.Object();
         should(kuzzle.dsl.filtersTree).be.empty();
 
@@ -116,7 +116,7 @@ describe('Test: hotelClerk.removeCustomerFromAllRooms', function () {
         roomId = createdRoom.roomId;
         return kuzzle.hotelClerk.removeCustomerFromAllRooms(connection);
       })
-      .then(function () {
+      .finally(function () {
         should(notified.roomId).be.exactly(roomId);
         should(notified.notification.error).be.null();
         should(notified.notification.result.count).be.exactly(1);
@@ -127,13 +127,20 @@ describe('Test: hotelClerk.removeCustomerFromAllRooms', function () {
   it('should log an error if a problem occurs while unsubscribing', function (done) {
     var
       finished = false,
+
       removeRoom = kuzzle.dsl.removeRoom;
 
-    kuzzle.dsl.removeRoom = function () { return Promise.reject(new Error('rejected')); };
+    kuzzle.dsl.removeRoom = function () {
+      var deferred = q.defer();
+
+      deferred.reject(new Error('rejected'));
+
+      return deferred.promise;
+    };
 
     this.timeout(500);
 
-    kuzzle.on('log:error', () => {
+    kuzzle.once('log:error', () => {
       if (!finished) {
         finished = true;
         kuzzle.dsl.removeRoom = removeRoom;
@@ -141,6 +148,6 @@ describe('Test: hotelClerk.removeCustomerFromAllRooms', function () {
       }
     });
 
-    should(kuzzle.hotelClerk.removeCustomerFromAllRooms(connection)).be.rejected();
+    kuzzle.hotelClerk.removeCustomerFromAllRooms(connection);
   });
 });

--- a/test/api/core/hotelClerck/removeSubscription.test.js
+++ b/test/api/core/hotelClerck/removeSubscription.test.js
@@ -125,7 +125,7 @@ describe('Test: hotelClerk.removeSubscription', function () {
 
   it('should clean up customers, rooms and filtersTree object', function () {
     return kuzzle.hotelClerk.removeSubscription(unsubscribeRequest, context)
-      .then(function () {
+      .finally(function () {
         should(kuzzle.dsl.filtersTree).be.an.Object();
         should(kuzzle.dsl.filtersTree).be.empty();
 

--- a/test/api/dsl/index/getFiltersPathsRecursively.test.js
+++ b/test/api/dsl/index/getFiltersPathsRecursively.test.js
@@ -12,13 +12,17 @@ describe('Test: dsl.getFiltersPathsRecursively', function () {
       filter = {
         and: {
           'message.subject.Potayto': undefined,
-          or: {
-            and: {
-              'message.subject.Potahto': undefined,
-              'message.subject.MisterSandman': undefined
+          or: [
+            {
+              and: {
+                'message.subject.Potahto': undefined,
+                'message.subject.MisterSandman': undefined
+              }
             },
-            'message.subject.BringUsADream': undefined
-          }
+            {
+              'message.subject.BringUsADream': undefined
+            }
+          ]
         }
       },
       result = getFiltersPathsRecursively(filter);

--- a/test/api/dsl/methods/exists.test.js
+++ b/test/api/dsl/methods/exists.test.js
@@ -63,8 +63,12 @@ describe('Test exists method', function () {
     return should(methods.exists('foo', 'bar', {})).be.rejectedWith(BadRequestError, { message: 'A filter can\'t be empty' });
   });
 
-  it('should return a rejected promise if the filter argument is invalid', function () {
+  it('should return a rejected promise if the filter argument does not contain a "field" term', function () {
     return should(methods.exists('foo', 'bar', { foo: 'bar' })).be.rejectedWith(BadRequestError, { message: 'Filter \'exists\' must contains \'field\' attribute' });
+  });
+
+  it('should return a rejected promise if the "field" term does not contain a string', function () {
+    return should(methods.exists('foo', 'bar', { field: {foo: 'bar'} })).be.rejectedWith(BadRequestError);
   });
 
   it('should return a rejected promise if buildCurriedFunction fails', function () {


### PR DESCRIPTION
* the recursive filter paths getter was still considering the content of a "or" filter to be an object, instead of an array
* the hotelClerk room destruction method destroyed a room only if the DSL successfully cleaned up the filters, instead of destroying it whenever the DSL finishes its work