### PR TITLE
add pre and postversion to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "crawl-coverage": "node coverage/scripts/feature-coverage-download.js",
     "codecov": "cat ./coverage/lcov.info | ./node_modules/.bin/codecov",
     "enable": "node bin/kuzzle enable",
-    "disable": "node bin/kuzzle disable"
+    "disable": "node bin/kuzzle disable",
+    "preversion": "git checkout master && git pull",
+    "postversion": "git push && git push --tags"    
   },
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
Allow to use npm to change version number and version tag in git.

# Process 

When a PR is merged on master, simply type the following in the kuzzle root directory in a console : 

```bash
npm version minor -m 'tag version %s'
```

Please refer to https://docs.npmjs.com/cli/version to understand how npm version works