### PR TITLE
Bugfixes

### DIFF
--- a/features/step_definitions/profiles.js
+++ b/features/step_definitions/profiles.js
@@ -6,6 +6,7 @@ var apiSteps = function () {
     if (!this.profiles[profile]) {
       return callback('Fixture for profile ' + profile + ' does not exists');
     }
+
     id = this.idPrefix + id;
 
     this.api.createOrReplaceProfile(id, this.profiles[profile])
@@ -70,7 +71,6 @@ var apiSteps = function () {
 
   this.Then(/^I'm ?(not)* able to find the profile with id "([^"]*)"(?: with profile "([^"]*)")?$/, {timeout: 20 * 1000}, function (not, id, profile, callback) {
     var
-      index,
       main;
 
     if (profile && !this.profiles[profile]) {
@@ -147,7 +147,7 @@ var apiSteps = function () {
       main;
 
     if (roleId) {
-      body.roles.push(roleId);
+      body.roles.push(this.idPrefix + roleId);
     }
 
     main = function (callbackAsync) {

--- a/features/support/apiRT.js
+++ b/features/support/apiRT.js
@@ -537,7 +537,7 @@ ApiRT.prototype.getUser = function (id, hydrate) {
 
 ApiRT.prototype.getCurrentUser = function () {
   return this.send({
-    controller: 'security',
+    controller: 'auth',
     action: 'getCurrentUser'
   });
 };

--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -76,7 +76,6 @@ var myHooks = function () {
   this.After('@cleanSecurity', function (scenario, callback) {
     cleanSecurity.call(this, callback);
   });
-
 };
 
 module.exports = myHooks;

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -64,7 +64,7 @@ module.exports = function AuthController (kuzzle) {
           return q(new ResponseObject(requestObject, {found: false}));
         }
 
-        if (requestObject.data.body.hydrate !== undefined && requestObject.data.body.hydrate === false) {
+        if (!requestObject.data.body.hydrate) {
           response = {
             _id: user._id,
             _source: kuzzle.repositories.user.serializeToDatabase(user)

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -1,7 +1,6 @@
 var
   q = require('q'),
   PassportWrapper = require('../core/auth/passportWrapper'),
-  BadRequestError = require('../core/errors/badRequestError'),
   ResponseObject = require('../core/models/responseObject');
 
 module.exports = function AuthController (kuzzle) {
@@ -80,30 +79,6 @@ module.exports = function AuthController (kuzzle) {
         delete response._source._id;
 
         return q(new ResponseObject(requestObject, response));
-      });
-  };
-
-  /**
-   * Checks the validity of a token.
-   *
-   * @param requestObject
-   * @param context
-   */
-  this.checkToken = function (requestObject, context) {
-    if (!requestObject.data.body || !requestObject.data.body.token) {
-      return q.reject(new BadRequestError('Cannot check token: no token provided'));
-    }
-
-    return kuzzle.repositories.token.verifyToken(requestObject.data.body.token)
-      .then(token => {
-        return q(new ResponseObject(requestObject, token));
-      })
-      .catch(invalid => {
-        if (invalid.status === 401) {
-          return q(new ResponseObject(requestObject, {valid: false, state: invalid.message}));
-        }
-
-        return q.reject(new ResponseObject(requestObject, invalid));
       });
   };
 };

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -64,7 +64,7 @@ module.exports = function AuthController (kuzzle) {
           return q(new ResponseObject(requestObject, {found: false}));
         }
 
-        if (!requestObject.data.body.hydrate) {
+        if (requestObject.data.body.hydrate !== undefined && requestObject.data.body.hydrate === false) {
           response = {
             _id: user._id,
             _source: kuzzle.repositories.user.serializeToDatabase(user)

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -1,6 +1,7 @@
 var
   q = require('q'),
   PassportWrapper = require('../core/auth/passportWrapper'),
+  BadRequestError = require('../core/errors/badRequestError'),
   ResponseObject = require('../core/models/responseObject');
 
 module.exports = function AuthController (kuzzle) {
@@ -42,6 +43,67 @@ module.exports = function AuthController (kuzzle) {
       })
       .catch((err) => {
         return q.reject(new ResponseObject(requestObject, err));
+      });
+  };
+
+  /**
+   * Returns the user identified by the given jwt token
+   * @param {RequestObject} requestObject
+   * @param context
+   * @returns {Promise}
+   */
+  this.getCurrentUser = function (requestObject, context) {
+    kuzzle.pluginsManager.trigger('security:getCurrentUser', requestObject);
+
+    requestObject.data._id = context.token.user._id;
+
+    return kuzzle.repositories.user.load(requestObject.data._id)
+      .then(user => {
+        var response;
+
+        if (!user) {
+          return q(new ResponseObject(requestObject, {found: false}));
+        }
+
+        if (requestObject.data.body.hydrate !== undefined && requestObject.data.body.hydrate === false) {
+          response = {
+            _id: user._id,
+            _source: kuzzle.repositories.user.serializeToDatabase(user)
+          };
+        }
+        else {
+          response = {
+            _id: user._id,
+            _source: user
+          };
+        }
+        delete response._source._id;
+
+        return q(new ResponseObject(requestObject, response));
+      });
+  };
+
+  /**
+   * Checks the validity of a token.
+   *
+   * @param requestObject
+   * @param context
+   */
+  this.checkToken = function (requestObject, context) {
+    if (!requestObject.data.body || !requestObject.data.body.token) {
+      return q.reject(new BadRequestError('Cannot check token: no token provided'));
+    }
+
+    return kuzzle.repositories.token.verifyToken(requestObject.data.body.token)
+      .then(token => {
+        return q(new ResponseObject(requestObject, token));
+      })
+      .catch(invalid => {
+        if (invalid.status === 401) {
+          return q(new ResponseObject(requestObject, {valid: false, state: invalid.message}));
+        }
+
+        return q.reject(new ResponseObject(requestObject, invalid));
       });
   };
 };

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -52,7 +52,7 @@ module.exports = function AuthController (kuzzle) {
    * @returns {Promise}
    */
   this.getCurrentUser = function (requestObject, context) {
-    kuzzle.pluginsManager.trigger('security:getCurrentUser', requestObject);
+    kuzzle.pluginsManager.trigger('auth:getCurrentUser', requestObject);
 
     requestObject.data._id = context.token.user._id;
 

--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -130,9 +130,9 @@ module.exports = function RouterController (kuzzle) {
         {verb: 'get', url: '/:index/_listCollections', controller: 'read', action: 'listCollections'},
         {verb: 'get', url: '/:index/_listCollections/:type', controller: 'read', action: 'listCollections'},
         {verb: 'get', url: '/:index/:collection/_mapping', controller: 'admin', action: 'getMapping'},
-        {verb: 'get', url: '/:index/:collection/:id', controller: 'read', action: 'get'},
         {verb: 'get', url: '/users/_me', controller: 'auth', action: 'getCurrentUser'},
         {verb: 'get', url: '/users/:id', controller: 'security', action: 'getUser'},
+        {verb: 'get', url: '/:index/:collection/:id', controller: 'read', action: 'get'},
 
         {verb: 'post', url: '/_bulk', controller: 'bulk', action: 'import'},
         {verb: 'post', url: '/_getStats', controller: 'admin', action: 'getStats'},

--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -131,7 +131,7 @@ module.exports = function RouterController (kuzzle) {
         {verb: 'get', url: '/:index/_listCollections/:type', controller: 'read', action: 'listCollections'},
         {verb: 'get', url: '/:index/:collection/_mapping', controller: 'admin', action: 'getMapping'},
         {verb: 'get', url: '/:index/:collection/:id', controller: 'read', action: 'get'},
-        {verb: 'get', url: '/users/_me', controller: 'security', action: 'getCurrentUser'},
+        {verb: 'get', url: '/users/_me', controller: 'auth', action: 'getCurrentUser'},
         {verb: 'get', url: '/users/:id', controller: 'security', action: 'getUser'},
 
         {verb: 'post', url: '/_bulk', controller: 'bulk', action: 'import'},
@@ -142,6 +142,7 @@ module.exports = function RouterController (kuzzle) {
         {verb: 'post', url: '/users/_create', controller: 'security', action: 'createUser'},
         {verb: 'post', url: '/users/:id', controller: 'security', action: 'updateUser'},
         {verb: 'post', url: '/_login', controller: 'auth', action: 'login'},
+        {verb: 'post', url: '/_checkToken', controller: 'auth', action: 'checkToken'},
         {verb: 'post', url: '/:index/_bulk', controller: 'bulk', action: 'import'},
         {verb: 'post', url: '/:index/:collection/_bulk', controller: 'bulk', action: 'import'},
         {verb: 'post', url: '/:index/:collection/_search', controller: 'read', action: 'search'},

--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -142,7 +142,6 @@ module.exports = function RouterController (kuzzle) {
         {verb: 'post', url: '/users/_create', controller: 'security', action: 'createUser'},
         {verb: 'post', url: '/users/:id', controller: 'security', action: 'updateUser'},
         {verb: 'post', url: '/_login', controller: 'auth', action: 'login'},
-        {verb: 'post', url: '/_checkToken', controller: 'auth', action: 'checkToken'},
         {verb: 'post', url: '/:index/_bulk', controller: 'bulk', action: 'import'},
         {verb: 'post', url: '/:index/:collection/_bulk', controller: 'bulk', action: 'import'},
         {verb: 'post', url: '/:index/:collection/_search', controller: 'read', action: 'search'},

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -222,18 +222,6 @@ module.exports = function SecurityController (kuzzle) {
   };
 
   /**
-   * Returns the user identified by the given jwt token
-   * @param {RequestObject} requestObject
-   * @param context
-   * @returns {Promise}
-   */
-  this.getCurrentUser = function (requestObject, context) {
-    requestObject.data._id = context.token.user._id;
-
-    return this.getUser(requestObject);
-  };
-
-  /**
    * Returns the User objects matching the given filters
    * @param {RequestObject} requestObject
    * @returns {Promise}

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -108,7 +108,7 @@ module.exports = function SecurityController (kuzzle) {
    * @returns {Promise}
    */
   this.getProfile = function (requestObject) {
-    kuzzle.pluginsManager.trigger('data:getProfile', requestObject);
+    kuzzle.pluginsManager.trigger('security:getProfile', requestObject);
 
     if (!requestObject.data._id) {
       return q.reject(new BadRequestError('Missing profile id'));
@@ -127,7 +127,7 @@ module.exports = function SecurityController (kuzzle) {
    * @returns {Promise}
    */
   this.createOrReplaceProfile = function (requestObject, context) {
-    kuzzle.pluginsManager.trigger('data:createOrReplaceProfile', requestObject);
+    kuzzle.pluginsManager.trigger('security:createOrReplaceProfile', requestObject);
 
     return kuzzle.repositories.profile.buildProfileFromRequestObject(requestObject)
       .then(profile => {
@@ -147,7 +147,7 @@ module.exports = function SecurityController (kuzzle) {
    * @returns {Promise}
    */
   this.deleteProfile = function (requestObject) {
-    kuzzle.pluginsManager.trigger('data:deleteProfile', requestObject);
+    kuzzle.pluginsManager.trigger('security:deleteProfile', requestObject);
 
     return kuzzle.repositories.profile.buildProfileFromRequestObject(requestObject)
       .then(profile => {
@@ -163,7 +163,7 @@ module.exports = function SecurityController (kuzzle) {
   this.searchProfiles = function (requestObject) {
     var roles = [];
 
-    kuzzle.pluginsManager.trigger('data:searchProfiles', requestObject);
+    kuzzle.pluginsManager.trigger('security:searchProfiles', requestObject);
 
     if (requestObject.data.body && requestObject.data.body.roles) {
       roles = requestObject.data.body.roles;

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -289,7 +289,7 @@ module.exports = function SecurityController (kuzzle) {
   this.createUser = function (requestObject) {
     var user = new User();
 
-    return kuzzle.pluginsManager.trigger('data:createUser', requestObject)
+    return kuzzle.pluginsManager.trigger('security:createUser', requestObject)
       .then(newRequestObject => {
         if (!newRequestObject.data.body || !newRequestObject.data.body.profile) {
           return q.reject(new BadRequestError('Invalid user object. No profile property found.'));

--- a/lib/api/core/models/repositories/profileRepository.js
+++ b/lib/api/core/models/repositories/profileRepository.js
@@ -39,7 +39,7 @@ module.exports = function (kuzzle) {
     }
     else {
       this.loadOneFromDatabase(profileKey)
-        .then(function (result) {
+        .then((result) => {
           var
             data,
             p = new Profile();
@@ -57,10 +57,8 @@ module.exports = function (kuzzle) {
             // no profile found
             deferred.resolve(null);
           }
-        }.bind(this))
-        .catch(function (error) {
-          deferred.reject(error);
-        });
+        })
+        .catch((error) => deferred.reject(error));
     }
 
     return deferred.promise;

--- a/lib/api/core/models/repositories/repository.js
+++ b/lib/api/core/models/repositories/repository.js
@@ -285,14 +285,18 @@ Repository.prototype.load = function (id, opts) {
 Repository.prototype.hydrate = function (object, data) {
   var
     deferred = q.defer(),
+    serializedData,
     o = {};
 
   if (data instanceof ResponseObject) {
-    if (Boolean(data.toJson().result._source)) {
-      o = _.extend(o, data.toJson().result._source);
+    serializedData = data.toJson();
+
+    if (Boolean(serializedData.result._source)) {
+      o._id = serializedData.result._id;
+      o = _.extend(o, serializedData.result._source);
     }
     else {
-      o = _.extend(o, data.toJson().result);
+      o = _.extend(o, serializedData.result);
     }
   }
   else {

--- a/lib/api/core/models/repositories/tokenRepository.js
+++ b/lib/api/core/models/repositories/tokenRepository.js
@@ -37,7 +37,7 @@ module.exports = function (kuzzle) {
   }
 
   TokenRepository.prototype = new Repository(kuzzle, {
-    index: '%kuzzle',
+    index: kuzzle.config.internalIndex,
     collection: 'token',
     ObjectConstructor: Token,
     cacheEngine: kuzzle.services.list.tokenCache,

--- a/lib/api/prepareDb.js
+++ b/lib/api/prepareDb.js
@@ -15,7 +15,10 @@ module.exports = function (kuzzle) {
 
   if (kuzzle.isServer) {
     kuzzle.pluginsManager.trigger('log:info', '== Starting DB preparation...');
-    return readFile.call(this, 'mappings')
+    return createInternalStructure.call(this)
+      .then(() => {
+        return readFile.call(this, 'mappings');
+      })
       .then(() => {
         return readFile.call(this, 'fixtures');
       })
@@ -35,6 +38,72 @@ module.exports = function (kuzzle) {
 
   return q();
 };
+
+function createInternalStructure () {
+  var requestObject = new RequestObject({controller: 'admin', action: 'createIndex', index: this.kuzzle.config.internalIndex});
+
+  if (this.kuzzle.indexCache.indexes[this.kuzzle.config.internalIndex]) {
+    return q();
+  }
+
+  this.kuzzle.pluginsManager.trigger('log:info', '== Creating Kuzzle internal index...');
+
+  this.kuzzle.pluginsManager.trigger('data:createIndex', requestObject);
+
+  return this.kuzzle.workerListener.add(requestObject)
+    .then(() => {
+      this.kuzzle.indexCache.add(this.kuzzle.config.internalIndex);
+
+      this.kuzzle.pluginsManager.trigger('log:info', '== Creating profiles collection...');
+
+      requestObject = new RequestObject({
+        controller: 'admin',
+        action: 'updateMapping',
+        index: this.kuzzle.config.internalIndex,
+        collection: 'profiles',
+        body: {
+          properties: {
+            roles: {
+              index: 'not_analyzed',
+              type: 'string'
+            }
+          }
+        }
+      });
+
+      this.kuzzle.pluginsManager.trigger('data:updateMapping', requestObject);
+      return this.kuzzle.workerListener.add(requestObject);
+    })
+    .then(() => {
+      this.kuzzle.indexCache.add(this.kuzzle.config.internalIndex, 'profiles');
+      this.kuzzle.pluginsManager.trigger('log:info', '== Creating users collection...');
+
+      requestObject = new RequestObject({
+        controller: 'admin',
+        action: 'updateMapping',
+        index: this.kuzzle.config.internalIndex,
+        collection: 'users',
+        body: {
+          properties: {
+            profile: {
+              index: 'not_analyzed',
+              type: 'string'
+            },
+            password: {
+              index: 'no',
+              type: 'string'
+            }
+          }
+        }
+      });
+
+      this.kuzzle.pluginsManager.trigger('data:updateMapping', requestObject);
+      return this.kuzzle.workerListener.add(requestObject);
+    })
+    .then(() => {
+      this.kuzzle.indexCache.add(this.kuzzle.config.internalIndex, 'users');
+    });
+}
 
 function readFile(which) {
   var
@@ -131,13 +200,13 @@ function importMapping () {
 
       requestObject = new RequestObject({
         controller: 'admin',
-        action: 'putMapping',
+        action: 'updateMapping',
         index: index,
         collection: collection,
         body: this.data.mappings[index][collection]
       });
 
-      this.kuzzle.pluginsManager.trigger('data:putMapping', requestObject);
+      this.kuzzle.pluginsManager.trigger('data:updateMapping', requestObject);
       this.kuzzle.workerListener.add(requestObject)
         .then(() => callbackCollection())
         .catch(response => callbackCollection('Mapping import error' + response.error.message));

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -10,6 +10,8 @@ var
   ResponseObject = require.main.require('lib/api/core/models/responseObject'),
   InternalError = require.main.require('lib/api/core/errors/internalError'),
   Token = require.main.require('lib/api/core/models/security/token'),
+  Profile = require.main.require('lib/api/core/models/security/profile'),
+  User = require.main.require('lib/api/core/models/security/user'),
   context = {},
   requestObject,
   MockupWrapper,
@@ -287,6 +289,25 @@ describe('Test the auth controller', function () {
           done();
         })
         .catch(err => done(err));
+    });
+  });
+
+  describe('#getCurrentUser', function () {
+    it('should return the user given in the context', done => {
+      kuzzle.funnel.auth.getCurrentUser(new RequestObject({
+        body: {}
+      }), {
+        token: { user: { _id: 'admin' } }
+      })
+        .then(response => {
+          should(response.data.body._id).be.exactly('admin');
+          should(response.data.body._source).be.an.instanceOf(User);
+          should(response.data.body._source.profile).be.an.instanceOf(Profile);
+          should(response.data.body._source.profile._id).be.exactly('admin');
+
+          done();
+        })
+        .catch(error => { done(error); });
     });
   });
 });

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -313,7 +313,7 @@ describe('Test the auth controller', function () {
   describe('#getCurrentUser', function () {
     it('should return the user given in the context', done => {
       kuzzle.funnel.auth.getCurrentUser(new RequestObject({
-        body: { hydrate: true }
+        body: {}
       }), {
         token: { user: { _id: 'admin' } }
       })
@@ -344,7 +344,7 @@ describe('Test the auth controller', function () {
 
     it('should return a non-hydrated response if hydrate===false', done => {
       kuzzle.funnel.auth.getCurrentUser(new RequestObject({
-        body: { hydrate: false}
+        body: {hydrate: false}
       }), {
         token: { user: { _id: 'admin' } }
       })

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -327,5 +327,37 @@ describe('Test the auth controller', function () {
         })
         .catch(error => { done(error); });
     });
+
+    it('should return a falsey response if the current user is unknown', done => {
+      kuzzle.funnel.auth.getCurrentUser(new RequestObject({
+        body: {}
+      }), {
+        token: { user: { _id: 'Carmen Sandiego' } }
+      })
+        .then(response => {
+          should(response.data.body._id).be.undefined();
+          should(response.data.body.found).be.false();
+          done();
+        })
+        .catch(error => { done(error); });
+    });
+
+    it('should return a non-hydrated response if hydrate===false', done => {
+      kuzzle.funnel.auth.getCurrentUser(new RequestObject({
+        body: { hydrate: false}
+      }), {
+        token: { user: { _id: 'admin' } }
+      })
+        .then(response => {
+          should(response.data.body._id).be.exactly('admin');
+          should(response.data.body._source).not.be.an.instanceOf(User);
+          should(response.data.body._source.profile).not.be.an.instanceOf(Profile);
+          should(response.data.body._source.name).be.a.String();
+          should(response.data.body._source.profile).be.eql('admin');
+
+          done();
+        })
+        .catch(error => { done(error); });
+    });
   });
 });

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -313,7 +313,7 @@ describe('Test the auth controller', function () {
   describe('#getCurrentUser', function () {
     it('should return the user given in the context', done => {
       kuzzle.funnel.auth.getCurrentUser(new RequestObject({
-        body: {}
+        body: { hydrate: true }
       }), {
         token: { user: { _id: 'admin' } }
       })

--- a/test/api/controllers/securityController/users.test.js
+++ b/test/api/controllers/securityController/users.test.js
@@ -101,25 +101,6 @@ describe('Test: security controller - users', function () {
     });
   });
 
-  describe('#getCurrentUser', function () {
-    it('should return the user given in the context', done => {
-      kuzzle.funnel.security.getCurrentUser(new RequestObject({
-        body: {}
-      }), {
-        token: { user: { _id: 'admin' } }
-      })
-        .then(response => {
-          should(response.data.body._id).be.exactly('admin');
-          should(response.data.body._source).be.an.instanceOf(User);
-          should(response.data.body._source.profile).be.an.instanceOf(Profile);
-          should(response.data.body._source.profile._id).be.exactly('admin');
-
-          done();
-        })
-        .catch(error => { done(error); });
-    });
-  });
-
   describe('#searchUsers', function () {
     it('should return a valid responseObject', done => {
       kuzzle.funnel.security.searchUsers(new RequestObject({

--- a/test/api/core/models/repositories/repository.test.js
+++ b/test/api/core/models/repositories/repository.test.js
@@ -422,7 +422,7 @@ describe('Test: repositories/repository', function () {
   });
 
   describe('#hydrate', function () {
-    it('should return a properly hydrated object', function (done) {
+    it('should return a properly hydrated object with a plain old object', function (done) {
       var
         object = new ObjectConstructor(),
         data = {
@@ -443,6 +443,60 @@ describe('Test: repositories/repository', function () {
         .catch(function (error) {
           done(error);
         });
+    });
+
+    it('should hydrate properly with a ResponseObject', function (done) {
+      var
+        object = new ObjectConstructor(),
+        data = new ResponseObject (null, {
+          value1: {
+            test: true
+          },
+          type: 'myType'
+        });
+
+      repository.hydrate(object, data)
+        .then(result => {
+          should(result).be.an.instanceOf(ObjectConstructor);
+          should(result.type).be.exactly('myType');
+          should(result.value1).be.eql({test: true});
+          should(result.value1.test).be.true();
+          done();
+        })
+        .catch(function (error) {
+          done(error);
+        });
+    });
+
+    it('should hydrate properly with a ResponseObject containing a _source member', function (done) {
+      var
+        object = new ObjectConstructor(),
+        data = new ResponseObject (null, {
+          _id: 'foo',
+          _source: {
+            value1: {
+              test: true
+            },
+            type: 'myType'
+          }
+        });
+
+      repository.hydrate(object, data)
+        .then(result => {
+          should(result).be.an.instanceOf(ObjectConstructor);
+          should(result.type).be.exactly('myType');
+          should(result.value1).be.eql({test: true});
+          should(result.value1.test).be.true();
+          should(result._id).be.eql('foo');
+          done();
+        })
+        .catch(function (error) {
+          done(error);
+        });
+    });
+
+    it('should return a rejected promise if the provided data is not an object', function () {
+      return should(repository.hydrate(new ObjectConstructor(), 'foobar')).be.rejectedWith(InternalError);
     });
   });
 


### PR DESCRIPTION
- Moved `getCurrentUser` from the `security` controller to the `auth` one
- Changed numerous hook names in security controller from `data:...` to `security:...`
- Bugfix: profiles weren't correctly linked to users, and roles to profiles, due to the parent ID not been correctly copied by the `repository` core component
- Bugfix: profile searches in functional tests didn't prefix the role id
- Bugfix: the `prepareDb` mapping import still used the `putMapping` API route instead of the `updateMapping` one
- Bugfix: `%kuzzle/profiles` and `%kuzzle/users` collections used default elasticsearch mapping. This lead to problems with profiles and roles searches, as `%kuzzle/users/profile` and `%kuzzle/profiles/roles` fields are storing documents ID while being indexed. This means that looking for roles or profiles would potentially return false negatives. Kuzzle's `prepareDb` module now creates the internal index, and the `users` and `profiles` collections with appropriate mappings