### PR TITLE
fixed index cache feature

### DIFF
--- a/bin/kuzzle-start.js
+++ b/bin/kuzzle-start.js
@@ -35,9 +35,16 @@ module.exports = function () {
       );
 
       console.log(`
-████████████████████████████████████
-██     KUZZLE ` + (kuzzle.isServer ? 'SERVER' : 'WORKER') + ` STARTED      ██
-████████████████████████████████████`);
+ ████████████████████████████████████
+ ██     KUZZLE ` + (kuzzle.isServer ? 'SERVER' : 'WORKER') + ` STARTED      ██`);
+
+      if (kuzzle.isServer) {
+        console.log(`
+ ██   ...WAITING FOR WORKERS...    ██
+ ████████████████████████████████████`);
+      } else {
+        console.log(' ████████████████████████████████████');
+      }
     })
     .then(() => {
       /*
@@ -45,8 +52,28 @@ module.exports = function () {
        */
       return kuzzle.services.list.broker.waitForListeners(kuzzle.config.queues.workerWriteTaskQueue);
     })
-    .then(() => { return kuzzle.cleanDb(); })
-    .then(() => { return kuzzle.prepareDb(); })
+    .then(() => {
+      if (kuzzle.isServer) {
+        console.log(`
+ ████████████████████████████████████
+ ██        WORKER CONNECTED        ██
+ ██    ...PREPARING DATABASE...    ██
+ ████████████████████████████████████`);
+      }
+
+      return kuzzle.cleanDb(kuzzle);
+    })
+    .then(() => {
+      return kuzzle.prepareDb(kuzzle);
+    })
+    .then(() => {
+      if (kuzzle.isServer) {
+        console.log(`
+ ████████████████████████████████████
+ ██          KUZZLE READY          ██
+ ████████████████████████████████████`);
+      }
+    })
     .catch(error => {
       console.error(error);
       process.exit(1);

--- a/lib/api/Kuzzle.js
+++ b/lib/api/Kuzzle.js
@@ -26,8 +26,6 @@ function Kuzzle () {
   this.workers = new Workers(this);
   this.services = new Services(this);
 
-  this.indexes = {};
-
   // Add methods
   this.cleanDb = require('./cleanDb');
   this.prepareDb = require('./prepareDb');

--- a/lib/api/cleanDb.js
+++ b/lib/api/cleanDb.js
@@ -2,28 +2,29 @@ var
   RequestObject = require('./core/models/requestObject'),
   q = require('q');
 
-module.exports = function () {
+module.exports = function (kuzzle) {
   var
     deferred = q.defer(),
     requestObject = new RequestObject({controller: 'admin', action: 'deleteIndexes'});
 
   // is a reset has been asked and we are launching a server ?
-  if (process.env.LIKE_A_VIRGIN !== '1' || !this.isServer) {
+  if (process.env.LIKE_A_VIRGIN !== '1' || !kuzzle.isServer) {
     deferred.resolve();
     return deferred.promise;
   }
 
   // @todo : manage internal index properly
-  this.pluginsManager.trigger('data:deleteIndexes', requestObject);
+  kuzzle.pluginsManager.trigger('data:deleteIndexes', requestObject);
 
-  this.workerListener.add(requestObject)
+  kuzzle.workerListener.add(requestObject)
     .then(() => {
-      this.pluginsManager.trigger('cleanDb:done', 'Reset done: Kuzzle is now like a virgin, touched for the very first time !');
+      kuzzle.indexCache.reset();
+      kuzzle.pluginsManager.trigger('cleanDb:done', 'Reset done: Kuzzle is now like a virgin, touched for the very first time !');
 
       deferred.resolve();
     })
     .catch(err => {
-      this.pluginsManager.trigger('cleanDb:error', err);
+      kuzzle.pluginsManager.trigger('cleanDb:error', err);
 
       // We resolve the promise, because we don't want stop the start process just because reset didn't work.
       // (can fail if the database is pristine)

--- a/lib/api/controllers/adminController.js
+++ b/lib/api/controllers/adminController.js
@@ -6,7 +6,11 @@ module.exports = function AdminController (kuzzle) {
    */
   this.deleteCollection = function (requestObject) {
     kuzzle.pluginsManager.trigger('data:deleteCollection', requestObject);
-    return kuzzle.workerListener.add(requestObject);
+    return kuzzle.workerListener.add(requestObject)
+      .then(response => {
+        kuzzle.indexCache.remove(requestObject.index, requestObject.collection);
+        return response;
+      });
   };
 
   /**
@@ -16,7 +20,11 @@ module.exports = function AdminController (kuzzle) {
    */
   this.putMapping = function (requestObject) {
     kuzzle.pluginsManager.trigger('data:putMapping', requestObject);
-    return kuzzle.workerListener.add(requestObject);
+    return kuzzle.workerListener.add(requestObject)
+      .then(response => {
+        kuzzle.indexCache.add(requestObject.index, requestObject.collection);
+        return response;
+      });
   };
 
   /**
@@ -81,7 +89,11 @@ module.exports = function AdminController (kuzzle) {
    */
   this.deleteIndexes = function (requestObject) {
     kuzzle.pluginsManager.trigger('data:deleteIndexes', requestObject);
-    return kuzzle.workerListener.add(requestObject);
+    return kuzzle.workerListener.add(requestObject)
+      .then(response => {
+        kuzzle.indexCache.reset();
+        return response;
+      });
   };
 
   /**
@@ -91,7 +103,11 @@ module.exports = function AdminController (kuzzle) {
    */
   this.createIndex = function (requestObject) {
     kuzzle.pluginsManager.trigger('data:createIndex', requestObject);
-    return kuzzle.workerListener.add(requestObject);
+    return kuzzle.workerListener.add(requestObject)
+      .then(response => {
+        kuzzle.indexCache.add(requestObject.index);
+        return response;
+      });
   };
 
   /**
@@ -101,7 +117,11 @@ module.exports = function AdminController (kuzzle) {
    */
   this.deleteIndex = function (requestObject) {
     kuzzle.pluginsManager.trigger('data:deleteIndex', requestObject);
-    return kuzzle.workerListener.add(requestObject);
+    return kuzzle.workerListener.add(requestObject)
+      .then(response => {
+        kuzzle.indexCache.remove(requestObject.index);
+        return response;
+      });
   };
 
   /**

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -52,7 +52,7 @@ module.exports = function FunnelController (kuzzle) {
         }
 
         // check if the current user is allowed to process
-        if (context.token.user.profile.isActionAllowed(requestObject, context, kuzzle.indexes) === false) {
+        if (context.token.user.profile.isActionAllowed(requestObject, context, kuzzle.indexCache.indexes) === false) {
           return q.reject(new UnauthorizedError('Unauthorized action [' + requestObject.index + '/' + requestObject.collection + '/' + requestObject.controller + '/' + requestObject.action + '] for user ' + context.token.user._id, 401));
         }
 

--- a/lib/api/controllers/writeController.js
+++ b/lib/api/controllers/writeController.js
@@ -1,3 +1,5 @@
+
+
 module.exports = function WriteController (kuzzle) {
   /**
    * Create a new document
@@ -34,9 +36,13 @@ module.exports = function WriteController (kuzzle) {
    */
   this.createOrUpdate = function (requestObject) {
     return requestObject.isValid()
-      .then(function () {
+      .then(() => {
         kuzzle.pluginsManager.trigger('data:createOrUpdate', requestObject);
         return kuzzle.workerListener.add(requestObject);
+      })
+      .then(response => {
+        kuzzle.indexCache.add(requestObject.index, requestObject.collection);
+        return response;
       });
   };
 
@@ -82,6 +88,10 @@ module.exports = function WriteController (kuzzle) {
    */
   this.createCollection = function (requestObject) {
     kuzzle.pluginsManager.trigger('data:createCollection', requestObject);
-    return kuzzle.workerListener.add(requestObject);
+    return kuzzle.workerListener.add(requestObject)
+      .then(response => {
+        kuzzle.indexCache.add(requestObject.index, requestObject.collection);
+        return response;
+      });
   };
 };

--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -231,7 +231,7 @@ module.exports = function HotelClerk (kuzzle) {
       requestObjectCollection.index = room.index;
       requestObjectCollection.collection = room.collection;
 
-      if (context.token.user.profile.isActionAllowed(requestObjectCollection, context, kuzzle.indexes) === false) {
+      if (context.token.user.profile.isActionAllowed(requestObjectCollection, context, kuzzle.indexCache.indexes) === false) {
         collectionNotAllowed.push(room.index + '.' + room.collection);
         return true;
       }

--- a/lib/api/core/indexCache.js
+++ b/lib/api/core/indexCache.js
@@ -1,0 +1,63 @@
+var
+  RequestObject = require('./models/requestObject');
+
+/**
+ * Index/collection cache management
+ */
+module.exports = function indexCache (kuzzle) {
+  this.indexes = {};
+
+  this.init = function () {
+    kuzzle.services.list.readEngine.listIndexes(new RequestObject({}))
+      .then(result => {
+        result.data.body.indexes.forEach(index => {
+          this.indexes[index] = [];
+
+          kuzzle.services.list.readEngine.listCollections(new RequestObject({index: index}))
+            .then(resultCollections => {
+              this.indexes[index] = resultCollections.data.body.collections.stored;
+            });
+        });
+      });
+  };
+
+  this.add = function (index, collection) {
+    if (index !== undefined) {
+      if (!this.indexes[index]) {
+        this.indexes[index] = [];
+      }
+
+      if (collection) {
+        if (this.indexes[index].indexOf(collection) === -1) {
+          this.indexes[index].push(collection);
+        }
+      }
+    }
+  };
+
+  this.remove = function (index, collection) {
+    var position;
+
+    if (index && this.indexes[index]) {
+      if (collection) {
+        position = this.indexes[index].indexOf(collection);
+
+        if (position >= 0) {
+          this.indexes[index].splice(position, 1);
+        }
+      }
+      else {
+        delete this.indexes[index];
+      }
+    }
+  };
+
+  this.reset = function (index) {
+    if (index !== undefined) {
+      this.indexes[index] = [];
+    }
+    else {
+      this.indexes = {};
+    }
+  };
+};

--- a/lib/api/core/models/security/role.js
+++ b/lib/api/core/models/security/role.js
@@ -13,17 +13,17 @@ function Role () {
 }
 
 function doesIndexExist(requestObject, indexes) {
-  return indexes[requestObject.index] !== undefined;
+  return indexes && indexes[requestObject.index] !== undefined;
 }
 
 function doesCollectionExist(requestObject, indexes) {
-  return _.contains(indexes[requestObject.index], requestObject.collection);
+  return indexes && _.contains(indexes[requestObject.index], requestObject.collection);
 }
 
 /**
  * @param requestObject
- * @param context
- * @param indexes
+ * @param context - user's context
+ * @param indexes - list of existing indexes/collections
  * @returns {*}
  */
 Role.prototype.isActionAllowed = function (requestObject, context, indexes) {
@@ -53,10 +53,10 @@ Role.prototype.isActionAllowed = function (requestObject, context, indexes) {
     return false;
   }
 
-  if (this.indexes._canCreate !== undefined &&
+  if (!doesIndexExist(requestObject, indexes) &&
+    this.indexes._canCreate !== undefined &&
     !this.indexes._canCreate &&
-    _.contains(['import', 'create', 'createCollection', 'putMapping', 'createOrUpdate'], requestObject.action) &&
-    !doesIndexExist(requestObject, indexes)) {
+    _.contains(['import', 'create', 'createCollection', 'putMapping', 'createOrUpdate'], requestObject.action)) {
     return false;
   }
 
@@ -77,10 +77,10 @@ Role.prototype.isActionAllowed = function (requestObject, context, indexes) {
     return false;
   }
 
-  if (indexRights.collections._canCreate !== undefined &&
+  if (!doesCollectionExist(requestObject, indexes) &&
+    indexRights.collections._canCreate !== undefined &&
     !indexRights.collections._canCreate &&
-    _.contains(['import', 'create', 'createCollection', 'putMapping', 'createOrUpdate'], requestObject.action) &&
-    !doesCollectionExist(requestObject, indexes)) {
+    _.contains(['import', 'create', 'createCollection', 'putMapping', 'createOrUpdate'], requestObject.action)) {
     return false;
   }
 

--- a/lib/api/prepareDb.js
+++ b/lib/api/prepareDb.js
@@ -9,19 +9,13 @@ var
     mappings: 'DEFAULT_MAPPING'
   };
 
-module.exports = function () {
-  this.actualIndexes = [];
+module.exports = function (kuzzle) {
+  this.kuzzle = kuzzle;
   this.data = {};
 
-  if (this.isServer) {
-    this.pluginsManager.trigger('log:info', '== Starting DB preparation...');
-    return this.services.list.readEngine.listIndexes(new RequestObject({}))
-      .then(_actualIndexes => {
-        this.actualIndexes = _actualIndexes.data.body.indexes || [];
-      })
-      .then(() => {
-        return readFile.call(this, 'mappings');
-      })
+  if (kuzzle.isServer) {
+    kuzzle.pluginsManager.trigger('log:info', '== Starting DB preparation...');
+    return readFile.call(this, 'mappings')
       .then(() => {
         return readFile.call(this, 'fixtures');
       })
@@ -35,7 +29,7 @@ module.exports = function () {
         return importFixtures.call(this);
       })
       .then(() => {
-        this.pluginsManager.trigger('log:info', '== DB preparation done.');
+        kuzzle.pluginsManager.trigger('log:info', '== DB preparation done.');
       });
   }
 
@@ -47,26 +41,26 @@ function readFile(which) {
     envVar = env[which];
 
   if (!process.env[envVar] || process.env[envVar] === '') {
-    this.pluginsManager.trigger('log:info', '== No default ' + which + ' file specified in env vars: continue.');
+    this.kuzzle.pluginsManager.trigger('log:info', '== No default ' + which + ' file specified in env vars: continue.');
     this.data[which] = {};
     return q();
   }
 
-  this.pluginsManager.trigger('log:info', '== Reading default ' + which + ' file ' + process.env[envVar] + '...');
+  this.kuzzle.pluginsManager.trigger('log:info', '== Reading default ' + which + ' file ' + process.env[envVar] + '...');
 
   try {
     this.data[which] = JSON.parse(fs.readFileSync(process.env[envVar], 'utf8'));
-    this.pluginsManager.trigger('log:info', '== Reading default ' + which + ' file ' + process.env[envVar] + ' done.');
+    this.kuzzle.pluginsManager.trigger('log:info', '== Reading default ' + which + ' file ' + process.env[envVar] + ' done.');
     return q();
   }
   catch (e) {
-    this.pluginsManager.trigger('log:info', 
+    this.kuzzle.pluginsManager.trigger('log:info',
       'An error occured when reading the ' + process.env[envVar] + ' file! \n' +
       'Remember to put the file into the docker scope...\n' +
       'Here is the original error: ' + e.message
     );
 
-    this.pluginsManager.trigger('preparedb:error', 'Error while loading the file ' + process.env[envVar]);
+    this.kuzzle.pluginsManager.trigger('preparedb:error', 'Error while loading the file ' + process.env[envVar]);
     return q.reject(new InternalError('Error while loading the file ' + process.env[envVar]));
   }
 }
@@ -79,34 +73,30 @@ function createIndexes () {
     (index, callback) => {
       var requestObject = new RequestObject({controller: 'admin', action: 'createIndex', index: index});
 
-      this.pluginsManager.trigger('log:info', '== Trying to create index "' + index + '"...');
-
-      if (this.actualIndexes.indexOf(index) > -1) {
-        this.pluginsManager.trigger('log:info', '== index "' + index + '" already exists.');
+      if (this.kuzzle.indexCache.indexes[index]) {
         callback(null, true);
 
       } else {
-        this.pluginsManager.trigger('data:createIndex', requestObject);
+        this.kuzzle.pluginsManager.trigger('data:createIndex', requestObject);
 
-        this.workerListener.add(requestObject)
+        this.kuzzle.workerListener.add(requestObject)
           .then(() => {
-            this.pluginsManager.trigger('log:info', '== index "' + index + '" created.');
-            this.actualIndexes.push(index);
+            this.kuzzle.pluginsManager.trigger('log:info', '== index "' + index + '" created.');
+            this.kuzzle.indexCache.add(index);
             callback(null, true);
           })
           .catch((error) => {
-            this.pluginsManager.trigger('log:error', '!! index "' + index + '" not created !');
-            this.pluginsManager.trigger('preparedb:error', 'index "' + index + '" not created !');
+            this.kuzzle.pluginsManager.trigger('log:error', '!! index "' + index + '" not created: ' + JSON.stringify(error));
             callback(error);
           });
       }
 
     }, 
     (error) => {
-      this.pluginsManager.trigger('log:info', '== Index creation process terminated.');
+      this.kuzzle.pluginsManager.trigger('log:info', '== Index creation process terminated.');
 
       if (error) {
-        this.pluginsManager.trigger('preparedb:error',
+        this.kuzzle.pluginsManager.trigger('preparedb:error',
           '!! An error occured during the indexes creation.\nHere is the original error message:\n'+error.message
         );
 
@@ -133,11 +123,11 @@ function importMapping () {
 
       if (!this.data.mappings[index][collection].properties) {
         msg = '== Invalid mapping detected: missing required "properties" field';
-        this.pluginsManager.trigger('log:err', msg);
+        this.kuzzle.pluginsManager.trigger('log:err', msg);
         return callbackCollection(msg);
       }
 
-      this.pluginsManager.trigger('log:info', '== Importing mapping for ' + index + ':' + collection + '...');
+      this.kuzzle.pluginsManager.trigger('log:info', '== Importing mapping for ' + index + ':' + collection + '...');
 
       requestObject = new RequestObject({
         controller: 'admin',
@@ -147,8 +137,8 @@ function importMapping () {
         body: this.data.mappings[index][collection]
       });
 
-      this.pluginsManager.trigger('data:putMapping', requestObject);
-      this.workerListener.add(requestObject)
+      this.kuzzle.pluginsManager.trigger('data:putMapping', requestObject);
+      this.kuzzle.workerListener.add(requestObject)
         .then(() => callbackCollection())
         .catch(response => callbackCollection('Mapping import error' + response.error.message));
     }, error => callbackIndex(error));
@@ -157,7 +147,7 @@ function importMapping () {
       return deferred.reject(new InternalError(error));
     }
 
-    this.pluginsManager.trigger('log:info', '== All mapping imports launched.');
+    this.kuzzle.pluginsManager.trigger('log:info', '== All mapping imports launched.');
     return deferred.resolve();
 
   });
@@ -181,11 +171,11 @@ function importFixtures() {
         },
         requestObject = new RequestObject(fixture);
 
-      this.pluginsManager.trigger('log:info', '== Importing fixtures for collection ' + index + ':' + collection + '...');
+      this.kuzzle.pluginsManager.trigger('log:info', '== Importing fixtures for collection ' + index + ':' + collection + '...');
 
-      this.pluginsManager.trigger('data:bulkImport', requestObject);
+      this.kuzzle.pluginsManager.trigger('data:bulkImport', requestObject);
 
-      this.workerListener.add(requestObject)
+      this.kuzzle.workerListener.add(requestObject)
         .then(() => callback())
         .catch(response => {
           // 206 = partial errors
@@ -205,11 +195,11 @@ function importFixtures() {
     });
   }, error => {
     if (error) {
-      this.pluginsManager.trigger('log:error', '== Fixture import error: ' + error.message);
+      this.kuzzle.pluginsManager.trigger('log:error', '== Fixture import error: ' + error.message);
       return deferred.reject(new InternalError(error));
     }
 
-    this.pluginsManager.trigger('log:info', '== All fixtures imports launched.');
+    this.kuzzle.pluginsManager.trigger('log:info', '== All fixtures imports launched.');
     return deferred.resolve();
   });
 

--- a/lib/api/start.js
+++ b/lib/api/start.js
@@ -7,7 +7,6 @@ var
   q = require('q'),
   packageInfo = require('../../package.json'),
   servers = require('./core/servers'),
-  RequestObject = require('./core/models/requestObject'),
   HotelClerk = require('./core/hotelClerk'),
   Notifier = require('./core/notifier'),
   Statistics = require('./core/statistics'),
@@ -17,7 +16,8 @@ var
   Dsl = require('./dsl'),
   // Load all configuration files (database, brokers...)
   config = require('../config'),
-  PluginsManager = require('./core/pluginsManager');
+  PluginsManager = require('./core/pluginsManager'),
+  IndexCache = require('./core/indexCache');
 
 
 /**
@@ -58,21 +58,12 @@ module.exports = function start (params, feature) {
   this.pluginsManager.init(this.isServer, feature.dummy);
   this.pluginsManager.run();
 
+  this.indexCache = new IndexCache(this);
+
   if (!this.isWorker) {
     if (!feature.dummy) {
       this.services.init({server: true});
-
-      this.services.list.readEngine.listIndexes(new RequestObject({}))
-        .then(result => {
-          result.data.indexes.forEach(index => {
-            this.indexes[index] = [];
-
-            this.services.list.readEngine.listCollections(new RequestObject({index: index}))
-              .then(resultCollections => {
-                this.indexes[index] = resultCollections.data.collections;
-              });
-          });
-        });
+      this.indexCache.init();
     }
     else {
       this.services.init({server: false, blacklist: ['mqBroker', 'perf', 'writeEngine', 'readEngine', 'notificationCache', 'monitoring', 'remoteActions', 'statsCache']});

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -6,8 +6,7 @@ var
   BadRequestError = require('../api/core/errors/badRequestError'),
   NotFoundError = require('../api/core/errors/notFoundError'),
   PartialError = require('../api/core/errors/partialError'),
-  es = require('elasticsearch'),
-  indexCache;
+  es = require('elasticsearch');
 
 /**
  *
@@ -51,13 +50,17 @@ module.exports = function (kuzzle, options) {
     return this.client.info()
       .then(res => {
         response.version = res.version.number;
+        /* jshint camelcase: false */
         response.lucene = res.version.lucene_version;
+        /* jshint camelcase: true */
 
         return this.client.cluster.health();
       })
       .then(res => {
         response.status = res.status;
+        /* jshint camelcase: false */
         response.nodes = res.number_of_nodes;
+        /* jshint camelcase: true */
         return this.client.cluster.stats({human: true});
       })
       .then(res => {
@@ -190,23 +193,15 @@ module.exports = function (kuzzle, options) {
    */
   this.create = function (requestObject) {
     var
-      deferred = q.defer(),
       data = cleanData.call(this, requestObject);
 
-    this.client.create(data)
-      .then(function (result) {
-        indexCache.add.call(kuzzle, data.index, data.type);
-
+    return this.client.create(data)
+      .then(result => {
         // extends the response with the source from requestObject
         // When we write in ES, the response from it doesn't contain the initial document content
         result = _.extend(result, {_source: requestObject.data.body});
-        deferred.resolve(new ResponseObject(requestObject, result));
-      })
-      .catch(function (error) {
-        deferred.reject(error);
+        return new ResponseObject(requestObject, result);
       });
-
-    return deferred.promise;
   };
 
   /**
@@ -217,23 +212,15 @@ module.exports = function (kuzzle, options) {
    */
   this.createOrUpdate = function (requestObject) {
     var
-      deferred = q.defer(),
       data = cleanData.call(this, requestObject);
 
-    this.client.index(data)
-      .then(function (result) {
-        indexCache.add.call(kuzzle, data.index, data.type);
-
+    return this.client.index(data)
+      .then(result => {
         // extends the response with the source from requestObject
         // When we write in ES, the response from it doesn't contain the initial document content
         result = _.extend(result, {_source: requestObject.data.body});
-        deferred.resolve(new ResponseObject(requestObject, result));
-      })
-      .catch(function (error) {
-        deferred.reject(error);
+        return new ResponseObject(requestObject, result);
       });
-
-    return deferred.promise;
   };
 
   /**
@@ -245,22 +232,14 @@ module.exports = function (kuzzle, options) {
    */
   this.update = function (requestObject) {
     var
-      deferred = q.defer(),
       data = cleanData.call(this, requestObject);
 
     data.body = {doc: data.body};
 
-    this.client.update(data)
-      .then(function (result) {
-        indexCache.add.call(kuzzle, data.index, data.type);
-
-        deferred.resolve(new ResponseObject(requestObject, result));
-      })
-      .catch(function (error) {
-        deferred.reject(error);
+    return this.client.update(data)
+      .then(result => {
+        return new ResponseObject(requestObject, result);
       });
-
-    return deferred.promise;
   };
 
   /**
@@ -271,18 +250,12 @@ module.exports = function (kuzzle, options) {
    */
   this.delete = function (requestObject) {
     var
-      deferred = q.defer(),
       data = cleanData.call(this, requestObject);
 
-    this.client.delete(data)
-      .then(function (result) {
-        deferred.resolve(new ResponseObject(requestObject, result));
-      })
-      .catch(function (error) {
-        deferred.reject(error);
+    return this.client.delete(data)
+      .then(result => {
+        return new ResponseObject(requestObject, result);
       });
-
-    return deferred.promise;
   };
 
   /**
@@ -300,30 +273,22 @@ module.exports = function (kuzzle, options) {
     data.scroll = '30s';
 
     getAllIdsFromQuery.call(this, data)
-      .then(function (ids) {
-        async.each(ids, function (id, callback) {
+      .then(ids => {
+        async.each(ids, (id, callback) => {
           bodyBulk.push({delete: {_index: data.index, _type: data.type, _id: id}});
           callback();
-        }, function () {
-
+        }, () => {
           if (bodyBulk.length === 0) {
             deferred.resolve(new ResponseObject(requestObject, {ids : []}));
             return false;
           }
 
           this.client.bulk({body: bodyBulk})
-            .then(function () {
-              deferred.resolve(new ResponseObject(requestObject, {ids : ids}));
-            })
-            .catch(function (error) {
-              deferred.reject(error);
-            });
-
-        }.bind(this));
-      }.bind(this))
-      .catch(function (error) {
-        deferred.reject(error);
-      });
+            .then(() => deferred.resolve(new ResponseObject(requestObject, {ids : ids})))
+            .catch(error => deferred.reject(error));
+        });
+      })
+      .catch(error => deferred.reject(error));
 
     return deferred.promise;
   };
@@ -335,19 +300,12 @@ module.exports = function (kuzzle, options) {
    */
   this.deleteCollection = function (requestObject) {
     var
-      deferred = q.defer(),
       data = cleanData.call(this, requestObject);
 
-    this.client.indices.deleteMapping(data)
-      .then(function () {
-        indexCache.remove.call(kuzzle, data.index, data.type);
-        deferred.resolve(new ResponseObject(requestObject));
-      })
-      .catch(function (error) {
-        deferred.reject(error);
+    return this.client.indices.deleteMapping(data)
+      .then(() => {
+        return new ResponseObject(requestObject);
       });
-
-    return deferred.promise;
   };
 
   /**
@@ -358,22 +316,15 @@ module.exports = function (kuzzle, options) {
    */
   this.createCollection = function (requestObject) {
     var
-      deferred = q.defer(),
       data = cleanData.call(this, requestObject);
 
     data.body = {};
     data.body[data.type] = {};
 
-    this.client.indices.putMapping(data)
-      .then(function () {
-        indexCache.add.call(kuzzle, data.index, data.type);
-        deferred.resolve(new ResponseObject(requestObject));
-      })
-      .catch(function (error) {
-        deferred.reject(error);
+    return this.client.indices.putMapping(data)
+      .then(() => {
+        return new ResponseObject(requestObject);
       });
-
-    return deferred.promise;
   };
 
   /**
@@ -471,10 +422,6 @@ module.exports = function (kuzzle, options) {
 
             async.each(result.items, function(resultItem, resultCallback) {
               async.each(Object.keys(resultItem), function(action, callback) {
-                var item = resultItem[action];
-                if (action === 'index' && !item.error) {
-                  indexCache.add.call(kuzzle, item._index, item._type);
-                }
                 callback();
               });
               resultCallback();
@@ -500,18 +447,12 @@ module.exports = function (kuzzle, options) {
    */
   this.putMapping = function (requestObject) {
     var
-      deferred = q.defer(),
       data = cleanData.call(this, requestObject);
 
-    this.client.indices.putMapping(data)
-      .then(function (result) {
-        deferred.resolve(new ResponseObject(requestObject, result));
-      })
-      .catch(function (error) {
-        deferred.reject(error);
+    return this.client.indices.putMapping(data)
+      .then(result => {
+        return new ResponseObject(requestObject, result);
       });
-
-    return deferred.promise;
   };
 
   /**
@@ -522,25 +463,18 @@ module.exports = function (kuzzle, options) {
    */
   this.getMapping = function (requestObject) {
     var
-      deferred = q.defer(),
       data = cleanData.call(this, requestObject);
 
     delete data.body;
 
-    this.client.indices.getMapping(data)
+    return this.client.indices.getMapping(data)
       .then(result => {
         if (result[requestObject.index]) {
-          deferred.resolve(new ResponseObject(requestObject, result));
+          return new ResponseObject(requestObject, result);
         }
-        else {
-          deferred.reject(new NotFoundError('No mapping for index "' + requestObject.index + '"'));
-        }
-      })
-      .catch(function (error) {
-        deferred.reject(error);
-      });
 
-    return deferred.promise;
+        return q.reject(new NotFoundError('No mapping for index "' + requestObject.index + '"'));
+      });
   };
 
   /**
@@ -551,12 +485,11 @@ module.exports = function (kuzzle, options) {
    */
   this.listCollections = function (requestObject) {
     var
-      deferred = q.defer(),
       data = cleanData.call(this, requestObject);
 
     delete data.body;
 
-    this.client.indices.getMapping(data)
+    return this.client.indices.getMapping(data)
       .then(result => {
         var collections = [];
 
@@ -564,11 +497,8 @@ module.exports = function (kuzzle, options) {
           collections = Object.keys(result[requestObject.index].mappings);
         }
 
-        deferred.resolve(new ResponseObject(requestObject, {collections: {stored: collections}}));
-      })
-      .catch(error => deferred.reject(error));
-
-    return deferred.promise;
+        return new ResponseObject(requestObject, {collections: {stored: collections}});
+      });
   };
 
   /**
@@ -581,22 +511,26 @@ module.exports = function (kuzzle, options) {
 
     return this.listIndexes(requestObject)
       .then(result => {
-        if (result.data.body.indexes.length !== 0) {
+        if (result.data.body.indexes.length > 0) {
           return this.client.indices.delete({index: result.data.body.indexes});
         }
       })
       .then(() => {
-        indexCache.reset.call(kuzzle);
         return new ResponseObject(requestObject, {});
       });
   };
 
+  /**
+   * List all known indexes
+   *
+   * @param {object} requestObject
+   * @returns {promise}
+   */
   this.listIndexes = function (requestObject) {
     var
-      indexes = [],
-      deferred = q.defer();
+      indexes = [];
 
-    this.client.indices.getMapping()
+    return this.client.indices.getMapping()
       .then(result => {
         indexes = Object.keys(result);
         indexes = indexes.filter(indexName => {
@@ -605,41 +539,40 @@ module.exports = function (kuzzle, options) {
           return indexName !== '';
         });
 
-        deferred.resolve(new ResponseObject(requestObject, {indexes: indexes}));
-      })
-      .catch(error => deferred.reject(error));
-
-    return deferred.promise;
+        return new ResponseObject(requestObject, {indexes: indexes});
+      });
   };
 
+  /**
+   * Create a new index
+   *
+   * @param {object} requestObject
+   * @returns promise}
+   */
   this.createIndex = function (requestObject) {
     var
-      deferred = q.defer(),
       data = cleanData.call(this, requestObject);
 
-    this.client.indices.create({index: data.index})
+    return this.client.indices.create({index: data.index})
       .then(result => {
-        indexCache.add.call(kuzzle, data.index);
-        deferred.resolve(new ResponseObject(requestObject, result));
-      })
-      .catch(error => deferred.reject(error));
-
-    return deferred.promise;
+        return new ResponseObject(requestObject, result);
+      });
   };
 
+  /**
+   * Delete an index
+   *
+   * @param {object} requestObject
+   * @returns {promise}
+   */
   this.deleteIndex = function (requestObject) {
     var
-      deferred = q.defer(),
       data = cleanData.call(this, requestObject);
 
-    this.client.indices.delete({index: data.index})
+    return this.client.indices.delete({index: data.index})
       .then(result => {
-        indexCache.remove.call(kuzzle, data.index);
-        deferred.resolve(new ResponseObject(requestObject, result));
-      })
-      .catch(error => deferred.reject(error));
-
-    return deferred.promise;
+        return new ResponseObject(requestObject, result);
+      });
   };
 };
 
@@ -708,37 +641,3 @@ function getAllIdsFromQuery(data) {
 
   return deferred.promise;
 }
-
-indexCache = {
-  add: function(index, collection) {
-    if (index !== undefined) {
-      if (this.indexes[index] === undefined) {
-        this.indexes[index] = [];
-      }
-
-      if (collection !== undefined) {
-        if (this.indexes[index].indexOf(collection) === -1) {
-          this.indexes[index].push(collection);
-        }
-      }
-    }
-  },
-  remove: function(index, collection) {
-    if (index !== undefined) {
-      if (collection !== undefined) {
-        this.indexes[index].splice(this.indexes[index].indexOf(collection));
-      }
-      else {
-        delete this.indexes[index];
-      }
-    }
-  },
-  reset: function(index) {
-    if (index !== undefined) {
-      this.indexes[index] = [];
-    }
-    else {
-      this.indexes = {};
-    }
-  }
-};

--- a/test/api/controllers/adminController.test.js
+++ b/test/api/controllers/adminController.test.js
@@ -9,7 +9,12 @@ var
 describe('Test: admin controller', function () {
   var
     kuzzle,
-    requestObject = new RequestObject({ controller: 'admin' }, { index: '%test', collection: 'unit-test-adminController' }, 'unit-test');
+    indexCacheRemove,
+    indexCacheAdd,
+    indexCacheReset,
+    index = '%text',
+    collection = 'unit-test-adminController',
+    requestObject = new RequestObject({ controller: 'admin' }, {index, collection}, 'unit-test');
 
   before(function (done) {
     kuzzle = new Kuzzle();
@@ -24,179 +29,302 @@ describe('Test: admin controller', function () {
           });
         };
 
+        kuzzle.workerListener = {
+          add: function (rq) {
+            return q(new ResponseObject(rq));
+          }
+        };
+
+        kuzzle.indexCache = {
+          add: (i, c) => {
+            should(i).be.eql(index);
+            if (c) {
+              should(c).be.eql(collection);
+            }
+            indexCacheAdd = true;
+          },
+          remove: (i, c) => {
+            should(i).be.eql(index);
+            if (c) {
+              should(c).be.eql(collection);
+            }
+            indexCacheRemove = true;
+          },
+          reset: i => {
+            if (i) {
+              should(i).be.eql(index);
+            }
+            indexCacheReset = true;
+          }
+        };
+
         done();
       });
   });
 
-  it('should activate a hook on a delete collection call', function (done) {
-    this.timeout(50);
+  beforeEach(function () {
+    indexCacheAdd = false;
+    indexCacheRemove = false;
+    indexCacheReset = false;
+  });
 
-    kuzzle.once('data:deleteCollection', function (obj) {
-      try {
-        should(obj).be.exactly(requestObject);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+  describe('#deleteCollection', function () {
+    it('should activate a hook on a delete collection call', function (done) {
+      this.timeout(50);
 
-    kuzzle.funnel.admin.deleteCollection(requestObject)
-      .catch(function (error) {
-        done(error);
+      kuzzle.once('data:deleteCollection', function (obj) {
+        try {
+          should(obj).be.exactly(requestObject);
+          done();
+        }
+        catch (e) {
+          done(e);
+        }
       });
-  });
 
-  it('should activate a hook on a put mapping call', function (done) {
-    this.timeout(50);
-
-    kuzzle.once('data:putMapping', function (obj) {
-      try {
-        should(obj).be.exactly(requestObject);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
+      kuzzle.funnel.admin.deleteCollection(requestObject)
+        .catch(function (error) {
+          done(error);
+        });
     });
 
-    kuzzle.funnel.admin.putMapping(requestObject)
-      .catch(function (error) {
-        done(error);
+    it('should remove the deleted collection from the cache', function (done) {
+      this.timeout(50);
+
+      kuzzle.funnel.admin.deleteCollection(requestObject)
+        .then(response => {
+          should(response).be.instanceof(ResponseObject);
+          should(indexCacheAdd).be.false();
+          should(indexCacheRemove).be.true();
+          should(indexCacheReset).be.false();
+          done();
+        })
+        .catch(err => done(err));
+    });
+  });
+
+  describe('#putMapping', function () {
+    it('should activate a hook on a put mapping call', function (done) {
+      this.timeout(50);
+
+      kuzzle.once('data:putMapping', function (obj) {
+        try {
+          should(obj).be.exactly(requestObject);
+          done();
+        }
+        catch (e) {
+          done(e);
+        }
       });
-  });
 
-  it('should return a mapping when requested', function () {
-    var r = kuzzle.funnel.admin.getMapping(requestObject);
-    return should(r).be.rejected();
-  });
-
-  it('should activate a hook on a get mapping call', function (done) {
-    this.timeout(50);
-
-    kuzzle.once('data:getMapping', function (obj) {
-      try {
-        should(obj).be.exactly(requestObject);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
+      kuzzle.funnel.admin.putMapping(requestObject)
+        .catch(function (error) {
+          done(error);
+        });
     });
 
-    kuzzle.funnel.admin.getMapping(requestObject);
+    it('should add the new collection to the cache', function (done) {
+      this.timeout(50);
+
+      kuzzle.funnel.admin.putMapping(requestObject)
+        .then(response => {
+          should(response).be.instanceof(ResponseObject);
+          should(indexCacheAdd).be.true();
+          should(indexCacheRemove).be.false();
+          should(indexCacheReset).be.false();
+          done();
+        })
+        .catch(err => done(err));
+    });
   });
 
-  it('should trigger a hook on a getStats call', function (done) {
-    this.timeout(50);
-
-    kuzzle.once('data:getStats', function (obj) {
-      try {
-        should(obj).be.exactly(requestObject);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
+  describe('#getMapping', function () {
+    it('should return a mapping when requested', function () {
+      var r = kuzzle.funnel.admin.getMapping(requestObject);
+      return should(r).be.rejected();
     });
 
-    kuzzle.funnel.admin.getStats(requestObject);
+    it('should activate a hook on a get mapping call', function (done) {
+      this.timeout(50);
+
+      kuzzle.once('data:getMapping', function (obj) {
+        try {
+          should(obj).be.exactly(requestObject);
+          done();
+        }
+        catch (e) {
+          done(e);
+        }
+      });
+
+      kuzzle.funnel.admin.getMapping(requestObject);
+    });
   });
 
-  it('should trigger a hook on a getLastStats call', function (done) {
-    this.timeout(50);
+  describe('#getStats', function () {
+    it('should trigger a hook on a getStats call', function (done) {
+      this.timeout(50);
 
-    kuzzle.once('data:getLastStats', function (obj) {
-      try {
-        should(obj).be.exactly(requestObject);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
+      kuzzle.once('data:getStats', function (obj) {
+        try {
+          should(obj).be.exactly(requestObject);
+          done();
+        }
+        catch (e) {
+          done(e);
+        }
+      });
+
+      kuzzle.funnel.admin.getStats(requestObject);
     });
-
-    kuzzle.funnel.admin.getLastStats(requestObject);
   });
 
-  it('should trigger a hook on a getAllStats call', function (done) {
-    this.timeout(50);
+  describe('#getLastStats', function () {
+    it('should trigger a hook on a getLastStats call', function (done) {
+      this.timeout(50);
 
-    kuzzle.once('data:getAllStats', function (obj) {
-      try {
-        should(obj).be.exactly(requestObject);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
+      kuzzle.once('data:getLastStats', function (obj) {
+        try {
+          should(obj).be.exactly(requestObject);
+          done();
+        }
+        catch (e) {
+          done(e);
+        }
+      });
+
+      kuzzle.funnel.admin.getLastStats(requestObject);
     });
-
-    kuzzle.funnel.admin.getAllStats(requestObject);
   });
 
-  it('should trigger a hook on a truncateCollection call', function (done) {
-    this.timeout(50);
+  describe('#getAllStats', function () {
+    it('should trigger a hook on a getAllStats call', function (done) {
+      this.timeout(50);
 
-    kuzzle.once('data:truncateCollection', obj => {
-      try {
-        should(obj).be.exactly(requestObject);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
+      kuzzle.once('data:getAllStats', function (obj) {
+        try {
+          should(obj).be.exactly(requestObject);
+          done();
+        }
+        catch (e) {
+          done(e);
+        }
+      });
+
+      kuzzle.funnel.admin.getAllStats(requestObject);
     });
-
-    kuzzle.funnel.admin.truncateCollection(requestObject);
   });
 
-  it('should trigger a hook on a deleteIndexes call', function (done) {
-    this.timeout(50);
+  describe('#truncateCollection', function () {
+    it('should trigger a hook on a truncateCollection call', function (done) {
+      this.timeout(50);
 
-    kuzzle.once('data:deleteIndexes', function (obj) {
-      try {
-        should(obj).be.exactly(requestObject);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
+      kuzzle.once('data:truncateCollection', obj => {
+        try {
+          should(obj).be.exactly(requestObject);
+          done();
+        }
+        catch (e) {
+          done(e);
+        }
+      });
+
+      kuzzle.funnel.admin.truncateCollection(requestObject);
     });
-
-    kuzzle.funnel.admin.deleteIndexes(requestObject);
   });
 
-  it('should trigger a hook on a createIndex call', function (done) {
-    this.timeout(50);
+  describe('#deleteIndexes', function () {
+    it('should trigger a hook on a deleteIndexes call', function (done) {
+      this.timeout(50);
 
-    kuzzle.once('data:createIndex', function (obj) {
-      try {
-        should(obj).be.exactly(requestObject);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
+      kuzzle.once('data:deleteIndexes', function (obj) {
+        try {
+          should(obj).be.exactly(requestObject);
+          done();
+        }
+        catch (e) {
+          done(e);
+        }
+      });
+
+      kuzzle.funnel.admin.deleteIndexes(requestObject);
     });
 
-    kuzzle.funnel.admin.createIndex(requestObject);
+    it('should reset the index cache', function (done) {
+      this.timeout(50);
+
+      kuzzle.funnel.admin.deleteIndexes(requestObject)
+        .then(response => {
+          should(response).be.instanceof(ResponseObject);
+          should(indexCacheAdd).be.false();
+          should(indexCacheRemove).be.false();
+          should(indexCacheReset).be.true();
+          done();
+        })
+        .catch(err => done(err));
+    });
   });
 
-  it('should trigger a hook on a deleteIndex call', function (done) {
-    this.timeout(50);
+  describe('#createIndex', function () {
+    it('should trigger a hook on a createIndex call', function (done) {
+      this.timeout(50);
 
-    kuzzle.once('data:deleteIndex', function (obj) {
-      try {
-        should(obj).be.exactly(requestObject);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
+      kuzzle.once('data:createIndex', function (obj) {
+        try {
+          should(obj).be.exactly(requestObject);
+          done();
+        }
+        catch (e) {
+          done(e);
+        }
+      });
+
+      kuzzle.funnel.admin.createIndex(requestObject);
     });
 
-    kuzzle.funnel.admin.deleteIndex(requestObject);
+    it('should add the new index to the cache', function (done) {
+      this.timeout(50);
+
+      kuzzle.funnel.admin.createIndex(requestObject)
+        .then(response => {
+          should(response).be.instanceof(ResponseObject);
+          should(indexCacheAdd).be.true();
+          should(indexCacheRemove).be.false();
+          should(indexCacheReset).be.false();
+          done();
+        })
+        .catch(err => done(err));
+    });
+  });
+
+  describe('#deleteIndex', function () {
+    it('should trigger a hook on a deleteIndex call', function (done) {
+      this.timeout(50);
+
+      kuzzle.once('data:deleteIndex', function (obj) {
+        try {
+          should(obj).be.exactly(requestObject);
+          done();
+        }
+        catch (e) {
+          done(e);
+        }
+      });
+
+      kuzzle.funnel.admin.deleteIndex(requestObject);
+    });
+
+    it('should remove the index from the cache', function (done) {
+      kuzzle.funnel.admin.deleteIndex(requestObject)
+        .then(response => {
+          should(response).be.instanceof(ResponseObject);
+          should(indexCacheAdd).be.false();
+          should(indexCacheRemove).be.true();
+          should(indexCacheReset).be.false();
+          done();
+        })
+        .catch(err => done(err));
+    });
   });
 
   describe('#removeRooms', function () {

--- a/test/api/core/indexCache.test.js
+++ b/test/api/core/indexCache.test.js
@@ -1,0 +1,138 @@
+var
+  should = require('should'),
+  q = require('q'),
+  params = require('rc')('kuzzle'),
+  Kuzzle = require.main.require('lib/api/Kuzzle'),
+  IndexCache = require.main.require('lib/api/core/indexCache');
+
+
+describe('Test: core/indexCache', function () {
+  var
+    kuzzle,
+    indexCache;
+
+  before(function (done) {
+    kuzzle = new Kuzzle();
+    kuzzle.start(params, {dummy: true})
+      .then(function () {
+        kuzzle.services.list.readEngine = {
+          listIndexes: () => {
+            var stubResponse = {
+              data: {
+                body: {
+                  indexes: ['foo']
+                }
+              }
+            };
+
+            return q(stubResponse);
+          },
+
+          listCollections: () => {
+            var stubResponse = {
+              data: {
+                body: {
+                  collections: {
+                    stored: ['bar', 'baz', 'qux']
+                  }
+                }
+              }
+            };
+
+            return q(stubResponse);
+          }
+        };
+
+        done();
+      });
+  });
+
+  beforeEach(function () {
+    indexCache = new IndexCache(kuzzle);
+  });
+
+  describe('#init', function () {
+    it('should initialize the index cache properly', function (done) {
+      this.timeout(50);
+      indexCache.init();
+
+      setTimeout(() => {
+        should(indexCache.indexes).be.an.Object().and.have.keys('foo');
+        should(indexCache.indexes.foo).be.an.Array().and.match(['bar', 'baz', 'qux']);
+        done();
+      }, 20);
+    });
+  });
+
+  describe('#add', function () {
+    it('should add a single index to the index cache', function () {
+      indexCache.add('foobar');
+      should(indexCache.indexes).have.keys('foobar');
+      should(indexCache.indexes.foobar).be.an.Array().and.be.empty();
+    });
+
+    it('should add a new collection to the index cache', function () {
+      indexCache.add('index', 'collection');
+      should(indexCache.indexes).have.keys('index');
+      should(indexCache.indexes.index).be.an.Array().and.match(['collection']);
+    });
+
+    it('should not add a collection if it is already in cache', function () {
+      indexCache.add('index', 'collection');
+      indexCache.add('index', 'collection');
+
+      should(indexCache.indexes).have.keys('index');
+      should(indexCache.indexes.index).be.an.Array().and.match(['collection']);
+    });
+
+    it('should do nothing if no index is provided', function () {
+      indexCache.add();
+      should(indexCache.indexes).be.empty();
+    });
+  });
+
+  describe('#remove', function () {
+    it('should remove an index from the cache', function () {
+      indexCache.add('index', 'collection');
+      indexCache.remove('index');
+      should(indexCache.indexes).be.empty();
+    });
+
+    it('should remove a single collection from the cache', function () {
+      indexCache.add('index', 'collection1');
+      indexCache.add('index', 'collection2');
+      indexCache.remove('index', 'collection1');
+      should(indexCache.indexes).have.keys('index');
+      should(indexCache.indexes.index).be.an.Array().and.match(['collection2']);
+    });
+
+    it('should do nothing if the index does not exist', function () {
+      indexCache.add('index', 'collection');
+      indexCache.remove('foo');
+      should(indexCache.indexes).match({index: ['collection']});
+    });
+
+    it('should do nothing if the collection does not exist', function () {
+      indexCache.add('index', 'collection');
+      indexCache.remove('index', 'foo');
+      should(indexCache.indexes).match({index: ['collection']});
+    });
+  });
+
+  describe('#reset', function () {
+    it('should empty the index cache if invoked with no argument', function () {
+      indexCache.add('index1', 'collection');
+      indexCache.add('index2', 'collection');
+      indexCache.reset();
+      should(indexCache.indexes).be.an.Object().and.be.empty();
+    });
+
+    it('should remove all collections of an index', function () {
+      indexCache.add('index', 'collection1');
+      indexCache.add('index', 'collection2');
+      indexCache.reset('index');
+      should(indexCache.indexes).be.an.Object().and.have.keys('index');
+      should(indexCache.indexes.index).be.an.Array().and.be.empty();
+    });
+  });
+});

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -10,9 +10,7 @@ var
 
 describe('Test: ElasticSearch service', function () {
   var
-    kuzzle = {
-      indexes: {}
-    },
+    kuzzle = {},
     index = '%test',
     collection = 'unit-tests-elasticsearch',
     createdDocumentId = 'id-test',
@@ -63,8 +61,6 @@ describe('Test: ElasticSearch service', function () {
       index: index,
       body: documentAda
     });
-
-    kuzzle.indexes[index] = [collection];
   });
 
   describe('#init', function () {
@@ -134,12 +130,7 @@ describe('Test: ElasticSearch service', function () {
   });
 
   describe('#create', function () {
-    it('should allow creating documents', function (done) {
-      var
-        ret;
-
-      kuzzle.indexes = {};
-
+    it('should allow creating documents', function () {
       elasticsearch.client.create = function (data) {
         should(data.index).be.exactly(index);
         should(data.type).be.exactly(collection);
@@ -148,16 +139,7 @@ describe('Test: ElasticSearch service', function () {
         return q({});
       };
 
-      ret = elasticsearch.create(requestObject);
-
-      should(ret).be.a.Promise();
-
-      ret
-        .then(function (result) {
-          should(kuzzle.indexes).be.an.instanceOf(Object).and.have.property(index, [collection]);
-          done();
-        })
-        .catch(error => done(error));
+      return should(elasticsearch.create(requestObject)).be.a.fulfilled();
     });
 
     it('should reject the create promise if elasticsearch throws an error', function () {
@@ -170,11 +152,7 @@ describe('Test: ElasticSearch service', function () {
   });
 
   describe('#createOrUpdate', function () {
-    it('should support createOrUpdate capability', function (done) {
-      var ret;
-
-      kuzzle.indexes = {};
-
+    it('should support createOrUpdate capability', function () {
       elasticsearch.client.index = function (data) {
         should(data.index).be.exactly(index);
         should(data.type).be.exactly(collection);
@@ -185,16 +163,7 @@ describe('Test: ElasticSearch service', function () {
       };
 
       requestObject.data._id = createdDocumentId;
-      ret = elasticsearch.createOrUpdate(requestObject);
-
-      should(ret).be.a.Promise();
-
-      ret
-        .then(function (result) {
-          should(kuzzle.indexes).be.an.instanceOf(Object).and.have.property(index, [collection]);
-          done();
-        })
-        .catch(error => done(error));
+      return should(elasticsearch.createOrUpdate(requestObject)).be.fulfilled();
     });
 
     it('should reject the createOrUpdate promise if elasticsearch throws an error', function () {
@@ -212,9 +181,7 @@ describe('Test: ElasticSearch service', function () {
   });
 
   describe('#get', function () {
-    it('should allow getting a single document', function (done) {
-      var ret;
-
+    it('should allow getting a single document', function () {
       elasticsearch.client.get = function (data) {
         should(data.id).be.exactly(createdDocumentId);
 
@@ -224,16 +191,7 @@ describe('Test: ElasticSearch service', function () {
       delete requestObject.data.body;
       requestObject.data._id = createdDocumentId;
 
-      ret = elasticsearch.get(requestObject);
-
-      should(ret).be.a.Promise();
-
-      ret
-        .then(result => {
-          should(kuzzle.indexes).be.an.instanceOf(Object).and.have.property(index, [collection]);
-          done();
-        })
-        .catch(error => done(error));
+      return should(elasticsearch.get(requestObject)).be.fulfilled();
     });
 
     it('should reject requests when the user search for a document with id _search', function () {
@@ -346,11 +304,7 @@ describe('Test: ElasticSearch service', function () {
   });
 
   describe('#update', function () {
-    it('should allow to update a document', function (done) {
-      var ret;
-
-      kuzzle.indexes = {};
-
+    it('should allow to update a document', function () {
       elasticsearch.client.update = function (data) {
         should(data.body.doc).be.exactly(documentAda);
         should(data.id).be.exactly(createdDocumentId);
@@ -360,15 +314,7 @@ describe('Test: ElasticSearch service', function () {
 
       requestObject.data._id = createdDocumentId;
 
-      ret = elasticsearch.update(requestObject);
-      should(ret).be.a.Promise();
-
-      ret
-        .then(function (result) {
-          should(kuzzle.indexes).be.an.instanceOf(Object).and.have.property(index, [collection]);
-          done();
-        })
-        .catch(error => done(error));
+      return should(elasticsearch.update(requestObject)).be.fulfilled();
     });
 
     it('should return a rejected promise if an update fails', function () {
@@ -565,8 +511,6 @@ describe('Test: ElasticSearch service', function () {
     });
 
     it('should override the type with the collection if one has been specified in the request', function () {
-      kuzzle.indexes = {};
-
       requestObject.data.body = [
         {index: {_id: 1, _index: index}},
         {firstName: 'foo'},
@@ -741,19 +685,14 @@ describe('Test: ElasticSearch service', function () {
   });
 
   describe('#deleteCollection', function () {
-    it('should allow deleting an entire collection', function (done) {
+    it('should allow deleting an entire collection', function () {
 
       elasticsearch.client.indices.deleteMapping = function (data) {
         return q({});
       };
 
       delete requestObject.data.body;
-      should(elasticsearch.deleteCollection(requestObject)).be.fulfilled()
-        .then(function (result) {
-          should(kuzzle.indexes).be.an.instanceOf(Object).and.have.property(index, []);
-          done();
-        })
-        .catch(error => done(error));
+      return should(elasticsearch.deleteCollection(requestObject)).be.fulfilled();
     });
 
     it('should return a rejected promise if the delete collection function fails', function () {
@@ -878,19 +817,13 @@ describe('Test: ElasticSearch service', function () {
   });
 
   describe('#createCollection', function () {
-    it('should allow creating a new collection', function (done) {
-
+    it('should allow creating a new collection', function () {
       elasticsearch.client.indices.putMapping = function (data) {
         return q();
       };
 
       requestObject.collection = '%foobar';
-      elasticsearch.createCollection(requestObject)
-        .then(function (result) {
-          should(kuzzle.indexes).be.an.instanceOf(Object).and.have.property(index, [collection, requestObject.collection]);
-          done();
-        })
-        .catch(error => done(error));
+      return should(elasticsearch.createCollection(requestObject)).be.fulfilled();
     });
 
     it('should reject the createCollection promise if elasticsearch throws an error', function () {
@@ -999,7 +932,6 @@ describe('Test: ElasticSearch service', function () {
 
       ret
         .then(function () {
-          should(kuzzle.indexes).be.an.instanceOf(Object).and.have.keys();
           should(deletedAll).be.true();
           done();
         })
@@ -1019,42 +951,17 @@ describe('Test: ElasticSearch service', function () {
 
       return should(elasticsearch.deleteIndexes(requestObject)).be.rejected();
     });
-
-    /*it('should not delete any index if only left %kuzzle internal index', function () {
-      elasticsearch.client.indices.getMapping = function (data) {
-        var indexes = {};
-        indexes['%kuzzle'] = [];
-        return q(indexes);
-      };
-      elasticsearch.client.indices.delete = function () {
-        return q.reject(new Error('rejected'));
-      };
-
-      return should(elasticsearch.deleteIndexes(requestObject)).be.fulfilled();
-    });*/
   });
 
   describe('#createIndex', function () {
-    it('should be able to create index', function (done) {
-      var ret;
-
-      kuzzle.indexes = {};
-
+    it('should be able to create index', function () {
       elasticsearch.client.indices.create = function (data) {
         should(data.index).be.exactly(requestObject.index);
 
         return q({});
       };
 
-      ret = elasticsearch.createIndex(requestObject);
-      should(ret).be.a.Promise();
-
-      ret
-        .then(function (result) {
-          should(kuzzle.indexes).be.an.instanceOf(Object).and.have.property(index, []);
-          done();
-        })
-        .catch(error => done(error));
+      return should(elasticsearch.createIndex(requestObject)).be.fulfilled();
     });
 
     it('should reject the createIndex promise if elasticsearch throws an error', function () {
@@ -1067,24 +974,14 @@ describe('Test: ElasticSearch service', function () {
   });
 
   describe('#deleteIndex', function () {
-    it('should be able to delete index', function (done) {
-      var ret;
-
+    it('should be able to delete index', function () {
       elasticsearch.client.indices.delete = function (data) {
         should(data.index).be.exactly(requestObject.index);
 
         return q({});
       };
 
-      ret = elasticsearch.deleteIndex(requestObject);
-      should(ret).be.a.Promise();
-
-      ret
-        .then(function (result) {
-          should(kuzzle.indexes).be.an.instanceOf(Object).and.have.keys();
-          done();
-        })
-        .catch(error => done(error));
+      return should(elasticsearch.deleteIndex(requestObject)).be.fulfilled();
     });
 
     it('should reject the deleteIndex promise if elasticsearch throws an error', function () {
@@ -1097,19 +994,14 @@ describe('Test: ElasticSearch service', function () {
   });
 
   describe('#listIndexes', function () {
-    it('should allow listing indexes', function (done) {
+    it('should allow listing indexes', function () {
       elasticsearch.client.indices.getMapping = function (data) {
         var indexes = {};
         indexes[index] = [];
         return q(indexes);
       };
 
-      elasticsearch.listIndexes(requestObject)
-        .then(result => {
-          should(result.data.body.indexes).be.an.instanceOf(Array).and.match([index]);
-          done();
-        })
-        .catch(error => done(error));
+      return should(elasticsearch.listIndexes(requestObject)).be.fulfilled();
     });
 
     it('should reject the listIndexes promise if elasticsearch throws an error', function () {


### PR DESCRIPTION
Bugfix: the index cache was handled by the elasticsearch service, called both by the server instance and its workers. Problem is: workers didn't have access to the index cache, thus leading to non-catched errors.

* created a new `indexCache` core component
* removed all index cache management from the elasticsearch service
* replaced `kuzzle.indexes` with `kuzzle.indexCache`, using the new core component
* the index cache is now refreshed by the `write` and `admin` controllers
* `cleanDb` and `prepareDb` now use and maintain the index cache
* `cleanDb` and `prepareDb` are now independant to Kuzzle to avoid adding unnecessary objects to the main context
* added new console messages to make the Kuzzle startup sequence clearer
