### PR TITLE
Fix remove index remove filter path

### DIFF
--- a/lib/api/dsl/index.js
+++ b/lib/api/dsl/index.js
@@ -577,6 +577,11 @@ function removeFilterPath(room, filterPath) {
     return false;
   }
 
+  // If we are on the index and if there is another collections
+  if (subPath === pathArray[0] && !_.isEmpty(parent[subPath])) {
+    return false;
+  }
+
   // If there is no another rooms that use this filter, we can remove the filter
   if (parent.fields) {
     delete parent.fields[subPath];

--- a/test/api/dsl/index/removeFilterPath.test.js
+++ b/test/api/dsl/index/removeFilterPath.test.js
@@ -22,6 +22,17 @@ describe('Test: dsl.removeFilterPath', function () {
               }
             }
           }
+        },
+        bCollection: {
+          rooms: [],
+          fields: {
+            aField: {
+              randomFilter: {
+                rooms: [],
+                fn: function () { }
+              }
+            }
+          }
         }
       }
     };
@@ -51,9 +62,21 @@ describe('Test: dsl.removeFilterPath', function () {
     should(dsl.filtersTree.anIndex.aCollection.fields.aField.randomFilter.rooms).be.an.Array().and.match(rooms);
   });
 
-  it('should remove the entire filter path if there is no room left', function () {
+  it('should remove the entire collection if there is no room left', function () {
     dsl.filtersTree.anIndex.aCollection.fields.aField.randomFilter.rooms = [ 'foo' ];
     removeFilterPath.call(dsl, {id: 'foo'}, 'anIndex.aCollection.aField.randomFilter');
+
+    should(dsl.filtersTree).be.an.Object().and.not.be.empty();
+    should.exist(dsl.filtersTree.anIndex);
+    should.exist(dsl.filtersTree.anIndex.bCollection);
+    should.not.exist(dsl.filtersTree.anIndex.aCollection);
+  });
+
+  it('should remove the entire index if there is no room left', function () {
+    dsl.filtersTree.anIndex.aCollection.fields.aField.randomFilter.rooms = [ 'foo' ];
+    dsl.filtersTree.anIndex.bCollection.fields.aField.randomFilter.rooms = [ 'foo' ];
+    removeFilterPath.call(dsl, {id: 'foo'}, 'anIndex.aCollection.aField.randomFilter');
+    removeFilterPath.call(dsl, {id: 'foo'}, 'anIndex.bCollection.aField.randomFilter');
 
     should(dsl.filtersTree).be.an.Object().and.be.empty();
   });


### PR DESCRIPTION
Fix problem when we have several collections in one index, and the user wants to unsubscribe from all collections.

Prevent this error:
```bash
kuzzle_1        | KuzzleServer-0 TypeError: Cannot read property 'fields' of undefined
kuzzle_1        | KuzzleServer-0     at Dsl.removeFilterPath (/var/app/lib/api/dsl/index.js:551:15)
kuzzle_1        | KuzzleServer-0     at /var/app/lib/api/dsl/index.js:249:22
kuzzle_1        | KuzzleServer-0     at /var/app/node_modules/async/lib/async.js:181:20
kuzzle_1        | KuzzleServer-0     at Object.async.forEachOf.async.eachOf (/var/app/node_modules/async/lib/async.js:233:13)
kuzzle_1        | KuzzleServer-0     at Object.async.forEach.async.each (/var/app/node_modules/async/lib/async.js:209:22)
kuzzle_1        | KuzzleServer-0     at Dsl.removeRoomFromFields (/var/app/lib/api/dsl/index.js:248:9)
kuzzle_1        | KuzzleServer-0     at /var/app/lib/api/dsl/index.js:185:30
kuzzle_1        | KuzzleServer-0     at /var/app/node_modules/async/lib/async.js:718:13
kuzzle_1        | KuzzleServer-0     at async.forEachOf.async.eachOf (/var/app/node_modules/async/lib/async.js:233:13)
kuzzle_1        | KuzzleServer-0     at _parallel (/var/app/node_modules/async/lib/async.js:717:9)
kuzzle_1        | KuzzleServer-0     at Object.async.parallel (/var/app/node_modules/async/lib/async.js:731:9)
kuzzle_1        | KuzzleServer-0     at Dsl.testFilters.async.parallel.onFields.removeRoom.async.parallel.callback [as removeRoom] (/var/app/lib/api/dsl/index.js:179:11)
kuzzle_1        | KuzzleServer-0     at HotelClerk.cleanUpRooms (/var/app/lib/api/core/hotelClerk.js:621:21)
kuzzle_1        | KuzzleServer-0     at HotelClerk.removeRoomForCustomer (/var/app/lib/api/core/hotelClerk.js:685:16)
kuzzle_1        | KuzzleServer-0     at /var/app/lib/api/core/hotelClerk.js:187:29
kuzzle_1        | KuzzleServer-0     at /var/app/node_modules/async/lib/async.js:181:20
kuzzle_1        | KuzzleWorker-1 info: [2016-04-14T18:06:13.551Z]: internalBroker:*: Socket closed with code 1006
kuzzle_1        | KuzzleWorker-1 ==> RECONNECTING IN 1000ms
kuzzle_1        | PM2 App [KuzzleServer] with id [0] and pid [762], exited with code [255] via signal [null]
kuzzle_1        | PM2 Starting execution sequence in -fork mode- for app name:KuzzleServer id:0
kuzzle_1        | PM2 App name:KuzzleServer id:0 online
kuzzle_1        | KuzzleServer-0 Debugger listening on port 7000
kuzzle_1        | KuzzleServer-0 Starting Kuzzle
```