### PR TITLE
remove unnecessary passport local plugin default config

### DIFF
--- a/.kuzzlerc
+++ b/.kuzzlerc
@@ -46,12 +46,6 @@
     "secret": "Kuzzle Rocks",
     "expiresIn": "1h"
   },
-  // Password Manager defaults.
-  "passwordManager": {
-    "secret": "jbsB8r69PFP39KdLtjVr25Z22",
-    "algorithm": "sha1",
-    "digest": "hex"
-  },
 
   // Default internal index
   "internalIndex": "%kuzzle",


### PR DESCRIPTION
This default settings are already set within the plugin's configuration file, so it is not needed here.
