### PR TITLE
 hotfix #540: listCollection returns realtime collections according to index 

### DIFF
--- a/lib/api/controllers/readController.js
+++ b/lib/api/controllers/readController.js
@@ -42,7 +42,7 @@ module.exports = function ReadController (kuzzle) {
   this.listCollections = function (requestObject) {
     var
       type = requestObject.data.body.type || 'all',
-      realtimeCollections,
+      realtimeCollections = [],
       modifiedRequestObject = null;
 
     if (['all', 'stored', 'realtime'].indexOf(type) === -1) {
@@ -63,7 +63,13 @@ module.exports = function ReadController (kuzzle) {
             });
         }
 
-        realtimeCollections = kuzzle.hotelClerk.getRealtimeCollections();
+        realtimeCollections = kuzzle.hotelClerk.getRealtimeCollections().filter(function(collection) {
+          if (collection.index === modifiedRequestObject.index) {
+            return collection;
+          }
+        }).map(function(collection) {
+          return collection.name;
+        });
 
         if (type === 'realtime') {
           return kuzzle.pluginsManager.trigger('data:afterListCollections', new ResponseObject(modifiedRequestObject, {type, collections: {realtime: realtimeCollections}}));

--- a/lib/api/controllers/readController.js
+++ b/lib/api/controllers/readController.js
@@ -63,13 +63,9 @@ module.exports = function ReadController (kuzzle) {
             });
         }
 
-        realtimeCollections = kuzzle.hotelClerk.getRealtimeCollections().filter(function(collection) {
-          if (collection.index === modifiedRequestObject.index) {
-            return collection;
-          }
-        }).map(function(collection) {
-          return collection.name;
-        });
+        realtimeCollections = kuzzle.hotelClerk.getRealtimeCollections()
+          .filter(collection => collection.index === requestObject.index)
+          .map(collection => collection.name);
 
         if (type === 'realtime') {
           return kuzzle.pluginsManager.trigger('data:afterListCollections', new ResponseObject(modifiedRequestObject, {type, collections: {realtime: realtimeCollections}}));

--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -283,10 +283,10 @@ module.exports = function HotelClerk (kuzzle) {
     var collections = [];
 
     Object.keys(this.rooms).forEach(room => {
-      collections.push(this.rooms[room].collection);
+      collections.push({name: this.rooms[room].collection, index: this.rooms[room].index});
     });
 
-    return _.uniq(collections);
+    return _.uniqWith(collections, _.isEqual);
   };
 };
 

--- a/test/api/controllers/readController.test.js
+++ b/test/api/controllers/readController.test.js
@@ -139,7 +139,7 @@ describe('Test: read controller', function () {
 
       kuzzle.hotelClerk.getRealtimeCollections = function () {
         realtime = true;
-        return ['foo', 'bar'];
+        return [{name: 'foo', index: 'index'}, {name: 'bar', index: 'index'}, {name: 'baz', index: 'wrong'}];
       };
 
       kuzzle.repositories.role.roles.anonymous = new Role();
@@ -161,7 +161,7 @@ describe('Test: read controller', function () {
     });
 
     it('should resolve to a full collections list', () => {
-      requestObject = new RequestObject({}, {}, '');
+      requestObject = new RequestObject({index: 'index'}, {}, '');
 
       return kuzzle.funnel.controllers.read.listCollections(requestObject, context)
         .then(result => {

--- a/test/api/core/hotelClerck/getRealtimeCollections.test.js
+++ b/test/api/core/hotelClerck/getRealtimeCollections.test.js
@@ -21,19 +21,23 @@ describe('Test: hotelClerk.getRealtimeCollections', function () {
   it('should return an array of unique collection names', function () {
     kuzzle.hotelClerk.rooms = {
       foo: {
-        collection: 'foo'
+        collection: 'foo',
+        index: index
       },
       bar: {
-        collection: 'bar'
+        collection: 'bar',
+        index: index
       },
       foobar: {
         collection: 'foo',
+        index: index
       },
       barfoo: {
-        collection: 'barfoo'
+        collection: 'barfoo',
+        index: index
       }
     };
 
-    should(kuzzle.hotelClerk.getRealtimeCollections()).be.an.Array().and.match(['foo', 'bar', 'barfoo']);
+    should(kuzzle.hotelClerk.getRealtimeCollections()).be.an.Array().and.match([{name: 'foo', index: index}, {name: 'bar', index: index}, {name: 'barfoo', index: index}]);
   });
 });


### PR DESCRIPTION
Fix a bug where listCollection were returning all the realtime collections despite the index