### PR TITLE
Little fix on closure args definition 

### DIFF
--- a/lib/api/core/models/security/role.js
+++ b/lib/api/core/models/security/role.js
@@ -323,7 +323,7 @@ function executeClosure (kuzzle, path, actionRights, requestObject, context) {
       this.closures[path].getArgsDefinitions = global.eval('(function (requestObject) {return ' +
         JSON
           .stringify(actionRights.args)
-          .replace(/"\$(requestObject\.data\.[a-zA-Z0-9_\-.]*[a-zA-Z0-9])"/g, '$1')
+          .replace(/"\$(requestObject\.[a-zA-Z0-9_\-.]*[a-zA-Z0-9])"/g, '$1')
           .replace('"$currentId"', 'requestObject.data._id') +
         ';})');
       /* jshint evil: false */


### PR DESCRIPTION
Allow to add any arguments of the request object, like $requestObject.index or $requestObject.collection, to the closure's fetch definition

Before this PR, we could only pass $requestObject.data.<some attribute> (ie. document's arguments) to the argument definitions.
Now, we can pass any attribute from the requestObject, like:
- the current index
- the current collection
- any headers or metadata

So, we can easily create a closure about current document, that will work regardless to the index, like that:
```
var role = {
  controllers: {
    write: {
      actions: {
        update: {
          args: {
            document: {
              index: "$requestObject.index",
              collection: "$requestObject.collection",
              action: {
                get: "$currentId"
              }
            }
          },
          test: "return args.document.content.user.id === $currentUserId"
        }
      }
    }
  }
};

```