### PR TITLE
Feature/docker switch to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kuzzleio/base
+FROM kuzzleio/base:alpine
 MAINTAINER Kuzzle <support@kuzzle.io>
 
 ADD ./ /var/app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,14 @@
-FROM kuzzleio/dev
+FROM kuzzleio/base
 MAINTAINER Kuzzle <support@kuzzle.io>
 
 ADD ./ /var/app/
 
-RUN npm install
+RUN set -ex && \
+    apk add \
+      build-base \
+      git \
+      python && \
+    npm install && \
+    apk del --purge \
+      build-base \
+      python

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ kuzzle:
     - FEATURE_COVERAGE
 
 redis:
-  image: redis:3.0
+  image: redis:3.0-alpine
 
 elasticsearch:
-  image: elasticsearch:1.7
+  image: kuzzleio/elasticsearch:2.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 kuzzle:
-  image: kuzzleio/kuzzle
+  image: kuzzleio/kuzzle:alpine
   ports:
     - "7511:7511"
     - "7512:7512"

--- a/docker-compose/debug.yml
+++ b/docker-compose/debug.yml
@@ -1,5 +1,5 @@
 kuzzle:
-  image: kuzzleio/kuzzle
+  image: kuzzleio/dev
   command: /run-debug.sh
   volumes:
     - "..:/var/app"
@@ -28,7 +28,7 @@ rabbit:
     - "15672:15672"
 
 redis:
-  image: redis:3.0
+  image: redis:3.0-alpine
 
 elasticsearch:
-  image: elasticsearch:2.2
+  image: kuzzleio/elasticsearch:2.2

--- a/docker-compose/debug.yml
+++ b/docker-compose/debug.yml
@@ -20,7 +20,7 @@ kuzzle:
     - FIXTURES=/var/app/features/fixtures/empty.json
 
 rabbit:
-  image: kuzzleio/rabbitmq
+  image: kuzzleio/rabbitmq:alpine
   ports:
     - "61613:61613"
     - "1883:1883"

--- a/docker-compose/debug.yml
+++ b/docker-compose/debug.yml
@@ -1,5 +1,5 @@
 kuzzle:
-  image: kuzzleio/dev
+  image: kuzzleio/dev:alpine
   command: /run-debug.sh
   volumes:
     - "..:/var/app"

--- a/docker-compose/perf.yml
+++ b/docker-compose/perf.yml
@@ -1,5 +1,5 @@
 kuzzle:
-  image: kuzzleio/kuzzle
+  image: kuzzleio/kuzzle:alpine
   volumes:
     - "..:/var/app"
     - "/var/log"

--- a/docker-compose/perf.yml
+++ b/docker-compose/perf.yml
@@ -27,10 +27,10 @@ rabbit:
     - "15672:15672"
 
 redis:
-  image: redis:3.0
+  image: redis:3.0-alpine
 
 elasticsearch:
-  image: elasticsearch:2.2
+  image: kuzzleio/elasticsearch:2.2
 
 logstash:
   image: logstash:1.5.2

--- a/docker-compose/perf.yml
+++ b/docker-compose/perf.yml
@@ -19,7 +19,7 @@ kuzzle:
     - FEATURE_COVERAGE
 
 rabbit:
-  image: kuzzleio/rabbitmq
+  image: kuzzleio/rabbitmq:alpine
   ports:
     - "61613:61613"
     - "1883:1883"

--- a/docker-compose/test-travis.yml
+++ b/docker-compose/test-travis.yml
@@ -23,7 +23,7 @@ kuzzle:
     - TRAVIS_REPO_SLUG
 
 rabbit:
-  image: kuzzleio/rabbitmq
+  image: kuzzleio/rabbitmq:alpine
 
 redis:
   image: redis:3.0-alpine

--- a/docker-compose/test-travis.yml
+++ b/docker-compose/test-travis.yml
@@ -1,5 +1,5 @@
 kuzzle:
-  image: kuzzleio/test
+  image: kuzzleio/test:alpine
   command: /run-test-travis.sh
   volumes:
     - "..:/var/app"

--- a/docker-compose/test-travis.yml
+++ b/docker-compose/test-travis.yml
@@ -1,5 +1,5 @@
 kuzzle:
-  image: kuzzleio/kuzzle
+  image: kuzzleio/test
   command: /run-test-travis.sh
   volumes:
     - "..:/var/app"
@@ -26,7 +26,7 @@ rabbit:
   image: kuzzleio/rabbitmq
 
 redis:
-  image: redis:3.0
+  image: redis:3.0-alpine
 
 elasticsearch:
-  image: elasticsearch:2.2
+  image: kuzzleio/elasticsearch:2.2

--- a/docker-compose/test.yml
+++ b/docker-compose/test.yml
@@ -18,7 +18,7 @@ kuzzle:
     - FIXTURES=/var/app/features/fixtures/empty.json
 
 rabbit:
-  image: kuzzleio/rabbitmq
+  image: kuzzleio/rabbitmq:alpine
   ports:
     - "61613:61613"
     - "1883:1883"

--- a/docker-compose/test.yml
+++ b/docker-compose/test.yml
@@ -1,5 +1,5 @@
 kuzzle:
-  image: kuzzleio/test
+  image: kuzzleio/test:alpine
   command: /run-test.sh
   volumes:
     - "..:/var/app"

--- a/docker-compose/test.yml
+++ b/docker-compose/test.yml
@@ -1,5 +1,5 @@
 kuzzle:
-  image: kuzzleio/kuzzle
+  image: kuzzleio/test
   command: /run-test.sh
   volumes:
     - "..:/var/app"
@@ -26,7 +26,7 @@ rabbit:
     - "15672:15672"
 
 redis:
-  image: redis:3.0
+  image: redis:3.0-alpine
 
 elasticsearch:
-  image: elasticsearch:2.2
+  image: kuzzleio/elasticsearch:2.2


### PR DESCRIPTION
Following [container switch to Alpine](https://github.com/kuzzleio/kuzzle-containers/pull/8), migrate Kuzzle docker-compose files to alpine version.