### PR TITLE
token manager bugfix

### DIFF
--- a/lib/api/core/auth/tokenManager.js
+++ b/lib/api/core/auth/tokenManager.js
@@ -29,12 +29,14 @@ module.exports = function (kuzzle) {
   };
 
   this.add = (token, context) => {
-    this.tokenizedConnections[token._id] = {
-      expiresAt: token.expiresAt,
-      connection: context.connection
-    };
+    if (context.connection && context.connection.id) {
+      this.tokenizedConnections[token._id] = {
+        expiresAt: token.expiresAt,
+        connection: context.connection
+      };
 
-    this.runTimer();
+      this.runTimer();
+    }
   };
 
   this.expire = (token) => {

--- a/test/api/core/auth/tokenManager.test.js
+++ b/test/api/core/auth/tokenManager.test.js
@@ -5,7 +5,7 @@ var
   RealTimeResponseObject = require.main.require('lib/api/core/models/realTimeResponseObject'),
   TokenManager = require.main.require('lib/api/core/auth/tokenManager');
 
-describe('Test: token manager core component', function (done) {
+describe('Test: token manager core component', function () {
   var
     kuzzle,
     tokenManager;
@@ -28,6 +28,34 @@ describe('Test: token manager core component', function (done) {
 
   beforeEach(function () {
     tokenManager = new TokenManager(kuzzle);
+  });
+
+  describe('#add', function () {
+    var token;
+
+    beforeEach(function () {
+      token = {_id: 'foobar', expiresAt: Date.now()+1000};
+    });
+
+    it('should not add a token if the context does not contain a connection object', function () {
+      tokenManager.add(token, {});
+      should(tokenManager.tokenizedConnections.foobar).be.undefined();
+    });
+
+    it('should not add a token if the context connection does not contain an id', function () {
+      tokenManager.add(token, {connection: {}});
+      should(tokenManager.tokenizedConnections.foobar).be.undefined();
+    });
+
+    it('should add the token if the context is properly formatted', function () {
+      var
+        context = {connection: {id: 'foo'}};
+      
+      tokenManager.add(token, context);
+      should(tokenManager.tokenizedConnections.foobar).be.an.Object();
+      should(tokenManager.tokenizedConnections.foobar.expiresAt).be.eql(token.expiresAt);
+      should(tokenManager.tokenizedConnections.foobar.connection).be.eql(context.connection);
+    });
   });
 
   describe('#expire', function () {


### PR DESCRIPTION
Bugfix: the token manager didn't check the availability of the `connection` part of a connection context before adding the token to the cache. When the token expired, the token garbage collector tried to access to this connection object, and crashed.
This bug caused some unit tests to fail randomly.