### PR TITLE
Action GET on /myIndex/myCollection/_search

### DIFF
--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -358,6 +358,18 @@ function executeFromRest(params, request, response) {
   response.setHeader('Access-Control-Allow-Origin', '*');
   response.setHeader('Access-Control-Allow-Headers', 'X-Requested-With');
 
+  // Just in case the user make a GET on url /mainindex/test/_search
+  // Without this test we return something weird: a result.hits.hits with all document without filter
+  if (data.controller === 'read' && data.action === 'get') {
+    if (['_search', '_bulk', '_count', '_create', '_query', '_truncate'].indexOf(data._id) !== -1) {
+      errorObject = new BadRequestError('The action ' + requestObject.data._id + ' can\'t be done with a GET');
+      response.writeHead(errorObject.status, {'Content-Type': 'application/json'});
+      response.end(stringify(errorObject.toJson()));
+
+      return false;
+    }
+  }
+
   this.repositories.user.loadFromToken(getBearerTokenFromHeaders(request.headers))
     .then(function (user) {
       context.user = user;

--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -362,10 +362,9 @@ function executeFromRest(params, request, response) {
   // Without this test we return something weird: a result.hits.hits with all document without filter because the body is empty in REST by default
   if (data.controller === 'read' && data.action === 'get') {
     if (['_search', '_bulk', '_count', '_create', '_query', '_truncate'].indexOf(data._id) !== -1) {
-      errorObject = new ResponseObject(requestObject, new BadRequestError('The action ' + requestObject.data._id + ' can\'t be done with a GET'));
+      errorObject = new ResponseObject({}, new BadRequestError('The action ' + requestObject.data._id + ' can\'t be done with a GET'));
       response.writeHead(errorObject.status, {'Content-Type': 'application/json'});
       response.end(stringify(errorObject.toJson()));
-
       return false;
     }
   }

--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -358,17 +358,6 @@ function executeFromRest(params, request, response) {
   response.setHeader('Access-Control-Allow-Origin', '*');
   response.setHeader('Access-Control-Allow-Headers', 'X-Requested-With');
 
-  // Just in case the user make a GET on url /mainindex/test/_search
-  // Without this test we return something weird: a result.hits.hits with all document without filter because the body is empty in REST by default
-  if (data.controller === 'read' && data.action === 'get') {
-    if (['_search', '_bulk', '_count', '_create', '_query', '_truncate'].indexOf(data._id) !== -1) {
-      errorObject = new ResponseObject({}, new BadRequestError('The action ' + requestObject.data._id + ' can\'t be done with a GET'));
-      response.writeHead(errorObject.status, {'Content-Type': 'application/json'});
-      response.end(stringify(errorObject.toJson()));
-      return false;
-    }
-  }
-
   this.repositories.user.loadFromToken(getBearerTokenFromHeaders(request.headers))
     .then(function (user) {
       context.user = user;

--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -359,10 +359,10 @@ function executeFromRest(params, request, response) {
   response.setHeader('Access-Control-Allow-Headers', 'X-Requested-With');
 
   // Just in case the user make a GET on url /mainindex/test/_search
-  // Without this test we return something weird: a result.hits.hits with all document without filter
+  // Without this test we return something weird: a result.hits.hits with all document without filter because the body is empty in REST by default
   if (data.controller === 'read' && data.action === 'get') {
     if (['_search', '_bulk', '_count', '_create', '_query', '_truncate'].indexOf(data._id) !== -1) {
-      errorObject = new BadRequestError('The action ' + requestObject.data._id + ' can\'t be done with a GET');
+      errorObject = new ResponseObject(requestObject, new BadRequestError('The action ' + requestObject.data._id + ' can\'t be done with a GET'));
       response.writeHead(errorObject.status, {'Content-Type': 'application/json'});
       response.end(stringify(errorObject.toJson()));
 

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -105,6 +105,12 @@ module.exports = function (kuzzle, options) {
 
     delete data.body;
 
+    // Just in case the user make a GET on url /mainindex/test/_search
+    // Without this test we return something weird: a result.hits.hits with all document without filter because the body is empty in REST by default
+    if (data.id === '_search') {
+      return q.reject(new BadRequestError('The action _search can\'t be done with a GET'));
+    }
+
     this.client.get(data)
       .then(function (result) {
         deferred.resolve(new ResponseObject(requestObject, result));

--- a/test/api/controllers/routerController/executeFromRest.test.js
+++ b/test/api/controllers/routerController/executeFromRest.test.js
@@ -91,10 +91,11 @@ describe('Test: routerController.executeFromRest', function () {
   it('should reject requests when the content-type is not application/json', function () {
     var
       params = { action: 'create', controller: 'write' },
-      data = {_body: true, headers: {'content-type': '"application/x-www-form-urlencoded'}, body: {resolve: true}, params: {collection: 'foobar', index: '%test'}};
+      data = {_body: true, headers: {'content-type': 'application/x-www-form-urlencoded'}, body: {resolve: true}, params: {collection: 'foobar', index: '%test'}};
 
     mockupResponse.init();
     executeFromRest.call(kuzzle, params, data, mockupResponse);
+
     should(mockupResponse.statusCode).be.exactly(400);
     should(mockupResponse.header['Content-Type']).not.be.undefined();
     should(mockupResponse.header['Content-Type']).be.exactly('application/json');
@@ -103,6 +104,24 @@ describe('Test: routerController.executeFromRest', function () {
     should(mockupResponse.response.error).not.be.null();
     should(mockupResponse.response.error.message).not.be.null();
     should(mockupResponse.response.error.message).startWith('Invalid request content-type');
+  });
+
+  it('should reject requests when a GET is done on _search', function () {
+    var
+      params = { action: 'get', controller: 'read', id: '_search' },
+      data = {_body: true, headers: {'content-type': 'application/json'}, body: {resolve: true}, params: {collection: 'foobar', index: '%test', id: '_search'}};
+
+    mockupResponse.init();
+    executeFromRest.call(kuzzle, params, data, mockupResponse);
+
+    should(mockupResponse.statusCode).be.exactly(400);
+    should(mockupResponse.header['Content-Type']).not.be.undefined();
+    should(mockupResponse.header['Content-Type']).be.exactly('application/json');
+    should(mockupResponse.response.result).be.null();
+    should(mockupResponse.response.status).be.exactly(400);
+    should(mockupResponse.response.error).not.be.null();
+    should(mockupResponse.response.error.message).not.be.null();
+    should(mockupResponse.response.error.message).startWith('The action _search can\'t be done with a GET');
   });
 
   it('should respond with a HTTP 200 message in case of success', function (done) {

--- a/test/api/controllers/routerController/executeFromRest.test.js
+++ b/test/api/controllers/routerController/executeFromRest.test.js
@@ -106,24 +106,6 @@ describe('Test: routerController.executeFromRest', function () {
     should(mockupResponse.response.error.message).startWith('Invalid request content-type');
   });
 
-  it('should reject requests when a GET is done on _search', function () {
-    var
-      params = { action: 'get', controller: 'read', id: '_search' },
-      data = {_body: true, headers: {'content-type': 'application/json'}, body: {resolve: true}, params: {collection: 'foobar', index: '%test', id: '_search'}};
-
-    mockupResponse.init();
-    executeFromRest.call(kuzzle, params, data, mockupResponse);
-
-    should(mockupResponse.statusCode).be.exactly(400);
-    should(mockupResponse.header['Content-Type']).not.be.undefined();
-    should(mockupResponse.header['Content-Type']).be.exactly('application/json');
-    should(mockupResponse.response.result).be.null();
-    should(mockupResponse.response.status).be.exactly(400);
-    should(mockupResponse.response.error).not.be.null();
-    should(mockupResponse.response.error.message).not.be.null();
-    should(mockupResponse.response.error.message).startWith('The action _search can\'t be done with a GET');
-  });
-
   it('should respond with a HTTP 200 message in case of success', function (done) {
     var
       params = { action: 'create', controller: 'write' },

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -4,6 +4,7 @@ var
   params = require('rc')('kuzzle'),
   Config = require.main.require('lib/config'),
   RequestObject = require.main.require('lib/api/core/models/requestObject'),
+  BadRequestError = require.main.require('lib/api/core/errors/badRequestError.js'),
   ES = rewire('../../../lib/services/elasticsearch');
 
 
@@ -235,6 +236,17 @@ describe('Test: ElasticSearch service', function () {
           done();
         })
         .catch(error => done(error));
+    });
+
+    it('should reject requests when the user search for a document with id _search', function () {
+      elasticsearch.client.get = function (data) {
+        should(data.id).be.exactly(createdDocumentId);
+
+        return Promise.resolve({});
+      };
+
+      requestObject.data._id = '_search';
+      return should(elasticsearch.get(requestObject)).be.rejectedWith(BadRequestError);
     });
   });
 


### PR DESCRIPTION
In case the user make a GET on url `/myIndex/myCollection/_search` or `/myIndex/myCollection/_bulk`, et, now we return a error.

Before that, on GET on url `/myIndex/myCollection/_search`  the response was something like

```
result: {
   hits: {
      hits: [ ... ],
      ...
   }
}
```

It's just an optional security
