### PR TITLE
Security routes fixes

### DIFF
--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -113,9 +113,7 @@ module.exports = function SecurityController (kuzzle) {
     kuzzle.pluginsManager.trigger('security:searchRole', requestObject);
 
     return kuzzle.repositories.role.searchRole(requestObject)
-      .then((response) => {
-        return new ResponseObject(requestObject, response);
-      });
+      .then(response => new ResponseObject(requestObject, response));
   };
 
   /**
@@ -126,7 +124,8 @@ module.exports = function SecurityController (kuzzle) {
    */
   this.createOrReplaceRole = function (requestObject, context) {
     kuzzle.pluginsManager.trigger('security:createOrReplaceRole', requestObject);
-    return createOrReplaceRole.call(kuzzle, requestObject, context, {method: 'createOrReplace'});
+    return createOrReplaceRole.call(kuzzle, requestObject, context, {method: 'createOrReplace'})
+      .then(role => new ResponseObject(requestObject, formatRoleForSerialization(role, true)));
   };
 
   /**
@@ -138,7 +137,8 @@ module.exports = function SecurityController (kuzzle) {
    */
   this.createRole = function (requestObject, context) {
     kuzzle.pluginsManager.trigger('security:createRole', requestObject);
-    return createOrReplaceRole.call(kuzzle, requestObject, context, {method: 'create'});
+    return createOrReplaceRole.call(kuzzle, requestObject, context, {method: 'create'})
+      .then(role => new ResponseObject(requestObject, formatRoleForSerialization(role, true)));
   };
 
   /**
@@ -167,9 +167,7 @@ module.exports = function SecurityController (kuzzle) {
     }
 
     return kuzzle.repositories.profile.buildProfileFromRequestObject(requestObject)
-      .then(profile => {
-        return kuzzle.repositories.profile.loadProfile(profile);
-      })
+      .then(profile => kuzzle.repositories.profile.loadProfile(profile))
       .then(profile => {
         if (!profile) {
           return q.reject(new NotFoundError(`Profile with id ${requestObject.data._id} not found`));
@@ -209,7 +207,8 @@ module.exports = function SecurityController (kuzzle) {
    */
   this.createOrReplaceProfile = function (requestObject, context) {
     kuzzle.pluginsManager.trigger('security:createOrReplaceProfile', requestObject);
-    return createOrReplaceProfile.call(kuzzle, requestObject, context, {method: 'createOrReplace'});
+    return createOrReplaceProfile.call(kuzzle, requestObject, context, {method: 'createOrReplace'})
+      .then(profile => q(new ResponseObject(requestObject, formatProfileForSerialization(profile))));
   };
 
   /**
@@ -220,7 +219,8 @@ module.exports = function SecurityController (kuzzle) {
    */
   this.createProfile = function (requestObject, context) {
     kuzzle.pluginsManager.trigger('security:createProfile', requestObject);
-    return createOrReplaceProfile.call(kuzzle, requestObject, context, {method: 'create'});
+    return createOrReplaceProfile.call(kuzzle, requestObject, context, {method: 'create'})
+      .then(profile => q(new ResponseObject(requestObject, formatProfileForSerialization(profile))));
   };
 
   /**
@@ -232,9 +232,7 @@ module.exports = function SecurityController (kuzzle) {
     kuzzle.pluginsManager.trigger('security:deleteProfile', requestObject);
 
     return kuzzle.repositories.profile.buildProfileFromRequestObject(requestObject)
-      .then(profile => {
-        return kuzzle.repositories.profile.deleteProfile(profile);
-      });
+      .then(profile => kuzzle.repositories.profile.deleteProfile(profile));
   };
 
   /**
@@ -257,8 +255,6 @@ module.exports = function SecurityController (kuzzle) {
       requestObject.data.body.size,
       requestObject.data.body.hydrate
     ).then((response) => {
-
-
       response.hits = response.hits.map((profile) => {
         return formatProfileForSerialization(profile, requestObject.data.body.hydrate);
       });
@@ -286,9 +282,8 @@ module.exports = function SecurityController (kuzzle) {
         }
 
         return formatUserForSerialization(user, true);
-      }).then(response => {
-        return q(new ResponseObject(requestObject, response));
-      });
+      })
+      .then(response => q(new ResponseObject(requestObject, response)));
   };
 
   /**
@@ -329,9 +324,7 @@ module.exports = function SecurityController (kuzzle) {
     }
 
     return kuzzle.repositories.user.delete(requestObject.data._id)
-      .then(() => {
-        return new ResponseObject(requestObject, {});
-      });
+      .then(() => new ResponseObject(requestObject, { _id: requestObject.data._id}));
   };
 
   /**
@@ -363,15 +356,9 @@ module.exports = function SecurityController (kuzzle) {
           .then(u => {
             return kuzzle.repositories.user.persist(u, { database: {method: 'create'} });
           })
-          .then(response => {
-            return formatUserForSerialization(response.data.body._source, false)
-              .then(u => {
-                response.data.body._source = u;
-                return q(response);
-              });
-          });
+          .then(u => formatUserForSerialization(u, true))
+          .then(serializedUser => new ResponseObject(requestObject, serializedUser));
       });
-
   };
 
   /**
@@ -389,7 +376,9 @@ module.exports = function SecurityController (kuzzle) {
         return kuzzle.repositories.user.load(newRequestObject.data._id)
           .then(user => {
             return kuzzle.repositories.user.persist(_.extend(user, newRequestObject.data.body), { database: { method: 'update' } });
-          });
+          })
+          .then(updatedUser => formatUserForSerialization(updatedUser, true))
+          .then(serialized => new ResponseObject(newRequestObject, serialized));
       });
   };
 
@@ -400,24 +389,20 @@ module.exports = function SecurityController (kuzzle) {
    * @returns {Promise}
    */
   this.updateProfile = function (requestObject, context) {
+    var newRequestObject;
+
     return kuzzle.pluginsManager.trigger('security:updateProfile', requestObject)
-      .then(newRequestObject => {
-        if (!newRequestObject.data._id) {
+      .then(rq => {
+        if (!rq.data._id) {
           return q.reject(new BadRequestError('No profile id given'));
         }
 
-        return kuzzle.repositories.profile.buildProfileFromRequestObject(newRequestObject)
-          .then(profile => {
-            return kuzzle.repositories.profile.loadProfile(profile);
-          })
-          .then(profile => {
-            return kuzzle.repositories.profile.validateAndSaveProfile(_.extend(profile, newRequestObject.data.body), context, { method: 'update' });
-          })
-          .then(result => {
-            // @todo reformat repository response to not have a response object
-            return q(new ResponseObject(newRequestObject, result.data.body));
-          });
-      });
+        newRequestObject = rq;
+        return kuzzle.repositories.profile.buildProfileFromRequestObject(newRequestObject);
+      })
+      .then(profile => kuzzle.repositories.profile.loadProfile(profile))
+      .then(profile => kuzzle.repositories.profile.validateAndSaveProfile(_.extend(profile, newRequestObject.data.body), context, { method: 'update' }))
+      .then(updatedProfile => q(new ResponseObject(newRequestObject, formatProfileForSerialization(updatedProfile, true))));
   };
 
   /**
@@ -433,17 +418,17 @@ module.exports = function SecurityController (kuzzle) {
           return q.reject(new BadRequestError('No role id given'));
         }
 
-
         return kuzzle.repositories.role.loadRole(
             kuzzle.repositories.role.getRoleFromRequestObject(requestObject)
           )
           .then(role => {
+            if (!role) {
+              return q.reject(new NotFoundError('Cannot update role "' + newRequestObject.data._id + '": role not found'));
+            }
+
             return kuzzle.repositories.role.validateAndSaveRole(_.extend(role, newRequestObject.data.body), context, { method: 'update' });
           })
-          .then(result => {
-            // @todo reformat repository response to not have a response object
-            return q(new ResponseObject(newRequestObject, result.data.body));
-          });
+          .then(updatedRole => q(new ResponseObject(newRequestObject, formatRoleForSerialization(updatedRole))));
       });
   };
 
@@ -465,29 +450,17 @@ module.exports = function SecurityController (kuzzle) {
         }
 
         return kuzzle.repositories.user.hydrate(user, newRequestObject.data.body)
-          .then(u => {
-            return kuzzle.repositories.user.persist(u);
-          })
-          .then(response => {
-            return formatUserForSerialization(response.data.body._source, false)
-              .then(u => {
-                response.data.body._source = u;
-                return q(response);
-              });
-          });
+          .then(u => kuzzle.repositories.user.persist(u))
+          .then(u => formatUserForSerialization(u, true))
+          .then(u => new ResponseObject(newRequestObject, u));
       });
   };
-
 };
 
 function createOrReplaceRole (requestObject, context, opts) {
-  return this.repositories.role.validateAndSaveRole(
-    this.repositories.role.getRoleFromRequestObject(requestObject), context, opts
-    )
-    .then(result => {
-      // @todo reformat repository response to not have a response object
-      return q(new ResponseObject(requestObject, result.data.body));
-    });
+  var role = this.repositories.role.getRoleFromRequestObject(requestObject);
+
+  return this.repositories.role.validateAndSaveRole(role, context, opts);
 }
 
 function createOrReplaceProfile (requestObject, context, opts) {
@@ -498,11 +471,7 @@ function createOrReplaceProfile (requestObject, context, opts) {
     .then(profile => {
       return this.repositories.profile.hydrate(profile, requestObject.data.body);
     })
-    .then(newProfile => {
-      return this.repositories.profile.validateAndSaveProfile(newProfile, context, opts);
-    })
-    .then(result => {
-      // @todo reformat repository response to not have a response object
-      return q(new ResponseObject(requestObject, result.data.body));
+    .then(hydratedProfile => {
+      return this.repositories.profile.validateAndSaveProfile(hydratedProfile, context, opts);
     });
 }

--- a/lib/api/core/models/repositories/profileRepository.js
+++ b/lib/api/core/models/repositories/profileRepository.js
@@ -215,6 +215,7 @@ module.exports = function (kuzzle) {
         this.profiles[profile._id] = this.serializeToDatabase(profile);
         return this.persistToDatabase(profile, opts);
       })
+      .then(() => this.hydrate(profile, this.profiles[profile._id]))
       .catch((error) => {
         return q.reject(error);
       });

--- a/lib/api/core/models/repositories/profileRepository.js
+++ b/lib/api/core/models/repositories/profileRepository.js
@@ -37,7 +37,6 @@ module.exports = function (kuzzle) {
   ProfileRepository.prototype.loadProfile = function (profile) {
     var
       profileId,
-      deferred = q.defer(),
       p = new Profile();
 
     if (profile instanceof Profile) {
@@ -52,21 +51,17 @@ module.exports = function (kuzzle) {
       return this.hydrate(p, this.profiles[profileId]);
     }
 
-    this.loadOneFromDatabase(profileId)
+    return this.loadOneFromDatabase(profileId)
       .then((result) => {
         if (result) {
           // we got a profile from the database, we can use it
           this.profiles[profileId] = this.serializeToDatabase(result);
-          deferred.resolve(result);
+          return q(result);
         }
-        else {
-          // no profile found
-          deferred.resolve(null);
-        }
-      })
-      .catch((error) => deferred.reject(error));
 
-    return deferred.promise;
+        // no profile found
+        return q(null);
+      });
   };
 
   /**

--- a/lib/api/core/models/repositories/roleRepository.js
+++ b/lib/api/core/models/repositories/roleRepository.js
@@ -208,7 +208,8 @@ module.exports = function (kuzzle) {
       .then(() => {
         this.roles[role._id] = role;
         return this.persistToDatabase(role, opts);
-      });
+      })
+      .then(() => role);
   };
 
   /**

--- a/lib/api/core/models/repositories/userRepository.js
+++ b/lib/api/core/models/repositories/userRepository.js
@@ -33,27 +33,17 @@ module.exports = function (kuzzle) {
 
   UserRepository.prototype.persist = function (user, opts) {
     var
-      deferred = q.defer(),
       options = opts || {},
       databaseOptions = options.database || {},
-      cacheOptions = options.cache || {},
-      response;
+      cacheOptions = options.cache || {};
 
     if (user._id === undefined || user._id === null) {
       user._id = uuid.v4();
     }
 
-    this.persistToDatabase(user, databaseOptions)
-      .then(r => {
-        response = r;
-        return this.persistToCache(user, cacheOptions);
-      })
-      .then(() => {
-        deferred.resolve(response);
-      })
-      .catch(error => { deferred.reject(error); });
-
-    return deferred.promise;
+    return this.persistToDatabase(user, databaseOptions)
+      .then(() => this.persistToCache(user, cacheOptions))
+      .then(() => q(user));
   };
 
 

--- a/test/api/controllers/securityController.test.js
+++ b/test/api/controllers/securityController.test.js
@@ -3,6 +3,7 @@ var
   should = require('should'),
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
+  Role = require.main.require('lib/api/core/models/security/role'),
   RequestObject = require.main.require('lib/api/core/models/requestObject'),
   ResponseObject = require.main.require('lib/api/core/models/responseObject');
 
@@ -15,12 +16,7 @@ describe('Test: security controller', function () {
     kuzzle.start(params, {dummy: true})
       .then(function () {
         kuzzle.repositories.role.validateAndSaveRole = role => {
-          return q(new ResponseObject({}, {
-            _index: '%kuzzle',
-            _type: 'roles',
-            _id: role._id,
-            created: true
-          }));
+          return q(role);
         };
 
         done();

--- a/test/api/controllers/securityController/profiles.test.js
+++ b/test/api/controllers/securityController/profiles.test.js
@@ -23,17 +23,12 @@ describe('Test: security controller - profiles', function () {
           if (profile._id === 'alreadyExists') {
             return q.reject();
           }
-
-          return q(new ResponseObject({}, {
-            _index: kuzzle.config.internalIndex,
-            _type: 'profiles',
-            _id: profile._id,
-            created: true
-          }));
+     
+          return q(profile);
         };
         kuzzle.repositories.profile.loadProfile = id => {
           var profileId;
-
+     
           if (id instanceof Profile) {
             profileId = id._id;
           }
@@ -45,15 +40,7 @@ describe('Test: security controller - profiles', function () {
             return q(null);
           }
 
-          return q({
-            _index: kuzzle.config.internalIndex,
-            _type: 'profiles',
-            _id: profileId,
-            roles: [{
-              _id: 'role1',
-              indexes: {}
-            }]
-          });
+          return q(id);
         };
         kuzzle.services.list.readEngine.search = requestObject => {
           return q(new ResponseObject(requestObject, {
@@ -237,12 +224,7 @@ describe('Test: security controller - profiles', function () {
     it('should return a valid ResponseObject', done => {
 
       kuzzle.repositories.profile.validateAndSaveProfile = profile => {
-        return q(new ResponseObject({}, {
-          _index: kuzzle.config.internalIndex,
-          _type: 'profiles',
-          _id: profile._id,
-          created: false
-        }));
+        return q(profile);
       };
 
       kuzzle.funnel.controllers.security.updateProfile(new RequestObject({
@@ -250,7 +232,6 @@ describe('Test: security controller - profiles', function () {
         }), {})
         .then(response => {
           should(response).be.an.instanceOf(ResponseObject);
-          should(response.data.body.created).be.exactly(false);
           should(response.data.body._id).be.exactly('test');
 
           done();

--- a/test/api/controllers/securityController/roles.test.js
+++ b/test/api/controllers/securityController/roles.test.js
@@ -22,12 +22,7 @@ describe('Test: security controller - roles', function () {
             return q.reject();
           }
 
-          return q(new ResponseObject({}, {
-            _index: kuzzle.config.internalIndex,
-            _type: 'roles',
-            _id: role._id,
-            created: true
-          }));
+          return q(role);
         };
         kuzzle.repositories.role.loadOneFromDatabase = id => {
           if (id === 'badId') {
@@ -167,12 +162,7 @@ describe('Test: security controller - roles', function () {
           return q.reject();
         }
 
-        return q(new ResponseObject({}, {
-          _index: kuzzle.config.internalIndex,
-          _type: 'roles',
-          _id: role._id,
-          created: false
-        }));
+        return q(role);
       };
 
       kuzzle.funnel.controllers.security.updateRole(new RequestObject({
@@ -180,7 +170,6 @@ describe('Test: security controller - roles', function () {
       }), {})
         .then(response => {
           should(response).be.an.instanceOf(ResponseObject);
-          should(response.data.body.created).be.exactly(false);
           should(response.data.body._id).be.exactly('test');
 
           done();
@@ -193,6 +182,13 @@ describe('Test: security controller - roles', function () {
         body: {}
       }), {}))
         .be.rejectedWith(BadRequestError);
+    });
+
+    it('should reject the promise if the role cannot be found in the database', () => {
+      return should(kuzzle.funnel.controllers.security.updateRole(new RequestObject({
+        body: { _id: 'badId' }
+      }), {}))
+        .be.rejectedWith(NotFoundError);
     });
   });
 
@@ -212,6 +208,12 @@ describe('Test: security controller - roles', function () {
         .catch(error => {
           done(error);
         });
+    });
+
+    it('should reject the promise if attempting to delete one of the core roles', function () {
+      return should(kuzzle.funnel.controllers.security.deleteRole(new RequestObject({
+        body: { _id: 'admin'}
+      }))).be.rejectedWith(BadRequestError);
     });
   });
 


### PR DESCRIPTION
Fixes issue #215 and more: several security weren't returning any useful data in the response, namely updateRole, updateProfile, updateUser, and deleteUser

Started to update repositories to make them return raw objects instead of ResponseObject.