### PR TITLE
functional tests on security layer - fixtures cleanup

### DIFF
--- a/features/AMQP.feature
+++ b/features/AMQP.feature
@@ -243,7 +243,7 @@ Feature: Test AMQP API
     Then I'm not able to find the index named "my-undefined-index" in index list
     Then I'm able to delete the index named "my-new-index"
 
-  @usingAMQP
+  @usingAMQP @cleanSecurity
   Scenario: login user
     Given I create a user "user1" with id "user1-id"
     When I log in as user1-id:testpwd
@@ -251,7 +251,7 @@ Feature: Test AMQP API
     Then I logout
     Then I can't write the document
 
-  @usingAMQP
+  @usingAMQP @cleanSecurity
   Scenario: Create/get/search/update/delete role
     When I create a new role "role1" with id "test"
     Then I'm able to find a role with id "test"
@@ -261,19 +261,19 @@ Feature: Test AMQP API
     And I delete the role with id "test"
     Then I'm not able to find a role with id "test"
 
-  @usingAMQP
+  @usingAMQP @cleanSecurity
   Scenario: create an invalid profile with unexisting role triggers an error
     Then I cannot create an invalid profile
 
-  @usingAMQP
+  @usingAMQP @cleanSecurity
   Scenario: get profile without id triggers an error
     Then I cannot a profile without ID
 
-  @usingAMQP
+  @usingAMQP @cleanSecurity
   Scenario: creating a profile with an empty set of roles triggers an error
     Then I cannot create a profile with an empty set of roles
 
-  @usingAMQP
+  @usingAMQP @cleanSecurity
   Scenario: create, get and delete a profile
     Given I create a new role "role1" with id "role1"
     And I create a new role "role2" with id "role2"
@@ -281,10 +281,8 @@ Feature: Test AMQP API
     Then I'm able to find the profile with id "my-new-profile"
     Given I delete the profile with id "my-new-profile"
     Then I'm not able to find the profile with id "my-new-profile"
-    Then I delete the role "role1"
-    Then I delete the role "role2"
 
-  @usingAMQP
+  @usingAMQP @cleanSecurity
   Scenario: search and update profiles
     Given I create a new role "role1" with id "role1"
     And I create a new role "role2" with id "role2"
@@ -296,12 +294,8 @@ Feature: Test AMQP API
     Given I update the profile with id "my-profile-2" by adding the role "role1"
     Then I'm able to find "2" profiles
     Then I'm able to find "2" profiles containing the role with id "role1"
-    Then I delete the profile "my-profile-1"
-    Then I delete the profile "my-profile-2"
-    Then I delete the role "role1"
-    Then I delete the role "role2"
 
-  @usingAMQP
+  @usingAMQP @cleanSecurity
   Scenario: user crudl
     And I create a new role "role1" with id "role1"
     And I create a new role "role2" with id "role2"
