### PR TITLE
configured retries on plugin installation

### DIFF
--- a/lib/api/core/pluginsManager.js
+++ b/lib/api/core/pluginsManager.js
@@ -67,7 +67,7 @@ module.exports = function PluginsManager (kuzzle) {
      */
     updateInProgress = fs.existsSync('./node_modules.lock');
 
-    lockfile.lock('./node_modules', {retries: 1000}, (err, release) => {
+    lockfile.lock('./node_modules', {retries: 1000, minTimeout: 200, maxTimeout: 1000}, (err, release) => {
       if (err) {
         return deferred.reject(err);
       }


### PR DESCRIPTION
This is a minor update concerning retries, when the plugin manager attempts to acquire the mutex to install plugins. Now these retries have a maximum timeout of 1 second.

**Explanation:**

Before this update, there were up to 1000 retries, with no maximum timeouts between retries, and an exponential backoff strategy. 
This means that, if one instance takes some time to install plugins, other instances will probably be waiting several seconds more before retrying to acquire the lock.

This has the following effects:
* sometimes, other instances won't be up until up to a couple seconds after the 1st instance is ready, maybe more
* this made some travis build fail if the server instance is the first to be up, as functional tests start as soon as the server is reachable, meaning that functional tests are launched without workers ready.

