### PR TITLE
Read user should not send the password

### DIFF
--- a/config/defaultPlugins.json
+++ b/config/defaultPlugins.json
@@ -21,7 +21,7 @@
     }
   },
   "kuzzle-plugin-auth-passport-local": {
-    "version": "1.3.1",
+    "version": "1.3.2",
     "activated": true,
     "name": "kuzzle-plugin-auth-passport-local",
     "defaultConfig": {

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -80,6 +80,7 @@ module.exports = function AuthController (kuzzle) {
             _id: user._id,
             _source: user
           };
+          delete response._source.password;
         }
         delete response._source._id;
 

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -65,7 +65,7 @@ module.exports = function AuthController (kuzzle) {
         var response;
 
         if (!user) {
-          return q(new ResponseObject(requestObject, {found: false}));
+          return q({found: false});
         }
 
         if (requestObject.data.body.hydrate !== undefined && requestObject.data.body.hydrate === false) {
@@ -82,10 +82,10 @@ module.exports = function AuthController (kuzzle) {
         }
         delete response._source._id;
 
-        return q(new ResponseObject(requestObject, response));
+        return  kuzzle.pluginsManager.trigger('auth:getCurrentUser', response);
       })
       .then(response => {
-        return  kuzzle.pluginsManager.trigger('auth:getCurrentUser', response);
+        return q(new ResponseObject(requestObject, response));
       });
   };
 

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -57,7 +57,6 @@ module.exports = function AuthController (kuzzle) {
    * @returns {Promise}
    */
   this.getCurrentUser = function (requestObject, context) {
-    kuzzle.pluginsManager.trigger('auth:getCurrentUser', requestObject);
 
     requestObject.data._id = context.token.user._id;
 
@@ -80,11 +79,13 @@ module.exports = function AuthController (kuzzle) {
             _id: user._id,
             _source: user
           };
-          delete response._source.password;
         }
         delete response._source._id;
 
         return q(new ResponseObject(requestObject, response));
+      })
+      .then(response => {
+        return  kuzzle.pluginsManager.trigger('auth:getCurrentUser', response);
       });
   };
 

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -236,8 +236,6 @@ module.exports = function SecurityController (kuzzle) {
    * @returns {Promise}
    */
   this.getUser = function (requestObject) {
-    kuzzle.pluginsManager.trigger('security:getUser', requestObject);
-
     if (!requestObject.data._id) {
       return q.reject(new BadRequestError('No user id given'));
     }
@@ -265,6 +263,9 @@ module.exports = function SecurityController (kuzzle) {
         delete response._source._id;
 
         return q(new ResponseObject(requestObject, response));
+      })
+      .then(response => {
+        return kuzzle.pluginsManager.trigger('security:getUser', response);
       });
   };
 
@@ -274,8 +275,6 @@ module.exports = function SecurityController (kuzzle) {
    * @returns {Promise}
    */
   this.searchUsers = function (requestObject) {
-    kuzzle.pluginsManager.trigger('security:searchUsers', requestObject);
-
     return kuzzle.repositories.user.search(
       requestObject.data.body.filter || {},
       requestObject.data.body.from,
@@ -288,6 +287,9 @@ module.exports = function SecurityController (kuzzle) {
         });
 
         return new ResponseObject(requestObject, {hits: users, total: users.length});
+      })
+      .then(response => {
+        return kuzzle.pluginsManager.trigger('security:searchUsers', response);
       });
   };
 

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -245,7 +245,7 @@ module.exports = function SecurityController (kuzzle) {
         var response;
 
         if (!user) {
-          return q(new ResponseObject(requestObject, {found: false}));
+          return q({found: false});
         }
 
         if (requestObject.data.body.hydrate !== undefined && requestObject.data.body.hydrate === false) {
@@ -262,10 +262,10 @@ module.exports = function SecurityController (kuzzle) {
         }
         delete response._source._id;
 
-        return q(new ResponseObject(requestObject, response));
+        return kuzzle.pluginsManager.trigger('security:getUser', response);
       })
       .then(response => {
-        return kuzzle.pluginsManager.trigger('security:getUser', response);
+        return q(new ResponseObject(requestObject, response));
       });
   };
 
@@ -286,10 +286,10 @@ module.exports = function SecurityController (kuzzle) {
           return formatUserForSerialization(user, requestObject.data.body.hydrate);
         });
 
-        return new ResponseObject(requestObject, {hits: users, total: users.length});
+        return kuzzle.pluginsManager.trigger('security:searchUsers', users);
       })
-      .then(response => {
-        return kuzzle.pluginsManager.trigger('security:searchUsers', response);
+      .then(users => {
+        return new ResponseObject(requestObject, {hits: users, total: users.length});
       });
   };
 


### PR DESCRIPTION
**Warning** This PR should be merged only after the authentication plugins have been updated.

The `getCurrentUser` call in the `authController` currently sends the user's (encrypted) password through the wire. This is bad, isn't it?