### PR TITLE
Token expiration notification

### DIFF
--- a/config/defaultPlugins.json
+++ b/config/defaultPlugins.json
@@ -11,7 +11,7 @@
     }
   },
   "kuzzle-plugin-socketio": {
-    "version": "1.0.5",
+    "version": "1.0.6",
     "activated": true,
     "name": "kuzzle-plugin-socketio",
     "defaultConfig": {

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -342,7 +342,7 @@ Messages emanating from Kuzzle are emitted using the following hooks. Protocol p
 |------|----------------|-----------------------------|
 | ``protocol:joinChannel`` | `{channel, id}`| Tells protocol plugins that the connection `id` subscribed to the channel `channel` |
 | ``protocol:leaveChannel`` | `{channel, id}` | Tells protocol plugins that the connection `id` left the channel `channel` |
-| ``protocol:notify`` | `{channel, id, payload}` | Asks the protocol plugins to emit a data `payload` to the connection `id`, on the channel `channel` |
+| ``protocol:notify`` | `{channel, id, payload}` | Asks protocol plugins to emit a data `payload` to the connection `id`, on the channel `channel` |
 | ``protocol:broadcast`` | `{channel, payload}` | Asks protocol plugins to emit a data `payload` to clients connected to the channel `channel` |
 
 *For more information about channels, see our [API Documentation](http://kuzzleio.github.io/kuzzle-api-documentation/#on)*

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -342,6 +342,7 @@ Messages emanating from Kuzzle are emitted using the following hooks. Protocol p
 |------|----------------|-----------------------------|
 | ``protocol:joinChannel`` | `{channel, id}`| Tells protocol plugins that the connection `id` subscribed to the channel `channel` |
 | ``protocol:leaveChannel`` | `{channel, id}` | Tells protocol plugins that the connection `id` left the channel `channel` |
+| ``protocol:notify`` | `{channel, id, payload}` | Asks the protocol plugins to emit a data `payload` to the connection `id`, on the channel `channel` |
 | ``protocol:broadcast`` | `{channel, payload}` | Asks protocol plugins to emit a data `payload` to clients connected to the channel `channel` |
 
 *For more information about channels, see our [API Documentation](http://kuzzleio.github.io/kuzzle-api-documentation/#on)*
@@ -364,6 +365,7 @@ First, link protocol hooks to their corresponding implementation methods:
 // Content of a hooks.js file:
 module.exports = {
   'protocol:broadcast': 'broadcast',
+  'protocol:notify': 'notify',
   'protocol:joinChannel': 'join',
   'protocol:leaveChannel': 'leave'
 };
@@ -407,6 +409,16 @@ module.exports = function () {
      by Kuzzle when a "data.payload" needs to be broadcasted to the
      "data.channel" channel
 
+     The payload is a ResponseObject
+    */
+  };
+  
+  this.notify = function (data) {
+    /*
+     Linked to the protocol:notify hook, emitted
+     by Kuzzle when a "data.payload" needs to be emitted to the
+     connection "data.id", on the channel "data.channel"
+     
      The payload is a ResponseObject
     */
   };

--- a/features/AMQP.feature
+++ b/features/AMQP.feature
@@ -246,7 +246,7 @@ Feature: Test AMQP API
   @usingAMQP @cleanSecurity
   Scenario: login user
     Given I create a user "user1" with id "user1-id"
-    When I log in as user1-id:testpwd
+    When I log in as user1-id:testpwd expiring in 1h
     Then I write the document
     Then I check the JWT Token
     And The token is valid
@@ -308,7 +308,7 @@ Feature: Test AMQP API
 
   @usingAMQP @cleanSecurity
   Scenario: user crudl
-    And I create a new role "role1" with id "role1"
+    When I create a new role "role1" with id "role1"
     And I create a new role "role2" with id "role2"
     And I create a new profile "profile2" with id "profile2"
     And I create a user "user1" with id "user1-id"
@@ -319,8 +319,16 @@ Feature: Test AMQP API
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 2 users
     Then I delete the user "user2-id"
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 1 users matching {"_id":"#prefix#user1-id","_source":{"name":{"first":"David","last":"Bowie"}}}
-    When I log in as user1-id:testpwd
+    When I log in as user1-id:testpwd expiring in 1h
     Then I am getting the current user, which matches {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin"}}}
     Then I log out
     Then I am getting the current user, which matches {"_id":-1,"_source":{"profile":{"_id":"anonymous"}}}
 
+
+  @usingWebsocket @cleanSecurity @unsubscribe
+  Scenario: token expiration
+    Given A room subscription listening to "lastName" having value "Hopper"
+    Given I create a user "user1" with id "user1-id"
+    When I log in as user1-id:testpwd expiring in 1s
+    Then I wait 1s
+    And I should receive a "jwtTokenExpired" notification

--- a/features/MQTT.feature
+++ b/features/MQTT.feature
@@ -246,7 +246,7 @@ Feature: Test MQTT API
   @usingMQTT @cleanSecurity
   Scenario: login user
     Given I create a user "user1" with id "user1-id"
-    When I log in as user1-id:testpwd
+    When I log in as user1-id:testpwd expiring in 1h
     Then I write the document
     Then I check the JWT Token
     And The token is valid
@@ -308,7 +308,7 @@ Feature: Test MQTT API
 
   @usingMQTT @cleanSecurity
   Scenario: user crudl
-    And I create a new role "role1" with id "role1"
+    When I create a new role "role1" with id "role1"
     And I create a new role "role2" with id "role2"
     And I create a new profile "profile2" with id "profile2"
     And I create a user "user1" with id "user1-id"
@@ -319,8 +319,16 @@ Feature: Test MQTT API
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 2 users
     Then I delete the user "user2-id"
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 1 users matching {"_id":"#prefix#user1-id","_source":{"name":{"first":"David","last":"Bowie"}}}
-    When I log in as user1-id:testpwd
+    When I log in as user1-id:testpwd expiring in 1h
     Then I am getting the current user, which matches {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin"}}}
     Then I log out
     Then I am getting the current user, which matches {"_id":-1,"_source":{"profile":{"_id":"anonymous"}}}
 
+
+  @usingWebsocket @cleanSecurity @unsubscribe
+  Scenario: token expiration
+    Given A room subscription listening to "lastName" having value "Hopper"
+    Given I create a user "user1" with id "user1-id"
+    When I log in as user1-id:testpwd expiring in 1s
+    Then I wait 1s
+    And I should receive a "jwtTokenExpired" notification

--- a/features/REST.feature
+++ b/features/REST.feature
@@ -130,7 +130,7 @@ Feature: Test REST API
   @usingREST @cleanSecurity
   Scenario: login user
     Given I create a user "user1" with id "user1-id"
-    When I log in as user1-id:testpwd
+    When I log in as user1-id:testpwd expiring in 1h
     Then I write the document
     Then I check the JWT Token
     And The token is valid
@@ -194,7 +194,7 @@ Feature: Test REST API
 
   @usingREST @cleanSecurity
   Scenario: user crudl
-    And I create a new role "role1" with id "role1"
+    When I create a new role "role1" with id "role1"
     And I create a new role "role2" with id "role2"
     And I create a new profile "profile2" with id "profile2"
     And I create a user "user1" with id "user1-id"
@@ -204,8 +204,7 @@ Feature: Test REST API
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 2 users
     Then I delete the user "user2-id"
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 1 users matching {"_id":"#prefix#user1-id","_source":{"name":{"first":"David","last":"Bowie"}}}
-    When I log in as user1-id:testpwd
+    When I log in as user1-id:testpwd expiring in 1h
     Then I am getting the current user, which matches {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin"}}}
     Then I log out
     Then I am getting the current user, which matches {"_id":-1,"_source":{"profile":{"_id":"anonymous"}}}
-

--- a/features/STOMP.feature
+++ b/features/STOMP.feature
@@ -246,7 +246,7 @@ Feature: Test STOMP API
   @usingSTOMP @cleanSecurity
   Scenario: login user
     Given I create a user "user1" with id "user1-id"
-    When I log in as user1-id:testpwd
+    When I log in as user1-id:testpwd expiring in 1h
     Then I write the document
     Then I check the JWT Token
     And The token is valid
@@ -308,7 +308,7 @@ Feature: Test STOMP API
 
   @usingSTOMP @cleanSecurity
   Scenario: user crudl
-    And I create a new role "role1" with id "role1"
+    When I create a new role "role1" with id "role1"
     And I create a new role "role2" with id "role2"
     And I create a new profile "profile2" with id "profile2"
     And I create a user "user1" with id "user1-id"
@@ -319,8 +319,15 @@ Feature: Test STOMP API
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 2 users
     Then I delete the user "user2-id"
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 1 users matching {"_id":"#prefix#user1-id","_source":{"name":{"first":"David","last":"Bowie"}}}
-    When I log in as user1-id:testpwd
+    When I log in as user1-id:testpwd expiring in 1h
     Then I am getting the current user, which matches {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin"}}}
     Then I log out
     Then I am getting the current user, which matches {"_id":-1,"_source":{"profile":{"_id":"anonymous"}}}
 
+  @usingWebsocket @cleanSecurity @unsubscribe
+  Scenario: token expiration
+    Given A room subscription listening to "lastName" having value "Hopper"
+    Given I create a user "user1" with id "user1-id"
+    When I log in as user1-id:testpwd expiring in 1s
+    Then I wait 1s
+    And I should receive a "jwtTokenExpired" notification

--- a/features/Websocket.feature
+++ b/features/Websocket.feature
@@ -248,7 +248,7 @@ Feature: Test websocket API
   @usingWebsocket @cleanSecurity
   Scenario: login user
     Given I create a user "user1" with id "user1-id"
-    When I log in as user1-id:testpwd
+    When I log in as user1-id:testpwd expiring in 1h
     Then I write the document
     Then I check the JWT Token
     And The token is valid
@@ -310,7 +310,7 @@ Feature: Test websocket API
 
   @usingWebsocket @cleanSecurity
   Scenario: user crudl
-    And I create a new role "role1" with id "role1"
+    When I create a new role "role1" with id "role1"
     And I create a new role "role2" with id "role2"
     And I create a new profile "profile2" with id "profile2"
     And I create a user "user1" with id "user1-id"
@@ -322,9 +322,15 @@ Feature: Test websocket API
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 2 users
     Then I delete the user "user2-id"
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 1 users matching {"_id":"#prefix#user1-id","_source":{"name":{"first":"David","last":"Bowie"}}}
-    When I log in as user1-id:testpwd
+    When I log in as user1-id:testpwd expiring in 1h
     Then I am getting the current user, which matches {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin"}}}
     Then I log out
     Then I am getting the current user, which matches {"_id":-1,"_source":{"profile":{"_id":"anonymous"}}}
 
-
+  @usingWebsocket @cleanSecurity @unsubscribe
+  Scenario: token expiration
+    Given A room subscription listening to "lastName" having value "Hopper"
+    Given I create a user "user1" with id "user1-id"
+    When I log in as user1-id:testpwd expiring in 1s
+    Then I wait 1s
+    And I should receive a "jwtTokenExpired" notification

--- a/features/step_definitions/authentication.js
+++ b/features/step_definitions/authentication.js
@@ -1,6 +1,6 @@
 var apiSteps = function () {
-  this.When(/^I log in as (.*?):(.*?)$/, function (login, password, callback) {
-    this.api.login('local', {username: this.idPrefix + login, password: password})
+  this.When(/^I log in as (.*?):(.*?) expiring in (.*?)$/, function (login, password, expiration, callback) {
+    this.api.login('local', {username: this.idPrefix + login, password: password, expiresIn: expiration})
       .then(body => {
         if (body.error) {
           callback(new Error(body.error.message));

--- a/features/support/apiRT.js
+++ b/features/support/apiRT.js
@@ -402,7 +402,8 @@ ApiRT.prototype.login = function (strategy, credentials) {
       body: {
         strategy: strategy,
         username: credentials.username,
-        password: credentials.password
+        password: credentials.password,
+        expiresIn: credentials.expiresIn
       }
     };
 

--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -91,6 +91,10 @@ function setAPI (world, apiName) {
 }
 
 function cleanSecurity (callback) {
+  if (this.currentUser) {
+    delete this.currentUser;
+  }
+
   this.api.listIndexes()
     .then(response => {
       if (response.result.indexes.indexOf('%kuzzle') === -1) {

--- a/lib/api/core/auth/tokenManager.js
+++ b/lib/api/core/auth/tokenManager.js
@@ -1,0 +1,78 @@
+var
+  RequestObject = require('../models/requestObject'),
+  RealTimeResponseObject = require('../models/realTimeResponseObject');
+
+/**
+ * Authentication token white-list.
+ *
+ * Maintains a list of valid tokens.
+ * When a token is invalidated, it cleans up the corresponding connection's subscriptions, and notify the
+ * user that the token has expired
+ *
+ * @param kuzzle
+ * @constructor
+ */
+module.exports = function (kuzzle) {
+  this.tokenizedConnections = {};
+  this.timer = null;
+
+  this.runTimer = () => {
+    var firstExpiryDate = Math.min.apply(null, Object.keys(this.tokenizedConnections).map(key => {
+      return this.tokenizedConnections[key].expiresAt;
+    }));
+
+    if (this.timer) {
+      clearTimeout(this.timer);
+    }
+
+    this.timer = setTimeout(this.checkTokensValidity, Date.now() - firstExpiryDate);
+  };
+
+  this.add = (token, context) => {
+    this.tokenizedConnections[token._id] = {
+      expiresAt: token.expiresAt,
+      connection: context.connection
+    };
+
+    this.runTimer();
+  };
+
+  this.expire = (token) => {
+    if (this.tokenizedConnections[token._id] !== undefined) {
+      this.tokenizedConnections[token._id].expiresAt = Date.now();
+    }
+
+    this.runTimer();
+  };
+
+  this.checkTokensValidity = () => {
+    var now = Date.now();
+
+    Object.keys(this.tokenizedConnections).forEach(key => {
+      var
+        rooms,
+        requestObject,
+        connectionId;
+
+      if (this.tokenizedConnections[key].expiresAt < now) {
+        connectionId = this.tokenizedConnections[key].connection.id;
+        // Send a token expiration notfication to the user
+        if (kuzzle.hotelClerk.customers[connectionId]) {
+          rooms = Object.keys(kuzzle.hotelClerk.customers[connectionId]);
+          requestObject = new RequestObject({
+            controller: 'auth',
+            action: 'jwtTokenExpired',
+            requestId: 'server notification'
+          });
+
+          kuzzle.notifier.notify(rooms, new RealTimeResponseObject(rooms, requestObject), connectionId);
+          kuzzle.hotelClerk.removeCustomerFromAllRooms(connectionId);
+        }
+
+        delete this.tokenizedConnections[key];
+      }
+    });
+
+    this.runTimer();
+  };
+};

--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -840,8 +840,27 @@ TokenizedConnectionsController = function(kuzzle) {
     var now = Date.now();
 
     Object.keys(tokenizedConnections).forEach(key => {
-      if (tokenizedConnections[key].expiresAt >= now) {
-        kuzzle.hotelClerk.removeCustomerFromAllRooms(tokenizedConnections[key].connection);
+      var
+        rooms,
+        requestObject,
+        connectionId;
+
+      if (tokenizedConnections[key].expiresAt < now) {
+        connectionId = tokenizedConnections[key].connection.id;
+        // Send a token expiration notfication to the user
+        if (kuzzle.hotelClerk.customers[connectionId]) {
+          rooms = Object.keys(kuzzle.hotelClerk.customers[connectionId]);
+          requestObject = new RequestObject({
+            controller: 'auth',
+            action: 'jwtTokenExpired',
+            requestId: 'server notification'
+          });
+
+          kuzzle.notifier.notify(rooms, new RealTimeResponseObject(rooms, requestObject), connectionId);
+          kuzzle.hotelClerk.removeCustomerFromAllRooms(connectionId);
+        }
+
+        delete tokenizedConnections[key];
       }
     });
 

--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -1,5 +1,4 @@
 var
-  TokenizedConnectionsController,
   _ = require('lodash'),
   async = require('async'),
   q = require('q'),
@@ -55,8 +54,6 @@ module.exports = function HotelClerk (kuzzle) {
    * }
    */
   this.customers = {};
-
-  this.tokenizedConnectionsController = new TokenizedConnectionsController(kuzzle);
 
   /**
    * Link a user connection to a room.
@@ -790,80 +787,3 @@ function subscribeToRoom (roomId, requestObject, context) {
 
   return deferred.promise;
 }
-
-
-/**
- * Authentication token white-list.
- *
- * Maintains a list of valid tokens.
- * When a token is invalidated, it removes all room subscriptions from connection.
- *
- * @param kuzzle
- * @constructor
- */
-TokenizedConnectionsController = function(kuzzle) {
-  var
-    tokenizedConnections = {},
-    runTimer,
-    timer = null;
-
-  runTimer = () => {
-    var firstExpiryDate = Math.min.apply(null, Object.keys(tokenizedConnections).map(function (key) {
-      return tokenizedConnections[key].expiresAt;
-    }));
-
-    if (timer) {
-      clearTimeout(timer);
-    }
-
-    timer = setTimeout(this.checkTokensValidity, Date.now() - firstExpiryDate);
-  };
-
-  this.add = function(token, context) {
-    tokenizedConnections[token._id] = {
-      expiresAt: token.expiresAt,
-      connection: context.connection
-    };
-
-    runTimer.call(this);
-  };
-
-  this.expire = function(token) {
-    if (tokenizedConnections[token._id] !== undefined) {
-      tokenizedConnections[token._id].expiresAt = Date.now();
-    }
-
-    runTimer.call(this);
-  };
-
-  this.checkTokensValidity = function () {
-    var now = Date.now();
-
-    Object.keys(tokenizedConnections).forEach(key => {
-      var
-        rooms,
-        requestObject,
-        connectionId;
-
-      if (tokenizedConnections[key].expiresAt < now) {
-        connectionId = tokenizedConnections[key].connection.id;
-        // Send a token expiration notfication to the user
-        if (kuzzle.hotelClerk.customers[connectionId]) {
-          rooms = Object.keys(kuzzle.hotelClerk.customers[connectionId]);
-          requestObject = new RequestObject({
-            controller: 'auth',
-            action: 'jwtTokenExpired',
-            requestId: 'server notification'
-          });
-
-          kuzzle.notifier.notify(rooms, new RealTimeResponseObject(rooms, requestObject), connectionId);
-          kuzzle.hotelClerk.removeCustomerFromAllRooms(connectionId);
-        }
-
-        delete tokenizedConnections[key];
-      }
-    });
-
-    runTimer.call(this);
-  };
-};

--- a/lib/api/core/models/repositories/tokenRepository.js
+++ b/lib/api/core/models/repositories/tokenRepository.js
@@ -51,7 +51,7 @@ module.exports = function (kuzzle) {
 
     Repository.prototype.expireFromCache.call(this, token)
       .then(() => {
-        kuzzle.hotelClerk.tokenizedConnectionsController.expire(token);
+        kuzzle.tokenManager.expire(token);
 
         deferred.resolve();
       })
@@ -106,7 +106,7 @@ module.exports = function (kuzzle) {
       .then((result) => {
         this.persistToCache(result);
 
-        kuzzle.hotelClerk.tokenizedConnectionsController.add(result, context);
+        kuzzle.tokenManager.add(result, context);
 
         deferred.resolve(result);
       })

--- a/lib/api/core/notifier.js
+++ b/lib/api/core/notifier.js
@@ -22,9 +22,10 @@ module.exports = function NotifierController (kuzzle) {
    *
    * @param rooms
    * @param {Object} response
+   * @param {string} connectionId
    * @returns {boolean}
    */
-  this.notify = function (rooms, response) {
+  this.notify = function (rooms, response, connectionId) {
     if (!rooms) {
       return false;
     }
@@ -34,7 +35,7 @@ module.exports = function NotifierController (kuzzle) {
     }
 
     async.each(rooms, function (roomName) {
-      send.call(kuzzle, roomName, response);
+      send.call(kuzzle, roomName, response, connectionId);
     });
   };
 
@@ -76,14 +77,30 @@ module.exports = function NotifierController (kuzzle) {
 };
 
 /**
- * Notify by broadcasting the message data on all corresponding channels
+ * Notify by send the message data on all corresponding channels
+ * If no connection ID is provided, broadcasts the message on all users connected to the channels
  *
  * @param {String} room
  * @param {object} responseObject
+ * @param {String} [connectionId] - ID of the connection to send the message
  */
-function send (room, responseObject) {
+function send (room, responseObject, connectionId) {
+  var
+    data = {
+      payload: responseObject
+    },
+    eventName;
+
+  if (connectionId) {
+    data.id = connectionId;
+    eventName = 'protocol:notify';
+  } else {
+    eventName = 'protocol:broadcast';
+  }
+
   this.hotelClerk.getChannels(room, responseObject).forEach(channel => {
-    this.pluginsManager.trigger('protocol:broadcast', {channel, payload: responseObject});
+    data.channel = channel;
+    this.pluginsManager.trigger(eventName, data);
     this.services.list.mqBroker.addExchange(channel, responseObject);
   });
 }

--- a/lib/api/core/notifier.js
+++ b/lib/api/core/notifier.js
@@ -77,7 +77,7 @@ module.exports = function NotifierController (kuzzle) {
 };
 
 /**
- * Notify by send the message data on all corresponding channels
+ * Notify by sending the message data on all corresponding channels
  * If no connection ID is provided, broadcasts the message on all users connected to the channels
  *
  * @param {String} room

--- a/lib/api/start.js
+++ b/lib/api/start.js
@@ -11,6 +11,7 @@ var
   Notifier = require('./core/notifier'),
   Statistics = require('./core/statistics'),
   WorkerListener = require('./core/workerListener'),
+  TokenManager = require('./core/auth/tokenManager'),
   FunnelController = require('./controllers/funnelController'),
   RouterController = require('./controllers/routerController'),
   Dsl = require('./dsl'),
@@ -57,6 +58,8 @@ module.exports = function start (params, feature) {
   this.pluginsManager = new PluginsManager(this);
   this.pluginsManager.init(this.isServer, feature.dummy);
   this.pluginsManager.run();
+
+  this.tokenManager = new TokenManager(this);
 
   this.indexCache = new IndexCache(this);
 

--- a/lib/config/hooks.js
+++ b/lib/config/hooks.js
@@ -15,7 +15,21 @@ module.exports = {
   'data:createIndex': ['write:add'],
   'data:deleteIndex': ['write:add'],
   'data:deleteIndexes': ['write:add'],
-  'data:createOrReplaceRole': [],
-  'data:createOrReplaceProfile': []
+  'security:createOrReplaceRole': [],
+  'security:createOrReplaceProfile': [],
+  'security:getRole': [],
+  'security:mGetRole': [],
+  'security:searchRole': [],
+  'security:deleteRole': [],
+  'security:getProfile': [],
+  'security:mGetProfile': [],
+  'security:deleteProfile': [],
+  'security:searchProfiles': [],
+  'security:getUser': [],
+  'security:searchUsers': [],
+  'security:deleteUser': [],
+  'security:createUser': [],
+  'security:updateUser': [],
+  'security:createOrReplaceUser': []
 };
 

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -154,7 +154,7 @@ describe('Test the auth controller', function () {
         });
     });
 
-    it('should register token in tokenizedConnectionsController when a connexion id is set', function (done) {
+    it('should register token in the token manager when a connexion id is set', function (done) {
       context = {
         connection: {
           id: 'banana'
@@ -163,7 +163,7 @@ describe('Test the auth controller', function () {
 
       requestObject.data.body.expiresIn = '1m';
 
-      kuzzle.hotelClerk.tokenizedConnectionsController.add = function(token, context) {
+      kuzzle.tokenManager.add = function(token) {
         should(token).be.an.instanceOf(Token);
         should(token.ttl).be.exactly(60000);
         should(token.expiresAt).be.approximately(Date.now() + token.ttl, 30);

--- a/test/api/core/auth/tokenManager.test.js
+++ b/test/api/core/auth/tokenManager.test.js
@@ -1,0 +1,140 @@
+var
+  should = require('should'),
+  params = require('rc')('kuzzle'),
+  Kuzzle = require.main.require('lib/api/Kuzzle'),
+  RealTimeResponseObject = require.main.require('lib/api/core/models/realTimeResponseObject'),
+  TokenManager = require.main.require('lib/api/core/auth/tokenManager');
+
+describe('Test: token manager core component', function () {
+  var
+    kuzzle,
+    tokenManager;
+
+  before(function () {
+    kuzzle = new Kuzzle();
+    return kuzzle.start(params, {dummy: true})
+      .then(() => {
+        kuzzle.hotelClerk.customers = {
+          'foobar': {
+            'room1': {},
+            'room2': {},
+            'room3': {}
+          }
+        };
+      });
+  });
+
+  beforeEach(function () {
+    tokenManager = new TokenManager(kuzzle);
+  });
+
+  describe('#expire', function () {
+    it('should force a token to expire when called', function () {
+      tokenManager.tokenizedConnections['foobar'] = {
+        expiresAt: Date.now() + 1000000
+      };
+
+      tokenManager.expire({_id: 'foobar'});
+
+      should(tokenManager.tokenizedConnections['foobar'].expiresAt).be.belowOrEqual(Date.now());
+    });
+  });
+
+  describe('#checkTokensValidity', function () {
+    var
+      notification,
+      rooms,
+      connectionId,
+      subscriptionsCleaned;
+
+    before(function () {
+      kuzzle.notifier.notify = (r, msg, id) => {
+        rooms = r;
+        notification = msg;
+        connectionId = id;
+      };
+
+      kuzzle.hotelClerk.removeCustomerFromAllRooms = () => subscriptionsCleaned = true;
+    });
+
+    beforeEach(function () {
+      notification = null;
+      rooms = null;
+      connectionId = '';
+      subscriptionsCleaned = false;
+    });
+
+    it('should do nothing if no token has expired', function () {
+      var stubTokens = {
+        foo: {
+          expiresAt: Date.now() + 1000000
+        },
+        bar: {
+          expiresAt: Date.now() + 1000000
+        }
+      };
+
+      tokenManager.tokenizedConnections = stubTokens;
+
+      tokenManager.checkTokensValidity();
+
+      should(notification).be.null();
+      should(subscriptionsCleaned).be.false();
+      should(tokenManager.tokenizedConnections).be.eql(stubTokens);
+    });
+
+    it('should clean up subscriptions upon a token expiration', function () {
+      var
+        stubTokens = {
+          foo: {
+            expiresAt: Date.now() - 1000,
+            connection: {
+              id: 'foobar'
+            }
+          },
+          bar: {
+            expiresAt: Date.now() + 1000000
+          }
+        };
+
+      tokenManager.tokenizedConnections = stubTokens;
+
+      tokenManager.checkTokensValidity();
+
+      should(subscriptionsCleaned).be.true();
+      should(rooms).match(['room1', 'room2', 'room3']);
+      should(connectionId).be.eql('foobar');
+      should(notification).be.instanceof(RealTimeResponseObject);
+      should(notification.roomId).be.eql(rooms);
+      should(notification.requestId).be.eql('server notification');
+      should(notification.controller).be.eql('auth');
+      should(notification.action).be.eql('jwtTokenExpired');
+      should(tokenManager.tokenizedConnections.foo).be.undefined();
+      should(tokenManager.tokenizedConnections.bar).be.eql(stubTokens.bar);
+    });
+
+    it('should behave correctly if the token does not match any subscription', function () {
+      var
+        stubTokens = {
+          foo: {
+            expiresAt: Date.now() - 1000,
+            connection: {
+              id: 'barfoo'
+            }
+          },
+          bar: {
+            expiresAt: Date.now() + 1000000
+          }
+        };
+
+      tokenManager.tokenizedConnections = stubTokens;
+
+      tokenManager.checkTokensValidity();
+
+      should(subscriptionsCleaned).be.false();
+      should(notification).be.null();
+      should(tokenManager.tokenizedConnections.foo).be.undefined();
+      should(tokenManager.tokenizedConnections.bar).be.eql(stubTokens.bar);
+    });
+  });
+});

--- a/test/api/core/auth/tokenManager.test.js
+++ b/test/api/core/auth/tokenManager.test.js
@@ -5,14 +5,14 @@ var
   RealTimeResponseObject = require.main.require('lib/api/core/models/realTimeResponseObject'),
   TokenManager = require.main.require('lib/api/core/auth/tokenManager');
 
-describe('Test: token manager core component', function () {
+describe('Test: token manager core component', function (done) {
   var
     kuzzle,
     tokenManager;
 
   before(function () {
     kuzzle = new Kuzzle();
-    return kuzzle.start(params, {dummy: true})
+    kuzzle.start(params, {dummy: true})
       .then(() => {
         kuzzle.hotelClerk.customers = {
           'foobar': {
@@ -21,7 +21,9 @@ describe('Test: token manager core component', function () {
             'room3': {}
           }
         };
-      });
+        done();
+      })
+      .catch(err => done(err));
   });
 
   beforeEach(function () {
@@ -30,13 +32,13 @@ describe('Test: token manager core component', function () {
 
   describe('#expire', function () {
     it('should force a token to expire when called', function () {
-      tokenManager.tokenizedConnections['foobar'] = {
+      tokenManager.tokenizedConnections.foobar = {
         expiresAt: Date.now() + 1000000
       };
 
       tokenManager.expire({_id: 'foobar'});
 
-      should(tokenManager.tokenizedConnections['foobar'].expiresAt).be.belowOrEqual(Date.now());
+      should(tokenManager.tokenizedConnections.foobar.expiresAt).be.belowOrEqual(Date.now());
     });
   });
 

--- a/test/api/core/auth/tokenManager.test.js
+++ b/test/api/core/auth/tokenManager.test.js
@@ -10,7 +10,7 @@ describe('Test: token manager core component', function (done) {
     kuzzle,
     tokenManager;
 
-  before(function () {
+  before(function (done) {
     kuzzle = new Kuzzle();
     kuzzle.start(params, {dummy: true})
       .then(() => {

--- a/test/api/core/models/repositories/tokenRepository.test.js
+++ b/test/api/core/models/repositories/tokenRepository.test.js
@@ -128,12 +128,10 @@ beforeEach(function (done) {
   kuzzle.repositories.user = mockUserRepository;
 
 
-  kuzzle.hotelClerk = {
-    tokenizedConnectionsController: {
-      add: function (token, context) {},
-      expire: function (token) {},
-      checkTokensValidity: function () {}
-    }
+  kuzzle.tokenManager = {
+    add: function (token, context) {},
+    expire: function (token) {},
+    checkTokensValidity: function () {}
   };
 
   done();
@@ -428,13 +426,13 @@ describe('Test: repositories/tokenRepository', function () {
         });
     });
 
-    it('should expire token in TokenizedConnectionsController', (done) => {
+    it('should expire token in the token manager', (done) => {
       var
-        tokenizedConnectionsControllerExpired = false,
+        tokenManagerExpired = false,
         user = new User();
 
-      kuzzle.hotelClerk.tokenizedConnectionsController.expire = function () {
-        tokenizedConnectionsControllerExpired = true;
+      kuzzle.tokenManager.expire = function () {
+        tokenManagerExpired = true;
       };
       user._id = 'userInCache';
 
@@ -443,7 +441,7 @@ describe('Test: repositories/tokenRepository', function () {
           return tokenRepository.expire(token);
         })
         .then(() => {
-          should(tokenizedConnectionsControllerExpired).be.exactly(true);
+          should(tokenManagerExpired).be.exactly(true);
           done();
         })
         .catch(function (error) {


### PR DESCRIPTION
- expired tokens now triggers a new `jwtTokenExpired` notification to all channels the user subscribed to
- bugfix: tokens were expired immediately instead of at their expiration time
- bugfix: expired tokens were kept in cache instead of being cleaned up
- moved token management from the `hotelClerk` to the new `tokenManager` core component
- added a new `protocol:notify` hook, allowing protocols to notify 1 user on all its channels by delivering a payload
- updated plugins documentation
- updated the socket.io plugin to version 1.0.6
- added unit & functional tests
- hooks configuration: moved some `data:...` hooks to `security:...`, and added all missing `security:...` hooks