### PR TITLE
Expose httpPort config in context

### DIFF
--- a/.kuzzlerc
+++ b/.kuzzlerc
@@ -1,6 +1,6 @@
 {
   // Kuzzle REST listening port
-  "port": 7511,
+  "httpPort": 7511,
 
   /*
    Internal collection used to store the service settings

--- a/lib/api/core/plugins/pluginsContext.js
+++ b/lib/api/core/plugins/pluginsContext.js
@@ -41,6 +41,9 @@ module.exports = function PluginContext(kuzzle) {
       removeConnection: kuzzle.router.removeConnection.bind(kuzzle.router)
     };
   };
+
+  context.httpPort = kuzzle.config.httpPort;
+
   return context;
 
 };

--- a/lib/api/core/servers.js
+++ b/lib/api/core/servers.js
@@ -16,7 +16,7 @@ module.exports = {
  */
 function runHttpServer (kuzzle, params) {
   var
-    port = process.env.KUZZLE_PORT || params.port || 7511,
+    port = params.httpPort,
     server;
 
   kuzzle.router.initRouterHttp();

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -20,6 +20,7 @@ module.exports = function (params) {
     repositories: params.repositories,
     pluginsManager: params.pluginsManager,
     internalIndex: params.internalIndex,
-    request: params.request
+    request: params.request,
+    httpPort: process.env.KUZZLE_HTTP_PORT || params.httpPort || 7511
   };
 };

--- a/test/api/core/servers.test.js
+++ b/test/api/core/servers.test.js
@@ -25,7 +25,7 @@ describe('Test: core/servers', function () {
         kuzzle.router.initRouterHttp = function () { httpServer = true; };
         kuzzle.router.routeMQListener = function () { mqServer = true; };
         kuzzle.router.routeHttp = function () { restRedirected = true; };
-        Servers.initAll(kuzzle, { port: port });
+        Servers.initAll(kuzzle, { httpPort: port });
         done();
       });
   });


### PR DESCRIPTION
In order to share the kuzzle http port to the LB, the multiplexer plugin must have this port.
Remove the fallback in server init and move it to the config in order to be sure about http port server.

**Note**: this variable will can be removed from context when the multiplexer will be removed and the communication between Kuzzle and LB will be done in Kuzzle core.