### PR TITLE
Fix security

### DIFF
--- a/features/AMQP.feature
+++ b/features/AMQP.feature
@@ -314,8 +314,7 @@ Feature: Test AMQP API
     And I create a new user "user1" with id "user1-id"
     And I create a user "user2" with id "user2-id"
     And I can't create a new user "user2" with id "user1-id"
-    Then I am able to get the user "user1-id" matching {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin","roles":[{"_id":"admin"}]}}}
-    Then I am able to get the unhydrated user "user1-id" matching {"_id":"#prefix#user1-id","_source":{"profile":"admin"}}
+    Then I am able to get the user "user1-id" matching {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin", "_source": {"roles":[{"_id":"admin"}]}}}}
     Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profile":{"_id":"#prefix#profile2"}}}
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 2 users
     Then I delete the user "user2-id"

--- a/features/MQTT.feature
+++ b/features/MQTT.feature
@@ -314,8 +314,7 @@ Feature: Test MQTT API
     And I create a new user "user1" with id "user1-id"
     And I create a user "user2" with id "user2-id"
     And I can't create a new user "user2" with id "user1-id"
-    Then I am able to get the user "user1-id" matching {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin","roles":[{"_id":"admin"}]}}}
-    Then I am able to get the unhydrated user "user1-id" matching {"_id":"#prefix#user1-id","_source":{"profile":"admin"}}
+    Then I am able to get the user "user1-id" matching {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin", "_source": {"roles":[{"_id":"admin"}]}}}}
     Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profile":{"_id":"#prefix#profile2"}}}
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 2 users
     Then I delete the user "user2-id"

--- a/features/REST.feature
+++ b/features/REST.feature
@@ -200,7 +200,7 @@ Feature: Test REST API
     And I create a new user "user1" with id "user1-id"
     And I create a user "user2" with id "user2-id"
     And I can't create a new user "user2" with id "user1-id"
-    Then I am able to get the user "user1-id" matching {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin","roles":[{"_id":"admin"}]}}}
+    Then I am able to get the user "user1-id" matching {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin", "_source": {"roles":[{"_id":"admin"}]}}}}
     Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profile":{"_id":"#prefix#profile2"}}}
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 2 users
     Then I delete the user "user2-id"

--- a/features/STOMP.feature
+++ b/features/STOMP.feature
@@ -314,8 +314,7 @@ Feature: Test STOMP API
     And I create a new user "user1" with id "user1-id"
     And I create a user "user2" with id "user2-id"
     And I can't create a new user "user2" with id "user1-id"
-    Then I am able to get the user "user1-id" matching {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin","roles":[{"_id":"admin"}]}}}
-    Then I am able to get the unhydrated user "user1-id" matching {"_id":"#prefix#user1-id","_source":{"profile":"admin"}}
+    Then I am able to get the user "user1-id" matching {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin", "_source": {"roles":[{"_id":"admin"}]}}}}
     Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profile":{"_id":"#prefix#profile2"}}}
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 2 users
     Then I delete the user "user2-id"

--- a/features/Websocket.feature
+++ b/features/Websocket.feature
@@ -313,11 +313,10 @@ Feature: Test websocket API
     When I create a new role "role1" with id "role1"
     And I create a new role "role2" with id "role2"
     And I create a new profile "profile2" with id "profile2"
-    And I create a user "user1" with id "user1-id"
+    And I create a new user "user1" with id "user1-id"
     And I create a user "user2" with id "user2-id"
     And I can't create a new user "user2" with id "user1-id"
-    Then I am able to get the user "user1-id" matching {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin","roles":[{"_id":"admin"}]}}}
-    Then I am able to get the unhydrated user "user1-id" matching {"_id":"#prefix#user1-id","_source":{"profile":"admin"}}
+    Then I am able to get the user "user1-id" matching {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin", "_source": {"roles":[{"_id":"admin"}]}}}}
     Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profile":{"_id":"#prefix#profile2"}}}
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 2 users
     Then I delete the user "user2-id"

--- a/features/step_definitions/profiles.js
+++ b/features/step_definitions/profiles.js
@@ -87,25 +87,17 @@ var apiSteps = function () {
               return callbackAsync(body.error.message);
             }
 
-            if (!body.result) {
-              if (not) {
-                return callbackAsync();
-              }
-
-              return callbackAsync('No result provided');
-            }
-
-            if (!body.result.roles) {
-              if (not) {
-                return callbackAsync();
-              }
-
-              return callbackAsync('Profile with id '+ id + ' exists');
+            if (not) {
+              return callbackAsync(`Profile with id ${id} exists`);
             }
 
             callbackAsync();
           })
           .catch(error => {
+            if (not) {
+              return callback();
+            }
+
             callback(error);
           });
       }, 20); // end setTimeout
@@ -170,9 +162,12 @@ var apiSteps = function () {
             return false;
           }
 
-          if (response.result.hits.length !== parseInt(profilesCount)) {
-            callbackAsync(new Error('Expected ' + profilesCount + ' profiles. Got ' + response.result.hits.length));
-            return false;
+          if (!response.result.hits) {
+            response.result.hits = response.result.hits.filter(doc => doc._id.indexOf(this.idPrefix));
+
+            if (response.result.hits.length !== parseInt(profilesCount)) {
+              return callbackAsync(`Expected ${profilesCount} profiles. Got ${response.result.hits.length}`);
+            }
           }
 
           callbackAsync();

--- a/features/step_definitions/role.js
+++ b/features/step_definitions/role.js
@@ -49,17 +49,13 @@ var apiSteps = function () {
               return callbackAsync('No result provided');
             }
 
-            if (!body.result.indexes) {
-              if (not) {
-                return callbackAsync();
-              }
-
-              return callbackAsync('Role with id '+ id + ' exists');
+            if (not) {
+              return callbackAsync(`Role with id ${id} exists`);
             }
 
             if (role) {
               index = Object.keys(this.roles[role].indexes)[0];
-              if (!body.result.indexes[index]) {
+              if (!body.result._source.indexes[index]) {
                 if (not) {
                   return callbackAsync();
                 }
@@ -71,6 +67,10 @@ var apiSteps = function () {
             callbackAsync();
           })
           .catch(error => {
+            if (not) {
+              return callback();
+            }
+
             callback(error);
           });
       }, 20); // end setTimeout
@@ -132,8 +132,12 @@ var apiSteps = function () {
               return false;
             }
 
-            if (!body.result.hits || body.result.hits.length !== parseInt(count)) {
-              return callbackAsync('Expected ' + count + ' roles, get ' + body.result.hits.length);
+            if (!body.result.hits) {
+              body.result.hits = body.result.hits.filter(doc => doc._id.indexOf(this.idPrefix));
+
+              if (body.result.hits.length !== parseInt(count)) {
+                return callbackAsync('Expected ' + count + ' roles, get ' + body.result.hits.length);
+              }
             }
 
             callbackAsync();

--- a/features/step_definitions/users.js
+++ b/features/step_definitions/users.js
@@ -35,12 +35,10 @@ module.exports = function () {
       });
   });
 
-  this.Then(/^I am able to get the (unhydrated )?user "(.*?)"(?: matching {(.*)})?$/, function (unhydrated, id, match, callback) {
-    var hydrate = unhydrated ? false : true;
-
+  this.Then(/^I am able to get the user "(.*?)"(?: matching {(.*)})?$/, function (id, match, callback) {
     id = this.idPrefix + id;
 
-    this.api.getUser(id, hydrate)
+    this.api.getUser(id)
       .then(body => {
         var
           matchObject;

--- a/features/support/apiRT.js
+++ b/features/support/apiRT.js
@@ -547,14 +547,11 @@ ApiRT.prototype.deleteProfile = function (id) {
   return this.send(msg);
 };
 
-ApiRT.prototype.getUser = function (id, hydrate) {
+ApiRT.prototype.getUser = function (id) {
   return this.send({
     controller: 'security',
     action: 'getUser',
-    _id: id,
-    body: {
-      hydrate: hydrate === undefined ? true : hydrate
-    }
+    _id: id
   });
 };
 

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -61,30 +61,7 @@ module.exports = function AuthController (kuzzle) {
 
     requestObject.data._id = context.token.user._id;
 
-    return kuzzle.repositories.user.load(requestObject.data._id)
-      .then(user => {
-        var response;
-
-        if (!user) {
-          return q(new ResponseObject(requestObject, {found: false}));
-        }
-
-        if (requestObject.data.body.hydrate !== undefined && requestObject.data.body.hydrate === false) {
-          response = {
-            _id: user._id,
-            _source: kuzzle.repositories.user.serializeToDatabase(user)
-          };
-        }
-        else {
-          response = {
-            _id: user._id,
-            _source: user
-          };
-        }
-        delete response._source._id;
-
-        return q(new ResponseObject(requestObject, response));
-      });
+    return kuzzle.funnel.security.getUser(requestObject);
   };
 
 

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -57,8 +57,6 @@ module.exports = function AuthController (kuzzle) {
    * @returns {Promise}
    */
   this.getCurrentUser = function (requestObject, context) {
-    kuzzle.pluginsManager.trigger('auth:getCurrentUser', requestObject);
-
     requestObject.data._id = context.token.user._id;
 
     return kuzzle.funnel.security.getUser(requestObject);

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -4,14 +4,19 @@ var
   uuid = require('node-uuid'),
   q = require('q'),
   BadRequestError = require('../core/errors/badRequestError'),
-  ResponseObject = require('../core/models/responseObject');
+  ResponseObject = require('../core/models/responseObject'),
+  NotFoundError = require('../core/errors/notFoundError');
 
 module.exports = function SecurityController (kuzzle) {
   var formatRoleForSerialization = function (role) {
     var parsedRole = {};
 
-    parsedRole._id = role._id;
-    parsedRole._source = {indexes: role.indexes};
+    if (role._id) {
+      parsedRole._id = role._id;
+    }
+    if (role.indexes) {
+      parsedRole._source = {indexes: role.indexes};
+    }
 
     return parsedRole;
   };
@@ -56,11 +61,11 @@ module.exports = function SecurityController (kuzzle) {
       kuzzle.repositories.role.getRoleFromRequestObject(requestObject)
       )
       .then(role => {
-        if (role && role.closures) {
-          delete role.closures;
+        if (!role) {
+          return q.reject(new NotFoundError(`Role with id ${requestObject.data._id} not found`));
         }
 
-        return q(new ResponseObject(requestObject, role || {}));
+        return q(new ResponseObject(requestObject, formatRoleForSerialization(role)));
       });
   };
 
@@ -140,7 +145,11 @@ module.exports = function SecurityController (kuzzle) {
 
     return kuzzle.repositories.profile.loadProfile(requestObject.data._id)
       .then(profile => {
-        return q(new ResponseObject(requestObject, profile || {}));
+        if (!profile) {
+          return q.reject(new NotFoundError(`Profile with id ${requestObject.data._id} not found`));
+        }
+
+        return q(new ResponseObject(requestObject, formatProfileForSerialization(profile, true)));
       });
   };
 
@@ -244,27 +253,11 @@ module.exports = function SecurityController (kuzzle) {
 
     return kuzzle.repositories.user.load(requestObject.data._id)
       .then(user => {
-        var response;
-
         if (!user) {
-          return q(new ResponseObject(requestObject, {found: false}));
+          return q.reject(new NotFoundError(`User with id ${requestObject.data._id} not found`));
         }
 
-        if (requestObject.data.body.hydrate !== undefined && requestObject.data.body.hydrate === false) {
-          response = {
-            _id: user._id,
-            _source: kuzzle.repositories.user.serializeToDatabase(user)
-          };
-        }
-        else {
-          response = {
-            _id: user._id,
-            _source: user
-          };
-        }
-        delete response._source._id;
-
-        return q(new ResponseObject(requestObject, response));
+        return q(new ResponseObject(requestObject, formatUserForSerialization(user, true)));
       });
   };
 

--- a/lib/api/core/models/repositories/profileRepository.js
+++ b/lib/api/core/models/repositories/profileRepository.js
@@ -46,6 +46,7 @@ module.exports = function (kuzzle) {
 
           if (result) {
             // we got a profile from the database, we can use it
+            this.profiles[profileKey] = result;
             deferred.resolve(result);
           }
           else if (kuzzle.config.defaultUserProfiles[profileKey]) {

--- a/lib/api/core/models/repositories/roleRepository.js
+++ b/lib/api/core/models/repositories/roleRepository.js
@@ -75,12 +75,13 @@ module.exports = function (kuzzle) {
           }
 
           q.all(promises)
-            .then(function (results) {
-              results.forEach(function (role) {
+            .then(results => {
+              results.forEach(role => {
                 buffer[role._id] = role;
+                this.roles[role._id] = role;
               });
 
-              Object.keys(buffer).forEach(function (key) {
+              Object.keys(buffer).forEach(key => {
                 result.push(buffer[key]);
               });
 
@@ -134,7 +135,14 @@ module.exports = function (kuzzle) {
       deferred.resolve(this.roles[role._id]);
     }
     else {
-      return this.loadOneFromDatabase(role._id);
+      return this.loadOneFromDatabase(role._id)
+        .then(loadedRole => {
+          if (loadedRole) {
+            this.roles[loadedRole._id] = loadedRole;
+          }
+
+          return loadedRole;
+        });
     }
 
     return deferred.promise;

--- a/test/api/controllers/funnelController/execute.test.js
+++ b/test/api/controllers/funnelController/execute.test.js
@@ -37,7 +37,8 @@ describe('Test execute function in funnel controller', function () {
       .then(function (anonymousToken) {
         context.token = anonymousToken;
         callback();
-      });
+      })
+      .catch(error => callback(error));
   });
 
   it('should reject the promise if no controller is specified', function () {

--- a/test/api/controllers/securityController/profiles.test.js
+++ b/test/api/controllers/securityController/profiles.test.js
@@ -30,7 +30,10 @@ describe('Test: security controller - profiles', function () {
             _index: kuzzle.config.internalIndex,
             _type: 'profiles',
             _id: id,
-            _source: {}
+            roles: [{
+              _id: 'role1',
+              indexes: {}
+            }]
           });
         };
         kuzzle.repositories.profile.searchProfiles = requestObject => {

--- a/test/api/controllers/securityController/profiles.test.js
+++ b/test/api/controllers/securityController/profiles.test.js
@@ -5,7 +5,8 @@ var
   Kuzzle = require.main.require('lib/api/Kuzzle'),
   BadRequestError = require.main.require('lib/api/core/errors/badRequestError'),
   RequestObject = require.main.require('lib/api/core/models/requestObject'),
-  ResponseObject = require.main.require('lib/api/core/models/responseObject');
+  ResponseObject = require.main.require('lib/api/core/models/responseObject'),
+  NotFoundError = require.main.require('lib/api/core/errors/notFoundError');
 
 describe('Test: security controller - profiles', function () {
   var
@@ -26,6 +27,10 @@ describe('Test: security controller - profiles', function () {
           });
         };
         kuzzle.repositories.profile.loadProfile = id => {
+          if (id === 'badId') {
+            return q(null);
+          }
+
           return q({
             _index: kuzzle.config.internalIndex,
             _type: 'profiles',
@@ -36,7 +41,7 @@ describe('Test: security controller - profiles', function () {
             }]
           });
         };
-        kuzzle.repositories.profile.searchProfiles = requestObject => {
+        kuzzle.repositories.profile.searchProfiles = () => {
           return q([{
             _id: 'test',
             roles: [
@@ -108,6 +113,10 @@ describe('Test: security controller - profiles', function () {
 
     it('should reject to an error on a getProfile call without id', () => {
       return should(kuzzle.funnel.security.getProfile(new RequestObject({body: {_id: ''}}))).be.rejectedWith(BadRequestError);
+    });
+
+    it('should reject NotFoundError on a getProfile call with a bad id', () => {
+      return should(kuzzle.funnel.security.getProfile(new RequestObject({body: {_id: 'badId'}}))).be.rejectedWith(NotFoundError);
     });
   });
 

--- a/test/api/controllers/securityController/roles.test.js
+++ b/test/api/controllers/securityController/roles.test.js
@@ -5,7 +5,8 @@ var
   Kuzzle = require.main.require('lib/api/Kuzzle'),
   RequestObject = require.main.require('lib/api/core/models/requestObject'),
   ResponseObject = require.main.require('lib/api/core/models/responseObject'),
-  BadRequestError = require.main.require('lib/api/core/errors/badRequestError');
+  BadRequestError = require.main.require('lib/api/core/errors/badRequestError'),
+  NotFoundError = require.main.require('lib/api/core/errors/notFoundError');
 
 describe('Test: security controller - roles', function () {
   var
@@ -25,6 +26,10 @@ describe('Test: security controller - roles', function () {
           });
         };
         kuzzle.repositories.role.loadOneFromDatabase = id => {
+          if (id === 'badId') {
+            return q(null);
+          }
+
           return q({
             _index: kuzzle.config.internalIndex,
             _type: 'roles',
@@ -83,6 +88,10 @@ describe('Test: security controller - roles', function () {
         .catch(error => {
           done(error);
         });
+    });
+
+    it('should reject NotFoundError on a getRole call with a bad id', () => {
+      return should(kuzzle.funnel.security.getRole(new RequestObject({body: {_id: 'badId'}}))).be.rejectedWith(NotFoundError);
     });
   });
 

--- a/test/api/controllers/securityController/users.test.js
+++ b/test/api/controllers/securityController/users.test.js
@@ -75,7 +75,7 @@ describe('Test: security controller - users', function () {
         .catch(error => { done(error); });
     });
 
-    it('should reject wit NotFoundError when the user is not found', () => {
+    it('should reject with NotFoundError when the user is not found', () => {
       var promise = kuzzle.funnel.security.getUser(new RequestObject({
         body: { _id: 'i.dont.exist' }
       }));

--- a/test/api/controllers/securityController/users.test.js
+++ b/test/api/controllers/securityController/users.test.js
@@ -75,7 +75,7 @@ describe('Test: security controller - users', function () {
         .catch(error => { done(error); });
     });
 
-    it('should respond found:false when the user is not found', () => {
+    it('should reject wit NotFoundError when the user is not found', () => {
       var promise = kuzzle.funnel.security.getUser(new RequestObject({
         body: { _id: 'i.dont.exist' }
       }));

--- a/test/api/controllers/securityController/users.test.js
+++ b/test/api/controllers/securityController/users.test.js
@@ -7,7 +7,8 @@ var
   User = require.main.require('lib/api/core/models/security/user'),
   RequestObject = require.main.require('lib/api/core/models/requestObject'),
   ResponseObject = require.main.require('lib/api/core/models/responseObject'),
-  BadRequestError = require.main.require('lib/api/core/errors/badRequestError');
+  BadRequestError = require.main.require('lib/api/core/errors/badRequestError'),
+  NotFoundError = require.main.require('lib/api/core/errors/notFoundError');
 
 describe('Test: security controller - users', function () {
   var
@@ -66,7 +67,7 @@ describe('Test: security controller - users', function () {
         .then(response => {
           should(response).be.an.instanceOf(ResponseObject);
           should(response.data.body._id).be.exactly(-1);
-          should(response.data.body._source.profile).be.an.instanceOf(Profile);
+          should(response.data.body._source.profile).not.be.empty().Object();
           should(response.data.body._source.profile._id).be.exactly('anonymous');
 
           done();
@@ -74,31 +75,12 @@ describe('Test: security controller - users', function () {
         .catch(error => { done(error); });
     });
 
-    it('should return an unhydrated user when asked', done => {
-      kuzzle.funnel.security.getUser(new RequestObject({
-        body: { hydrate: false, _id: 'anonymous' }
-      }))
-        .then(response => {
-          should(response.data.body._source.profile).be.a.String();
-          should(response.data.body._source.profile).be.exactly('anonymous');
-
-          done();
-
-        })
-        .catch(error => { done(error); });
-    });
-
-    it('should respond found:false when the user is not found', done => {
-      kuzzle.funnel.security.getUser(new RequestObject({
+    it('should respond found:false when the user is not found', () => {
+      var promise = kuzzle.funnel.security.getUser(new RequestObject({
         body: { _id: 'i.dont.exist' }
-      }))
-        .then(response => {
-          should(response).be.an.instanceOf(ResponseObject);
-          should(response.data.body).match({found: false});
+      }));
 
-          done();
-        })
-        .catch(error => { done(error); });
+      return should(promise).be.rejectedWith(NotFoundError);
     });
   });
 


### PR DESCRIPTION
**Bugfix**
* Always return `_source` attribute (also in nested profile/role)
* Return `NotFoundError` on `getUser`, `getProfile` and `getRole` when document with id doesn't exist
* Store in memory (cache) profiles and roles
* In functionnal testing, on `searchUsers`, `searchProfiles` and `searchRoles`, only check results for `world.idPrefix`. Avoid to mix with role/user/profil from real user data

**Clean**
* In `authController` use `getUser` for function `kuzzle.funnel.security.getCurrentUser` instead of reimplement the function