### PR TITLE
Deleted the branch name from general docker-compose.yml file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 kuzzle:
-  image: kuzzleio/kuzzle:alpine
+  image: kuzzleio/kuzzle
   ports:
     - "7511:7511"
     - "7512:7512"


### PR DESCRIPTION
We decided that the general-purpose `docker-compose.yml` file should point to the latest official release, which is merged on master by convention. This is the reason why we delete the branch name from the docker-compose file. This hotfix will be merged on `master` and `develop`.