### PR TITLE
removed useless MQ functional tests

### DIFF
--- a/features/AMQP.feature
+++ b/features/AMQP.feature
@@ -324,12 +324,3 @@ Feature: Test AMQP API
     Then I am getting the current user, which matches {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin"}}}
     Then I log out
     Then I am getting the current user, which matches {"_id":-1,"_source":{"profile":{"_id":"anonymous"}}}
-
-
-  @usingWebsocket @cleanSecurity @unsubscribe
-  Scenario: token expiration
-    Given A room subscription listening to "lastName" having value "Hopper"
-    Given I create a user "user1" with id "user1-id"
-    When I log in as user1-id:testpwd expiring in 1s
-    Then I wait 1s
-    And I should receive a "jwtTokenExpired" notification

--- a/features/MQTT.feature
+++ b/features/MQTT.feature
@@ -324,12 +324,3 @@ Feature: Test MQTT API
     Then I am getting the current user, which matches {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin"}}}
     Then I log out
     Then I am getting the current user, which matches {"_id":-1,"_source":{"profile":{"_id":"anonymous"}}}
-
-
-  @usingWebsocket @cleanSecurity @unsubscribe
-  Scenario: token expiration
-    Given A room subscription listening to "lastName" having value "Hopper"
-    Given I create a user "user1" with id "user1-id"
-    When I log in as user1-id:testpwd expiring in 1s
-    Then I wait 1s
-    And I should receive a "jwtTokenExpired" notification

--- a/features/STOMP.feature
+++ b/features/STOMP.feature
@@ -324,11 +324,3 @@ Feature: Test STOMP API
     Then I am getting the current user, which matches {"_id":"#prefix#user1-id","_source":{"profile":{"_id":"admin"}}}
     Then I log out
     Then I am getting the current user, which matches {"_id":-1,"_source":{"profile":{"_id":"anonymous"}}}
-
-  @usingWebsocket @cleanSecurity @unsubscribe
-  Scenario: token expiration
-    Given A room subscription listening to "lastName" having value "Hopper"
-    Given I create a user "user1" with id "user1-id"
-    When I log in as user1-id:testpwd expiring in 1s
-    Then I wait 1s
-    And I should receive a "jwtTokenExpired" notification


### PR DESCRIPTION
Functional tests involving the `jwtTokenExpired` event were executed using the websocket protocol instead of AMQP/MQTT/STOMP.

These tests cannot be ported to MQ protocols as of now, because of the way they are currently implemented, using RabbitMQ.

Instead of working on the way we implemented MQ protocols, we'll wait for them to be migrated to protocol plugins: we'll then get rid of RabbitMQ, and each one of these protocol will act as a server, allowing to handle rooms and channels as we do with websockets.

Until then, this pull request removes these useless functional tests.