### PR TITLE
changed all ES6 Promises to Q

### DIFF
--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -46,7 +46,7 @@ module.exports = function SecurityController (kuzzle) {
           delete role.closures;
         }
 
-        return Promise.resolve(new ResponseObject(requestObject, role || {}));
+        return q(new ResponseObject(requestObject, role || {}));
       });
   };
 
@@ -66,7 +66,7 @@ module.exports = function SecurityController (kuzzle) {
           });
         }
 
-        return Promise.resolve(response);
+        return q(response);
       });
   };
 
@@ -82,7 +82,7 @@ module.exports = function SecurityController (kuzzle) {
       kuzzle.repositories.role.getRoleFromRequestObject(requestObject)
       )
       .then(result => {
-        return Promise.resolve(new ResponseObject(requestObject, result));
+        return q(new ResponseObject(requestObject, result));
       });
   };
 

--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -257,16 +257,13 @@ module.exports = function HotelClerk (kuzzle) {
    */
   this.join = function (requestObject, context) {
     var
-      deferred = q.defer(),
       roomId = requestObject.data.body.roomId;
 
     if (!this.rooms[roomId]) {
-      return Promise.reject(new InternalError('No room found for id ' + roomId));
+      return q.reject(new InternalError('No room found for id ' + roomId));
     }
 
-    deferred.resolve(subscribeToRoom.call(this, roomId, requestObject, context));
-
-    return deferred.promise;
+    return q(subscribeToRoom.call(this, roomId, requestObject, context));
   };
 
   /**

--- a/lib/api/core/models/repositories/profileRepository.js
+++ b/lib/api/core/models/repositories/profileRepository.js
@@ -75,7 +75,7 @@ module.exports = function (kuzzle) {
     var profile = new Profile();
 
     if (!requestObject.data._id) {
-      return Promise.reject(new BadRequestError('Missing profile id'));
+      return q.reject(new BadRequestError('Missing profile id'));
     }
 
     profile._id = requestObject.data._id;
@@ -86,7 +86,7 @@ module.exports = function (kuzzle) {
       profile.roles = requestObject.data.body.roles;
     }
 
-    return Promise.resolve(profile);
+    return q(profile);
   };
 
   /**
@@ -149,7 +149,7 @@ module.exports = function (kuzzle) {
    */
   ProfileRepository.prototype.deleteProfile = function (profile) {
     if (!profile._id) {
-      return Promise.reject(new BadRequestError('Missing profile id'));
+      return q.reject(new BadRequestError('Missing profile id'));
     }
 
     return this.deleteFromDatabase(profile._id)
@@ -158,7 +158,7 @@ module.exports = function (kuzzle) {
           delete this.profiles[profile._id];
         }
 
-        return Promise.resolve(response);
+        return response;
       });
   };
 
@@ -197,7 +197,7 @@ module.exports = function (kuzzle) {
     };
 
     if (!profile._id) {
-      return Promise.reject(new BadRequestError('Missing profile id'));
+      return q.reject(new BadRequestError('Missing profile id'));
     }
 
     return profile.validateDefinition(context)
@@ -206,7 +206,7 @@ module.exports = function (kuzzle) {
         return this.persistToDatabase(profile);
       })
       .catch(error => {
-        return Promise.reject(error);
+        return q.reject(error);
       });
   };
 

--- a/lib/api/core/models/repositories/roleRepository.js
+++ b/lib/api/core/models/repositories/roleRepository.js
@@ -178,7 +178,7 @@ module.exports = function (kuzzle) {
     };
 
     if (!role._id) {
-      return Promise.reject(new BadRequestError('Missing role id'));
+      return q.reject(new BadRequestError('Missing role id'));
     }
 
     return role.validateDefinition(context)
@@ -195,7 +195,7 @@ module.exports = function (kuzzle) {
    */
   RoleRepository.prototype.deleteRole = function (role) {
     if (!role._id) {
-      return Promise.reject(new BadRequestError('Missing role id'));
+      return q.reject(new BadRequestError('Missing role id'));
     }
 
     return this.deleteFromDatabase(role._id)
@@ -204,7 +204,7 @@ module.exports = function (kuzzle) {
           delete this.roles[role._id];
         }
 
-        return Promise.resolve(response);
+        return response;
       });
   };
 

