### PR TITLE
Fixed statistics TTL

### DIFF
--- a/lib/api/core/statistics.js
+++ b/lib/api/core/statistics.js
@@ -6,7 +6,7 @@ var
 
 module.exports = function (kuzzle) {
   this.kuzzle = kuzzle;
-  this.ttl = kuzzle.config.stats.ttl * 1000;
+  this.ttl = kuzzle.config.stats.ttl;
   this.interval = kuzzle.config.stats.statsInterval * 1000;
   this.lastFrame = null;
 


### PR DESCRIPTION
Statistics TTL was multiplied by 1000 to convert it to milliseconds... but Redis API TTL is in seconds.
So we were saving 1000 times too many stats frames.