### PR TITLE
[BETA] Prevent event loop saturation

### DIFF
--- a/.kuzzlerc
+++ b/.kuzzlerc
@@ -186,7 +186,7 @@
     "pipeTimeout": 250
   },
   "request": {
-    "maxConcurrentRequests": 10,
+    "maxConcurrentRequests": 50,
     "maxRetainedRequests": 2000
   }
 }

--- a/.kuzzlerc
+++ b/.kuzzlerc
@@ -184,5 +184,9 @@
   "pluginsManager": {
     "pipeWarnTime": 40,
     "pipeTimeout": 250
+  },
+  "request": {
+    "maxConcurrentRequests": 10,
+    "maxRetainedRequests": 2000
   }
 }

--- a/config/defaultPlugins.json
+++ b/config/defaultPlugins.json
@@ -11,6 +11,7 @@
     }
   },
   "kuzzle-plugin-socketio": {
+    "path": "/var/app/socketio",
     "version": "1.0.6",
     "activated": true,
     "name": "kuzzle-plugin-socketio",

--- a/config/defaultPlugins.json
+++ b/config/defaultPlugins.json
@@ -1,18 +1,33 @@
 {
   "kuzzle-plugin-logger": {
-    "version": "1.0.6",
+    "version": "2.0.1",
     "activated": true,
     "name": "kuzzle-plugin-logger",
     "defaultConfig": {
-      "service": "winston",
-      "level": "info",
-      "addDate": true,
+      "services": {
+        "file": {
+          "outputs": {
+            "error": {
+              "level": "error",
+              "filename": "kuzzle-error.log"
+            },
+            "warning": {
+              "level": "warn",
+              "filename": "kuzzle-warning.log"
+            }
+          },
+          "addDate": true
+        },
+        "stdout": {
+          "level": "info",
+          "addDate": true
+        }
+      },
       "loadedBy": "all"
     }
   },
   "kuzzle-plugin-socketio": {
-    "path": "/var/app/socketio",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "activated": true,
     "name": "kuzzle-plugin-socketio",
     "defaultConfig": {

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -354,8 +354,8 @@ To access these methods, simply call ``context.getRouter().<router method>``:
 
 | Router method | Arguments    | Returns | Description              |
 |-----------------|--------------|---------|--------------------------|
-| ``newConnection`` | ``protocol name`` (string) <br>``connection ID`` (string) | A promise resolving to a ``context`` object | Declare a new connection to Kuzzle. |
-| ``execute`` | ``optional JWT Headers`` (string)<br>``RequestObject`` (object)<br>``context`` (obtained with ``newConnection``) | A promise resolving to the corresponding ``ResponseObject`` | Execute a client request. |
+| ``newConnection`` | ``protocol name`` (string) <br/>``connection ID`` (string) | A promise resolving to a ``context`` object | Declare a new connection to Kuzzle. |
+| ``execute`` | ``optional JWT Headers`` (string)<br/>``RequestObject`` (object)<br/>``context`` (obtained with ``newConnection``)<br/>A node callback resolved with the request response |  | Execute a client request. |
 | ``removeConnection`` | ``context`` (obtained with ``newConnection``) | | Asks Kuzzle to remove the corresponding connection and all its subscriptions |
 
 #### Example
@@ -390,14 +390,14 @@ module.exports = function () {
       });
 
     // whenever a client sends a request
-    context.getRouter().execute(null, requestObject, this.contexts["id"])
-      .then(response => {
-        // forward the response to the client
-      })
-      .catch(error => {
+    context.getRouter().execute(null, requestObject, this.contexts["id"], (error, response) => {
+      if (error) {
         // errors are encapsulated in a ResponseObject. You may simply
         // forward it to the client too
-      });
+      } else {
+        // forward the response to the client
+      }
+    });
 
     // whenever a client is disconnected
     context.getRouter().removeConnection(this.contexts["id"]);

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -59,7 +59,7 @@ module.exports = function AuthController (kuzzle) {
   this.getCurrentUser = function (requestObject, context) {
     requestObject.data._id = context.token.user._id;
 
-    return kuzzle.funnel.security.getUser(requestObject);
+    return kuzzle.funnel.controllers.security.getUser(requestObject);
   };
 
 

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -10,75 +10,126 @@ var
   BadRequestError = require('../core/errors/badRequestError'),
   UnauthorizedError = require('../core/errors/unauthorizedError');
 
-module.exports = function FunnelController (kuzzle) {
+// Constants
+var
+  REQUESTQUEUE = 'requestQueue';
 
-  this.write = null;
-  this.subscribe = null;
-  this.read = null;
-  this.admin = null;
-  this.bulk = null;
-  this.security = null;
-  this.auth = null;
+module.exports = function FunnelController (kuzzle) {
+  this.concurrentRequests = 0;
+  this.retainedRequests = 0;
+  this.lastWarningTime = 0;
+  this.controllers = {};
 
   this.init = function () {
-    this.write = new WriteController(kuzzle);
-    this.read = new ReadController(kuzzle);
-    this.subscribe = new SubscribeController(kuzzle);
-    this.bulk = new BulkController(kuzzle);
-    this.admin = new AdminController(kuzzle);
-    this.security = new SecurityController(kuzzle);
-    this.auth = new AuthController(kuzzle);
+    this.controllers.write = new WriteController(kuzzle);
+    this.controllers.read = new ReadController(kuzzle);
+    this.controllers.subscribe = new SubscribeController(kuzzle);
+    this.controllers.bulk = new BulkController(kuzzle);
+    this.controllers.admin = new AdminController(kuzzle);
+    this.controllers.security = new SecurityController(kuzzle);
+    this.controllers.auth = new AuthController(kuzzle);
 
     kuzzle.pluginsManager.injectControllers();
   };
 
   /**
-   * Execute in parallel all tests for check whether the object is well constructed
+   * Execute in parallel all tests to check if the object is well constructed
    * Then generate a requestId if not provided and execute the right controller/action
    *
    * @param {RequestObject} requestObject
    * @param {Object} context
-   * depending on who call execute (websocket or http)
+   * @param {Function} callback
    */
-  this.execute = function (requestObject, context) {
-    var
-      deferred = q.defer();
+  this.execute = function (requestObject, context, callback) {
+    var now;
 
-    kuzzle.statistics.startRequest(requestObject);
+    // execute the request immediately if kuzzle is not overloaded
+    if (this.concurrentRequests <= kuzzle.config.request.maxConcurrentRequests) {
+      this.concurrentRequests++;
 
-    requestObject.checkInformation()
-      .then(() => {
-        if (!this[requestObject.controller] ||
-          !this[requestObject.controller][requestObject.action] ||
-          typeof this[requestObject.controller][requestObject.action] !== 'function') {
-          return q.reject(new BadRequestError('No corresponding action ' + requestObject.action + ' in controller ' + requestObject.controller));
-        }
+      return processRequest(kuzzle, this.controllers, requestObject, context)
+        .then(responseObject => callback(null, responseObject))
+        .catch(error => callback(error))
+        .finally(() => this.concurrentRequests--);
+    }
 
-        // check if the current user is allowed to process
-        return context.token.user.profile.isActionAllowed(requestObject, context, kuzzle.indexCache.indexes, kuzzle);
-      })
-      .then(isAllowed => {
-        if (!isAllowed) {
-          return q.reject(new UnauthorizedError('Unauthorized action [' +
-            requestObject.index + '/' +
-            requestObject.collection + '/' +
-            requestObject.controller + '/' +
-            requestObject.action + '] for user ' +
-            context.token.user._id, 401));
-        }
+    /*
+     if kuzzle is overloaded, print a warning and store the request in cache,
+     to be executed at a later time
+     */
+    now = Date.now();
+    if (this.lastWarningTime === 0 || this.lastWarningTime < now - 1000) {
+      kuzzle.pluginsManager.trigger('log:warn', '[!WARNING!] Kuzzle overloaded. Delaying requests...');
+      this.lastWarningTime = now;
+    }
 
-        return this[requestObject.controller][requestObject.action](requestObject, context);
-      })
-      .then(responseObject => {
-        kuzzle.statistics.completedRequest(requestObject);
-        deferred.resolve(responseObject);
-      })
-      .catch(error => {
-        kuzzle.statistics.failedRequest(requestObject);
-        deferred.reject(error);
-      });
-
-    return deferred.promise;
+    kuzzle.services.list.queryCache.push(REQUESTQUEUE, {request: requestObject, context: context});
   };
-
 };
+
+/**
+ * Execute the request immediately
+ * @param kuzzle
+ * @param controllers
+ * @param requestObject
+ * @param context
+ */
+function processRequest(kuzzle, controllers, requestObject, context) {
+  //kuzzle.statistics.startRequest(requestObject);
+
+  return kuzzle.repositories.token.verifyToken(getBearerTokenFromHeaders(requestObject.headers))
+    .then(userToken => {
+      context.token = userToken;
+
+      return requestObject.checkInformation();
+    })
+    .then(() => {
+      if (!controllers[requestObject.controller] ||
+        !controllers[requestObject.controller][requestObject.action] ||
+        typeof controllers[requestObject.controller][requestObject.action] !== 'function') {
+        return q.reject(new BadRequestError('No corresponding action ' + requestObject.action + ' in controller ' + requestObject.controller));
+      }
+
+      // check if the current user is allowed to process
+      return context.token.user.profile.isActionAllowed(requestObject, context, kuzzle.indexCache.indexes, kuzzle);
+    })
+    .then(isAllowed => {
+      if (!isAllowed) {
+        return q.reject(new UnauthorizedError('Unauthorized action [' +
+          requestObject.index + '/' +
+          requestObject.collection + '/' +
+          requestObject.controller + '/' +
+          requestObject.action + '] for user ' +
+          context.token.user._id, 401));
+      }
+
+      return controllers[requestObject.controller][requestObject.action](requestObject, context);
+    })
+    .then(responseObject => {
+      //kuzzle.statistics.completedRequest(requestObject);
+      return responseObject;
+    })
+    .catch(error => {
+      //kuzzle.statistics.failedRequest(requestObject);
+      return q.reject(error);
+    });
+}
+
+/**
+ * Extract the Bearer token from the given headers
+ * @param {Object} headers
+ * @returns {*}
+ */
+function getBearerTokenFromHeaders(headers) {
+  var
+    r;
+
+  if (headers !== undefined && headers.authorization !== undefined) {
+    r = /^Bearer (.+)$/.exec(headers.authorization);
+    if (r !== null && r[1].trim() !== '') {
+      return r[1].trim();
+    }
+  }
+
+  return null;
+}

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -182,7 +182,7 @@ function playCachedRequests(kuzzle, funnel) {
     funnel.overloaded = false;
     now = Date.now();
 
-    if (funnel.lastOverloadTime === 0 || funnel.lastOverloadTime < now - 1000) {
+    if (funnel.lastOverloadTime === 0 || funnel.lastOverloadTime < now - 500) {
       kuzzle.pluginsManager.trigger('log:info', 'End of overloaded state. Resuming normal activity.');
       funnel.lastOverloadTime = now;
     }

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -8,17 +8,17 @@ var
   SecurityController = require('./securityController'),
   AuthController = require('./authController'),
   BadRequestError = require('../core/errors/badRequestError'),
-  UnauthorizedError = require('../core/errors/unauthorizedError');
-
-// Constants
-var
-  REQUESTQUEUE = 'requestQueue';
+  UnauthorizedError = require('../core/errors/unauthorizedError'),
+  ServiceUnavailableError = require('../core/errors/serviceUnavailableError');
 
 module.exports = function FunnelController (kuzzle) {
+  this.overloaded = false;
   this.concurrentRequests = 0;
-  this.retainedRequests = 0;
-  this.lastWarningTime = 0;
+  this.cachedRequests = 0;
   this.controllers = {};
+  this.requestsCache = [];
+  this.lastOverloadTime = 0;
+  this.lastWarningTime = 0;
 
   this.init = function () {
     this.controllers.write = new WriteController(kuzzle);
@@ -33,18 +33,29 @@ module.exports = function FunnelController (kuzzle) {
   };
 
   /**
-   * Execute in parallel all tests to check if the object is well constructed
-   * Then generate a requestId if not provided and execute the right controller/action
+   * Execute the right controller/action
    *
    * @param {RequestObject} requestObject
    * @param {Object} context
    * @param {Function} callback
    */
   this.execute = function (requestObject, context, callback) {
-    var now;
+    var 
+      now,
+      overloadPercentage;
+
+    if (this.overloaded) {
+      now = Date.now();
+      if (this.lastWarningTime === 0 || this.lastWarningTime < now - 500) {
+        overloadPercentage = Math.round(10000 * this.cachedRequests / kuzzle.config.request.maxRetainedRequests) / 100;
+        kuzzle.pluginsManager.trigger('server:overload', overloadPercentage + '%');
+        kuzzle.pluginsManager.trigger('log:warn', '[!WARNING!] Kuzzle overloaded: ' + overloadPercentage + '%. Delaying requests...');
+        this.lastWarningTime = now;
+      }
+    }
 
     // execute the request immediately if kuzzle is not overloaded
-    if (this.concurrentRequests <= kuzzle.config.request.maxConcurrentRequests) {
+    if (this.concurrentRequests < kuzzle.config.request.maxConcurrentRequests) {
       this.concurrentRequests++;
 
       return processRequest(kuzzle, this.controllers, requestObject, context)
@@ -54,16 +65,26 @@ module.exports = function FunnelController (kuzzle) {
     }
 
     /*
-     if kuzzle is overloaded, print a warning and store the request in cache,
-     to be executed at a later time
+      If kuzzle is overloaded, check the requests cache.
+      There are two possibilities:
+        1- the cache limit has not been reached. A warning is emitted, and the
+           request is cached and will be played as soon as the maxConcurrentRequests
+           property allows it
+
+        2- the number of cached requests is equal to the maxRetainedRequests property.
+           The request is then discarded and an error is returned to the sender
      */
-    now = Date.now();
-    if (this.lastWarningTime === 0 || this.lastWarningTime < now - 1000) {
-      kuzzle.pluginsManager.trigger('log:warn', '[!WARNING!] Kuzzle overloaded. Delaying requests...');
-      this.lastWarningTime = now;
+    if (!this.overloaded) {
+      this.overloaded = true;
+      setTimeout(() => playCachedRequests(kuzzle, this), 10);
     }
 
-    kuzzle.services.list.queryCache.push(REQUESTQUEUE, {request: requestObject, context: context});
+    if (this.cachedRequests >= kuzzle.config.request.maxRetainedRequests) {
+      return callback(new ServiceUnavailableError('Request discarded: Kuzzle Server is temporarily overloaded'));
+    }
+
+    this.cachedRequests++;
+    this.requestsCache.push({requestObject, context, callback});
   };
 };
 
@@ -75,7 +96,7 @@ module.exports = function FunnelController (kuzzle) {
  * @param context
  */
 function processRequest(kuzzle, controllers, requestObject, context) {
-  //kuzzle.statistics.startRequest(requestObject);
+  kuzzle.statistics.startRequest(requestObject);
 
   return kuzzle.repositories.token.verifyToken(getBearerTokenFromHeaders(requestObject.headers))
     .then(userToken => {
@@ -106,11 +127,11 @@ function processRequest(kuzzle, controllers, requestObject, context) {
       return controllers[requestObject.controller][requestObject.action](requestObject, context);
     })
     .then(responseObject => {
-      //kuzzle.statistics.completedRequest(requestObject);
+      kuzzle.statistics.completedRequest(requestObject);
       return responseObject;
     })
     .catch(error => {
-      //kuzzle.statistics.failedRequest(requestObject);
+      kuzzle.statistics.failedRequest(requestObject);
       return q.reject(error);
     });
 }
@@ -132,4 +153,38 @@ function getBearerTokenFromHeaders(headers) {
   }
 
   return null;
+}
+
+/**
+ * Background task. Checks if there are any requests in cache, and replay them
+ * if Kuzzle is not overloaded anymore,
+ *
+ * @param kuzzle
+ * @param funnel
+ */
+function playCachedRequests(kuzzle, funnel) {
+  var
+    request,
+    now;
+
+  if (funnel.cachedRequests > 0) {
+    // If there is room to play bufferized requests, do it now. If not, retry later
+    if (funnel.concurrentRequests < kuzzle.config.request.maxConcurrentRequests) {
+      request = funnel.requestsCache.shift();
+      funnel.cachedRequests--;
+      funnel.execute(request.requestObject, request.context, request.callback);
+      return process.nextTick(() => playCachedRequests(kuzzle, funnel));
+    }
+
+    setTimeout(() => playCachedRequests(kuzzle, funnel), 10);
+  } else {
+    // No request remaining in cache => stop the background task and return to normal behavior
+    funnel.overloaded = false;
+    now = Date.now();
+
+    if (funnel.lastOverloadTime === 0 || funnel.lastOverloadTime < now - 1000) {
+      kuzzle.pluginsManager.trigger('log:info', 'End of overloaded state. Resuming normal activity.');
+      funnel.lastOverloadTime = now;
+    }
+  }
 }

--- a/lib/api/controllers/readController.js
+++ b/lib/api/controllers/readController.js
@@ -93,19 +93,17 @@ module.exports = function ReadController (kuzzle) {
         services: {}
       };
 
-    Object.keys(kuzzle.funnel).forEach(controller => {
+    Object.keys(kuzzle.funnel.controllers).forEach(controller => {
       var actionList = [];
 
-      if (typeof kuzzle.funnel[controller] === 'object') {
-        Object.keys(kuzzle.funnel[controller]).forEach(action => {
-          if (typeof kuzzle.funnel[controller][action] === 'function') {
-            actionList.push(action);
-          }
-        });
-
-        if (actionList.length > 0) {
-          response.kuzzle.api.routes[controller] = actionList;
+      Object.keys(kuzzle.funnel.controllers[controller]).forEach(action => {
+        if (typeof kuzzle.funnel.controllers[controller][action] === 'function') {
+          actionList.push(action);
         }
+      });
+
+      if (actionList.length > 0) {
+        response.kuzzle.api.routes[controller] = actionList;
       }
     });
 

--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -86,40 +86,37 @@ module.exports = function RouterController(kuzzle) {
    * @param {String} context - connection context, obtained using the newConnection() method
    * @return {Promise} ResponseObject
    */
-  this.execute = function (requestObject, context) {
+  this.execute = function (requestObject, context, callback) {
     var error;
 
     if (!requestObject) {
       error = new PluginImplementationError('Request execution error: no provided request');
       kuzzle.pluginsManager.trigger('log:error', error);
-      return q.reject(new ResponseObject(requestObject, error));
+      return callback(new ResponseObject(requestObject, error));
     }
 
     if (!context || !context.connection) {
       error = new PluginImplementationError('Unable to execute request: ' + requestObject +
         '\nReason: invalid context. Use context.getRouter().newConnection() to get a valid context.');
       kuzzle.pluginsManager.trigger('log:error', error);
-      return q.reject(new ResponseObject(requestObject, error));
+      return callback(new ResponseObject(requestObject, error));
     }
 
     if (!context.connection.id || !this.connections[context.connection.id]) {
       error = new PluginImplementationError('Unable to execute request: unknown context. ' +
         'Has context.getRouter().newConnection() been called before executing requests?');
       kuzzle.pluginsManager.trigger('log:error', error);
-      return q.reject(new ResponseObject(requestObject, error));
+      return callback(new ResponseObject(requestObject, error));
     }
 
-    return kuzzle.repositories.token.verifyToken(getBearerTokenFromHeaders(requestObject.headers))
-      .then(userToken => {
-        return kuzzle.funnel.execute(requestObject, _.extend(context, {token: userToken}));
-      })
-      .then(response => {
-        return response;
-      })
-      .catch(e => {
-        kuzzle.pluginsManager.trigger('log:error', e);
-        return q.reject(new ResponseObject(requestObject, e));
-      });
+    kuzzle.funnel.execute(requestObject, context, (error, response) => {
+      if (error) {
+        kuzzle.pluginsManager.trigger('log:error', error);
+        return callback(new ResponseObject(requestObject, error));
+      }
+
+      callback(null, response);
+    });
   };
 
   /**
@@ -320,22 +317,11 @@ module.exports = function RouterController(kuzzle) {
 
       requestObject = new RequestObject(data, {}, 'mq');
 
-      kuzzle.repositories.token.verifyToken(getBearerTokenFromHeaders(data.headers))
-        .then(userToken => {
-          context.token = userToken;
+      kuzzle.funnel.execute(requestObject, context, (error, responseObject) => {
+        var errorObject;
 
-          return kuzzle.funnel.execute(requestObject, context);
-        })
-        .then(function (responseObject) {
-          if (context.connection.type === 'amq') {
-            kuzzle.services.list.mqBroker.replyTo(msg.properties.replyTo, responseObject.toJson());
-          }
-          else {
-            kuzzle.services.list.mqBroker.addExchange('mqtt.' + context.connection.id, responseObject.toJson());
-          }
-        })
-        .catch(function (error) {
-          var errorObject = new ResponseObject(requestObject, error);
+        if (error) {
+          errorObject = new ResponseObject(requestObject, error);
           kuzzle.pluginsManager.trigger('log:error', error);
           if (context.connection.type === 'amq') {
             kuzzle.services.list.mqBroker.replyTo(msg.properties.replyTo, errorObject.toJson());
@@ -343,10 +329,19 @@ module.exports = function RouterController(kuzzle) {
           else {
             kuzzle.services.list.mqBroker.addExchange('mqtt.' + context.connection.id, errorObject.toJson());
           }
-        });
+
+          return false;
+        }
+
+        if (context.connection.type === 'amq') {
+          kuzzle.services.list.mqBroker.replyTo(msg.properties.replyTo, responseObject.toJson());
+        }
+        else {
+          kuzzle.services.list.mqBroker.addExchange('mqtt.' + context.connection.id, responseObject.toJson());
+        }
+      });
     });
   };
-
 };
 
 /**
@@ -416,40 +411,16 @@ function executeFromRest(params, request, response) {
   response.setHeader('Access-Control-Allow-Origin', '*');
   response.setHeader('Access-Control-Allow-Headers', 'X-Requested-With');
 
-  this.repositories.token.verifyToken(getBearerTokenFromHeaders(request.headers))
-    .then(userToken => {
-      context.token = userToken;
-
-      return this.funnel.execute(requestObject, context);
-    })
-    .then(function (responseObject) {
-      response.writeHead(responseObject.status, {'Content-Type': 'application/json'});
-      response.end(stringify(responseObject.toJson()));
-    })
-    .catch(error => {
+  this.funnel.execute(requestObject, context, (error, responseObject) => {
+    if (error) {
       errorObject = new ResponseObject(requestObject, error);
       this.emit(requestObject.controller + ':websocket:funnel:reject', error);
       this.pluginsManager.trigger('log:error', error);
       response.writeHead(errorObject.status, {'Content-Type': 'application/json'});
       response.end(stringify(errorObject.toJson()));
-    });
-}
-
-/**
- * Extract the Bearer token from the given headers
- * @param {Object} headers
- * @returns {*}
- */
-function getBearerTokenFromHeaders(headers) {
-  var
-    r;
-
-  if (headers !== undefined && headers.authorization !== undefined) {
-    r = /^Bearer (.+)$/.exec(headers.authorization);
-    if (r !== null && r[1].trim() !== '') {
-      return r[1].trim();
+    } else {
+      response.writeHead(responseObject.status, {'Content-Type': 'application/json'});
+      response.end(stringify(responseObject.toJson()));
     }
-  }
-
-  return null;
+  });
 }

--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -109,10 +109,10 @@ module.exports = function RouterController(kuzzle) {
       return callback(new ResponseObject(requestObject, error));
     }
 
-    kuzzle.funnel.execute(requestObject, context, (error, response) => {
-      if (error) {
-        kuzzle.pluginsManager.trigger('log:error', error);
-        return callback(new ResponseObject(requestObject, error));
+    kuzzle.funnel.execute(requestObject, context, (err, response) => {
+      if (err) {
+        kuzzle.pluginsManager.trigger('log:error', err);
+        return callback(new ResponseObject(requestObject, err));
       }
 
       callback(null, response);
@@ -131,7 +131,7 @@ module.exports = function RouterController(kuzzle) {
     }
     else {
       kuzzle.pluginsManager.trigger('log:error', new PluginImplementationError('Unable to remove connection: ' +
-        context + '.\nReason: unknown context'));
+        JSON.stringify(context) + '.\nReason: unknown context'));
     }
   };
 
@@ -381,7 +381,8 @@ function executeFromRest(params, request, response) {
   data = {
     controller: params.controller,
     action: params.action || request.params.action,
-    collection: request.params.collection
+    collection: request.params.collection,
+    headers: request.headers
   };
 
   if (request.params.action) {
@@ -414,7 +415,6 @@ function executeFromRest(params, request, response) {
   this.funnel.execute(requestObject, context, (error, responseObject) => {
     if (error) {
       errorObject = new ResponseObject(requestObject, error);
-      this.emit(requestObject.controller + ':websocket:funnel:reject', error);
       this.pluginsManager.trigger('log:error', error);
       response.writeHead(errorObject.status, {'Content-Type': 'application/json'});
       response.end(stringify(errorObject.toJson()));

--- a/lib/api/core/pluginsManager.js
+++ b/lib/api/core/pluginsManager.js
@@ -184,7 +184,7 @@ module.exports = function PluginsManager (kuzzle) {
    */
   this.injectControllers = function () {
     _.forEach(this.controllers, function (controller, name) {
-      kuzzle.funnel[name] = controller();
+      kuzzle.funnel.controllers[name] = controller();
     });
   };
 };

--- a/lib/api/core/pluginsManager.js
+++ b/lib/api/core/pluginsManager.js
@@ -44,7 +44,7 @@ module.exports = function PluginsManager (kuzzle) {
       process.exit(1);
     }
 
-    this.isDummy = isDummy;
+    this.isDummy = isDummy || false;
     this.isServer = isServer;
 
     if (this.isDummy) {
@@ -76,8 +76,6 @@ module.exports = function PluginsManager (kuzzle) {
       if (!plugin.activated) {
         return true;
       }
-
-      console.log('Starting plugin: ', pluginName);
 
       plugin.object.init(plugin.config, context, this.isDummy);
 

--- a/lib/api/prepareDb.js
+++ b/lib/api/prepareDb.js
@@ -141,7 +141,7 @@ function createInternalStructure () {
       });
 
 
-      return this.kuzzle.funnel.security.createOrReplaceRole(requestObject, {});
+      return this.kuzzle.funnel.controllers.security.createOrReplaceRole(requestObject, {});
     })
     .then(() => {
       this.kuzzle.pluginsManager.trigger('log:info', '== Creating default role for default...');
@@ -154,7 +154,7 @@ function createInternalStructure () {
         body: this.defaultRoleDefinition
       });
 
-      return this.kuzzle.funnel.security.createOrReplaceRole(requestObject, {});
+      return this.kuzzle.funnel.controllers.security.createOrReplaceRole(requestObject, {});
     })
     .then(() => {
       this.kuzzle.indexCache.add(this.kuzzle.config.internalIndex, 'roles');
@@ -169,7 +169,7 @@ function createInternalStructure () {
       });
 
 
-      return this.kuzzle.funnel.security.createOrReplaceRole(requestObject, {});
+      return this.kuzzle.funnel.controllers.security.createOrReplaceRole(requestObject, {});
     })
 
     .then(() => {
@@ -182,7 +182,7 @@ function createInternalStructure () {
       });
 
 
-      return this.kuzzle.funnel.security.createOrReplaceProfile(requestObject, {});
+      return this.kuzzle.funnel.controllers.security.createOrReplaceProfile(requestObject, {});
     })
     .then(() => {
       this.kuzzle.pluginsManager.trigger('log:info', '== Creating default profile for anonymous...');
@@ -193,7 +193,7 @@ function createInternalStructure () {
         body: {_id: 'anonymous', roles: [ 'anonymous' ]}
       });
 
-      return this.kuzzle.funnel.security.createOrReplaceProfile(requestObject, {});
+      return this.kuzzle.funnel.controllers.security.createOrReplaceProfile(requestObject, {});
     })
     .then(() => {
       this.kuzzle.pluginsManager.trigger('log:info', '== Creating default profile for admin...');
@@ -204,7 +204,7 @@ function createInternalStructure () {
         body: {_id: 'admin', roles: [ 'admin' ]}
       });
 
-      return this.kuzzle.funnel.security.createOrReplaceProfile(requestObject, {});
+      return this.kuzzle.funnel.controllers.security.createOrReplaceProfile(requestObject, {});
     });
 
 }

--- a/lib/config/hooks.js
+++ b/lib/config/hooks.js
@@ -32,6 +32,7 @@ module.exports = {
   'security:deleteUser': [],
   'security:createUser': [],
   'security:updateUser': [],
-  'security:createOrReplaceUser': []
+  'security:createOrReplaceUser': [],
+  'server:overload': []
 };
 

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -17,6 +17,7 @@ module.exports = function (params) {
     defaultUserRoles: params.userRoles,
     repositories: params.repositories,
     pluginsManager: params.pluginsManager,
-    internalIndex: params.internalIndex
+    internalIndex: params.internalIndex,
+    request: params.request
   };
 };

--- a/lib/config/models/cache.js
+++ b/lib/config/models/cache.js
@@ -2,6 +2,6 @@ module.exports = function (params) {
   return {
     host: process.env.CACHE_HOST || params.cache.host || 'localhost',
     port: process.env.CACHE_PORT || params.cache.port || 6379,
-    databases: ['notificationCache', 'statsCache', 'userCache', 'internalCache', 'tokenCache', 'queryCache']
+    databases: ['notificationCache', 'statsCache', 'userCache', 'internalCache', 'tokenCache']
   };
 };

--- a/lib/config/models/cache.js
+++ b/lib/config/models/cache.js
@@ -2,6 +2,6 @@ module.exports = function (params) {
   return {
     host: process.env.CACHE_HOST || params.cache.host || 'localhost',
     port: process.env.CACHE_PORT || params.cache.port || 6379,
-    databases: ['notificationCache', 'statsCache', 'userCache', 'internalCache', 'tokenCache']
+    databases: ['notificationCache', 'statsCache', 'userCache', 'internalCache', 'tokenCache', 'queryCache']
   };
 };

--- a/lib/config/services.js
+++ b/lib/config/services.js
@@ -11,7 +11,6 @@ module.exports = function () {
     monitoring: 'newrelic',
     remoteActions: 'remoteActions',
     statsCache: 'redis',
-    tokenCache: 'redis',
-    queryCache: 'redis'
+    tokenCache: 'redis'
   };
 };

--- a/lib/config/services.js
+++ b/lib/config/services.js
@@ -11,6 +11,7 @@ module.exports = function () {
     monitoring: 'newrelic',
     remoteActions: 'remoteActions',
     statsCache: 'redis',
-    tokenCache: 'redis'
+    tokenCache: 'redis',
+    queryCache: 'redis'
   };
 };

--- a/lib/services/redis.js
+++ b/lib/services/redis.js
@@ -207,7 +207,7 @@ module.exports = function (kuzzle, options) {
    */
   this.mget = function (key) {
     if (key.length === 0) {
-      return q();
+      return q([]);
     }
 
     return q.ninvoke(this.client, 'mget', key);
@@ -259,32 +259,5 @@ module.exports = function (kuzzle, options) {
    */
   this.getAllKeys = function () {
     return this.searchKeys('*');
-  };
-
-  /**
-   * Push a value "value" at the end of the list stored in the "key" entry
-   * @param key
-   * @param value
-   * @returns {promise}
-   */
-  this.push = function (key, value) {
-    if (key.length === 0) {
-      return q();
-    }
-
-    return q.ninvoke(this.client, 'rpush', key, value);
-  };
-
-  /**
-   * Pop the first value of the list stored in the "key" entry
-   * @param key
-   * @returns {promise}
-   */
-  this.pop = function (key) {
-    if (key.length === 0) {
-      return q();
-    }
-
-    return q.ninvoke(this.client, 'lpop', key);
   };
 };

--- a/lib/services/redis.js
+++ b/lib/services/redis.js
@@ -93,14 +93,14 @@ module.exports = function (kuzzle, options) {
       addSet = [key];
 
     if (!values) {
-      return q.when(0);
+      return q(0);
     }
 
     if (typeof values === 'string') {
       addSet.push(values);
     } else {
       if (values.length === 0) {
-        return q.when(0);
+        return q(0);
       }
       addSet = addSet.concat(values);
     }
@@ -207,7 +207,7 @@ module.exports = function (kuzzle, options) {
    */
   this.mget = function (key) {
     if (key.length === 0) {
-      return q.when([]);
+      return q();
     }
 
     return q.ninvoke(this.client, 'mget', key);
@@ -259,5 +259,32 @@ module.exports = function (kuzzle, options) {
    */
   this.getAllKeys = function () {
     return this.searchKeys('*');
+  };
+
+  /**
+   * Push a value "value" at the end of the list stored in the "key" entry
+   * @param key
+   * @param value
+   * @returns {promise}
+   */
+  this.push = function (key, value) {
+    if (key.length === 0) {
+      return q();
+    }
+
+    return q.ninvoke(this.client, 'rpush', key, value);
+  };
+
+  /**
+   * Pop the first value of the list stored in the "key" entry
+   * @param key
+   * @returns {promise}
+   */
+  this.pop = function (key) {
+    if (key.length === 0) {
+      return q();
+    }
+
+    return q.ninvoke(this.client, 'lpop', key);
   };
 };

--- a/test/api/controllers/adminController.test.js
+++ b/test/api/controllers/adminController.test.js
@@ -82,7 +82,7 @@ describe('Test: admin controller', function () {
         }
       });
 
-      kuzzle.funnel.admin.deleteCollection(requestObject)
+      kuzzle.funnel.controllers.admin.deleteCollection(requestObject)
         .catch(function (error) {
           done(error);
         });
@@ -91,7 +91,7 @@ describe('Test: admin controller', function () {
     it('should remove the deleted collection from the cache', function (done) {
       this.timeout(50);
 
-      kuzzle.funnel.admin.deleteCollection(requestObject)
+      kuzzle.funnel.controllers.admin.deleteCollection(requestObject)
         .then(response => {
           should(response).be.instanceof(ResponseObject);
           should(indexCacheAdd).be.false();
@@ -117,7 +117,7 @@ describe('Test: admin controller', function () {
         }
       });
 
-      kuzzle.funnel.admin.updateMapping(requestObject)
+      kuzzle.funnel.controllers.admin.updateMapping(requestObject)
         .catch(function (error) {
           done(error);
         });
@@ -126,7 +126,7 @@ describe('Test: admin controller', function () {
     it('should add the new collection to the cache', function (done) {
       this.timeout(50);
 
-      kuzzle.funnel.admin.updateMapping(requestObject)
+      kuzzle.funnel.controllers.admin.updateMapping(requestObject)
         .then(response => {
           should(response).be.instanceof(ResponseObject);
           should(indexCacheAdd).be.true();
@@ -140,7 +140,7 @@ describe('Test: admin controller', function () {
 
   describe('#getMapping', function () {
     it('should return a mapping when requested', function () {
-      var r = kuzzle.funnel.admin.getMapping(requestObject);
+      var r = kuzzle.funnel.controllers.admin.getMapping(requestObject);
       return should(r).be.rejected();
     });
 
@@ -157,7 +157,7 @@ describe('Test: admin controller', function () {
         }
       });
 
-      kuzzle.funnel.admin.getMapping(requestObject);
+      kuzzle.funnel.controllers.admin.getMapping(requestObject);
     });
   });
 
@@ -175,7 +175,7 @@ describe('Test: admin controller', function () {
         }
       });
 
-      kuzzle.funnel.admin.getStats(requestObject);
+      kuzzle.funnel.controllers.admin.getStats(requestObject);
     });
   });
 
@@ -193,7 +193,7 @@ describe('Test: admin controller', function () {
         }
       });
 
-      kuzzle.funnel.admin.getLastStats(requestObject);
+      kuzzle.funnel.controllers.admin.getLastStats(requestObject);
     });
   });
 
@@ -211,7 +211,7 @@ describe('Test: admin controller', function () {
         }
       });
 
-      kuzzle.funnel.admin.getAllStats(requestObject);
+      kuzzle.funnel.controllers.admin.getAllStats(requestObject);
     });
   });
 
@@ -229,7 +229,7 @@ describe('Test: admin controller', function () {
         }
       });
 
-      kuzzle.funnel.admin.truncateCollection(requestObject);
+      kuzzle.funnel.controllers.admin.truncateCollection(requestObject);
     });
   });
 
@@ -288,13 +288,13 @@ describe('Test: admin controller', function () {
         }
       });
 
-      kuzzle.funnel.admin.deleteIndexes(requestObject, context);
+      kuzzle.funnel.controllers.admin.deleteIndexes(requestObject, context);
     });
 
     it('should delete only the allowed indexes', function (done) {
       this.timeout(50);
 
-      kuzzle.funnel.admin.deleteIndexes(requestObject, context)
+      kuzzle.funnel.controllers.admin.deleteIndexes(requestObject, context)
         .then(response => {
           should(response).be.instanceof(ResponseObject);
           should(response.data.body.deleted).be.eql(['%text1', '%text2']);
@@ -306,7 +306,7 @@ describe('Test: admin controller', function () {
     it('should reset the index cache', function (done) {
       this.timeout(50);
 
-      kuzzle.funnel.admin.deleteIndexes(requestObject, context)
+      kuzzle.funnel.controllers.admin.deleteIndexes(requestObject, context)
         .then(response => {
           should(response).be.instanceof(ResponseObject);
           should(indexCacheAdd).be.false();
@@ -332,13 +332,13 @@ describe('Test: admin controller', function () {
         }
       });
 
-      kuzzle.funnel.admin.createIndex(requestObject);
+      kuzzle.funnel.controllers.admin.createIndex(requestObject);
     });
 
     it('should add the new index to the cache', function (done) {
       this.timeout(50);
 
-      kuzzle.funnel.admin.createIndex(requestObject)
+      kuzzle.funnel.controllers.admin.createIndex(requestObject)
         .then(response => {
           should(response).be.instanceof(ResponseObject);
           should(indexCacheAdd).be.true();
@@ -364,11 +364,11 @@ describe('Test: admin controller', function () {
         }
       });
 
-      kuzzle.funnel.admin.deleteIndex(requestObject);
+      kuzzle.funnel.controllers.admin.deleteIndex(requestObject);
     });
 
     it('should remove the index from the cache', function (done) {
-      kuzzle.funnel.admin.deleteIndex(requestObject)
+      kuzzle.funnel.controllers.admin.deleteIndex(requestObject)
         .then(response => {
           should(response).be.instanceof(ResponseObject);
           should(indexCacheAdd).be.false();
@@ -394,11 +394,11 @@ describe('Test: admin controller', function () {
         }
       });
 
-      kuzzle.funnel.admin.removeRooms(requestObject);
+      kuzzle.funnel.controllers.admin.removeRooms(requestObject);
     });
 
     it('should resolve to a promise', function () {
-      return should(kuzzle.funnel.admin.removeRooms(requestObject)).be.rejected();
+      return should(kuzzle.funnel.controllers.admin.removeRooms(requestObject)).be.rejected();
     });
   });
 });

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -9,19 +9,14 @@ var
   RequestObject = require.main.require('lib/api/core/models/requestObject'),
   ResponseObject = require.main.require('lib/api/core/models/responseObject'),
   BadRequestError = require.main.require('lib/api/core/errors/badRequestError'),
-  InternalError = require.main.require('lib/api/core/errors/internalError'),
   NotFoundError = require.main.require('lib/api/core/errors/notFoundError'),
   Token = require.main.require('lib/api/core/models/security/token'),
-  Profile = require.main.require('lib/api/core/models/security/profile'),
-  User = require.main.require('lib/api/core/models/security/user'),
   context = {},
   requestObject,
   MockupWrapper,
   MockupStrategy;
 
 MockupStrategy = function(name, verify) {
-  var options = {};
-
   passport.Strategy.call(this);
   this.name = name;
   this._verify = verify;
@@ -29,7 +24,7 @@ MockupStrategy = function(name, verify) {
 };
 util.inherits(MockupStrategy, passport.Strategy);
 
-MockupStrategy.prototype.authenticate = function(req, options) {
+MockupStrategy.prototype.authenticate = function(req) {
   var
     self = this,
     username;

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -111,8 +111,8 @@ describe('Test the auth controller', function () {
     it('should resolve to a valid jwt token if authentication succeed', function (done) {
       this.timeout(50);
 
-      kuzzle.funnel.auth.passport = new MockupWrapper('resolve');
-      kuzzle.funnel.auth.login(requestObject, {})
+      kuzzle.funnel.controllers.auth.passport = new MockupWrapper('resolve');
+      kuzzle.funnel.controllers.auth.login(requestObject, {})
         .then(function(response) {
           var decodedToken = jwt.verify(response.data.body.jwt, params.jsonWebToken.secret);
           should(decodedToken._id).be.equal('jdoe');
@@ -126,8 +126,8 @@ describe('Test the auth controller', function () {
     it('should resolve to a redirect url', function(done) {
       this.timeout(50);
 
-      kuzzle.funnel.auth.passport = new MockupWrapper('oauth');
-      kuzzle.funnel.auth.login(requestObject, {})
+      kuzzle.funnel.controllers.auth.passport = new MockupWrapper('oauth');
+      kuzzle.funnel.controllers.auth.login(requestObject, {})
         .then(function(response) {
           should(response.data.body.headers.Location).be.equal('http://github.com');
           done();
@@ -140,7 +140,7 @@ describe('Test the auth controller', function () {
     it('should use local strategy if no one is set', function (done) {
       this.timeout(50);
 
-      kuzzle.funnel.auth.passport = {
+      kuzzle.funnel.controllers.auth.passport = {
         authenticate: function(data, strategy) {
           should(strategy).be.exactly('local');
           done();
@@ -150,7 +150,7 @@ describe('Test the auth controller', function () {
 
       delete requestObject.data.body.strategy;
 
-      kuzzle.funnel.auth.login(requestObject, {});
+      kuzzle.funnel.controllers.auth.login(requestObject, {});
     });
 
     it('should be able to set authentication expiration', function (done) {
@@ -158,8 +158,8 @@ describe('Test the auth controller', function () {
 
       requestObject.data.body.expiresIn = '1s';
 
-      kuzzle.funnel.auth.passport = new MockupWrapper('resolve');
-      kuzzle.funnel.auth.login(requestObject, {connection: {id: 'banana'}})
+      kuzzle.funnel.controllers.auth.passport = new MockupWrapper('resolve');
+      kuzzle.funnel.controllers.auth.login(requestObject, {connection: {id: 'banana'}})
         .then(function(response) {
           var decodedToken = jwt.verify(response.data.body.jwt, params.jsonWebToken.secret);
           should(decodedToken._id).be.equal('jdoe');
@@ -195,8 +195,8 @@ describe('Test the auth controller', function () {
         done();
       };
 
-      kuzzle.funnel.auth.passport = new MockupWrapper('resolve');
-      kuzzle.funnel.auth.login(requestObject, context)
+      kuzzle.funnel.controllers.auth.passport = new MockupWrapper('resolve');
+      kuzzle.funnel.controllers.auth.login(requestObject, context)
         .catch(function (error) {
           done(error);
         });
@@ -204,8 +204,8 @@ describe('Test the auth controller', function () {
 
     it('should reject if authentication failure', function (done) {
       this.timeout(50);
-      kuzzle.funnel.auth.passport = new MockupWrapper('reject');
-      kuzzle.funnel.auth.login(requestObject)
+      kuzzle.funnel.controllers.auth.passport = new MockupWrapper('reject');
+      kuzzle.funnel.controllers.auth.login(requestObject)
         .catch((error) => {
           should(error).be.an.instanceOf(ResponseObject);
           should(error.error.message).be.exactly('Mockup Wrapper Error');
@@ -248,7 +248,7 @@ describe('Test the auth controller', function () {
         }
       };
 
-      kuzzle.funnel.auth.logout(requestObject, context)
+      kuzzle.funnel.controllers.auth.logout(requestObject, context)
         .then(response => {
           should(response).be.instanceof(ResponseObject);
           done();
@@ -265,7 +265,7 @@ describe('Test the auth controller', function () {
         }
       };
 
-      return should(kuzzle.funnel.auth.logout(requestObject, context)).be.rejectedWith(ResponseObject);
+      return should(kuzzle.funnel.controllers.auth.logout(requestObject, context)).be.rejectedWith(ResponseObject);
     });
 
     it('should expire token', function (done) {
@@ -276,7 +276,7 @@ describe('Test the auth controller', function () {
         return q();
       };
 
-      kuzzle.funnel.auth.logout(requestObject, context)
+      kuzzle.funnel.controllers.auth.logout(requestObject, context)
         .then(response => {
           should(response).be.instanceof(ResponseObject);
           done();
@@ -291,7 +291,7 @@ describe('Test the auth controller', function () {
         return q.reject();
       };
 
-      return should(kuzzle.funnel.auth.logout(requestObject, context)).be.rejectedWith(ResponseObject);
+      return should(kuzzle.funnel.controllers.auth.logout(requestObject, context)).be.rejectedWith(ResponseObject);
     });
 
     it('should remove all room registration for current connexion', function (done) {
@@ -302,7 +302,7 @@ describe('Test the auth controller', function () {
         return q();
       };
 
-      kuzzle.funnel.auth.logout(requestObject, context)
+      kuzzle.funnel.controllers.auth.logout(requestObject, context)
         .then(response => {
           should(response).be.instanceof(ResponseObject);
           done();
@@ -321,7 +321,7 @@ describe('Test the auth controller', function () {
 
       delete context.connection.id;
 
-      kuzzle.funnel.auth.logout(requestObject, context)
+      kuzzle.funnel.controllers.auth.logout(requestObject, context)
         .then(() => {
           should(removeCustomerFromAllRooms).be.exactly(false);
           done();
@@ -332,7 +332,7 @@ describe('Test the auth controller', function () {
 
   describe('#getCurrentUser', function () {
     it('should return the user given in the context', done => {
-      kuzzle.funnel.auth.getCurrentUser(new RequestObject({
+      kuzzle.funnel.controllers.auth.getCurrentUser(new RequestObject({
         body: {}
       }), {
         token: { user: { _id: 'admin' } }
@@ -349,7 +349,7 @@ describe('Test the auth controller', function () {
     });
 
     it('should return a falsey response if the current user is unknown', () => {
-      var promise = kuzzle.funnel.auth.getCurrentUser(new RequestObject({
+      var promise = kuzzle.funnel.controllers.auth.getCurrentUser(new RequestObject({
         body: {}
       }), {
         token: { user: { _id: 'unknown_user' } }
@@ -374,7 +374,7 @@ describe('Test the auth controller', function () {
     });
 
     it('should return a rejected promise if no token is provided', function () {
-      return should(kuzzle.funnel.auth.checkToken(new RequestObject({ body: {}}))).be.rejectedWith(BadRequestError);
+      return should(kuzzle.funnel.controllers.auth.checkToken(new RequestObject({ body: {}}))).be.rejectedWith(BadRequestError);
     });
 
     it('should return a valid response if the token is valid', function (done) {
@@ -383,7 +383,7 @@ describe('Test the auth controller', function () {
         return q(stubToken);
       };
 
-      kuzzle.funnel.auth.checkToken(requestObject)
+      kuzzle.funnel.controllers.auth.checkToken(requestObject)
         .then(response => {
           should(response).be.instanceof(ResponseObject);
           should(response.data.body.valid).be.true();
@@ -400,7 +400,7 @@ describe('Test the auth controller', function () {
         return q.reject({status: 401, message: 'foobar'});
       };
 
-      kuzzle.funnel.auth.checkToken(requestObject)
+      kuzzle.funnel.controllers.auth.checkToken(requestObject)
         .then(response => {
           should(response).be.instanceof(ResponseObject);
           should(response.data.body.valid).be.false();
@@ -417,7 +417,7 @@ describe('Test the auth controller', function () {
         return q.reject({status: 500});
       };
 
-      return should(kuzzle.funnel.auth.checkToken(requestObject)).be.rejected();
+      return should(kuzzle.funnel.controllers.auth.checkToken(requestObject)).be.rejected();
     });
   });
 });

--- a/test/api/controllers/bulkController.test.js
+++ b/test/api/controllers/bulkController.test.js
@@ -27,7 +27,7 @@ describe('Test the bulk controller', function () {
       }
     });
 
-    kuzzle.funnel.bulk.import(requestObject)
+    kuzzle.funnel.controllers.bulk.import(requestObject)
       .catch(function (error) {
         done(error);
       });

--- a/test/api/controllers/funnelController/execute.test.js
+++ b/test/api/controllers/funnelController/execute.test.js
@@ -108,15 +108,17 @@ describe('funnelController.execute', function () {
     });
 
     it('should not fire the hook if one was fired less than 500ms ago', function (done) {
-      kuzzle.once('server:overload', function () {
+      var listener = function () {
         done(new Error('server:overload hook fired unexpectedly'));
-      });
+      };
+
+      kuzzle.once('server:overload', listener);
 
       funnel.overloaded = true;
       funnel.lastWarningTime = Date.now() - 200;
       funnel.execute(requestObject, context, () => {});
       setTimeout(() => {
-        kuzzle.removeAllListeners('server:overload');
+        kuzzle.off('server:overload', listener);
         done();
       }, 200);
     });

--- a/test/api/controllers/funnelController/execute.test.js
+++ b/test/api/controllers/funnelController/execute.test.js
@@ -1,0 +1,185 @@
+var
+  should = require('should'),
+  q = require('q'),
+  RequestObject = require.main.require('lib/api/core/models/requestObject'),
+  ResponseObject = require.main.require('lib/api/core/models/responseObject'),
+  ServiceUnavailableError = require.main.require('lib/api/core/errors/serviceUnavailableError'),
+  params = require('rc')('kuzzle'),
+  Kuzzle = require.main.require('lib/api/Kuzzle'),
+  rewire = require('rewire'),
+  FunnelController = rewire('../../../../lib/api/controllers/funnelController');
+
+describe('funnelController.execute', function () {
+  var
+    kuzzle,
+    funnel,
+    processRequestCalled,
+    requestObject,
+    context,
+    requestReplayed;
+
+  before(function (callback) {
+    context = {
+      connection: {id: 'connectionid'},
+      token: null
+    };
+
+    kuzzle = new Kuzzle();
+    kuzzle.start(params, {dummy: true})
+      .then(() => {
+        FunnelController.__set__('processRequest', function (requestObject) {
+          processRequestCalled = true;
+
+          if (requestObject.errorMe) {
+            return q.reject(new Error('errored on purpose'));
+          }
+
+          return q(new ResponseObject(requestObject));
+        });
+
+        FunnelController.__set__('playCachedRequests', function () {
+          requestReplayed = true;
+        });
+
+        callback();
+      });
+  });
+
+  beforeEach(function () {
+    processRequestCalled = false;
+    requestReplayed = false;
+
+    requestObject = new RequestObject({
+      controller: 'foo',
+      action: 'bar'
+    });
+
+    funnel = new FunnelController(kuzzle);
+    funnel.init();
+  });
+
+  describe('#normal state', function () {
+    it('should execute the request immediately if not overloaded', function (done) {
+      funnel.execute(requestObject, context, (err, res) => {
+        should(err).be.null();
+        should(res).be.instanceOf(ResponseObject);
+        should(processRequestCalled).be.true();
+        done();
+      });
+    });
+
+    it('should forward any error occuring during the request execution', function (done) {
+      requestObject.errorMe = true;
+
+      funnel.execute(requestObject, context, (err, res) => {
+        should(err).be.instanceOf(Error);
+        should(res).be.undefined();
+        should(processRequestCalled).be.true();
+        should(funnel.overloaded).be.false();
+        should(requestReplayed).be.false();
+        done();
+      });
+    });
+  });
+
+  describe('#server:overload hook', function () {
+    it('should fire the hook the first time Kuzzle is in overloaded state', function (done) {
+      this.timeout(500);
+
+      kuzzle.once('server:overload', function () {
+        done();
+      });
+
+      funnel.overloaded = true;
+      funnel.execute(requestObject, context, () => {
+      });
+    });
+
+    it('should fire the hook if the last one was fired more than 500ms ago', function (done) {
+      this.timeout(500);
+
+      kuzzle.once('server:overload', function () {
+        done();
+      });
+
+      funnel.overloaded = true;
+      funnel.lastWarningTime = Date.now() - 501;
+      funnel.execute(requestObject, context, () => {});
+    });
+
+    it('should not fire the hook if one was fired less than 500ms ago', function (done) {
+      kuzzle.once('server:overload', function () {
+        done(new Error('server:overload hook fired unexpectedly'));
+      });
+
+      funnel.overloaded = true;
+      funnel.lastWarningTime = Date.now() - 200;
+      funnel.execute(requestObject, context, () => {});
+      setTimeout(() => {
+        kuzzle.removeAllListeners('server:overload');
+        done();
+      }, 200);
+    });
+  });
+
+  describe('#overloaded state', function () {
+    it('should enter overloaded state if the maxConcurrentRequests property is reached', function (done) {
+      var callback = () => {
+        done(new Error('Request executed. It should have been queued instead'));
+      };
+
+      funnel.concurrentRequests = kuzzle.config.request.maxConcurrentRequests;
+
+      funnel.execute(requestObject, context, callback);
+
+      setTimeout(() => {
+        should(funnel.overloaded).be.true();
+        should(requestReplayed).be.true();
+        should(processRequestCalled).be.false();
+        should(funnel.cachedRequests).be.eql(1);
+        should(funnel.requestsCache[0]).match({requestObject, context, callback});
+        done();
+      }, 100);
+    });
+
+    it('should not relaunch the request replayer background task if already in overloaded state', function (done) {
+      var callback = () => {
+        done(new Error('Request executed. It should have been queued instead'));
+      };
+
+      funnel.concurrentRequests = kuzzle.config.request.maxConcurrentRequests;
+      funnel.overloaded = true;
+
+      funnel.execute(requestObject, context, callback);
+
+      setTimeout(() => {
+        should(funnel.overloaded).be.true();
+        should(requestReplayed).be.false();
+        should(processRequestCalled).be.false();
+        should(funnel.cachedRequests).be.eql(1);
+        should(funnel.requestsCache[0]).match({requestObject, context, callback});
+        done();
+      }, 100);
+    });
+
+    it('should discard the request if the maxRetainedRequests property is reached', function (done) {
+      this.timeout(500);
+
+      funnel.concurrentRequests = kuzzle.config.request.maxConcurrentRequests;
+      funnel.cachedRequests = kuzzle.config.request.maxRetainedRequests;
+      funnel.overloaded = true;
+
+      funnel.execute(requestObject, context, (err, res) => {
+        should(funnel.overloaded).be.true();
+        should(requestReplayed).be.false();
+        should(processRequestCalled).be.false();
+        should(funnel.cachedRequests).be.eql(kuzzle.config.request.maxRetainedRequests);
+        should(funnel.requestsCache).be.empty();
+        should(res).be.undefined();
+        should(err).be.instanceOf(ServiceUnavailableError);
+        done();
+      });
+    });
+  });
+});
+

--- a/test/api/controllers/funnelController/getBearerFromToken.test.js
+++ b/test/api/controllers/funnelController/getBearerFromToken.test.js
@@ -1,0 +1,17 @@
+var
+  should = require('should'),
+  rewire = require('rewire'),
+  FunnelController = rewire('../../../../lib/api/controllers/funnelController');
+
+describe('#getBearerTokenFromHeaders', () => {
+  var
+    getBearerTokenFromHeader = FunnelController.__get__('getBearerTokenFromHeaders');
+
+  it('should extract the bearer token from the header', () => {
+    var result = getBearerTokenFromHeader({
+      authorization: 'Bearer sometoken'
+    });
+
+    should(result).be.exactly('sometoken');
+  });
+});

--- a/test/api/controllers/funnelController/playCachedRequests.test.js
+++ b/test/api/controllers/funnelController/playCachedRequests.test.js
@@ -44,7 +44,6 @@ describe('funnelController.playCachedRequests', function () {
         });
 
         playCachedRequests = FunnelController.__get__('playCachedRequests');
-
         done();
       });
   });

--- a/test/api/controllers/funnelController/playCachedRequests.test.js
+++ b/test/api/controllers/funnelController/playCachedRequests.test.js
@@ -35,14 +35,6 @@ describe('funnelController.playCachedRequests', function () {
     kuzzle = new Kuzzle();
     kuzzle.start(params, {dummy: true})
       .then(() => {
-        FunnelController.__set__('execute', function (r, c, cb) {
-          executeCalled = true;
-
-          should(r).be.eql(requestObject);
-          should(c).be.eql(context);
-          should(cb).be.eql(callback);
-        });
-
         FunnelController.__set__('setTimeout', function () {
           setTimeoutCalled = true;
         });
@@ -65,6 +57,13 @@ describe('funnelController.playCachedRequests', function () {
     funnel = new FunnelController(kuzzle);
     funnel.init();
     funnel.lastOverloadTime = 0;
+    funnel.execute = function (r, c, cb) {
+      executeCalled = true;
+
+      should(r).be.eql(requestObject);
+      should(c).be.eql(context);
+      should(cb).be.eql(callback);
+    };
   });
 
   describe('#returning to normal state', function () {
@@ -133,6 +132,7 @@ describe('funnelController.playCachedRequests', function () {
       funnel.cachedRequests = 1;
       funnel.concurrentRequests = 0;
       funnel.requestsCache = [{requestObject, context, callback}];
+      playCachedRequests(kuzzle, funnel);
 
       should(nextTickCalled).be.true();
       should(setTimeoutCalled).be.false();

--- a/test/api/controllers/funnelController/playCachedRequests.test.js
+++ b/test/api/controllers/funnelController/playCachedRequests.test.js
@@ -1,0 +1,142 @@
+var
+  should = require('should'),
+  q = require('q'),
+  params = require('rc')('kuzzle'),
+  Kuzzle = require.main.require('lib/api/Kuzzle'),
+  RequestObject = require.main.require('lib/api/core/models/requestObject'),
+  rewire = require('rewire'),
+  FunnelController = rewire('../../../../lib/api/controllers/funnelController');
+
+describe('funnelController.playCachedRequests', function () {
+  var
+    kuzzle,
+    funnel,
+    executeCalled,
+    requestObject,
+    context,
+    callback,
+    nextTickCalled,
+    setTimeoutCalled,
+    playCachedRequests;
+
+  before(function (done) {
+    context = {
+      connection: {id: 'connectionid'},
+      token: null
+    };
+
+    requestObject = new RequestObject({
+      controller: 'foo',
+      action: 'bar'
+    });
+
+    callback = () => {};
+
+    kuzzle = new Kuzzle();
+    kuzzle.start(params, {dummy: true})
+      .then(() => {
+        FunnelController.__set__('execute', function (r, c, cb) {
+          executeCalled = true;
+
+          should(r).be.eql(requestObject);
+          should(c).be.eql(context);
+          should(cb).be.eql(callback);
+        });
+
+        FunnelController.__set__('setTimeout', function () {
+          setTimeoutCalled = true;
+        });
+
+        FunnelController.__set__('process', {
+          nextTick: () => { nextTickCalled = true; }
+        });
+
+        playCachedRequests = FunnelController.__get__('playCachedRequests');
+
+        done();
+      });
+  });
+
+  beforeEach(function () {
+    executeCalled = false;
+    nextTickCalled = false;
+    setTimeoutCalled = false;
+
+    funnel = new FunnelController(kuzzle);
+    funnel.init();
+    funnel.lastOverloadTime = 0;
+  });
+
+  describe('#returning to normal state', function () {
+    it('should return to normal state if there is no more cached request to play', function (done) {
+      this.timeout(500);
+
+      kuzzle.once('log:info', msg => {
+        should(funnel.overloaded).be.false();
+        should(nextTickCalled).be.false();
+        should(setTimeoutCalled).be.false();
+        should(msg).startWith('End of overloaded state');
+        done();
+      });
+
+      funnel.overloaded = true;
+      playCachedRequests(kuzzle, funnel);
+    });
+  });
+  
+  it('should fire a log hook if the last one was fired more than 500ms ago', function (done) {
+    this.timeout(500);
+
+    kuzzle.once('log:info', msg => {
+      should(funnel.overloaded).be.false();
+      should(nextTickCalled).be.false();
+      should(setTimeoutCalled).be.false();
+      should(msg).startWith('End of overloaded state');
+      done();
+    });
+
+    funnel.lastOverloadTime = Date.now() - 501;
+    funnel.overloaded = true;
+    playCachedRequests(kuzzle, funnel);
+  });
+
+  it('should not fire a log hook if the last one occured less than 500ms ago', function (done) {
+    kuzzle.once('log:info', () => {
+      done(new Error('Log hook fired unexpectedly'));
+    });
+
+    funnel.lastOverloadTime = Date.now() - 200;
+    funnel.overloaded = true;
+    playCachedRequests(kuzzle, funnel);
+
+    setTimeout(() => {
+      should(funnel.overloaded).be.false();
+      should(nextTickCalled).be.false();
+      should(setTimeoutCalled).be.false();
+      kuzzle.removeAllListeners('log:info');
+      done();
+    }, 200);
+  });
+
+  describe('#replaying requests', function () {
+    it('should do nothing if there is no room to replay request yet', function () {
+      funnel.cachedRequests = 1;
+      funnel.concurrentRequests = kuzzle.config.request.maxConcurrentRequests;
+      playCachedRequests(kuzzle, funnel);
+
+      should(nextTickCalled).be.false();
+      should(setTimeoutCalled).be.true();
+      should(executeCalled).be.false();
+    });
+
+    it('should resubmit a request and itself if there is room for a new request', function () {
+      funnel.cachedRequests = 1;
+      funnel.concurrentRequests = 0;
+      funnel.requestsCache = [{requestObject, context, callback}];
+
+      should(nextTickCalled).be.true();
+      should(setTimeoutCalled).be.false();
+      should(executeCalled).be.true();
+    });
+  });
+});

--- a/test/api/controllers/funnelController/processRequest.test.js
+++ b/test/api/controllers/funnelController/processRequest.test.js
@@ -12,7 +12,7 @@ var
   rewire = require('rewire'),
   FunnelController = rewire('../../../../lib/api/controllers/funnelController');
 
-describe('Test execute function in funnel controller', function () {
+describe('funnelController.processRequest', function () {
   var
     context = {
       connection: {id: 'connectionid'},

--- a/test/api/controllers/readController.test.js
+++ b/test/api/controllers/readController.test.js
@@ -45,7 +45,7 @@ describe('Test: read controller', function () {
 
       this.timeout(50);
       kuzzle.once('data:search', () => done());
-      kuzzle.funnel.read.search(requestObject);
+      kuzzle.funnel.controllers.read.search(requestObject);
     });
   });
 
@@ -55,7 +55,7 @@ describe('Test: read controller', function () {
 
       this.timeout(50);
       kuzzle.once('data:get', () => done());
-      kuzzle.funnel.read.get(requestObject);
+      kuzzle.funnel.controllers.read.get(requestObject);
     });
   });
 
@@ -65,7 +65,7 @@ describe('Test: read controller', function () {
 
       this.timeout(50);
       kuzzle.once('data:count', () => done());
-      kuzzle.funnel.read.count(requestObject);
+      kuzzle.funnel.controllers.read.count(requestObject);
     });
   });
 
@@ -112,7 +112,7 @@ describe('Test: read controller', function () {
     it('should resolve to a full collections list', function (done) {
       var
         requestObject = new RequestObject({}, {}, ''),
-        r = kuzzle.funnel.read.listCollections(requestObject, context);
+        r = kuzzle.funnel.controllers.read.listCollections(requestObject, context);
 
       should(r).be.a.Promise();
 
@@ -136,19 +136,19 @@ describe('Test: read controller', function () {
 
       this.timeout(50);
       kuzzle.once('data:listCollections', () => done());
-      kuzzle.funnel.read.listCollections(requestObject);
+      kuzzle.funnel.controllers.read.listCollections(requestObject);
     });
 
     it('should reject the request if an invalid "type" argument is provided', function () {
       var requestObject = new RequestObject({body: {type: 'foo'}}, {}, '');
 
-      return should(kuzzle.funnel.read.listCollections(requestObject, context)).be.rejectedWith(BadRequestError);
+      return should(kuzzle.funnel.controllers.read.listCollections(requestObject, context)).be.rejectedWith(BadRequestError);
     });
 
    it('should only return stored collections with type = stored', function () {
       var requestObject = new RequestObject({body: {type: 'stored'}}, {}, '');
 
-      return kuzzle.funnel.read.listCollections(requestObject, context).then(response => {
+      return kuzzle.funnel.controllers.read.listCollections(requestObject, context).then(response => {
         should(response.data.body.type).be.exactly('stored');
         should(realtime).be.false();
         should(stored).be.true();
@@ -158,7 +158,7 @@ describe('Test: read controller', function () {
     it('should only return realtime collections with type = realtime', function () {
       var requestObject = new RequestObject({body: {type: 'realtime'}}, {}, '');
 
-      return kuzzle.funnel.read.listCollections(requestObject, context).then(response => {
+      return kuzzle.funnel.controllers.read.listCollections(requestObject, context).then(response => {
         should(response.data.body.type).be.exactly('realtime');
         should(realtime).be.true();
         should(stored).be.false();
@@ -172,13 +172,13 @@ describe('Test: read controller', function () {
 
       this.timeout(50);
       kuzzle.once('data:now', () => done());
-      kuzzle.funnel.read.now(requestObject);
+      kuzzle.funnel.controllers.read.now(requestObject);
     });
 
     it('should resolve to a number', function () {
       var
         requestObject = new RequestObject({}),
-        promisedResult = kuzzle.funnel.read.now(requestObject);
+        promisedResult = kuzzle.funnel.controllers.read.now(requestObject);
 
       should(promisedResult).be.a.Promise();
 
@@ -195,14 +195,14 @@ describe('Test: read controller', function () {
 
       this.timeout(50);
       kuzzle.once('data:listIndexes', () => done());
-      kuzzle.funnel.read.listIndexes(requestObject);
+      kuzzle.funnel.controllers.read.listIndexes(requestObject);
     });
   });
 
   describe('#serverInfo', function () {
     it('should return a properly formatted server information object', function () {
       var requestObject = new RequestObject({});
-      return kuzzle.funnel.read.serverInfo(requestObject)
+      return kuzzle.funnel.controllers.read.serverInfo(requestObject)
         .then(res => {
           res = res.toJson();
           should(res.status).be.exactly(200);

--- a/test/api/controllers/routerController/executeFromRest.test.js
+++ b/test/api/controllers/routerController/executeFromRest.test.js
@@ -33,26 +33,21 @@ describe('Test: routerController.executeFromRest', function () {
 
   before(function (done) {
     var
-      mockupFunnel = function (requestObject) {
-        var
-          deferred = q.defer();
-
+      mockupFunnel = function (requestObject, context, callback) {
         savedRequestObject = requestObject;
         forwardedObject = new ResponseObject(requestObject, {});
 
         if (requestObject.data.body.resolve) {
           if (requestObject.data.body.empty) {
-            deferred.resolve({});
+            callback(null, {});
           }
           else {
-            deferred.resolve(forwardedObject);
+            callback(null, forwardedObject);
           }
         }
         else {
-          deferred.reject(new Error('rejected'));
+          callback(new Error('rejected'));
         }
-
-        return deferred.promise;
       },
       mockupRouterListener = {
         listener: {

--- a/test/api/controllers/routerController/routeMQListener.test.js
+++ b/test/api/controllers/routerController/routeMQListener.test.js
@@ -26,24 +26,20 @@ describe('Test: routerController.routeMQListener', function () {
 
   before(function (done) {
     var
-      mockupFunnel = function (requestObject) {
-        var deferred = q.defer();
-
+      mockupFunnel = function (requestObject, context, callback) {
         forwardedObject = new ResponseObject(requestObject, {});
 
         if (requestObject.data.body.resolve) {
           if (requestObject.data.body.empty) {
-            deferred.resolve({});
+            callback(null, {});
           }
           else {
-            deferred.resolve(forwardedObject);
+            callback(null, forwardedObject);
           }
         }
         else {
-          deferred.reject(new Error('rejected'));
+          callback(new Error('rejected'));
         }
-
-        return deferred.promise;
       },
       mockupSendMessage = replyChannel => {
         messageSent = true;

--- a/test/api/controllers/routerController/routerController.test.js
+++ b/test/api/controllers/routerController/routerController.test.js
@@ -4,7 +4,6 @@ var
   Kuzzle = require.main.require('lib/api/Kuzzle'),
   rewire = require('rewire'),
   q = require('q'),
-  RouterController = rewire('../../../../lib/api/controllers/routerController'),
   RequestObject = require.main.require('lib/api/core/models/requestObject'),
   Token = require.main.require('lib/api/core/models/security/token'),
   User = require.main.require('lib/api/core/models/security/user'),
@@ -14,19 +13,6 @@ var
   PluginImplementationError = require.main.require('lib/api/core/errors/pluginImplementationError');
 
 describe('Test: routerController', () => {
-  describe('#getBearerTokenFromHeaders', () => {
-    var
-      getBearerTokenFromHeader = RouterController.__get__('getBearerTokenFromHeaders');
-
-    it('should extract the bearer token from the header', () => {
-      var result = getBearerTokenFromHeader({
-        authorization: 'Bearer sometoken'
-      });
-
-      should(result).be.exactly('sometoken');
-    });
-  });
-
   describe('#newConnection', () => {
     var
       kuzzle,
@@ -132,19 +118,33 @@ describe('Test: routerController', () => {
         .catch(error => done(error));
     });
 
-    it('should return a fulfilled promise with the right arguments', () => {
-      return should(kuzzle.router.execute(requestObject, context)).be.fulfilled();
+    it('should return a fulfilled promise with the right arguments', (done) => {
+      kuzzle.router.execute(requestObject, context, done);
     });
 
-    it('should return an error if no request object is provided', () => {
-      return should(kuzzle.router.execute(undefined, context)).be.rejectedWith(ResponseObject);
+    it('should return an error if no request object is provided', (done) => {
+      kuzzle.router.execute(undefined, context, (err) => {
+        if (err && err instanceof ResponseObject) {
+          done();
+        }
+        else {
+          done(new Error('Returned successfully. Expected an error'));
+        }
+      });
     });
 
-    it('should return an error if an invalid context is provided', () => {
-      return should(kuzzle.router.execute(requestObject, {})).be.rejectedWith(ResponseObject);
+    it('should return an error if an invalid context is provided', (done) => {
+      kuzzle.router.execute(requestObject, {}, (err) => {
+        if (err && err instanceof ResponseObject) {
+          done();
+        }
+        else {
+          done(new Error('Returned successfully. Expected an error'));
+        }
+      });
     });
 
-    it('should return an error if an invalid context ID is provided', () => {
+    it('should return an error if an invalid context ID is provided', (done) => {
       var
         invalidContext = {
           connection: {
@@ -152,13 +152,28 @@ describe('Test: routerController', () => {
             type: 'jude'
           }
         };
-      return should(kuzzle.router.execute(requestObject, invalidContext)).be.rejectedWith(ResponseObject);
+
+      kuzzle.router.execute(requestObject, invalidContext, (err) => {
+        if (err && err instanceof ResponseObject) {
+          done();
+        }
+        else {
+          done(new Error('Returned successfully. Expected an error'));
+        }
+      });
     });
 
-    it('should forward any error that occured during execution back to the protocol plugin', () => {
-      kuzzle.funnel.execute = () => { return q.reject(new Error('rejected')); };
+    it('should forward any error that occured during execution back to the protocol plugin', (done) => {
+      kuzzle.funnel.execute = (r, c, cb) => { cb(new Error('rejected')); };
 
-      return should(kuzzle.router.execute(requestObject, context)).be.rejectedWith(ResponseObject);
+      kuzzle.router.execute(requestObject, context, (err) => {
+        if (err && err instanceof ResponseObject) {
+          done();
+        }
+        else {
+          done(new Error('Returned successfully. Expected an error'));
+        }
+      });
     });
   });
 

--- a/test/api/controllers/securityController.test.js
+++ b/test/api/controllers/securityController.test.js
@@ -31,7 +31,7 @@ describe('Test: security controller', function () {
   });
 
   it('should resolve to a responseObject on a createOrUpdateRole call', done => {
-    kuzzle.funnel.security.createOrReplaceRole(new RequestObject({
+    kuzzle.funnel.controllers.security.createOrReplaceRole(new RequestObject({
         body: { _id: 'test', indexes: {} }
       }))
       .then(result => {
@@ -45,7 +45,7 @@ describe('Test: security controller', function () {
   });
 
   it('should be rejected if creating a profile with bad roles property form', () => {
-    var promise = kuzzle.funnel.security.createOrReplaceProfile(new RequestObject({
+    var promise = kuzzle.funnel.controllers.security.createOrReplaceProfile(new RequestObject({
       body: { _id: 'test', roles: 'not-an-array-role' }
     }));
 

--- a/test/api/controllers/securityController/profiles.test.js
+++ b/test/api/controllers/securityController/profiles.test.js
@@ -90,7 +90,7 @@ describe('Test: security controller - profiles', function () {
 
   describe('#createOrReplaceProfile', function () {
     it('should resolve to a responseObject on a createOrReplaceProfile call', done => {
-      kuzzle.funnel.security.createOrReplaceProfile(new RequestObject({
+      kuzzle.funnel.controllers.security.createOrReplaceProfile(new RequestObject({
           body: {_id: 'test', roles: ['role1']}
         }))
         .then(result => {
@@ -106,7 +106,7 @@ describe('Test: security controller - profiles', function () {
 
   describe('#createProfile', function () {
     it('should reject when a profile already exists with the id', () => {
-      var promise = kuzzle.funnel.security.createProfile(new RequestObject({
+      var promise = kuzzle.funnel.controllers.security.createProfile(new RequestObject({
           body: {_id: 'alreadyExists', roles: ['role1']}
         }));
 
@@ -114,7 +114,7 @@ describe('Test: security controller - profiles', function () {
     });
 
     it('should resolve to a responseObject on a createProfile call', () => {
-      var promise = kuzzle.funnel.security.createProfile(new RequestObject({
+      var promise = kuzzle.funnel.controllers.security.createProfile(new RequestObject({
         body: {_id: 'test', roles: ['role1']}
       }));
 
@@ -124,7 +124,7 @@ describe('Test: security controller - profiles', function () {
 
   describe('#getProfile', function () {
     it('should resolve to a responseObject on a getProfile call', done => {
-      kuzzle.funnel.security.getProfile(new RequestObject({
+      kuzzle.funnel.controllers.security.getProfile(new RequestObject({
           body: {_id: 'test'}
         }))
         .then(result => {
@@ -138,21 +138,21 @@ describe('Test: security controller - profiles', function () {
     });
 
     it('should reject to an error on a getProfile call without id', () => {
-      return should(kuzzle.funnel.security.getProfile(new RequestObject({body: {_id: ''}}))).be.rejectedWith(BadRequestError);
+      return should(kuzzle.funnel.controllers.security.getProfile(new RequestObject({body: {_id: ''}}))).be.rejectedWith(BadRequestError);
     });
 
     it('should reject NotFoundError on a getProfile call with a bad id', () => {
-      return should(kuzzle.funnel.security.getProfile(new RequestObject({body: {_id: 'badId'}}))).be.rejectedWith(NotFoundError);
+      return should(kuzzle.funnel.controllers.security.getProfile(new RequestObject({body: {_id: 'badId'}}))).be.rejectedWith(NotFoundError);
     });
   });
 
   describe('#mGetProfiles', function () {
     it('should reject to an error on a mGetProfiles call without ids', () => {
-      return should(kuzzle.funnel.security.mGetProfiles(new RequestObject({body: {}}))).be.rejectedWith(BadRequestError);
+      return should(kuzzle.funnel.controllers.security.mGetProfiles(new RequestObject({body: {}}))).be.rejectedWith(BadRequestError);
     });
 
     it('should resolve to a responseObject on a mGetProfiles call', done => {
-      kuzzle.funnel.security.mGetProfiles(new RequestObject({
+      kuzzle.funnel.controllers.security.mGetProfiles(new RequestObject({
           body: {ids: ['test']}
         }))
         .then(result => {
@@ -172,7 +172,7 @@ describe('Test: security controller - profiles', function () {
     });
 
     it('should resolve to a responseObject with roles on a mGetProfiles call with hydrate', done => {
-      kuzzle.funnel.security.mGetProfiles(new RequestObject({
+      kuzzle.funnel.controllers.security.mGetProfiles(new RequestObject({
           body: {ids: ['test'], hydrate: true}
         }))
         .then(result => {
@@ -194,7 +194,7 @@ describe('Test: security controller - profiles', function () {
 
   describe('#searchProfiles', function () {
     it('should return a ResponseObject containing an array of profiles on searchProfile call', done => {
-      kuzzle.funnel.security.searchProfiles(new RequestObject({
+      kuzzle.funnel.controllers.security.searchProfiles(new RequestObject({
           body: {}
         }))
         .then(result => {
@@ -212,7 +212,7 @@ describe('Test: security controller - profiles', function () {
     });
 
     it('should return a ResponseObject containing an array of profiles on searchProfile call with hydrate', done => {
-      kuzzle.funnel.security.searchProfiles(new RequestObject({
+      kuzzle.funnel.controllers.security.searchProfiles(new RequestObject({
           body: {
             roles: ['role1'],
             hydrate: true
@@ -245,7 +245,7 @@ describe('Test: security controller - profiles', function () {
         }));
       };
 
-      kuzzle.funnel.security.updateProfile(new RequestObject({
+      kuzzle.funnel.controllers.security.updateProfile(new RequestObject({
           body: { _id: 'test', foo: 'bar' }
         }), {})
         .then(response => {
@@ -259,7 +259,7 @@ describe('Test: security controller - profiles', function () {
     });
 
     it('should reject the promise if no id is given', () => {
-      return should(kuzzle.funnel.security.updateProfile(new RequestObject({
+      return should(kuzzle.funnel.controllers.security.updateProfile(new RequestObject({
         body: {}
       }), {}))
         .be.rejectedWith(BadRequestError);
@@ -268,7 +268,7 @@ describe('Test: security controller - profiles', function () {
 
   describe('#deleteProfile', function () {
     it('should return response with on deleteProfile call', done => {
-      kuzzle.funnel.security.deleteProfile(new RequestObject({
+      kuzzle.funnel.controllers.security.deleteProfile(new RequestObject({
           body: {_id: 'test'}
         }))
         .then(result => {

--- a/test/api/controllers/securityController/roles.test.js
+++ b/test/api/controllers/securityController/roles.test.js
@@ -65,7 +65,7 @@ describe('Test: security controller - roles', function () {
 
   describe('#createOrReplaceRole', function () {
     it('should resolve to a responseObject on a createOrReplaceRole call', done => {
-      kuzzle.funnel.security.createOrReplaceRole(new RequestObject({
+      kuzzle.funnel.controllers.security.createOrReplaceRole(new RequestObject({
           body: {_id: 'test', indexes: {}}
         }))
         .then(result => {
@@ -81,7 +81,7 @@ describe('Test: security controller - roles', function () {
 
   describe('#createRole', function () {
     it('should reject when a role already exists with the id', () => {
-      var promise = kuzzle.funnel.security.createRole(new RequestObject({
+      var promise = kuzzle.funnel.controllers.security.createRole(new RequestObject({
         body: {_id: 'alreadyExists', indexes: {}}
       }));
 
@@ -89,7 +89,7 @@ describe('Test: security controller - roles', function () {
     });
 
     it('should resolve to a responseObject on a createRole call', () => {
-      var promise = kuzzle.funnel.security.createRole(new RequestObject({
+      var promise = kuzzle.funnel.controllers.security.createRole(new RequestObject({
         body: {_id: 'test', indexes: {}}
       }));
 
@@ -99,7 +99,7 @@ describe('Test: security controller - roles', function () {
 
   describe('#getRole', function () {
     it('should resolve to a responseObject on a getRole call', done => {
-      kuzzle.funnel.security.getRole(new RequestObject({
+      kuzzle.funnel.controllers.security.getRole(new RequestObject({
           body: {_id: 'test'}
         }))
         .then(result => {
@@ -113,17 +113,17 @@ describe('Test: security controller - roles', function () {
     });
 
     it('should reject NotFoundError on a getRole call with a bad id', () => {
-      return should(kuzzle.funnel.security.getRole(new RequestObject({body: {_id: 'badId'}}))).be.rejectedWith(NotFoundError);
+      return should(kuzzle.funnel.controllers.security.getRole(new RequestObject({body: {_id: 'badId'}}))).be.rejectedWith(NotFoundError);
     });
   });
 
   describe('#mGetRoles', function () {
     it('should reject an error if no ids is provided', () => {
-      return should(kuzzle.funnel.security.mGetRoles(new RequestObject({body: {}}))).be.rejectedWith(BadRequestError);
+      return should(kuzzle.funnel.controllers.security.mGetRoles(new RequestObject({body: {}}))).be.rejectedWith(BadRequestError);
     });
 
     it('should resolve to a responseObject', done => {
-      kuzzle.funnel.security.mGetRoles(new RequestObject({
+      kuzzle.funnel.controllers.security.mGetRoles(new RequestObject({
           body: {ids: ['test']}
         }))
         .then(result => {
@@ -141,7 +141,7 @@ describe('Test: security controller - roles', function () {
 
   describe('#searchRoles', function () {
     it('should return response with an array of roles on searchRole call', done => {
-      kuzzle.funnel.security.searchRoles(new RequestObject({
+      kuzzle.funnel.controllers.security.searchRoles(new RequestObject({
           body: {_id: 'test'}
         }))
         .then(result => {
@@ -175,7 +175,7 @@ describe('Test: security controller - roles', function () {
         }));
       };
 
-      kuzzle.funnel.security.updateRole(new RequestObject({
+      kuzzle.funnel.controllers.security.updateRole(new RequestObject({
         body: { _id: 'test', foo: 'bar' }
       }), {})
         .then(response => {
@@ -189,7 +189,7 @@ describe('Test: security controller - roles', function () {
     });
 
     it('should reject the promise if no id is given', () => {
-      return should(kuzzle.funnel.security.updateRole(new RequestObject({
+      return should(kuzzle.funnel.controllers.security.updateRole(new RequestObject({
         body: {}
       }), {}))
         .be.rejectedWith(BadRequestError);
@@ -198,7 +198,7 @@ describe('Test: security controller - roles', function () {
 
   describe('#deleteRole', function () {
     it('should return response with on deleteRole call', done => {
-      kuzzle.funnel.security.deleteRole(new RequestObject({
+      kuzzle.funnel.controllers.security.deleteRole(new RequestObject({
           body: {_id: 'test'}
         }))
         .then(result => {

--- a/test/api/controllers/securityController/users.test.js
+++ b/test/api/controllers/securityController/users.test.js
@@ -56,12 +56,12 @@ describe('Test: security controller - users', function () {
 
   describe('#getUser', function () {
     it('should reject the promise if no id is given', () => {
-      return should(kuzzle.funnel.security.getUser(new RequestObject({})))
+      return should(kuzzle.funnel.controllers.security.getUser(new RequestObject({})))
         .be.rejectedWith(BadRequestError);
     });
 
     it('should return an hydrated responseObject', done => {
-      kuzzle.funnel.security.getUser(new RequestObject({
+      kuzzle.funnel.controllers.security.getUser(new RequestObject({
         body: { _id: 'anonymous' }
       }))
         .then(response => {
@@ -76,7 +76,7 @@ describe('Test: security controller - users', function () {
     });
 
     it('should reject with NotFoundError when the user is not found', () => {
-      var promise = kuzzle.funnel.security.getUser(new RequestObject({
+      var promise = kuzzle.funnel.controllers.security.getUser(new RequestObject({
         body: { _id: 'i.dont.exist' }
       }));
 
@@ -86,7 +86,7 @@ describe('Test: security controller - users', function () {
 
   describe('#searchUsers', function () {
     it('should return a valid responseObject', done => {
-      kuzzle.funnel.security.searchUsers(new RequestObject({
+      kuzzle.funnel.controllers.security.searchUsers(new RequestObject({
         body: {
           filter: {},
           from: 0,
@@ -103,7 +103,7 @@ describe('Test: security controller - users', function () {
     });
 
     it('should return some unhydrated users when asked', done => {
-      kuzzle.funnel.security.searchUsers(new RequestObject({
+      kuzzle.funnel.controllers.security.searchUsers(new RequestObject({
         body: { hydrate: false }
       }))
         .then(response => {
@@ -120,7 +120,7 @@ describe('Test: security controller - users', function () {
 
   describe('#deleteUser', function () {
     it('should return a valid responseObject', done => {
-      kuzzle.funnel.security.deleteUser(new RequestObject({
+      kuzzle.funnel.controllers.security.deleteUser(new RequestObject({
         body: { _id: 'test' }
       }))
         .then(response => {
@@ -133,14 +133,14 @@ describe('Test: security controller - users', function () {
     });
 
     it('should not resolve the promise when no id is given', () => {
-      return should(kuzzle.funnel.security.deleteUser(new RequestObject({})))
+      return should(kuzzle.funnel.controllers.security.deleteUser(new RequestObject({})))
         .be.rejectedWith(BadRequestError);
     });
   });
 
   describe('#createUser', function () {
     it('should return a valid a valid response', done => {
-      kuzzle.funnel.security.createUser(new RequestObject({
+      kuzzle.funnel.controllers.security.createUser(new RequestObject({
         body: { _id: 'test', name: 'John Doe', profile: 'anonymous' }
       }))
         .then(response => {
@@ -154,7 +154,7 @@ describe('Test: security controller - users', function () {
     });
 
     it('should compute a user id if none is provided', done => {
-      kuzzle.funnel.security.createUser(new RequestObject({
+      kuzzle.funnel.controllers.security.createUser(new RequestObject({
         body: { name: 'John Doe', profile: 'anonymous' }
       }))
         .then(response => {
@@ -168,7 +168,7 @@ describe('Test: security controller - users', function () {
     });
 
     it('should reject the promise if no profile is given', () => {
-      return should(kuzzle.funnel.security.createUser(new RequestObject({
+      return should(kuzzle.funnel.controllers.security.createUser(new RequestObject({
         body: {}
       })))
         .be.rejectedWith(BadRequestError);
@@ -177,7 +177,7 @@ describe('Test: security controller - users', function () {
 
   describe('#updateUser', function () {
     it('should return a valid ResponseObject', done => {
-      kuzzle.funnel.security.updateUser(new RequestObject({
+      kuzzle.funnel.controllers.security.updateUser(new RequestObject({
         body: { _id: 'anonymous', foo: 'bar' }
       }))
         .then(response => {
@@ -191,7 +191,7 @@ describe('Test: security controller - users', function () {
     });
 
     it('should reject the promise if no id is given', () => {
-      return should(kuzzle.funnel.security.updateUser(new RequestObject({
+      return should(kuzzle.funnel.controllers.security.updateUser(new RequestObject({
         body: {}
       })))
         .be.rejectedWith(BadRequestError);
@@ -200,7 +200,7 @@ describe('Test: security controller - users', function () {
 
   describe('#createOrReplaceUser', function () {
     it('should return a valid responseObject', done => {
-      kuzzle.funnel.security.createOrReplaceUser(new RequestObject({
+      kuzzle.funnel.controllers.security.createOrReplaceUser(new RequestObject({
         body: {
           _id: 'test',
           profile: 'admin'
@@ -216,7 +216,7 @@ describe('Test: security controller - users', function () {
     });
 
     it('should reject the promise if no profile is given', () => {
-      return should(kuzzle.funnel.security.createOrReplaceUser(new RequestObject({
+      return should(kuzzle.funnel.controllers.security.createOrReplaceUser(new RequestObject({
         _id: 'test'
       })))
         .be.rejectedWith(BadRequestError);

--- a/test/api/controllers/subscribeController.test.js
+++ b/test/api/controllers/subscribeController.test.js
@@ -34,7 +34,7 @@ describe('Test: subscribe controller', function () {
   beforeEach(() =>  requestObject = new RequestObject({index: 'test', collection: 'collection', controller: 'subscribe'}, {}, 'unit-test'));
 
   it('should forward new subscriptions to the hotelClerk core component', function () {
-    var foo = kuzzle.funnel.subscribe.on(requestObject, {
+    var foo = kuzzle.funnel.controllers.subscribe.on(requestObject, {
       connection: {id: 'foobar'},
       token: anonymousToken
     });
@@ -48,7 +48,7 @@ describe('Test: subscribe controller', function () {
       result;
 
     requestObject.data.body = { roomId: 'foobar' };
-    result = kuzzle.funnel.subscribe.off(requestObject, {
+    result = kuzzle.funnel.controllers.subscribe.off(requestObject, {
       connection: {id: newUser },
       token: anonymousToken
     });
@@ -58,7 +58,7 @@ describe('Test: subscribe controller', function () {
 
   it('should forward subscription counts queries to the hotelClerk core component', function () {
     var
-      foo = kuzzle.funnel.subscribe.count(requestObject);
+      foo = kuzzle.funnel.controllers.subscribe.count(requestObject);
 
     return should(foo).be.rejectedWith(BadRequestError, { message: 'The room Id is mandatory to count subscriptions' });
   });
@@ -68,7 +68,7 @@ describe('Test: subscribe controller', function () {
       this.timeout(50);
 
       kuzzle.once('subscription:list', () => done());
-      should(kuzzle.funnel.subscribe.list(requestObject, {
+      should(kuzzle.funnel.controllers.subscribe.list(requestObject, {
         connection: {id: 'foobar'} ,
         token: anonymousToken
       })).be.a.Promise();
@@ -79,7 +79,7 @@ describe('Test: subscribe controller', function () {
     it('should trigger a hook and return a promise', function (done) {
       this.timeout(50);
       kuzzle.once('subscription:join', () => done());
-      should(kuzzle.funnel.subscribe.join(requestObject, {
+      should(kuzzle.funnel.controllers.subscribe.join(requestObject, {
         connection: {id: 'foobar'},
         token: anonymousToken
       })).be.a.Promise();

--- a/test/api/controllers/writeController.test.js
+++ b/test/api/controllers/writeController.test.js
@@ -47,28 +47,28 @@ describe('Test: write controller', function () {
     var requestObject = new RequestObject({});
     delete requestObject.data.body;
 
-    return should(kuzzle.funnel.write.create(requestObject)).be.rejected();
+    return should(kuzzle.funnel.controllers.write.create(requestObject)).be.rejected();
   });
 
   it('should reject an empty createOrReplace request', function () {
     var requestObject = new RequestObject({});
     delete requestObject.data.body;
 
-    return should(kuzzle.funnel.write.createOrReplace(requestObject)).be.rejected();
+    return should(kuzzle.funnel.controllers.write.createOrReplace(requestObject)).be.rejected();
   });
 
   it('should reject an empty update request', function () {
     var requestObject = new RequestObject({});
     delete requestObject.data.body;
 
-    return should(kuzzle.funnel.write.update(requestObject)).be.rejected();
+    return should(kuzzle.funnel.controllers.write.update(requestObject)).be.rejected();
   });
 
   it('should reject an empty replace request', function () {
     var requestObject = new RequestObject({});
     delete requestObject.data.body;
 
-    return should(kuzzle.funnel.write.replace(requestObject)).be.rejected();
+    return should(kuzzle.funnel.controllers.write.replace(requestObject)).be.rejected();
   });
 
   describe('#create', function () {
@@ -88,7 +88,7 @@ describe('Test: write controller', function () {
         }
       });
 
-      kuzzle.funnel.write.create(requestObject)
+      kuzzle.funnel.controllers.write.create(requestObject)
         .catch(function (error) {
           done(error);
         });
@@ -117,7 +117,7 @@ describe('Test: write controller', function () {
         }
       };
 
-      kuzzle.funnel.write.publish(requestObject)
+      kuzzle.funnel.controllers.write.publish(requestObject)
         .catch(function (error) {
           done(error);
         });
@@ -126,7 +126,7 @@ describe('Test: write controller', function () {
     it('should return a rejected promise if publishing fails', function () {
       var requestObject = new RequestObject({body: {foo: 'bar'}}, {}, 'unit-test');
       kuzzle.notifier.publish = function () { return q.reject(new Error('error')); };
-      return should(kuzzle.funnel.write.publish(requestObject)).be.rejectedWith(Error);
+      return should(kuzzle.funnel.controllers.write.publish(requestObject)).be.rejectedWith(Error);
     });
   });
 
@@ -146,7 +146,7 @@ describe('Test: write controller', function () {
         }
       });
 
-      kuzzle.funnel.write.createOrReplace(requestObject)
+      kuzzle.funnel.controllers.write.createOrReplace(requestObject)
         .catch(function (error) {
           done(error);
         });
@@ -156,7 +156,7 @@ describe('Test: write controller', function () {
       var requestObject = new RequestObject({body: {foo: 'bar'}}, {}, 'unit-test');
       this.timeout(50);
 
-      kuzzle.funnel.write.createOrReplace(requestObject)
+      kuzzle.funnel.controllers.write.createOrReplace(requestObject)
         .then(response => {
           should(response).be.instanceof(ResponseObject);
           should(indexCacheAdded).be.true();
@@ -182,7 +182,7 @@ describe('Test: write controller', function () {
         }
       });
 
-      kuzzle.funnel.write.update(requestObject)
+      kuzzle.funnel.controllers.write.update(requestObject)
         .catch(function (error) {
           done(error);
         });
@@ -205,7 +205,7 @@ describe('Test: write controller', function () {
         }
       });
 
-      kuzzle.funnel.write.replace(requestObject)
+      kuzzle.funnel.controllers.write.replace(requestObject)
         .catch(function (error) {
           done(error);
         });
@@ -228,7 +228,7 @@ describe('Test: write controller', function () {
         }
       });
 
-      kuzzle.funnel.write.delete(requestObject)
+      kuzzle.funnel.controllers.write.delete(requestObject)
         .catch(function (error) {
           done(error);
         });
@@ -251,7 +251,7 @@ describe('Test: write controller', function () {
         }
       });
 
-      kuzzle.funnel.write.deleteByQuery(requestObject)
+      kuzzle.funnel.controllers.write.deleteByQuery(requestObject)
         .catch(function (error) {
           done(error);
         });
@@ -275,14 +275,14 @@ describe('Test: write controller', function () {
         }
       });
 
-      kuzzle.funnel.write.createCollection(requestObject);
+      kuzzle.funnel.controllers.write.createCollection(requestObject);
     });
 
     it('should add the new collection to the index cache', function (done) {
       var requestObject = new RequestObject({}, {}, 'unit-test');
       this.timeout(50);
 
-      kuzzle.funnel.write.createCollection(requestObject)
+      kuzzle.funnel.controllers.write.createCollection(requestObject)
         .then(response => {
           should(response).be.instanceof(ResponseObject);
           should(indexCacheAdded).be.true();

--- a/test/api/kuzzle.test.js
+++ b/test/api/kuzzle.test.js
@@ -668,12 +668,14 @@ describe('Test kuzzle constructor', function () {
             internalIndex: 'foobar'
           },
           funnel: {
-            security: {
-              createOrReplaceRole: function(requestObject) {
-                requests.push(requestObject);
-              },
-              createOrReplaceProfile: function(requestObject) {
-                requests.push(requestObject);
+            controllers: {
+              security: {
+                createOrReplaceRole: function (requestObject) {
+                  requests.push(requestObject);
+                },
+                createOrReplaceProfile: function (requestObject) {
+                  requests.push(requestObject);
+                }
               }
             }
           }


### PR DESCRIPTION
Prior to this pull request, when flooding Kuzzle (with >2000 requests/second), the NodeJS event loop was gradually filled with promises, Kuzzle was becoming slower and slower, eventually crashing if the flood persisted. If the flood stopped before Kuzzle crashes, it took several minutes to Kuzzle to recover from this state.

The purpose of this pull request is to make Kuzzle resilient under stressful conditions:

* Replaced promises with callback in protocol plugins, in the router controller and in the funnel controller. This was made to keep tight control on the event loop, as promises go in it, while callbacks don't.
* Added two properties in the `.kuzzlerc` configuration file:
  * `maxConcurrentRequests` configures the maximum number of requests that can be executed at the same time. All requests submitted above that number are queued to be executed at a later time
  * `maxRetainedRequests` configures the maximum number of requests that can be queued. Once this limit is reached, subsequent requests are discarded with a "service temporarily unavailable" error (status code 503)
* The funnel controller now has 2 states:
  * normal state: when a request is submitted, if it's under the `maxConcurrentRequests` limit, it's executed immediately, as before
  * overloaded state: the funnel controller enters this state if the `maxConcurrentRequests` limit is reached. In this state, new requests are queued and a background task is started to replay delayed requests as soon as possible. The background task stops automatically when the funnel switch back to normal state
* Moved token retrieval from the router controller to the request execution part in the funnel controller. This avoids repetition of code, and it helps controlling the event loop by performing these tasks once it was made sure that the request could be executed
* Added a new `server:overload` hook, fired at most each 500ms. The purpose of this hook is to inform potential plugins, or Kuzzle itself, about the overload state. The overload percentage is provided to the listeners (for instance: '28.63%'). This percentage reflects the number of queued requests compared to the `maxRetainedRequests` property
* Updated the SocketIO protocol plugin to use a callback instead of a promise for the `getRouter().execute` plugin context method
* Updated protocol plugins documentation