--- a/lib/api/core/models/repositories/userRepository.js
+++ b/lib/api/core/models/repositories/userRepository.js
@@ -173,15 +173,13 @@ module.exports = function (kuzzle) {
   };
 
   UserRepository.prototype.hydrate = function (user, data) {
-    var
-      deferred = q.defer(),
-      result;
+    var result;
 
     if (!_.isObject(data)) {
-      return Promise.resolve(user);
+      return q(user);
     }
 
-    Repository.prototype.hydrate(user, data)
+    return Repository.prototype.hydrate(user, data)
       .then(u => {
         result = u;
 
@@ -189,7 +187,7 @@ module.exports = function (kuzzle) {
           return this.anonymous()
             .then(anonymousUser => {
               result = anonymousUser;
-              return Promise.resolve(anonymousUser.profile);
+              return anonymousUser.profile;
             });
         }
 
@@ -197,13 +195,8 @@ module.exports = function (kuzzle) {
       })
       .then(function (profile) {
         result.profile = profile;
-        deferred.resolve(result);
-      })
-      .catch(function (error) {
-        deferred.reject(error);
+        return result;
       });
-
-    return deferred.promise;
   };
 
   UserRepository.prototype.serializeToCache = function (user) {

--- a/lib/api/core/models/security/profile.js
+++ b/lib/api/core/models/security/profile.js
@@ -1,5 +1,6 @@
 var
   BadRequestError = require('../../errors/badRequestError'),
+  q = require('q'),
   _ = require('lodash');
 
 function Profile () {
@@ -16,29 +17,25 @@ function Profile () {
  * @return {boolean}
  */
 Profile.prototype.isActionAllowed = function (requestObject, context, indexes) {
-  var result = false;
-
   if (this.roles === undefined || this.roles.length === 0) {
     return false;
   }
 
-  result = this.roles.some(function (role) {
+  return this.roles.some(function (role) {
     return role.isActionAllowed(requestObject, context, indexes);
   });
-
-  return result;
 };
 
 Profile.prototype.validateDefinition = function () {
   if (!_.isArray(this.roles)) {
-    return Promise.reject(new BadRequestError('The roles member must be an array'));
+    return q.reject(new BadRequestError('The roles member must be an array'));
   }
 
   if (_.isEmpty(this.roles)) {
-    return Promise.reject(new BadRequestError('The roles member array cannot be empty'));
+    return q.reject(new BadRequestError('The roles member array cannot be empty'));
   }
 
-  return Promise.resolve(true);
+  return q(true);
 };
 
 module.exports = Profile;

--- a/lib/api/core/models/security/role.js
+++ b/lib/api/core/models/security/role.js
@@ -285,13 +285,13 @@ Role.prototype.validateDefinition = function (context) {
                 var error;
 
                 if (result.result !== undefined && _.isBoolean(result.result)) {
-                  return Promise.resolve(result.result);
+                  return q(result.result);
                 }
 
                 error = new BadRequestError('Invalid definition for '+ [indexKey, collectionKey, controllerKey, actionKey] + '. Error executing function');
                 error.detail = result.err;
 
-                return Promise.reject(error);
+                return q.reject(error);
               });
             })());
           }

--- a/lib/api/core/sandbox/index.js
+++ b/lib/api/core/sandbox/index.js
@@ -29,7 +29,7 @@ function Sandbox (options) {
  */
 Sandbox.prototype.run = function (data) {
   if (this.child !== null && this.child.connected) {
-    return Promise.reject(new InternalError('A process is already running for this sandbox'));
+    return q.reject(new InternalError('A process is already running for this sandbox'));
   }
 
   return (() => {
@@ -55,7 +55,7 @@ Sandbox.prototype.run = function (data) {
       return deferred.promise;
     }
 
-    return Promise.resolve(execArgv);
+    return q(execArgv);
   })()
     .then(execArgv => {
       var
@@ -84,7 +84,7 @@ Sandbox.prototype.run = function (data) {
 
       }
       catch (e) {
-        return Promise.reject(e);
+        return q.reject(e);
       }
 
       return deferred.promise;

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -384,16 +384,15 @@ module.exports = function (kuzzle, options) {
    */
   this.truncateCollection = function (requestObject) {
     var
-      deferred = q.defer(),
       mappings,
       data = cleanData.call(this, requestObject);
 
     delete data.body;
 
-    this.client.indices.getMapping(data)
+    return this.client.indices.getMapping(data)
       .then(mapping => {
         if (!mapping[data.index]) {
-          return Promise.reject(new NotFoundError('The collection "' + data.type + '" in index "' + data.index + '" does not exist'));
+          return q.reject(new NotFoundError('The collection "' + data.type + '" in index "' + data.index + '" does not exist'));
         }
 
         mappings = mapping[data.index].mappings[data.type];
@@ -406,11 +405,8 @@ module.exports = function (kuzzle, options) {
         return this.client.indices.putMapping(data);
       })
       .then(result => {
-        deferred.resolve(new ResponseObject(requestObject, result));
-      })
-      .catch(error => deferred.reject(error));
-
-    return deferred.promise;
+        return new ResponseObject(requestObject, result);
+      });
   };
 
   /**
@@ -493,7 +489,7 @@ module.exports = function (kuzzle, options) {
       return deferred.promise;
     }
 
-    return Promise.reject(new BadRequestError('Bulk import: Parse error: document <body> is missing'));
+    return q.reject(new BadRequestError('Bulk import: Parse error: document <body> is missing'));
   };
 
   /**
@@ -581,26 +577,18 @@ module.exports = function (kuzzle, options) {
    * @return {Promise}
    */
   this.deleteIndexes = function (requestObject) {
-    var
-      deferred = q.defer();
-
     delete requestObject.data.body;
 
-    this.listIndexes(requestObject)
+    return this.listIndexes(requestObject)
       .then(result => {
-        if (result.data.body.indexes.length === 0) {
-          return Promise.resolve();
+        if (result.data.body.indexes.length !== 0) {
+          return this.client.indices.delete({index: result.data.body.indexes});
         }
-
-        return this.client.indices.delete({index: result.data.body.indexes});
       })
       .then(() => {
         indexCache.reset.call(kuzzle);
-        deferred.resolve(new ResponseObject(requestObject, {}));
-      })
-      .catch(error => deferred.reject(error));
-
-    return deferred.promise;
+        return new ResponseObject(requestObject, {});
+      });
   };
 
   this.listIndexes = function (requestObject) {

--- a/lib/services/rabbit.js
+++ b/lib/services/rabbit.js
@@ -43,7 +43,7 @@ module.exports = function (kuzzle) {
       self = this;
 
     if (toggle === self.enabled) {
-      return Promise.reject(new InternalError('RabbitMQ service is already ' + (toggle ? 'enabled' : 'disabled')));
+      return q.reject(new InternalError('RabbitMQ service is already ' + (toggle ? 'enabled' : 'disabled')));
     }
 
     deferred = q.defer();

--- a/lib/workers/index.js
+++ b/lib/workers/index.js
@@ -31,6 +31,6 @@ function loadWorker(worker) {
   catch (error) {
     this.kuzzle.pluginsManager.trigger('log:error', 'Worker Loader: unable to load worker', worker, ': ', error.message);
     this.kuzzle.pluginsManager.trigger('log:info', 'Resuming loading workers...');
-    return Promise.reject(error);
+    return q.reject(error);
   }
 }

--- a/test/api/controllers/adminController.test.js
+++ b/test/api/controllers/adminController.test.js
@@ -1,5 +1,6 @@
 var
   should = require('should'),
+  q = require('q'),
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
   RequestObject = require.main.require('lib/api/core/models/requestObject'),
@@ -15,7 +16,7 @@ describe('Test: admin controller', function () {
     kuzzle.start(params, {dummy: true})
       .then(function () {
         kuzzle.repositories.role.validateAndSaveRole = role => {
-          return Promise.resolve({
+          return q({
             _index: '%kuzzle',
             _type: 'roles',
             _id: role._id,

--- a/test/api/controllers/funnelController/execute.test.js
+++ b/test/api/controllers/funnelController/execute.test.js
@@ -1,5 +1,6 @@
 var
   should = require('should'),
+  q = require('q'),
   RequestObject = require.main.require('lib/api/core/models/requestObject'),
   UnauthorizedError = require.main.require('lib/api/core/errors/unauthorizedError'),
   params = require('rc')('kuzzle'),
@@ -140,7 +141,7 @@ describe('Test execute function in funnel controller', function () {
     var
       pluginController = {
         bar: function(requestObject){
-          return Promise.resolve();
+          return q();
         }
       },
       FooController = function(context) {

--- a/test/api/controllers/readController.test.js
+++ b/test/api/controllers/readController.test.js
@@ -21,11 +21,11 @@ before(function (done) {
   kuzzle.start(params, {dummy: true})
     .then(function () {
       kuzzle.services.list.readEngine = {
-        search: function(requestObject) { return Promise.resolve(new ResponseObject(requestObject, {})); },
-        get: function(requestObject) { return Promise.resolve(new ResponseObject(requestObject, {})); },
-        count: function(requestObject) { return Promise.resolve(new ResponseObject(requestObject, {})); },
-        listCollections: function(requestObject) { return Promise.resolve(new ResponseObject(requestObject, {})); },
-        listIndexes: function(requestObject) { return Promise.resolve(new ResponseObject(requestObject, {})); },
+        search: function(requestObject) { return q(new ResponseObject(requestObject, {})); },
+        get: function(requestObject) { return q(new ResponseObject(requestObject, {})); },
+        count: function(requestObject) { return q(new ResponseObject(requestObject, {})); },
+        listCollections: function(requestObject) { return q(new ResponseObject(requestObject, {})); },
+        listIndexes: function(requestObject) { return q(new ResponseObject(requestObject, {})); },
       };
 
       Object.keys(kuzzle.services.list).forEach(service => {

--- a/test/api/controllers/securityController/profiles.test.js
+++ b/test/api/controllers/securityController/profiles.test.js
@@ -1,5 +1,6 @@
 var
   should = require('should'),
+  q = require('q'),
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
   BadRequestError = require.main.require('lib/api/core/errors/badRequestError'),
@@ -17,7 +18,7 @@ describe('Test: security controller - profiles', function () {
         // Mock
         kuzzle.repositories.role.roles.role1 = { _id: 'role1' };
         kuzzle.repositories.profile.validateAndSaveProfile = profile => {
-          return Promise.resolve({
+          return q({
             _index: '%kuzzle',
             _type: 'profiles',
             _id: profile._id,
@@ -25,7 +26,7 @@ describe('Test: security controller - profiles', function () {
           });
         };
         kuzzle.repositories.profile.loadProfile = id => {
-          return Promise.resolve({
+          return q({
             _index: '%kuzzle',
             _type: 'profiles',
             _id: id,
@@ -33,7 +34,7 @@ describe('Test: security controller - profiles', function () {
           });
         };
         kuzzle.repositories.profile.searchProfiles = requestObject => {
-          return Promise.resolve(new ResponseObject(requestObject, {
+          return q(new ResponseObject(requestObject, {
             hits: [{
               _id: 'test',
               roles: [
@@ -47,7 +48,7 @@ describe('Test: security controller - profiles', function () {
           }));
         };
         kuzzle.repositories.profile.deleteProfile = requestObject => {
-          return Promise.resolve(new ResponseObject(requestObject, {_id: 'test'}));
+          return q(new ResponseObject(requestObject, {_id: 'test'}));
         };
 
         done();

--- a/test/api/controllers/securityController/roles.test.js
+++ b/test/api/controllers/securityController/roles.test.js
@@ -1,5 +1,6 @@
 var
   should = require('should'),
+  q = require('q'),
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
   RequestObject = require.main.require('lib/api/core/models/requestObject'),
@@ -15,7 +16,7 @@ describe('Test: security controller - roles', function () {
       .then(function () {
         // Mock
         kuzzle.repositories.role.validateAndSaveRole = role => {
-          return Promise.resolve({
+          return q({
             _index: '%kuzzle',
             _type: 'roles',
             _id: role._id,
@@ -23,7 +24,7 @@ describe('Test: security controller - roles', function () {
           });
         };
         kuzzle.repositories.role.loadOneFromDatabase = id => {
-          return Promise.resolve({
+          return q({
             _index: '%kuzzle',
             _type: 'roles',
             _id: id,
@@ -31,13 +32,13 @@ describe('Test: security controller - roles', function () {
           });
         };
         kuzzle.services.list.readEngine.search = requestObject => {
-          return Promise.resolve(new ResponseObject(requestObject, {
+          return q(new ResponseObject(requestObject, {
             hits: [{_id: 'test'}],
             total: 1
           }));
         };
         kuzzle.repositories.role.deleteFromDatabase = requestObject => {
-          return Promise.resolve(new ResponseObject(requestObject, {_id: 'test'}));
+          return q(new ResponseObject(requestObject, {_id: 'test'}));
         };
 
         done();

--- a/test/api/controllers/writeController.test.js
+++ b/test/api/controllers/writeController.test.js
@@ -1,5 +1,6 @@
 var
   should = require('should'),
+  q = require('q'),
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
   RequestObject = require.main.require('lib/api/core/models/requestObject');
@@ -65,7 +66,7 @@ describe('Test: write controller', function () {
       this.timeout(50);
 
       kuzzle.dsl.testFilters = function () {
-        return Promise.resolve(mockupRooms);
+        return q(mockupRooms);
       };
 
       kuzzle.notifier.notify = function (rooms) {
@@ -86,7 +87,7 @@ describe('Test: write controller', function () {
 
     it('should return a rejected promise if publishing fails', function () {
       var requestObject = new RequestObject({body: {foo: 'bar'}}, {}, 'unit-test');
-      kuzzle.notifier.publish = function () { return Promise.reject(new Error('error')); };
+      kuzzle.notifier.publish = function () { return q.reject(new Error('error')); };
       return should(kuzzle.funnel.write.publish(requestObject)).be.rejectedWith(Error);
     });
   });

--- a/test/api/core/hotelClerck/addSubscription.test.js
+++ b/test/api/core/hotelClerck/addSubscription.test.js
@@ -1,5 +1,6 @@
 var
   should = require('should'),
+  q = require('q'),
   RequestObject = require.main.require('lib/api/core/models/requestObject'),
   InternalError = require.main.require('lib/api/core/errors/internalError'),
   BadRequestError = require.main.require('lib/api/core/errors/badRequestError'),
@@ -264,7 +265,7 @@ describe('Test: hotelClerk.addSubscription', function () {
         should(result).be.an.instanceOf(RealTimeResponseObject);
         should(result).have.property('roomId');
 
-        return Promise.resolve(result.roomId);
+        return q(result.roomId);
       })
       .then(id => {
         var requestObject2 = new RequestObject({

--- a/test/api/core/models/repositories/profileRepository.test.js
+++ b/test/api/core/models/repositories/profileRepository.test.js
@@ -1,5 +1,6 @@
 var
   params = require('rc')('kuzzle'),
+  q = require('q'),
   should = require('should'),
   Role = require.main.require('lib/api/core/models/security/role'),
   Profile = require.main.require('lib/api/core/models/security/profile'),
@@ -31,25 +32,25 @@ describe('Test: repositories/profileRepository', function () {
       var err;
 
       if (requestObject.data._id === 'testprofile') {
-        return Promise.resolve(new ResponseObject(requestObject, testProfilePlain));
+        return q(new ResponseObject(requestObject, testProfilePlain));
       }
       if (requestObject.data._id === 'errorprofile') {
-        return Promise.resolve(new ResponseObject(requestObject, errorProfilePlain));
+        return q(new ResponseObject(requestObject, errorProfilePlain));
       }
 
       err = new NotFoundError('Not found');
       err.found = false;
       err._id = requestObject.data._id;
-      return Promise.resolve(err);
+      return q(err);
     }
   };
   mockRoleRepository = {
     loadRoles: function (keys) {
       if (keys.length === 1 && keys[0] === 'error') {
-        return Promise.reject(new InternalError('Error'));
+        return q.reject(new InternalError('Error'));
       }
 
-      return Promise.resolve(keys.map(function (key) {
+      return q(keys.map(function (key) {
         var role = new Role();
         role._id = key;
         return role;
@@ -111,7 +112,7 @@ describe('Test: repositories/profileRepository', function () {
 
     it('should reject the promise in case of error', done => {
       profileRepository.loadOneFromDatabase = () => {
-        return Promise.reject(new InternalError('Error'));
+        return q.reject(new InternalError('Error'));
       };
 
       should(profileRepository.loadProfile('id')).be.rejectedWith(InternalError);
@@ -215,7 +216,7 @@ describe('Test: repositories/profileRepository', function () {
 
     it('should return a ResponseObject after deleting', () => {
       profileRepository.deleteFromDatabase = id => {
-        return Promise.resolve(new ResponseObject({
+        return q(new ResponseObject({
           body: {
             _id: id
           }
@@ -251,7 +252,7 @@ describe('Test: repositories/profileRepository', function () {
   describe('#searchProfiles', () => {
     it('should return a ResponseObject containing an array of profiles', (done) => {
       profileRepository.search = () => {
-        return Promise.resolve(new ResponseObject({}, {
+        return q(new ResponseObject({}, {
           hits: [{_id: 'test'}],
           total: 1
         }));
@@ -274,7 +275,7 @@ describe('Test: repositories/profileRepository', function () {
 
     it('should properly format the roles filter', (done) => {
       profileRepository.search = (filter) => {
-        return Promise.resolve(new ResponseObject({}, {
+        return q(new ResponseObject({}, {
           hits: [{_id: 'test'}],
           total: 1,
           filter: filter
@@ -313,7 +314,7 @@ describe('Test: repositories/profileRepository', function () {
 
     it('should properly persist the profile', () => {
       profileRepository.persistToDatabase = (profile) => {
-        return Promise.resolve(new ResponseObject({}, {
+        return q(new ResponseObject({}, {
           body: {
             _id: profile._id
           }

--- a/test/api/core/models/repositories/repository.test.js
+++ b/test/api/core/models/repositories/repository.test.js
@@ -35,19 +35,19 @@ describe('Test: repositories/repository', function () {
   mockCacheEngine = {
     get: function (key) {
       if (key === repository.index + '/' + repository.collection + '/persisted') {
-        return Promise.resolve(JSON.stringify(persistedObject));
+        return q(JSON.stringify(persistedObject));
       }
       if (key === repository.index + '/' + repository.collection + '/cached') {
-        return Promise.resolve(JSON.stringify(cachedObject));
+        return q(JSON.stringify(cachedObject));
       }
       if (key === repository.index + '/' + repository.collection + '/error') {
-        return Promise.reject(new InternalError('Error'));
+        return q.reject(new InternalError('Error'));
       }
       if (key === repository.index + '/' + repository.collection + '/string') {
-        return Promise.resolve('a string');
+        return q('a string');
       }
 
-      return Promise.resolve(null);
+      return q(null);
     },
     set: (key, value) => { forwardedObject = {op: 'set', key: key, value: JSON.parse(value)}; },
     volatileSet: (key, value, ttl) => { forwardedObject = {op: 'volatileSet', key: key, value: JSON.parse(value), ttl: ttl }; },
@@ -61,22 +61,22 @@ describe('Test: repositories/repository', function () {
         forwardedObject = requestObject;
       }
       if (requestObject.data._id === 'persisted') {
-        return Promise.resolve(new ResponseObject(requestObject, persistedObject));
+        return q(new ResponseObject(requestObject, persistedObject));
       }
       if (requestObject.data._id === 'uncached') {
-        return Promise.resolve(new ResponseObject(requestObject, uncachedObject));
+        return q(new ResponseObject(requestObject, uncachedObject));
       }
       if (requestObject.data._id === 'cached') {
-        return Promise.resolve(new ResponseObject(requestObject, uncachedObject));
+        return q(new ResponseObject(requestObject, uncachedObject));
       }
       if (requestObject.data._id === 'error') {
-        return Promise.reject(new InternalError('Error'));
+        return q.reject(new InternalError('Error'));
       }
 
       err = new NotFoundError('Not found');
       err.found = false;
       err._id = requestObject.data._id;
-      return Promise.resolve(err);
+      return q(err);
     },
     mget: function (requestObject) {
       var
@@ -108,11 +108,11 @@ describe('Test: repositories/repository', function () {
             return response;
           })});
 
-          return Promise.resolve(result);
+          return q(result);
         });
     },
     search: function (requestObject) {
-      return Promise.resolve(new ResponseObject(requestObject, {hits: [{_id: 'role'}]}));
+      return q(new ResponseObject(requestObject, {hits: [{_id: 'role'}]}));
     }
   };
   mockWriteEngine = {

--- a/test/api/core/models/repositories/roleRepository.test.js
+++ b/test/api/core/models/repositories/roleRepository.test.js
@@ -51,16 +51,16 @@ describe('Test: repositories/roleRepository', function () {
       var err;
 
       if (requestObject.data._id === 'persisted1') {
-        return Promise.resolve(new ResponseObject(requestObject, persistedObject1));
+        return q(new ResponseObject(requestObject, persistedObject1));
       }
       if (requestObject.data._id === 'persisted2') {
-        return Promise.resolve(new ResponseObject(requestObject, persistedObject2));
+        return q(new ResponseObject(requestObject, persistedObject2));
       }
 
       err = new NotFoundError('Not found');
       err.found = false;
       err._id = requestObject.data._id;
-      return Promise.resolve(err);
+      return q(err);
     },
     mget: function (requestObject) {
       var
@@ -77,14 +77,14 @@ describe('Test: repositories/roleRepository', function () {
           results.push({_id: id, found: false});
         }
       });
-      return Promise.resolve(new ResponseObject(requestObject, {docs: results}));
+      return q(new ResponseObject(requestObject, {docs: results}));
     }
   };
 
   mockWriteEngine = {
     createOrUpdate: function (requestObject) {
       forwardedObject = requestObject;
-      return Promise.resolve(new ResponseObject(requestObject, {}));
+      return q(new ResponseObject(requestObject, {}));
     }
   };
 
@@ -115,12 +115,12 @@ describe('Test: repositories/roleRepository', function () {
       var result;
 
       roleRepository.loadMultiFromDatabase = () => {
-        return Promise.reject(new InternalError('Error'));
+        return q.reject(new InternalError('Error'));
       };
       result = roleRepository.loadRoles([-999, -998])
         .catch(error => {
           delete roleRepository.loadMultiFromDatabase;
-          return Promise.reject(error);
+          return q.reject(error);
         });
 
       return should(result).be.rejectedWith(InternalError);
@@ -130,13 +130,13 @@ describe('Test: repositories/roleRepository', function () {
       var result;
 
       roleRepository.hydrate = () => {
-        return Promise.reject(new InternalError('Error'));
+        return q.reject(new InternalError('Error'));
       };
 
       result = roleRepository.loadRoles(['guest'])
         .catch(error => {
           delete roleRepository.hydrate;
-          return Promise.reject(error);
+          return q.reject(error);
         });
 
       return should(result).be.rejectedWith(InternalError);
@@ -200,7 +200,7 @@ describe('Test: repositories/roleRepository', function () {
       roleRepository.roles = {roleId : {myRole : {}}};
       RoleRepository.prototype.loadOneFromDatabase = () => {
         isLoadFromDB = true;
-        return Promise.resolve();
+        return q();
       };
 
       return roleRepository.loadRole({_id: 'roleId'})
@@ -216,7 +216,7 @@ describe('Test: repositories/roleRepository', function () {
       roleRepository.roles = {otherRoleId : {myRole : {}}};
       RoleRepository.prototype.loadOneFromDatabase = () => {
         isLoadFromDB = true;
-        return Promise.resolve(roleRepository.roles.otherRoleId);
+        return q(roleRepository.roles.otherRoleId);
       };
 
       return roleRepository.loadRole({_id: 'roleId'})
@@ -241,7 +241,7 @@ describe('Test: repositories/roleRepository', function () {
         savedSize = size;
         savedHydrate = hydrate;
 
-        return Promise.resolve();
+        return q();
       };
 
       return roleRepository.searchRole(new RequestObject({body: {from: 1, size: 3, hydrate: false}}))
@@ -266,7 +266,7 @@ describe('Test: repositories/roleRepository', function () {
         savedSize = size;
         savedHydrate = hydrate;
 
-        return Promise.resolve();
+        return q();
       };
 
       return roleRepository.searchRole(new RequestObject({body: {indexes: ['test']}}))
@@ -293,7 +293,7 @@ describe('Test: repositories/roleRepository', function () {
 
       RoleRepository.prototype.deleteFromDatabase = id => {
         isDeletedFromDB = true;
-        return Promise.resolve();
+        return q();
       };
 
       return roleRepository.deleteRole({_id: 'myRole'})

--- a/test/api/core/models/repositories/userRepository.test.js
+++ b/test/api/core/models/repositories/userRepository.test.js
@@ -35,9 +35,9 @@ before(function (done) {
   mockCacheEngine = {
     get: function (key) {
       if (key === userRepository.index + '/' + userRepository.collection + '/userInCache') {
-        return Promise.resolve(JSON.stringify(userInCache));
+        return q(JSON.stringify(userInCache));
       }
-      return Promise.resolve(null);
+      return q(null);
     },
     volatileSet: function (key, value, ttl) { forwardedResult = {key: key, value: JSON.parse(value), ttl: ttl }; },
     expire: function (key, ttl) { forwardedResult = {key: key, ttl: ttl}; }
@@ -45,10 +45,10 @@ before(function (done) {
   mockReadEngine = {
     get: function (requestObject) {
       if (requestObject.data._id === 'userInDB') {
-        return Promise.resolve(new ResponseObject(requestObject, userInDB));
+        return q(new ResponseObject(requestObject, userInDB));
       }
 
-      return Promise.resolve(new NotFoundError('User not found in db'));
+      return q(new NotFoundError('User not found in db'));
     }
   };
   mockWriteEngine = {
@@ -58,7 +58,7 @@ before(function (done) {
     loadProfile: function (profileKey) {
       var profile = new Profile();
       profile._id = profileKey;
-      return Promise.resolve(profile);
+      return q(profile);
     }
   };
   userInCache = {
@@ -161,14 +161,14 @@ describe('Test: repositories/userRepository', function () {
         user = new User();
 
       Repository.prototype.hydrate = () => {
-        return Promise.reject(new InternalError('Error'));
+        return q.reject(new InternalError('Error'));
       };
 
       return should(userRepository.hydrate(user, {})
         .catch(err => {
           Repository.prototype.hydrate = protoHydrate;
 
-          return Promise.reject(err);
+          return q.reject(err);
         })).be.rejectedWith(InternalError);
     });
   });
@@ -207,14 +207,14 @@ describe('Test: repositories/userRepository', function () {
       var token = jwt.sign({_id: 'auser'}, params.jsonWebToken.secret, {algorithm: params.jsonWebToken.algorithm});
 
       userRepository.loadFromCache = () => {
-        return Promise.reject(new InternalError('Error'));
+        return q.reject(new InternalError('Error'));
       };
 
       return should(userRepository.loadFromToken(token)
         .catch(err => {
           delete userRepository.loadFromCache;
 
-          return Promise.reject(err);
+          return q.reject(err);
         })).be.rejectedWith(InternalError);
     });
 
@@ -222,13 +222,13 @@ describe('Test: repositories/userRepository', function () {
       var token = jwt.sign({_id: 'auser'}, params.jsonWebToken.secret, {algorithm: params.jsonWebToken.algorithm});
 
       userRepository.loadOneFromDatabase = () => {
-        return Promise.reject(new InternalError('Error'));
+        return q.reject(new InternalError('Error'));
       };
       return should(userRepository.loadFromToken(token)
         .catch(err => {
           delete userRepository.loadOneFromDatabase;
 
-          return Promise.reject(err);
+          return q.reject(err);
         })).be.rejectedWith(InternalError);
     });
 
@@ -242,7 +242,7 @@ describe('Test: repositories/userRepository', function () {
         .catch(err => {
           delete userRepository.admin;
 
-          return Promise.reject(err);
+          return q.reject(err);
         })).be.rejectedWith(InternalError, {details: {message: 'Uncaught error'}});
     });
 
@@ -312,7 +312,7 @@ describe('Test: repositories/userRepository', function () {
         .catch(err => {
           kuzzle.config.jsonWebToken.algorithm = params.jsonWebToken.algorithm;
 
-          return Promise.reject(err);
+          return q.reject(err);
         })).be.rejectedWith(InternalError);
     });
 
@@ -376,14 +376,14 @@ describe('Test: repositories/userRepository', function () {
     it('should reject the promise if an error occurred while fetching the user', () => {
 
       userRepository.load = () => {
-        return Promise.reject(new InternalError('Error'));
+        return q.reject(new InternalError('Error'));
       };
 
       return should(userRepository.loadByUsernameAndPassword('userInCache', 'azerty')
         .catch(err => {
           delete userRepository.load;
 
-          return Promise.reject(err);
+          return q.reject(err);
         })).be.rejectedWith(InternalError);
     });
   });

--- a/test/api/core/models/security/role.test.js
+++ b/test/api/core/models/security/role.test.js
@@ -1,5 +1,6 @@
 var
   should = require('should'),
+  q = require('q'),
   rewire = require('rewire'),
   BadRequestError = require.main.require('lib/api/core/errors/badRequestError'),
   InternalError = require.main.require('lib/api/core/errors/internalError'),
@@ -636,7 +637,7 @@ describe('Test: security/roleTest', function () {
         Role.__with__({
           Sandbox: function () {
             this.run = function (data) {
-              return Promise.reject(new Error('our unit test error'));
+              return q.reject(new Error('our unit test error'));
             };
           }
         })(() => {
@@ -672,7 +673,7 @@ describe('Test: security/roleTest', function () {
         Role.__with__({
           Sandbox: function () {
             this.run = function (data) {
-              return Promise.resolve({
+              return q({
                 result: 'I am not a boolean'
               });
             };
@@ -708,7 +709,7 @@ describe('Test: security/roleTest', function () {
         Role.__with__({
           Sandbox: function () {
             this.run = function (data) {
-              return Promise.resolve({ result: true });
+              return q({ result: true });
             };
           }
         })(() => {

--- a/test/api/core/notifier/checkNewRoutes.test.js
+++ b/test/api/core/notifier/checkNewRoutes.test.js
@@ -6,6 +6,7 @@
  */
 var
   should = require('should'),
+  q = require('q'),
   _ = require('lodash'),
   rewire = require('rewire'),
   RequestObject = require.main.require('lib/api/core/models/requestObject'),
@@ -58,7 +59,7 @@ describe('Test: notifier.checkNewRoutes', function () {
       performedActions = [],
       mockupAction = function (responseObject) {
         performedActions.push(responseObject.action);
-        return Promise.resolve({});
+        return q({});
       };
 
     this.timeout(100);

--- a/test/api/core/notifier/notifyDocumentCreate.test.js
+++ b/test/api/core/notifier/notifyDocumentCreate.test.js
@@ -24,7 +24,7 @@ var mockupCacheService = {
   add: function (id, room) {
     this.id = id;
     this.room = room;
-    return Promise.resolve({});
+    return q({});
   }
 };
 

--- a/test/api/core/notifier/notifyDocumentDelete.test.js
+++ b/test/api/core/notifier/notifyDocumentDelete.test.js
@@ -7,6 +7,7 @@
  */
 var
   should = require('should'),
+  q = require('q'),
   rewire = require('rewire'),
   RequestObject = require.main.require('lib/api/core/models/requestObject'),
   ResponseObject = require.main.require('lib/api/core/models/responseObject'),
@@ -19,15 +20,15 @@ var mockupCacheService = {
 
   remove: function (id) {
     this.id = id;
-    return Promise.resolve({});
+    return q({});
   },
 
   search: function (id) {
     if (id === 'errorme') {
-      return Promise.reject(new Error());
+      return q.reject(new Error());
     }
     else {
-      return Promise.resolve(['']);
+      return q(['']);
     }
   }
 };

--- a/test/api/core/notifier/notifyDocumentUpdate.test.js
+++ b/test/api/core/notifier/notifyDocumentUpdate.test.js
@@ -7,6 +7,7 @@
  */
 var
   should = require('should'),
+  q = require('q'),
   rewire = require('rewire'),
   RequestObject = require.main.require('lib/api/core/models/requestObject'),
   ResponseObject = require.main.require('lib/api/core/models/responseObject'),
@@ -28,41 +29,41 @@ var mockupCacheService = {
       this.addId = id;
       this.room = room;
     }
-    return Promise.resolve({});
+    return q({});
   },
 
   remove: function (id, room) {
     if (room.length > 0) {
       this.removeId = id;
     }
-    return Promise.resolve({});
+    return q({});
   },
 
   search: function (id) {
     if (id === 'removeme') {
-      return Promise.resolve(['foobar']);
+      return q(['foobar']);
     }
     else {
-      return Promise.resolve([]);
+      return q([]);
     }
   }
 };
 
 var mockupTestFilters = function (responseObject) {
   if (responseObject.data.body._id === 'errorme') {
-    return Promise.reject(new Error('rejected'));
+    return q.reject(new Error('rejected'));
   }
   else if (responseObject.data.body._id === 'removeme') {
-    return Promise.resolve([]);
+    return q([]);
   }
   else {
-    return Promise.resolve(['foobar']);
+    return q(['foobar']);
   }
 };
 
 var mockupReadEngine = {
   get: function (requestObject) {
-    return Promise.resolve(new ResponseObject(requestObject, requestObject.data));
+    return q(new ResponseObject(requestObject, requestObject.data));
   }
 };
 

--- a/test/api/core/notifier/publish.test.js
+++ b/test/api/core/notifier/publish.test.js
@@ -5,6 +5,7 @@
  */
 var
   should = require('should'),
+  q = require('q'),
   rewire = require('rewire'),
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
@@ -27,7 +28,7 @@ describe('Test: notifier.publish', function () {
     kuzzle.start(params, {dummy: true})
       .then(() => {
         kuzzle.services.list.notificationCache = {
-          add: function () { cached = true; return Promise.resolve({}); },
+          add: function () { cached = true; return q({}); },
           expire: function () { expired = true; }
         };
 
@@ -47,7 +48,7 @@ describe('Test: notifier.publish', function () {
 
     notifier = new Notifier(kuzzle);
     notifier.notify = function () { notified = true; };
-    kuzzle.dsl.testFilters = function () { return Promise.resolve(rooms); };
+    kuzzle.dsl.testFilters = function () { return q(rooms); };
     notified = false;
     cached = false;
     expired = false;
@@ -109,11 +110,13 @@ describe('Test: notifier.publish', function () {
     request.action = 'create';
 
     notifier.publish(new RequestObject(request)).then(result => {
-      should(result).be.instanceof(ResponseObject);
-      should(notified).be.true();
-      should(cached).be.true();
-      should(expired).be.true();
-      done();
+      setTimeout(() => {
+        should(result).be.instanceof(ResponseObject);
+        should(notified).be.true();
+        should(cached).be.true();
+        should(expired).be.true();
+        done();
+      }, 20);
     })
     .catch(error => done(error));
   });
@@ -122,11 +125,13 @@ describe('Test: notifier.publish', function () {
     request.action = 'createOrUpdate';
 
     notifier.publish(new RequestObject(request)).then(result => {
-      should(result).be.instanceof(ResponseObject);
-      should(notified).be.true();
-      should(cached).be.true();
-      should(expired).be.true();
-      done();
+      setTimeout(() => {
+        should(result).be.instanceof(ResponseObject);
+        should(notified).be.true();
+        should(cached).be.true();
+        should(expired).be.true();
+        done();
+      }, 20);
     })
       .catch(error => done(error));
   });
@@ -141,17 +146,19 @@ describe('Test: notifier.publish', function () {
 
     published
       .then(result => {
-        should(result).be.instanceof(ResponseObject);
-        should(notified).be.false();
-        should(cached).be.false();
-        should(expired).be.false();
-        done();
+        setTimeout(() => {
+          should(result).be.instanceof(ResponseObject);
+          should(notified).be.false();
+          should(cached).be.false();
+          should(expired).be.false();
+          done();
+        });
       })
       .catch(error => done(error));
   });
 
   it('should return a rejected promise if testFilters fails', function () {
-    kuzzle.dsl.testFilters = function () { return Promise.reject(new Error('')); };
+    kuzzle.dsl.testFilters = function () { return q.reject(new Error('')); };
     return should(notifier.publish(new RequestObject(request))).be.rejected();
   });
 });

--- a/test/api/core/notifier/workerNotification.test.js
+++ b/test/api/core/notifier/workerNotification.test.js
@@ -8,6 +8,7 @@
  */
 var
   should = require('should'),
+  q = require('q'),
   rewire = require('rewire'),
   RequestObject = require.main.require('lib/api/core/models/requestObject'),
   ResponseObject = require.main.require('lib/api/core/models/responseObject'),
@@ -34,9 +35,9 @@ describe('Test: notifier.workerNotification', function () {
     responseObject.action = 'create';
 
     Notifier.__with__({
-      notifyDocumentCreate: function () { created = true; return Promise.resolve({}); },
-      notifyDocumentUpdate: function () { anyOtherAction = true; return Promise.resolve({}); },
-      notifyDocumentDelete: function () { anyOtherAction = true; return Promise.resolve({}); }
+      notifyDocumentCreate: function () { created = true; return q({}); },
+      notifyDocumentUpdate: function () { anyOtherAction = true; return q({}); },
+      notifyDocumentDelete: function () { anyOtherAction = true; return q({}); }
     })(function () {
       (Notifier.__get__('workerNotification'))(responseObject);
       should(created).be.true();
@@ -52,9 +53,9 @@ describe('Test: notifier.workerNotification', function () {
     responseObject.action = 'update';
 
     Notifier.__with__({
-      notifyDocumentCreate: function () { anyOtherAction = true; return Promise.resolve({}); },
-      notifyDocumentUpdate: function () { updated = true; return Promise.resolve({}); },
-      notifyDocumentDelete: function () { anyOtherAction = true; return Promise.resolve({}); }
+      notifyDocumentCreate: function () { anyOtherAction = true; return q({}); },
+      notifyDocumentUpdate: function () { updated = true; return q({}); },
+      notifyDocumentDelete: function () { anyOtherAction = true; return q({}); }
     })(function () {
       (Notifier.__get__('workerNotification'))(responseObject);
       should(updated).be.true();
@@ -70,9 +71,9 @@ describe('Test: notifier.workerNotification', function () {
     responseObject.action = 'delete';
 
     Notifier.__with__({
-      notifyDocumentCreate: function () { anyOtherAction = true; return Promise.resolve({}); },
-      notifyDocumentUpdate: function () { anyOtherAction = true; return Promise.resolve({}); },
-      notifyDocumentDelete: function () { deleted = true; return Promise.resolve({}); }
+      notifyDocumentCreate: function () { anyOtherAction = true; return q({}); },
+      notifyDocumentUpdate: function () { anyOtherAction = true; return q({}); },
+      notifyDocumentDelete: function () { deleted = true; return q({}); }
     })(function () {
       (Notifier.__get__('workerNotification'))(responseObject);
       should(deleted).be.true();
@@ -88,9 +89,9 @@ describe('Test: notifier.workerNotification', function () {
     responseObject.action = 'deleteByQuery';
 
     Notifier.__with__({
-      notifyDocumentCreate: function () { anyOtherAction = true; return Promise.resolve({}); },
-      notifyDocumentUpdate: function () { anyOtherAction = true; return Promise.resolve({}); },
-      notifyDocumentDelete: function () { deleted = true; return Promise.resolve({}); }
+      notifyDocumentCreate: function () { anyOtherAction = true; return q({}); },
+      notifyDocumentUpdate: function () { anyOtherAction = true; return q({}); },
+      notifyDocumentDelete: function () { deleted = true; return q({}); }
     })(function () {
       (Notifier.__get__('workerNotification'))(responseObject);
       should(deleted).be.true();
@@ -105,9 +106,9 @@ describe('Test: notifier.workerNotification', function () {
     responseObject.action = 'foo';
 
     Notifier.__with__({
-      notifyDocumentCreate: function () { tookAction = true; return Promise.resolve({}); },
-      notifyDocumentUpdate: function () { tookAction = true; return Promise.resolve({}); },
-      notifyDocumentDelete: function () { tookAction = true; return Promise.resolve({}); }
+      notifyDocumentCreate: function () { tookAction = true; return q({}); },
+      notifyDocumentUpdate: function () { tookAction = true; return q({}); },
+      notifyDocumentDelete: function () { tookAction = true; return q({}); }
     })(function () {
       (Notifier.__get__('workerNotification'))(responseObject);
       should(tookAction).be.false();
@@ -128,7 +129,7 @@ describe('Test: notifier.workerNotification', function () {
       });
 
       Notifier.__with__({
-        notifyDocumentCreate: function () { return Promise.reject(new Error('rejected')); }
+        notifyDocumentCreate: function () { return q.reject(new Error('rejected')); }
       })(function () {
         (Notifier.__get__('workerNotification')).call(kuzzle, responseObject);
       });

--- a/test/api/core/statistics.test.js
+++ b/test/api/core/statistics.test.js
@@ -3,6 +3,7 @@
  */
 var
   should = require('should'),
+  q = require('q'),
   rewire = require('rewire'),
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
@@ -377,7 +378,7 @@ describe('Test: statistics core component', function () {
     var statsCache = kuzzle.services.list.statsCache;
 
     kuzzle.services.list.statsCache = {
-      get: () => { return Promise.reject(new Error()); }
+      get: () => { return q.reject(new Error()); }
     };
 
     stats.lastFrame = Date.now();
@@ -386,7 +387,7 @@ describe('Test: statistics core component', function () {
       stats.getLastStats(requestObject)
         .catch(error => {
           kuzzle.services.list.statsCache = statsCache;
-          return Promise.reject(error);
+          return q.reject(error);
         })
     ).be.rejected();
   });

--- a/test/api/dsl/index/removeRoom.test.js
+++ b/test/api/dsl/index/removeRoom.test.js
@@ -1,5 +1,6 @@
 var
   should = require('should'),
+  q = require('q'),
   rewire = require('rewire'),
   RequestObject = require.main.require('lib/api/core/models/requestObject'),
   params = require('rc')('kuzzle'),
@@ -78,7 +79,7 @@ describe('Test removeRoom function index.js file from DSL', function () {
 
   it('should return a reject promise on fail', function () {
     Dsl.__with__({
-      removeRoomFromFields: function () { return Promise.reject(new Error('rejected')); }
+      removeRoomFromFields: function () { return q.reject(new Error('rejected')); }
     })(function () {
       var dsl = new Dsl(kuzzle);
       return should(dsl.removeRoom(kuzzle.hotelClerk.rooms[roomId])).be.rejected();

--- a/test/api/dsl/index/testFieldFilters.test.js
+++ b/test/api/dsl/index/testFieldFilters.test.js
@@ -1,5 +1,6 @@
 var
   should = require('should'),
+  q = require('q'),
   rewire = require('rewire'),
   RequestObject = require.main.require('lib/api/core/models/requestObject'),
   Dsl = rewire('../../../../lib/api/dsl/index');
@@ -17,7 +18,7 @@ describe('Test: dsl.testFieldFilters', function () {
 
   before(function () {
     Dsl.__set__('testRooms', function (rooms) {
-      return Promise.resolve(rooms);
+      return q(rooms);
     });
   });
 
@@ -120,7 +121,7 @@ describe('Test: dsl.testFieldFilters', function () {
     };
 
     return Dsl.__with__({
-      testRooms: function () { return Promise.reject(new Error('rejected')); }
+      testRooms: function () { return q.reject(new Error('rejected')); }
     })(function () {
       result = testFieldFilters.call(dsl, requestObject, { 'foo.bar.baz': '' }, {});
       return should(result).be.rejectedWith('rejected');

--- a/test/api/dsl/index/testFilters.test.js
+++ b/test/api/dsl/index/testFilters.test.js
@@ -1,5 +1,6 @@
 var
   should = require('should'),
+  q = require('q'),
   rewire = require('rewire'),
   RequestObject = require.main.require('lib/api/core/models/requestObject'),
   params = require('rc')('kuzzle'),
@@ -181,7 +182,7 @@ describe('Test: dsl.testFilters', function () {
     });
 
     Dsl.__with__({
-      testFieldFilters: function () { return Promise.reject(new Error('rejected')); }
+      testFieldFilters: function () { return q.reject(new Error('rejected')); }
     })(function () {
       var dsl = new Dsl(kuzzle);
       dsl.filtersTree[requestObjectCreateGrace.index] = {};
@@ -204,7 +205,7 @@ describe('Test: dsl.testFilters', function () {
     });
 
     Dsl.__with__({
-      testGlobalsFilters: function () { return Promise.reject(new Error('rejected')); }
+      testGlobalsFilters: function () { return q.reject(new Error('rejected')); }
     })(function () {
       var dsl = new Dsl(kuzzle);
       dsl.filtersTree[requestObjectCreateGrace.index] = {};

--- a/test/api/dsl/index/testGlobalsFilter.test.js
+++ b/test/api/dsl/index/testGlobalsFilter.test.js
@@ -1,5 +1,6 @@
 var
   should = require('should'),
+  q = require('q'),
   rewire = require('rewire'),
   RequestObject = require.main.require('lib/api/core/models/requestObject'),
   Dsl = rewire('../../../../lib/api/dsl/index');
@@ -22,7 +23,7 @@ describe('Test: dsl.testGlobalsFilters', function () {
       should(rooms).be.an.Array();
       should(body).be.exactly(flattenBody);
       should(cache).match(cachedResult);
-      return Promise.resolve(rooms);
+      return q(rooms);
     });
 
     dsl = new Dsl();

--- a/test/api/dsl/methods/and.test.js
+++ b/test/api/dsl/methods/and.test.js
@@ -1,5 +1,6 @@
 var
   should = require('should'),
+  q = require('q'),
   rewire = require('rewire'),
   methods = rewire('../../../../lib/api/dsl/methods');
 
@@ -84,7 +85,7 @@ describe('Test and method', function () {
 
   it('should return a rejected promise if getFormattedFilters fails', function () {
     return methods.__with__({
-      getFormattedFilters: function () { return Promise.reject(new Error('rejected')); }
+      getFormattedFilters: function () { return q.reject(new Error('rejected')); }
     })(function () {
       return should(methods.and(roomId, index, collection, filter)).be.rejectedWith('rejected');
     });

--- a/test/api/dsl/methods/bool.test.js
+++ b/test/api/dsl/methods/bool.test.js
@@ -1,5 +1,6 @@
 var
   should = require('should'),
+  q = require('q'),
   rewire = require('rewire'),
   methods = rewire('../../../../lib/api/dsl/methods'),
   BadRequestError = require.main.require('lib/api/core/errors/badRequestError');
@@ -168,7 +169,7 @@ describe('Test bool method', function () {
   it('should return a rejected promise if one of the bool sub-methods fails', function () {
     var f = { must: [ { foo: 'bar' } ] };
 
-    methods.must = function () { return Promise.reject(new Error('rejected')); };
+    methods.must = function () { return q.reject(new Error('rejected')); };
     return should(methods.bool(roomId, index, collection, f)).be.rejectedWith('rejected');
   });
 });

--- a/test/api/dsl/methods/getFormattedFilters.test.js
+++ b/test/api/dsl/methods/getFormattedFilters.test.js
@@ -1,6 +1,7 @@
 var
   should = require('should'),
   rewire = require('rewire'),
+  q = require('q'),
   methods = rewire('../../../../lib/api/dsl/methods'),
   BadRequestError = require.main.require('lib/api/core/errors/badRequestError');
 
@@ -137,7 +138,7 @@ describe('Test: dsl.getFormattedFilters method', function () {
         }
       };
 
-    methods.exists = function () { return Promise.reject(new Error('rejected')); };
+    methods.exists = function () { return q.reject(new Error('rejected')); };
 
     return should(getFormattedFilters('roomId', 'index', 'collection', filter)).be.rejectedWith('rejected');
   });

--- a/test/api/dsl/methods/must.test.js
+++ b/test/api/dsl/methods/must.test.js
@@ -1,18 +1,17 @@
 var
   should = require('should'),
   rewire = require('rewire'),
+  q = require('q'),
   methods = rewire('../../../../lib/api/dsl/methods');
-
-
 
 describe('Test: dsl.must method', function () {
   before(function () {
     methods.__set__('getFormattedFilters', function (roomId) {
       if (roomId === 'resolve') {
-        return Promise.resolve('resolved');
+        return q('resolved');
       }
       else {
-        return Promise.reject(new Error('rejected'));
+        return q.reject(new Error('rejected'));
       }
     });
   });

--- a/test/api/dsl/methods/or.test.js
+++ b/test/api/dsl/methods/or.test.js
@@ -1,10 +1,9 @@
 var
   should = require('should'),
   rewire = require('rewire'),
+  q = require('q'),
   methods = rewire('../../../../lib/api/dsl/methods'),
   BadRequestError = require.main.require('lib/api/core/errors/badRequestError');
-
-
 
 describe('Test or method', function () {
 
@@ -111,7 +110,7 @@ describe('Test or method', function () {
 
   it('should return a rejected promise if getFormattedFilters fails', function () {
     return methods.__with__({
-      getFormattedFilters: function () { return Promise.reject(new Error('rejected')); }
+      getFormattedFilters: function () { return q.reject(new Error('rejected')); }
     })(function () {
       return should(methods.or(roomId, index, collection, filter)).be.rejectedWith('rejected');
     });

--- a/test/api/dsl/methods/should.test.js
+++ b/test/api/dsl/methods/should.test.js
@@ -1,18 +1,17 @@
 var
   should = require('should'),
   rewire = require('rewire'),
+  q = require('q'),
   methods = rewire('../../../../lib/api/dsl/methods');
-
-
 
 describe('Test: dsl.should method', function () {
   before(function () {
     methods.__set__('getFormattedFilters', function (roomId) {
       if (roomId === 'resolve') {
-        return Promise.resolve('resolved');
+        return q('resolved');
       }
       else {
-        return Promise.reject(new Error('rejected'));
+        return q.reject(new Error('rejected'));
       }
     });
   });

--- a/test/api/kuzzle.test.js
+++ b/test/api/kuzzle.test.js
@@ -1,5 +1,6 @@
 var
   rc = require('rc'),
+  q = require('q'),
   should = require('should'),
   Kuzzle = require.main.require('lib/api/Kuzzle');
 
@@ -53,12 +54,12 @@ describe('Test kuzzle constructor', function () {
 
       kuzzle.services.list.writeEngine.deleteIndexes = function() {
         hasDeletedIndexes = true;
-        return Promise.resolve();
+        return q();
       };
 
       kuzzle.services.list.writeEngine.createIndex = function() {
         hasCreatedIndex = true;
-        return Promise.resolve();
+        return q();
       };
 
       kuzzle.cleanDb()
@@ -86,12 +87,12 @@ describe('Test kuzzle constructor', function () {
       };
 
       kuzzle.services.list.writeEngine.deleteIndexes = function() {
-        return Promise.reject();
+        return q.reject();
       };
 
 
       kuzzle.services.list.writeEngine.createIndex = function() {
-        return Promise.reject();
+        return q.reject();
       };
 
       should(kuzzle.cleanDb()).be.fulfilled();
@@ -111,12 +112,12 @@ describe('Test kuzzle constructor', function () {
 
       kuzzle.services.list.writeEngine.deleteIndexes = function() {
         hasDeletedIndexes = true;
-        return Promise.reject();
+        return q.reject();
       };
 
       kuzzle.services.list.writeEngine.createIndex = function() {
         hasCreatedIndex = true;
-        return Promise.reject();
+        return q.reject();
       };
 
 
@@ -155,17 +156,17 @@ describe('Test kuzzle constructor', function () {
 
       kuzzle.services.list.readEngine.listIndexes = function() {
         hasListedIndexes = true;
-        return Promise.resolve({data: {body: {indexes: [] } } });
+        return q({data: {body: {indexes: [] } } });
       };
 
       kuzzle.services.list.writeEngine.createIndex = function() {
         hasCreatedIndex = true;
-        return Promise.resolve();
+        return q();
       };
 
       kuzzle.services.list.writeEngine.putMapping = function() {
         hasPutMapping = true;
-        return Promise.resolve();
+        return q();
       };
 
       kuzzle.prepareDb()
@@ -196,17 +197,17 @@ describe('Test kuzzle constructor', function () {
 
       kuzzle.services.list.readEngine.listIndexes = function() {
         hasListedIndexes = true;
-        return Promise.resolve({data: {body: {indexes: [] } } });
+        return q({data: {body: {indexes: [] } } });
       };
 
       kuzzle.services.list.writeEngine.createIndex = function() {
         hasCreatedIndex = true;
-        return Promise.resolve();
+        return q();
       };
 
       kuzzle.services.list.writeEngine.import = function() {
         hasImportedFixtures = true;
-        return Promise.resolve();
+        return q();
       };
 
       kuzzle.prepareDb()
@@ -235,7 +236,7 @@ describe('Test kuzzle constructor', function () {
 
       kuzzle.services.list.readEngine.listIndexes = function() {
         hasListedIndexes = true;
-        return Promise.resolve({data: {body: {indexes: [] } } });
+        return q({data: {body: {indexes: [] } } });
       };
 
       kuzzle.prepareDb()

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -1,14 +1,12 @@
 var
   should = require('should'),
+  q = require('q'),
   rewire = require('rewire'),
   params = require('rc')('kuzzle'),
   Config = require.main.require('lib/config'),
   RequestObject = require.main.require('lib/api/core/models/requestObject'),
   BadRequestError = require.main.require('lib/api/core/errors/badRequestError.js'),
   ES = rewire('../../../lib/services/elasticsearch');
-
-
-
 
 describe('Test: ElasticSearch service', function () {
   var
@@ -106,7 +104,7 @@ describe('Test: ElasticSearch service', function () {
       elasticsearch.client.search = function (data) {
         should(data.body).be.exactly(filter);
 
-        return Promise.resolve({total: 0, hits: []});
+        return q({total: 0, hits: []});
       };
 
       requestObject.data.body = filter;
@@ -128,7 +126,7 @@ describe('Test: ElasticSearch service', function () {
       elasticsearch.client.search = function (data) {
         should(data.body).not.be.exactly(filter);
 
-        return Promise.reject(new Error());
+        return q.reject(new Error());
       };
 
       return should(elasticsearch.search(requestObject)).be.rejected();
@@ -147,7 +145,7 @@ describe('Test: ElasticSearch service', function () {
         should(data.type).be.exactly(collection);
         should(data.body).be.exactly(documentAda);
 
-        return Promise.resolve({});
+        return q({});
       };
 
       ret = elasticsearch.create(requestObject);
@@ -164,7 +162,7 @@ describe('Test: ElasticSearch service', function () {
 
     it('should reject the create promise if elasticsearch throws an error', function () {
       elasticsearch.client.create = function () {
-        return Promise.reject(new Error());
+        return q.reject(new Error());
       };
 
       return should(elasticsearch.create(requestObject)).be.rejected();
@@ -183,7 +181,7 @@ describe('Test: ElasticSearch service', function () {
         should(data.body).be.exactly(documentAda);
         should(data.id).be.exactly(createdDocumentId);
 
-        return Promise.resolve({});
+        return q({});
       };
 
       requestObject.data._id = createdDocumentId;
@@ -203,7 +201,7 @@ describe('Test: ElasticSearch service', function () {
       var ret;
 
       elasticsearch.client.index = function (data) {
-        return Promise.reject(new Error());
+        return q.reject(new Error());
       };
 
       requestObject.data._id = createdDocumentId;
@@ -220,7 +218,7 @@ describe('Test: ElasticSearch service', function () {
       elasticsearch.client.get = function (data) {
         should(data.id).be.exactly(createdDocumentId);
 
-        return Promise.resolve({});
+        return q({});
       };
 
       delete requestObject.data.body;
@@ -242,7 +240,7 @@ describe('Test: ElasticSearch service', function () {
       elasticsearch.client.get = function (data) {
         should(data.id).be.exactly(createdDocumentId);
 
-        return Promise.resolve({});
+        return q({});
       };
 
       requestObject.data._id = '_search';
@@ -257,7 +255,7 @@ describe('Test: ElasticSearch service', function () {
       elasticsearch.client.get = function (data) {
         should(data.id).be.undefined();
 
-        return Promise.reject(new Error());
+        return q.reject(new Error());
       };
 
 
@@ -269,7 +267,7 @@ describe('Test: ElasticSearch service', function () {
       elasticsearch.client.mget = function (data) {
         should(data.body.ids).be.an.Array();
 
-        return Promise.resolve(new Error());
+        return q(new Error());
       };
 
       delete requestObject.data.body;
@@ -282,7 +280,7 @@ describe('Test: ElasticSearch service', function () {
       elasticsearch.client.mget = function (data) {
         should(data.body.ids).be.undefined();
 
-        return Promise.reject(new Error());
+        return q.reject(new Error());
       };
 
       requestObject.data.body = {};
@@ -298,7 +296,7 @@ describe('Test: ElasticSearch service', function () {
       elasticsearch.client.count = function (data) {
         should(data.body).have.keys();
 
-        return Promise.resolve({});
+        return q({});
       };
 
       requestObject.data.body = {};
@@ -318,7 +316,7 @@ describe('Test: ElasticSearch service', function () {
       elasticsearch.client.count = function (data) {
         should(data.body).be.an.instanceOf(Object).and.have.property('query', {foo: 'bar'});
 
-        return Promise.resolve({});
+        return q({});
       };
 
       requestObject.data.body = {};
@@ -337,7 +335,7 @@ describe('Test: ElasticSearch service', function () {
     it('should return a rejected promise if the count fails', function () {
 
       elasticsearch.client.count = function (data) {
-        return Promise.reject(new Error());
+        return q.reject(new Error());
       };
 
       requestObject.data.body = {};
@@ -357,7 +355,7 @@ describe('Test: ElasticSearch service', function () {
         should(data.body.doc).be.exactly(documentAda);
         should(data.id).be.exactly(createdDocumentId);
 
-        return Promise.resolve({});
+        return q({});
       };
 
       requestObject.data._id = createdDocumentId;
@@ -378,7 +376,7 @@ describe('Test: ElasticSearch service', function () {
       elasticsearch.client.update = function (data) {
         should(data.id).be.undefined();
 
-        return Promise.reject(new Error());
+        return q.reject(new Error());
       };
 
       return should(elasticsearch.update(requestObject)).be.rejected();
@@ -391,7 +389,7 @@ describe('Test: ElasticSearch service', function () {
       elasticsearch.client.delete = function (data) {
         should(data.id).be.exactly(createdDocumentId);
 
-        return Promise.resolve({});
+        return q({});
       };
 
       delete requestObject.data.body;
@@ -405,7 +403,7 @@ describe('Test: ElasticSearch service', function () {
       elasticsearch.client.delete = function (data) {
         should(data.id).be.undefined();
 
-        return Promise.reject(new Error());
+        return q.reject(new Error());
       };
 
       return should(elasticsearch.delete(requestObject)).be.rejected();
@@ -452,12 +450,12 @@ describe('Test: ElasticSearch service', function () {
           done(error);
         }
 
-        return Promise.resolve(mockupIds);
+        return q(mockupIds);
       };
 
       ES.__with__({
         getAllIdsFromQuery: function () {
-          return Promise.resolve(mockupIds);
+          return q(mockupIds);
         }
       })(function () {
         elasticsearch.deleteByQuery(requestObject)
@@ -488,13 +486,13 @@ describe('Test: ElasticSearch service', function () {
 
     it('should return a rejected promise if the delete by query fails because of a bulk failure', function () {
       elasticsearch.client.bulk = function () {
-        return Promise.reject(new Error('rejected'));
+        return q.reject(new Error('rejected'));
       };
       requestObject.data.body = {};
 
       return ES.__with__({
         getAllIdsFromQuery: function () {
-          return Promise.resolve(['foo', 'bar']);
+          return q(['foo', 'bar']);
         }
       })(function () {
         return should(elasticsearch.deleteByQuery(requestObject)).be.rejected();
@@ -517,7 +515,7 @@ describe('Test: ElasticSearch service', function () {
       elasticsearch.client.bulk = function (data) {
         should(data.body).be.exactly(requestObject.data.body);
 
-        return Promise.resolve({});
+        return q({});
       };
 
       return should(elasticsearch.import(requestObject)).be.fulfilled();
@@ -539,7 +537,7 @@ describe('Test: ElasticSearch service', function () {
       elasticsearch.client.bulk = function (data) {
         should(data.body).be.exactly(requestObject.data.body);
 
-        return Promise.resolve({
+        return q({
           errors: true,
           items: {
             12: {index: {status: 404, error: 'DocumentMissingException'}},
@@ -590,7 +588,7 @@ describe('Test: ElasticSearch service', function () {
           {delete: {_id: 2, _index: 'indexAlt', _type: collection}}
         ]);
 
-        return Promise.resolve({
+        return q({
           items: [
             {index: {_id: 1, _index: index, _type: collection}},
             {index: {_id: 2, _index: 'indexAlt', _type: collection}},
@@ -615,7 +613,7 @@ describe('Test: ElasticSearch service', function () {
       ];
 
       elasticsearch.client.bulk = function (data) {
-        return Promise.reject(new Error());
+        return q.reject(new Error());
       };
 
       return should(elasticsearch.import(requestObject)).be.rejected();
@@ -640,7 +638,7 @@ describe('Test: ElasticSearch service', function () {
       ];
 
       elasticsearch.client.bulk = function (data) {
-        return Promise.resolve({});
+        return q({});
       };
 
       return should(elasticsearch.import(requestObject)).be.rejected();
@@ -660,7 +658,7 @@ describe('Test: ElasticSearch service', function () {
       ];
 
       elasticsearch.client.bulk = function (data) {
-        return Promise.resolve({});
+        return q({});
       };
 
       return should(elasticsearch.import(requestObject)).be.rejected();
@@ -677,7 +675,7 @@ describe('Test: ElasticSearch service', function () {
       elasticsearch.client.indices.putMapping = function (data) {
         should(data.body).be.exactly(requestObject.data.body);
 
-        return Promise.resolve({});
+        return q({});
       };
 
       return should(elasticsearch.putMapping(requestObject)).be.fulfilled();
@@ -688,7 +686,7 @@ describe('Test: ElasticSearch service', function () {
       elasticsearch.client.indices.putMapping = function (data) {
         should(data.body).not.have.key('properties');
 
-        return Promise.reject({});
+        return q.reject({});
       };
 
       return should(elasticsearch.putMapping(requestObject)).be.rejected();
@@ -703,7 +701,7 @@ describe('Test: ElasticSearch service', function () {
 
         mappings[index] = {mappings: {}};
 
-        return Promise.resolve(mappings);
+        return q(mappings);
       };
 
       elasticsearch.getMapping(requestObject)
@@ -726,7 +724,7 @@ describe('Test: ElasticSearch service', function () {
         mappings[index] = {mappings: {}};
         mappings[index].mappings[collection] = {};
 
-        return Promise.resolve(mappings);
+        return q(mappings);
       };
 
       return should(elasticsearch.getMapping(requestObject)).be.rejected();
@@ -735,7 +733,7 @@ describe('Test: ElasticSearch service', function () {
     it('should reject the getMapping promise if elasticsearch throws an error', function () {
 
       elasticsearch.client.indices.getMapping = function (data) {
-        return Promise.reject(new Error());
+        return q.reject(new Error());
       };
 
       return should(elasticsearch.getMapping(requestObject)).be.rejected();
@@ -746,7 +744,7 @@ describe('Test: ElasticSearch service', function () {
     it('should allow deleting an entire collection', function (done) {
 
       elasticsearch.client.indices.deleteMapping = function (data) {
-        return Promise.resolve({});
+        return q({});
       };
 
       delete requestObject.data.body;
@@ -761,7 +759,7 @@ describe('Test: ElasticSearch service', function () {
     it('should return a rejected promise if the delete collection function fails', function () {
       // because we already deleted the collection in the previous test, it should naturally fail
       elasticsearch.client.indices.deleteMapping = function (data) {
-        return Promise.reject(new Error());
+        return q.reject(new Error());
       };
 
       delete requestObject.data.body;
@@ -860,7 +858,7 @@ describe('Test: ElasticSearch service', function () {
         mappings[index] = {mappings: {}};
         mappings[index].mappings[collection] = {};
 
-        return Promise.resolve(mappings);
+        return q(mappings);
       };
 
       delete requestObject.data.body;
@@ -870,7 +868,7 @@ describe('Test: ElasticSearch service', function () {
     it('should reject the listCollections promise if elasticsearch throws an error', function () {
 
       elasticsearch.client.indices.getMapping = function (data) {
-        return Promise.reject(new Error());
+        return q.reject(new Error());
       };
 
       requestObject.index = 'kuzzle-unit-tests-fakeindex';
@@ -883,7 +881,7 @@ describe('Test: ElasticSearch service', function () {
     it('should allow creating a new collection', function (done) {
 
       elasticsearch.client.indices.putMapping = function (data) {
-        return Promise.resolve();
+        return q();
       };
 
       requestObject.collection = '%foobar';
@@ -898,7 +896,7 @@ describe('Test: ElasticSearch service', function () {
     it('should reject the createCollection promise if elasticsearch throws an error', function () {
 
       elasticsearch.client.indices.putMapping = function (data) {
-        return Promise.reject(new Error());
+        return q.reject(new Error());
       };
 
       return should(elasticsearch.createCollection(requestObject)).be.rejected();
@@ -918,16 +916,16 @@ describe('Test: ElasticSearch service', function () {
 
       elasticsearch.client.indices.getMapping = function (data) {
         hasRetrievedMapping = true;
-        return Promise.resolve(mapping);
+        return q(mapping);
       };
       elasticsearch.client.indices.deleteMapping = function (data) {
         hasDeletedMapping = true;
-        return Promise.resolve();
+        return q();
       };
       elasticsearch.client.indices.putMapping = function (data) {
         should(data.body[data.type]).be.exactly(mapping[requestObject.index].mappings[requestObject.collection]);
         hasCreatedMapping = true;
-        return Promise.resolve();
+        return q();
       };
 
       elasticsearch.truncateCollection(requestObject)
@@ -948,10 +946,10 @@ describe('Test: ElasticSearch service', function () {
       mapping[index].mappings[collection] = {foo: 'bar'};
 
       elasticsearch.client.indices.getMapping = function (data) {
-        return Promise.resolve(mapping);
+        return q(mapping);
       };
       elasticsearch.client.indices.deleteMapping = function (data) {
-        return Promise.reject();
+        return q.reject();
       };
 
       requestObject.collection = 'non existing collection';
@@ -966,7 +964,7 @@ describe('Test: ElasticSearch service', function () {
       mapping[index].mappings[collection] = {foo: 'bar'};
 
       elasticsearch.client.indices.getMapping = function (data) {
-        return Promise.resolve(mapping);
+        return q(mapping);
       };
 
       requestObject.index = 'non existing index';
@@ -981,18 +979,18 @@ describe('Test: ElasticSearch service', function () {
         deletedAll = false;
 
       elasticsearch.client.cat.indices = function (data) {
-        return Promise.resolve('      \n %kuzzle      \n ' + index + ' \n  ');
+        return q('      \n %kuzzle      \n ' + index + ' \n  ');
       };
 
       elasticsearch.client.indices.delete = function (param) {
         try {
           should(param).be.an.Object().and.match({index: [index]});
           deletedAll = true;
-          return Promise.resolve({});
+          return q({});
         }
         catch (error) {
           done(error);
-          return Promise.reject(error);
+          return q.reject(error);
         }
       };
 
@@ -1013,10 +1011,10 @@ describe('Test: ElasticSearch service', function () {
         var indexes = {};
         indexes['%kuzzle'] = [];
         indexes[index] = [];
-        return Promise.resolve(indexes);
+        return q(indexes);
       };
       elasticsearch.client.indices.delete = function () {
-        return Promise.reject(new Error('rejected'));
+        return q.reject(new Error('rejected'));
       };
 
       return should(elasticsearch.deleteIndexes(requestObject)).be.rejected();
@@ -1026,10 +1024,10 @@ describe('Test: ElasticSearch service', function () {
       elasticsearch.client.indices.getMapping = function (data) {
         var indexes = {};
         indexes['%kuzzle'] = [];
-        return Promise.resolve(indexes);
+        return q(indexes);
       };
       elasticsearch.client.indices.delete = function () {
-        return Promise.reject(new Error('rejected'));
+        return q.reject(new Error('rejected'));
       };
 
       return should(elasticsearch.deleteIndexes(requestObject)).be.fulfilled();
@@ -1045,7 +1043,7 @@ describe('Test: ElasticSearch service', function () {
       elasticsearch.client.indices.create = function (data) {
         should(data.index).be.exactly(requestObject.index);
 
-        return Promise.resolve({});
+        return q({});
       };
 
       ret = elasticsearch.createIndex(requestObject);
@@ -1061,7 +1059,7 @@ describe('Test: ElasticSearch service', function () {
 
     it('should reject the createIndex promise if elasticsearch throws an error', function () {
       elasticsearch.client.indices.create = function (data) {
-        return Promise.reject(new Error());
+        return q.reject(new Error());
       };
 
       return should(elasticsearch.createIndex(requestObject)).be.rejected();
@@ -1075,7 +1073,7 @@ describe('Test: ElasticSearch service', function () {
       elasticsearch.client.indices.delete = function (data) {
         should(data.index).be.exactly(requestObject.index);
 
-        return Promise.resolve({});
+        return q({});
       };
 
       ret = elasticsearch.deleteIndex(requestObject);
@@ -1091,7 +1089,7 @@ describe('Test: ElasticSearch service', function () {
 
     it('should reject the deleteIndex promise if elasticsearch throws an error', function () {
       elasticsearch.client.indices.delete = function (data) {
-        return Promise.reject(new Error());
+        return q.reject(new Error());
       };
 
       return should(elasticsearch.deleteIndex(requestObject)).be.rejected();
@@ -1103,7 +1101,7 @@ describe('Test: ElasticSearch service', function () {
       elasticsearch.client.indices.getMapping = function (data) {
         var indexes = {};
         indexes[index] = [];
-        return Promise.resolve(indexes);
+        return q(indexes);
       };
 
       elasticsearch.listIndexes(requestObject)
@@ -1116,7 +1114,7 @@ describe('Test: ElasticSearch service', function () {
 
     it('should reject the listIndexes promise if elasticsearch throws an error', function () {
       elasticsearch.client.indices.getMapping = function (data) {
-        return Promise.reject(new Error());
+        return q.reject(new Error());
       };
 
       return should(elasticsearch.listIndexes(requestObject)).be.rejected();
@@ -1125,7 +1123,7 @@ describe('Test: ElasticSearch service', function () {
 
   describe('#getInfos', function () {
     it('should allow getting elasticsearch informations', function () {
-      var esStub = function () { return Promise.resolve({version: {}, indices: {store: {}}}); };
+      var esStub = function () { return q({version: {}, indices: {store: {}}}); };
 
       elasticsearch.client.info = elasticsearch.client.cluster.health = elasticsearch.client.cluster.stats = esStub;
       return should(elasticsearch.getInfos(requestObject)).be.fulfilled();

--- a/test/services/remoteActions.test.js
+++ b/test/services/remoteActions.test.js
@@ -1,6 +1,7 @@
 var
   should = require('should'),
   rewire = require('rewire'),
+  q = require('q'),
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
   RemoteActions = rewire('../../lib/services/remoteActions');
@@ -108,7 +109,7 @@ describe('Testing: Remote Actions service', function () {
     kuzzle.services.list.mockupService = {
       toggle: function (flag) {
         enabled = flag;
-        return Promise.resolve('Enabled: ' + flag.toString());
+        return q('Enabled: ' + flag.toString());
       }
     };
 
@@ -143,7 +144,7 @@ describe('Testing: Remote Actions service', function () {
   it('should forward to kuzzle a failed result if togging the service fails', function (done) {
     kuzzle.services.list.mockupService = {
       toggle: function () {
-        return Promise.reject(new Error('rejected'));
+        return q.reject(new Error('rejected'));
       }
     };
 

--- a/test/workers/write.test.js
+++ b/test/workers/write.test.js
@@ -1,12 +1,11 @@
 var
   should = require('should'),
   rewire = require('rewire'),
+  q = require('q'),
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
   RequestObject = require.main.require('lib/api/core/models/requestObject'),
   Worker = rewire('../../lib/workers/write');
-
-
 
 describe('Testing: write worker', function () {
   var
@@ -21,10 +20,10 @@ describe('Testing: write worker', function () {
         kuzzle.services.init = function () {};
 
         // we test successful write commands using a mockup 'create' action...
-        kuzzle.services.list.writeEngine.create = function (request) { return Promise.resolve(request); };
+        kuzzle.services.list.writeEngine.create = function (request) { return q(request); };
 
         // ...and failed write command with a mockup 'update' action
-        kuzzle.services.list.writeEngine.update = function () { return Promise.reject(new Error('rejected')); };
+        kuzzle.services.list.writeEngine.update = function () { return q.reject(new Error('rejected')); };
 
         done();
       });


### PR DESCRIPTION
- Changed all ES6 Promises to Q Promises, to guarantee that all promises throughout the Kuzzle code are compatibles.
- Simplified promises management here and there
- Fixed `notifier.publish` unit tests as they did not always had the time to test that redis.expiry has correctly been invoked