### PR TITLE
follow #159: invoke formatUserForSerialization() also for createUser and createOrReplaceUser

### DIFF
--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -356,6 +356,20 @@ module.exports = function SecurityController (kuzzle) {
         return kuzzle.repositories.user.hydrate(user, pojoUser)
           .then(u => {
             return kuzzle.repositories.user.persist(u, { database: {method: 'create'} });
+          })
+          .then(response => {
+            return formatUserForSerialization(response.data.body._source, false)
+              .then(u => {
+                response.data.body._source = u;
+                return q(response);
+              });
+          })
+          .catch(error => {
+            return formatUserForSerialization(error.error._source, false)
+              .then(u => {
+                error.error._source = u;
+                return q.reject(error);
+              });
           });
       });
 
@@ -401,6 +415,20 @@ module.exports = function SecurityController (kuzzle) {
         return kuzzle.repositories.user.hydrate(user, newRequestObject.data.body)
           .then(u => {
             return kuzzle.repositories.user.persist(u);
+          })
+          .then(response => {
+            return formatUserForSerialization(response.data.body._source, false)
+              .then(u => {
+                response.data.body._source = u;
+                return q(response);
+              });
+          })
+          .catch(error => {
+            return formatUserForSerialization(error.error._source, false)
+              .then(u => {
+                error.error._source = u;
+                return q.reject(error);
+              });
           });
       });
   };

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -363,13 +363,6 @@ module.exports = function SecurityController (kuzzle) {
                 response.data.body._source = u;
                 return q(response);
               });
-          })
-          .catch(error => {
-            return formatUserForSerialization(error.error._source, false)
-              .then(u => {
-                error.error._source = u;
-                return q.reject(error);
-              });
           });
       });
 
@@ -421,13 +414,6 @@ module.exports = function SecurityController (kuzzle) {
               .then(u => {
                 response.data.body._source = u;
                 return q(response);
-              });
-          })
-          .catch(error => {
-            return formatUserForSerialization(error.error._source, false)
-              .then(u => {
-                error.error._source = u;
-                return q.reject(error);
               });
           });
       });


### PR DESCRIPTION
Because these methods also give back the user object in the response, we need to format user data and trigger the security:formatUserForSerialization pipe, to permit plugins to, for example, remove the password from the ResposeObject.
