### PR TITLE
Plugins manager : inject a "context" object at plugin initialization

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -31,7 +31,7 @@ A plugin configuration can have attributes:
 * `customConfig`: config for the plugin. Each plugin has a different configuration (required or optional), check the corresponding plugin documentation for more information.
 * `defaultConfig`: Don't edit this attribute. The defaultConfig is provided by the plugin itself. If you need to change the configuration, edit the `customConfig` attribute
 
-**Note:** 
+**Note:**
 * URL or version are required. The URL is checked first, so if you have set a version and an URL, the version will be ignored.
 
 # Default plugins
@@ -83,10 +83,10 @@ module.exports = {
 module.exports = function () {
 
   this.hooks = require('./config/hooks.js');
-  this.init = function (config, isDummy) {
+  this.init = function (config, context, isDummy) {
     // do something
   }
-  
+
   this.myFunction = function (message, event) {
     console.log('Event', event, 'is triggered');
     console.log('There is the message', message);
@@ -126,10 +126,10 @@ module.exports = {
 module.exports = function () {
 
   this.pipes = require('./config/pipes.js');
-  this.init = function (config, isDummy) {
+  this.init = function (config, context, isDummy) {
     // do something
   }
-  
+
   this.addCreatedAt = function (requestObject, callback) {
     requestObject.data.body.createdAt = Date.now();
     callback(null, requestObject);
@@ -197,13 +197,15 @@ module.exports = function () {
 
   this.controllers = require('./config/controllers.js');
   this.routes = require('./config/routes.js');
-  this.init = function (config, isDummy) {
+  this.context = null;
+  this.init = function (config, context, isDummy) {
+    this.context = context;
     // do something
   };
 
-  this.MyController = function (context) {
+  this.MyController = function () {
     MyController = require('./controllers/myController'),
-    return new MyController(context);
+    return new MyController(this.context);
   };
 };
 ```

--- a/lib/api/core/pluginsContext.js
+++ b/lib/api/core/pluginsContext.js
@@ -2,7 +2,7 @@ var
   walk = require('walk'),
   path = require('path');
 
-module.exports = function PluginContext() {
+module.exports = function PluginContext(kuzzle) {
   var
     context = {
       ResponseObject: require('./models/responseObject'),
@@ -21,6 +21,11 @@ module.exports = function PluginContext() {
       }
     };
   walk.walkSync(path.join(__dirname, 'errors'), options);
+
+  // Add lazy-loading repositories getter:
+  context.repositories = function() {
+    return kuzzle.repositories;
+  };
 
   return context;
 

--- a/lib/api/core/pluginsManager.js
+++ b/lib/api/core/pluginsManager.js
@@ -63,6 +63,7 @@ module.exports = function PluginsManager (kuzzle) {
   this.run = function () {
     _.forEach(this.plugins, function (plugin, pluginName) {
       var
+        context = new PluginContext(kuzzle),
         pipeWarnTime = this.config.pipeWarnTime,
         pipeTimeout = this.config.pipeTimeout;
 
@@ -70,7 +71,7 @@ module.exports = function PluginsManager (kuzzle) {
         return true;
       }
 
-      plugin.object.init(plugin.config, this.isDummy);
+      plugin.object.init(plugin.config, context, this.isDummy);
 
       if (plugin.object.hooks) {
         _.forEach(plugin.object.hooks, function (fn, event) {
@@ -173,9 +174,8 @@ module.exports = function PluginsManager (kuzzle) {
    * Inject plugin controllers within funnel Controller
    */
   this.injectControllers = function () {
-    var context = new PluginContext();
     _.forEach(this.controllers, function (controller, name) {
-      kuzzle.funnel[name] = controller(context);
+      kuzzle.funnel[name] = controller();
     });
   };
 };


### PR DESCRIPTION
+ add a lazy-loading repositories() getter (useful for authentication plugins, and probably other kinds of plugins in a future)

See also this PR on plugin-logger : https://github.com/kuzzleio/kuzzle-plugin-logger/pull/2
