### PR TITLE
subscription on null filters bugfix

### DIFF
--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -474,17 +474,17 @@ function createRoom (index, collection, filters) {
    Ensure the resulting room id is identical even if the order of filters terms is changed.
    This should do the trick for now, but a deep sort() would probably be better.
     */
-  if (filters) {
-    Object.keys(filters).forEach(key => sortedFilters.push([key, filters[key]]));
-    stringifiedFilters = stringify(sortedFilters.sort((a, b) => {
-      return String(a[0]).localeCompare(b[0]);
-    }));
+  if (!filters) {
+    filters = {};
+  }
 
-    stringifiedObject = stringify({index: index, collection: collection, filters: stringifiedFilters});
-  }
-  else {
-    stringifiedObject = stringify({index: index, collection: collection, filters: filters});
-  }
+  Object.keys(filters).forEach(key => sortedFilters.push([key, filters[key]]));
+  stringifiedFilters = stringify(sortedFilters.sort((a, b) => {
+    return String(a[0]).localeCompare(b[0]);
+  }));
+
+  stringifiedObject = stringify({index: index, collection: collection, filters: stringifiedFilters});
+
   roomId = crypto.createHash('md5').update(stringifiedObject).digest('hex');
 
   async.retry(function(callback) {

--- a/test/api/core/hotelClerck/addSubscription.test.js
+++ b/test/api/core/hotelClerck/addSubscription.test.js
@@ -348,4 +348,34 @@ describe('Test: hotelClerk.addSubscription', function () {
     ))
       .be.rejectedWith(BadRequestError);
   });
+
+  it('should treat null/undefined filters as empty filters', function (done) {
+    var
+      requestObject1 = new RequestObject({
+        controller: 'subscribe',
+        collection: collection,
+        index: index,
+        body: {}
+      }),
+      requestObject2 = new RequestObject({
+        controller: 'subscribe',
+        collection: collection,
+        index: index,
+        body: null
+      }),
+      response;
+
+    return kuzzle.hotelClerk.addSubscription(requestObject1, context)
+      .then(result => {
+        response = result;
+        return kuzzle.hotelClerk.addSubscription(requestObject2, context);
+      })
+      .then(result => {
+        should(result.roomId).be.exactly(response.roomId);
+        done();
+      })
+      .catch(error => {
+        done(error);
+      });
+  });
 });


### PR DESCRIPTION
Subscriptions made on empty filters and on null/undefined filters generated different room IDs, whereas the same room ID should be generated.