@@ -311,15 +305,11 @@ Feature: Test AMQP API
     Then I am able to get the user "user1-id" matching {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin","roles":[{"_id":"admin"}]}}}
     Then I am able to get the unhydrated user "user1-id" matching {"_id":"#prefix#user1-id","_source":{"profile":"admin"}}
     Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profile":{"_id":"#prefix#profile2"}}}
-    Then I search for {"regexp":{"_id":"^#prefix#.*"}} and find 2 users
+    Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 2 users
     Then I delete the user "user2-id"
-    Then I search for {"regexp":{"_id":"^#prefix#.*"}} and find 1 users matching {"_id":"#prefix#user1-id","_source":{"name":{"first":"David","last":"Bowie"}}}
+    Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 1 users matching {"_id":"#prefix#user1-id","_source":{"name":{"first":"David","last":"Bowie"}}}
     When I log in as user1-id:testpwd
     Then I am getting the current user, which matches {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin"}}}
     Then I log out
     Then I am getting the current user, which matches {"_id":-1,"_source":{"profile":{"_id":"anonymous"}}}
-    Then I delete the user "user1-id"
-    Then I delete the profile "profile2"
-    Then I delete the role "role1"
-    Then I delete the role "role2"
 

--- a/features/MQTT.feature
+++ b/features/MQTT.feature
@@ -243,7 +243,7 @@ Feature: Test MQTT API
     Then I'm not able to find the index named "my-undefined-index" in index list
     Then I'm able to delete the index named "my-new-index"
 
-  @usingMQTT
+  @usingMQTT @cleanSecurity
   Scenario: login user
     Given I create a user "user1" with id "user1-id"
     When I log in as user1-id:testpwd
@@ -251,7 +251,7 @@ Feature: Test MQTT API
     Then I logout
     Then I can't write the document
 
-  @usingMQTT
+  @usingMQTT @cleanSecurity
   Scenario: Create/get/search/update/delete role
     When I create a new role "role1" with id "test"
     Then I'm able to find a role with id "test"
@@ -261,19 +261,19 @@ Feature: Test MQTT API
     And I delete the role with id "test"
     Then I'm not able to find a role with id "test"
 
-  @usingMQTT
+  @usingMQTT @cleanSecurity
   Scenario: create an invalid profile with unexisting role triggers an error
     Then I cannot create an invalid profile
 
-  @usingMQTT
+  @usingMQTT @cleanSecurity
   Scenario: get profile without id triggers an error
     Then I cannot a profile without ID
 
-  @usingMQTT
+  @usingMQTT @cleanSecurity
   Scenario: creating a profile with an empty set of roles triggers an error
     Then I cannot create a profile with an empty set of roles
 
-  @usingMQTT
+  @usingMQTT @cleanSecurity
   Scenario: create, get and delete a profile
     Given I create a new role "role1" with id "role1"
     And I create a new role "role2" with id "role2"
@@ -281,10 +281,8 @@ Feature: Test MQTT API
     Then I'm able to find the profile with id "my-new-profile"
     Given I delete the profile with id "my-new-profile"
     Then I'm not able to find the profile with id "my-new-profile"
-    Then I delete the role "role1"
-    Then I delete the role "role2"
 
-  @usingMQTT
+  @usingMQTT @cleanSecurity
   Scenario: search and update profiles
     Given I create a new role "role1" with id "role1"
     And I create a new role "role2" with id "role2"
@@ -296,12 +294,8 @@ Feature: Test MQTT API
     Given I update the profile with id "my-profile-2" by adding the role "role1"
     Then I'm able to find "2" profiles
     Then I'm able to find "2" profiles containing the role with id "role1"
-    Then I delete the profile "my-profile-1"
-    Then I delete the profile "my-profile-2"
-    Then I delete the role "role1"
-    Then I delete the role "role2"
 
-  @usingMQTT
+  @usingMQTT @cleanSecurity
   Scenario: user crudl
     And I create a new role "role1" with id "role1"
     And I create a new role "role2" with id "role2"
@@ -311,15 +305,11 @@ Feature: Test MQTT API
     Then I am able to get the user "user1-id" matching {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin","roles":[{"_id":"admin"}]}}}
     Then I am able to get the unhydrated user "user1-id" matching {"_id":"#prefix#user1-id","_source":{"profile":"admin"}}
     Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profile":{"_id":"#prefix#profile2"}}}
-    Then I search for {"regexp":{"_id":"^#prefix#.*"}} and find 2 users
+    Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 2 users
     Then I delete the user "user2-id"
-    Then I search for {"regexp":{"_id":"^#prefix#.*"}} and find 1 users matching {"_id":"#prefix#user1-id","_source":{"name":{"first":"David","last":"Bowie"}}}
+    Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 1 users matching {"_id":"#prefix#user1-id","_source":{"name":{"first":"David","last":"Bowie"}}}
     When I log in as user1-id:testpwd
     Then I am getting the current user, which matches {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin"}}}
     Then I log out
     Then I am getting the current user, which matches {"_id":-1,"_source":{"profile":{"_id":"anonymous"}}}
-    Then I delete the user "user1-id"
-    Then I delete the profile "profile2"
-    Then I delete the role "role1"
-    Then I delete the role "role2"
 

--- a/features/REST.feature
+++ b/features/REST.feature
@@ -127,7 +127,7 @@ Feature: Test REST API
     Then I'm not able to find the index named "my-undefined-index" in index list
     Then I'm able to delete the index named "my-new-index"
 
-  @usingREST
+  @usingREST @cleanSecurity
   Scenario: login user
     Given I create a user "user1" with id "user1-id"
     When I log in as user1-id:testpwd
@@ -135,7 +135,7 @@ Feature: Test REST API
     Then I logout
     Then I can't write the document
 
-  @usingREST
+  @usingREST @cleanSecurity
   Scenario: Create/get/search/update/delete role
     When I create a new role "role1" with id "test"
     Then I'm able to find a role with id "test"
@@ -149,23 +149,20 @@ Feature: Test REST API
     And I create a new role "role1" with id "test3"
     Then I'm able to find "3" role by searching index corresponding to role "role1"
     Then I'm able to find "1" role by searching index corresponding to role "role1" from "0" to "1"
-    Then I delete the role "test"
-    Then I delete the role "test2"
-    Then I delete the role "test3"
 
-  @usingREST
+  @usingREST @cleanSecurity
   Scenario: create an invalid profile with unexisting role triggers an error
     Then I cannot create an invalid profile
 
-  @usingREST
+  @usingREST @cleanSecurity
   Scenario: get profile without id triggers an error
     Then I cannot a profile without ID
 
-  @usingREST
+  @usingREST @cleanSecurity
   Scenario: creating a profile with an empty set of roles triggers an error
     Then I cannot create a profile with an empty set of roles
 
-  @usingREST
+  @usingREST @cleanSecurity
   Scenario: create, get and delete a profile
     Given I create a new role "role1" with id "role1"
     And I create a new role "role2" with id "role2"
@@ -173,10 +170,8 @@ Feature: Test REST API
     Then I'm able to find the profile with id "my-new-profile"
     Given I delete the profile with id "my-new-profile"
     Then I'm not able to find the profile with id "my-new-profile"
-    Then I delete the role "role1"
-    Then I delete the role "role2"
 
-  @usingREST
+  @usingREST @cleanSecurity
   Scenario: search and update profiles
     Given I create a new role "role1" with id "role1"
     And I create a new role "role2" with id "role2"
@@ -190,10 +185,8 @@ Feature: Test REST API
     Then I'm able to find "2" profiles containing the role with id "role1"
     Then I delete the profile "my-profile-1"
     Then I delete the profile "my-profile-2"
-    Then I delete the role "role1"
-    Then I delete the role "role2"
 
-  @usingREST
+  @usingREST @cleanSecurity
   Scenario: user crudl
     And I create a new role "role1" with id "role1"
     And I create a new role "role2" with id "role2"
@@ -202,15 +195,11 @@ Feature: Test REST API
     And I create a user "user2" with id "user2-id"
     Then I am able to get the user "user1-id" matching {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin","roles":[{"_id":"admin"}]}}}
     Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profile":{"_id":"#prefix#profile2"}}}
-    Then I search for {"regexp":{"_id":"^#prefix#.*"}} and find 2 users
+    Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 2 users
     Then I delete the user "user2-id"
-    Then I search for {"regexp":{"_id":"^#prefix#.*"}} and find 1 users matching {"_id":"#prefix#user1-id","_source":{"name":{"first":"David","last":"Bowie"}}}
+    Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 1 users matching {"_id":"#prefix#user1-id","_source":{"name":{"first":"David","last":"Bowie"}}}
     When I log in as user1-id:testpwd
     Then I am getting the current user, which matches {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin"}}}
     Then I log out
     Then I am getting the current user, which matches {"_id":-1,"_source":{"profile":{"_id":"anonymous"}}}
-    Then I delete the user "user1-id"
-    Then I delete the profile "profile2"
-    Then I delete the role "role1"
-    Then I delete the role "role2"
 

--- a/features/STOMP.feature
+++ b/features/STOMP.feature
@@ -243,7 +243,7 @@ Feature: Test STOMP API
     Then I'm not able to find the index named "my-undefined-index" in index list
     Then I'm able to delete the index named "my-new-index"
 
-  @usingSTOMP
+  @usingSTOMP @cleanSecurity
   Scenario: login user
     Given I create a user "user1" with id "user1-id"
     When I log in as user1-id:testpwd
@@ -251,7 +251,7 @@ Feature: Test STOMP API
     Then I logout
     Then I can't write the document
 
-  @usingSTOMP
+  @usingSTOMP @cleanSecurity
   Scenario: Create/get/search/update/delete role
     When I create a new role "role1" with id "test"
     Then I'm able to find a role with id "test"
@@ -261,11 +261,11 @@ Feature: Test STOMP API
     And I delete the role with id "test"
     Then I'm not able to find a role with id "test"
 
-  @usingSTOMP
+  @usingSTOMP @cleanSecurity
   Scenario: create an invalid profile with unexisting role triggers an error
     Then I cannot create an invalid profile
 
-  @usingSTOMP
+  @usingSTOMP @cleanSecurity
   Scenario: get profile without id triggers an error
     Then I cannot a profile without ID
 
@@ -273,7 +273,7 @@ Feature: Test STOMP API
   Scenario: creating a profile with an empty set of roles triggers an error
     Then I cannot create a profile with an empty set of roles
 
-  @usingSTOMP
+  @usingSTOMP @cleanSecurity
   Scenario: create, get and delete a profile
     Given I create a new role "role1" with id "role1"
     And I create a new role "role2" with id "role2"
@@ -281,10 +281,8 @@ Feature: Test STOMP API
     Then I'm able to find the profile with id "my-new-profile"
     Given I delete the profile with id "my-new-profile"
     Then I'm not able to find the profile with id "my-new-profile"
-    Then I delete the role "role1"
-    Then I delete the role "role2"
 
-  @usingSTOMP
+  @usingSTOMP @cleanSecurity
   Scenario: search and update profiles
     Given I create a new role "role1" with id "role1"
     And I create a new role "role2" with id "role2"
@@ -296,12 +294,8 @@ Feature: Test STOMP API
     Given I update the profile with id "my-profile-2" by adding the role "role1"
     Then I'm able to find "2" profiles
     Then I'm able to find "2" profiles containing the role with id "role1"
-    Then I delete the profile "my-profile-1"
-    Then I delete the profile "my-profile-2"
-    Then I delete the role "role1"
-    Then I delete the role "role2"
 
-  @usingSTOMP
+  @usingSTOMP @cleanSecurity
   Scenario: user crudl
     And I create a new role "role1" with id "role1"
     And I create a new role "role2" with id "role2"
@@ -311,15 +305,11 @@ Feature: Test STOMP API
     Then I am able to get the user "user1-id" matching {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin","roles":[{"_id":"admin"}]}}}
     Then I am able to get the unhydrated user "user1-id" matching {"_id":"#prefix#user1-id","_source":{"profile":"admin"}}
     Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profile":{"_id":"#prefix#profile2"}}}
-    Then I search for {"regexp":{"_id":"^#prefix#.*"}} and find 2 users
+    Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 2 users
     Then I delete the user "user2-id"
-    Then I search for {"regexp":{"_id":"^#prefix#.*"}} and find 1 users matching {"_id":"#prefix#user1-id","_source":{"name":{"first":"David","last":"Bowie"}}}
+    Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 1 users matching {"_id":"#prefix#user1-id","_source":{"name":{"first":"David","last":"Bowie"}}}
     When I log in as user1-id:testpwd
     Then I am getting the current user, which matches {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin"}}}
     Then I log out
     Then I am getting the current user, which matches {"_id":-1,"_source":{"profile":{"_id":"anonymous"}}}
-    Then I delete the user "user1-id"
-    Then I delete the profile "profile2"
-    Then I delete the role "role1"
-    Then I delete the role "role2"
 

--- a/features/Websocket.feature
+++ b/features/Websocket.feature
@@ -245,7 +245,7 @@ Feature: Test websocket API
     Then I'm not able to find the index named "my-undefined-index" in index list
     Then I'm able to delete the index named "my-new-index"
 
-  @usingWebsocket
+  @usingWebsocket @cleanSecurity
   Scenario: login user
     Given I create a user "user1" with id "user1-id"
     When I log in as user1-id:testpwd
@@ -253,7 +253,7 @@ Feature: Test websocket API
     Then I logout
     Then I can't write the document
 
-  @usingWebsocket
+  @usingWebsocket @cleanSecurity
   Scenario: Create/get/search/update/delete role
     When I create a new role "role1" with id "test"
     Then I'm able to find a role with id "test"
@@ -263,19 +263,19 @@ Feature: Test websocket API
     And I delete the role with id "test"
     Then I'm not able to find a role with id "test"
 
-  @usingWebsocket
+  @usingWebsocket @cleanSecurity
   Scenario: create an invalid profile with unexisting role triggers an error
     Then I cannot create an invalid profile
 
-  @usingWebsocket
+  @usingWebsocket @cleanSecurity
   Scenario: get profile without id triggers an error
     Then I cannot a profile without ID
 
-  @usingWebsocket
+  @usingWebsocket @cleanSecurity
   Scenario: creating a profile with an empty set of roles triggers an error
     Then I cannot create a profile with an empty set of roles
 
-  @usingWebsocket
+  @usingWebsocket @cleanSecurity
   Scenario: create, get and delete a profile
     Given I create a new role "role1" with id "role1"
     And I create a new role "role2" with id "role2"
@@ -283,10 +283,8 @@ Feature: Test websocket API
     Then I'm able to find the profile with id "my-new-profile"
     Given I delete the profile with id "my-new-profile"
     Then I'm not able to find the profile with id "my-new-profile"
-    Then I delete the role "role1"
-    Then I delete the role "role2"
 
-  @usingWebsocket
+  @usingWebsocket @cleanSecurity
   Scenario: search and update profiles
     Given I create a new role "role1" with id "role1"
     And I create a new role "role2" with id "role2"
@@ -298,12 +296,8 @@ Feature: Test websocket API
     Given I update the profile with id "my-profile-2" by adding the role "role1"
     Then I'm able to find "2" profiles
     Then I'm able to find "2" profiles containing the role with id "role1"
-    Then I delete the profile "my-profile-1"
-    Then I delete the profile "my-profile-2"
-    Then I delete the role "role1"
-    Then I delete the role "role2"
 
-  @usingWebsocket
+  @usingWebsocket @cleanSecurity
   Scenario: user crudl
     And I create a new role "role1" with id "role1"
     And I create a new role "role2" with id "role2"
@@ -313,16 +307,12 @@ Feature: Test websocket API
     Then I am able to get the user "user1-id" matching {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin","roles":[{"_id":"admin"}]}}}
     Then I am able to get the unhydrated user "user1-id" matching {"_id":"#prefix#user1-id","_source":{"profile":"admin"}}
     Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profile":{"_id":"#prefix#profile2"}}}
-    Then I search for {"regexp":{"_id":"^#prefix#.*"}} and find 2 users
+    Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 2 users
     Then I delete the user "user2-id"
-    Then I search for {"regexp":{"_id":"^#prefix#.*"}} and find 1 users matching {"_id":"#prefix#user1-id","_source":{"name":{"first":"David","last":"Bowie"}}}
+    Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 1 users matching {"_id":"#prefix#user1-id","_source":{"name":{"first":"David","last":"Bowie"}}}
     When I log in as user1-id:testpwd
     Then I am getting the current user, which matches {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin"}}}
     Then I log out
     Then I am getting the current user, which matches {"_id":-1,"_source":{"profile":{"_id":"anonymous"}}}
-    Then I delete the user "user1-id"
-    Then I delete the profile "profile2"
-    Then I delete the role "role1"
-    Then I delete the role "role2"
 
 

--- a/features/support/apiREST.js
+++ b/features/support/apiREST.js
@@ -134,9 +134,9 @@ ApiREST.prototype.deleteById = function (id, index) {
   return this.callApi(options);
 };
 
-ApiREST.prototype.deleteByQuery = function (filters, index) {
+ApiREST.prototype.deleteByQuery = function (filters, index, collection) {
   var options = {
-    url: this.apiPath(((typeof index !== 'string') ? this.world.fakeIndex : index) + '/' + this.world.fakeCollection + '/_query'),
+    url: this.apiPath(((typeof index !== 'string') ? this.world.fakeIndex : index) + '/' + (collection || this.world.fakeCollection) + '/_query'),
     method: 'DELETE',
     json: filters
   };
@@ -436,7 +436,7 @@ ApiREST.prototype.searchUsers = function (body) {
   return this.callApi({
     url: this.apiPath('users/_search'),
     method: 'POST',
-    json: body
+    json: { filter: body }
   });
 };
 

--- a/features/support/apiRT.js
+++ b/features/support/apiRT.js
@@ -139,11 +139,11 @@ ApiRT.prototype.deleteById = function (id, index) {
   return this.send(msg);
 };
 
-ApiRT.prototype.deleteByQuery = function (filters, index) {
+ApiRT.prototype.deleteByQuery = function (filters, index, collection) {
   var
     msg = {
       controller: 'write',
-      collection: this.world.fakeCollection,
+      collection: collection || this.world.fakeCollection,
       index: index || this.world.fakeIndex,
       action: 'deleteByQuery',
       body: filters
@@ -546,7 +546,9 @@ ApiRT.prototype.searchUsers = function (body) {
   return this.send({
     controller: 'security',
     action: 'searchUsers',
-    body: body
+    body: {
+      filter: body
+    }
   });
 };
 

--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -95,7 +95,7 @@ function cleanSecurity (callback) {
   this.api.listIndexes()
     .then(response => {
       if (response.result.indexes.indexOf('%kuzzle') === -1) {
-        return true;
+        return q.reject(new ReferenceError('%kuzzle index not found'));
       }
     })
     .then(() => {
@@ -122,5 +122,11 @@ function cleanSecurity (callback) {
     .then(() => {
       callback();
     })
-    .catch(error => { callback(error); });
+    .catch(error => {
+      if (error instanceof ReferenceError && error.message === '%kuzzle index not found') {
+        // The %kuzzle index is not created yet. Is not a problem if the tests are run for the first time.
+        callback();
+      }
+      callback(error);
+    });
 }

--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -75,7 +75,7 @@ var myHooks = function () {
 
   this.After('@cleanSecurity', function (scenario, callback) {
     cleanSecurity.call(this, callback);
-  })
+  });
 
 };
 
@@ -89,7 +89,7 @@ function setAPI (world, apiName) {
   api.init(world);
 
   return api;
-};
+}
 
 function cleanSecurity (callback) {
   this.api.listIndexes()
@@ -103,7 +103,7 @@ function cleanSecurity (callback) {
         { filter: { regexp: { _uid: 'users.' + this.idPrefix + '.*' } } },
         '%kuzzle',
         'users'
-      )
+      );
     })
     .then(() => {
       return this.api.deleteByQuery(
@@ -123,4 +123,4 @@ function cleanSecurity (callback) {
       callback();
     })
     .catch(error => { callback(error); });
-};
+}

--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -69,11 +69,19 @@ var myHooks = function () {
     }, error => callback(error));
   });
 
+  this.Before('@cleanSecurity', function (scenario, callback) {
+    cleanSecurity.call(this, callback);
+  });
+
+  this.After('@cleanSecurity', function (scenario, callback) {
+    cleanSecurity.call(this, callback);
+  })
+
 };
 
 module.exports = myHooks;
 
-var setAPI = function (world, apiName) {
+function setAPI (world, apiName) {
   var
     Api = require('./api' + apiName),
     api = new Api();
@@ -81,4 +89,38 @@ var setAPI = function (world, apiName) {
   api.init(world);
 
   return api;
+};
+
+function cleanSecurity (callback) {
+  this.api.listIndexes()
+    .then(response => {
+      if (response.result.indexes.indexOf('%kuzzle') === -1) {
+        return true;
+      }
+    })
+    .then(() => {
+      return this.api.deleteByQuery(
+        { filter: { regexp: { _uid: 'users.' + this.idPrefix + '.*' } } },
+        '%kuzzle',
+        'users'
+      )
+    })
+    .then(() => {
+      return this.api.deleteByQuery(
+        { filter: { regexp: { _uid: 'profiles.' + this.idPrefix + '.*' } } },
+        '%kuzzle',
+        'profiles'
+      );
+    })
+    .then(() => {
+      return this.api.deleteByQuery(
+        {filter: { regexp: { _uid: 'roles.' + this.idPrefix + '.*' } } },
+        '%kuzzle',
+        'roles'
+      );
+    })
+    .then(() => {
+      callback();
+    })
+    .catch(error => { callback(error); });
 };


### PR DESCRIPTION
Introducing the @cleanSecurity tag back.
The hooks now run before & after the tags and perform a deleteByQuery on the test prefixed ids instead of dropping the whole %kuzzle index.