### PR TITLE
fix getServerInfo route

### DIFF
--- a/lib/api/controllers/readController.js
+++ b/lib/api/controllers/readController.js
@@ -93,19 +93,17 @@ module.exports = function ReadController (kuzzle) {
         services: {}
       };
 
-    Object.keys(kuzzle.funnel).forEach(controller => {
+    Object.keys(kuzzle.funnel.controllers).forEach(controller => {
       var actionList = [];
 
-      if (typeof kuzzle.funnel[controller] === 'object') {
-        Object.keys(kuzzle.funnel[controller]).forEach(action => {
-          if (typeof kuzzle.funnel[controller][action] === 'function') {
-            actionList.push(action);
-          }
-        });
-
-        if (actionList.length > 0) {
-          response.kuzzle.api.routes[controller] = actionList;
+      Object.keys(kuzzle.funnel.controllers[controller]).forEach(action => {
+        if (typeof kuzzle.funnel.controllers[controller][action] === 'function') {
+          actionList.push(action);
         }
+      });
+
+      if (actionList.length > 0) {
+        response.kuzzle.api.routes[controller] = actionList;
       }
     });
 


### PR DESCRIPTION
The pull request adding the anti-flood system broke the `serverInfo` API route. This PR fixes it.