### PR TITLE
[master] hotfix #264: kuzzle install fails

### DIFF
--- a/bin/commands/plugins.js
+++ b/bin/commands/plugins.js
@@ -34,7 +34,7 @@ module.exports = function pluginsManager (plugin, options) {
   dbService.init();
 
   // Prevents multiple 'kuzzle install' to install plugins at the same time.
-  lockfile.lock('./node_modules', {retries: 1000, minTimeout: 200, maxTimeout: 1000, stale: 60000, update: 10000}, (err, release) => {
+  lockfile.lock('./node_modules', {retries: 1000, minTimeout: 200, maxTimeout: 1000}, (err, release) => {
     if (err) {
       console.error(clcError('███ kuzzle-plugins: Unable to acquire lock: '), err);
       process.exit(1);


### PR DESCRIPTION
As reported by issue #264, Kuzzle plugins installation may fail on slow connections.
This happens because plugins are installed synchronously, thus blocking the NodeJS call stack and preventing refreshs on the lock file, leading to a `stale` state.

This PR changes the CLI to make it download plugins asynchronously, allowing the lock file to be refreshed normally.