### PR TITLE
KUZ-580 Replace eval with arguments storage

### DIFF
--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -32,7 +32,7 @@ module.exports = function HotelClerk (kuzzle) {
    *      collection: 'message', // -> the collection name
    *      filters: {
    *        and : {
-   *          'message.subject.termSubjectKuzzle': filtersTree.message.subject.termSubjectKuzzle.fn
+   *          'message.subject.termSubjectKuzzle': filtersTree.message.subject.termSubjectKuzzle.args
    *        }
    *      }
    *    }
@@ -331,8 +331,8 @@ function removeAllRoomsInCollection (index, collection) {
       }
 
       _.forEach(this.kuzzle.dsl.filtersTree[index][collection].fields, field => {
-        _.forEach(field, curryFunction => {
-          async.each(curryFunction.rooms, (roomId, callback) => {
+        _.forEach(field, fieldFilter => {
+          async.each(fieldFilter.rooms, (roomId, callback) => {
             removeRoomEverywhere.call(this, roomId)
               .then(() => {
                 callback();
@@ -514,12 +514,10 @@ function addRoomForCustomer (connection, roomId, metadata) {
  */
 function createChannelConfiguration (requestObject) {
   var
-    deferred = q.defer(),
     channel = {};
 
   if (requestObject.state && ['all', 'done', 'pending'].indexOf(requestObject.state) === -1) {
-    deferred.reject(new BadRequestError('Incorrect value for the "state" parameter. Expected: all, done or pending. Got: ' + requestObject.state));
-    return deferred.promise;
+    return q.reject(new BadRequestError('Incorrect value for the "state" parameter. Expected: all, done or pending. Got: ' + requestObject.state));
   } else if (!requestObject.state) {
     channel.state = 'done';
   } else {
@@ -527,8 +525,7 @@ function createChannelConfiguration (requestObject) {
   }
 
   if (requestObject.scope && ['all', 'in', 'out', 'none'].indexOf(requestObject.scope) === -1) {
-    deferred.reject(new BadRequestError('Incorrect value for the "scope" parameter. Expected: all, in, out or none. Got: ' + requestObject.scope));
-    return deferred.promise;
+    return q.reject(new BadRequestError('Incorrect value for the "scope" parameter. Expected: all, in, out or none. Got: ' + requestObject.scope));
   } else if (!requestObject.scope) {
     channel.scope = 'all';
   } else {
@@ -536,17 +533,14 @@ function createChannelConfiguration (requestObject) {
   }
 
   if (requestObject.users && ['all', 'in', 'out', 'none'].indexOf(requestObject.users) === -1) {
-    deferred.reject(new BadRequestError('Incorrect value for the "users" parameter. Expected: all, in, out or none. Got: ' + requestObject.users));
-    return deferred.promise;
+    return q.reject(new BadRequestError('Incorrect value for the "users" parameter. Expected: all, in, out or none. Got: ' + requestObject.users));
   } else if (!requestObject.users) {
     channel.users = 'none';
   } else {
     channel.users = requestObject.users;
   }
 
-  deferred.resolve(channel);
-
-  return deferred.promise;
+  return q(channel);
 }
 
 /**
@@ -577,7 +571,6 @@ function cleanUpRooms (roomId) {
         deferred.reject(error);
       })
       .finally(() => delete this.rooms[roomId]);
-
   }
   else {
     deferred.resolve(roomId);
@@ -611,19 +604,13 @@ function removeRoomEverywhere (roomId) {
  * @return {Promise} promise
  */
 function removeRoomForCustomer (connection, roomId) {
-  var deferred = q.defer();
-
   if (!this.customers[connection.id]) {
-    deferred.reject(new NotFoundError('The user with connection ' + connection.id + ' doesn\'t exist'));
-    return deferred.promise;
+    return q.reject(new NotFoundError('The user with connection ' + connection.id + ' doesn\'t exist'));
   }
 
   if (!this.customers[connection.id][roomId]) {
-    deferred.reject(new NotFoundError('The user with connectionId ' + connection.id + ' doesn\'t listen the room ' + roomId));
-    return deferred.promise;
+    return q.reject(new NotFoundError('The user with connectionId ' + connection.id + ' doesn\'t listen the room ' + roomId));
   }
-
-  deferred.resolve(roomId);
 
   Object.keys(this.rooms[roomId].channels).forEach(channel => {
     this.kuzzle.pluginsManager.trigger('protocol:leaveChannel', {channel, id: connection.id});
@@ -631,7 +618,7 @@ function removeRoomForCustomer (connection, roomId) {
 
   this.rooms[roomId].customers.splice(this.rooms[roomId].customers.indexOf(connection.id), 1);
 
-  cleanUpRooms.call(this, roomId)
+  return cleanUpRooms.call(this, roomId)
     .then(() => {
       var
         count = this.rooms[roomId] ? this.rooms[roomId].customers.length : 0,
@@ -655,9 +642,9 @@ function removeRoomForCustomer (connection, roomId) {
       } else {
         delete this.customers[connection.id];
       }
-    });
 
-  return deferred.promise;
+      return roomId;
+    });
 }
 
 /**
@@ -690,16 +677,16 @@ function removeRoomForAllCustomers (roomId) {
 /** MANAGE FILTERS TREE **/
 
 /**
- * Create curried filters function and add collection/field/filters/room to the filtersTree object
+ * Add filters to the filtersTree object
  *
- * Transform something like:
+ * Transforms a filter like this one:
  * {
  *  term: { 'subject': 'kuzzle' }
  * }
  *
- * Into something like:
+ * Into an encoded version:
  * {
- *  subject: { 'termSubjectKuzzle' : { fn: function () {}, rooms: [] } },
+ *  subject: { 'termSubjectKuzzle' : { args: {operator, not, field, value}, rooms: [] } },
  * }
  * And inject it in the right place in filtersTree according to the collection and field
  *
@@ -707,14 +694,14 @@ function removeRoomForAllCustomers (roomId) {
  * @param {String} index
  * @param {String} collection
  * @param {Object} filters
- * @return {promise} promise. Resolve a list of path that points to filtersTree object
+ * @return {promise} promise. Resolves a list of path that points to filtersTree object
  */
 function addRoomAndFilters (roomId, index, collection, filters) {
   if (!filters || _.isEmpty(filters)) {
     return this.kuzzle.dsl.addCollectionSubscription(roomId, index, collection);
   }
 
-  return this.kuzzle.dsl.addCurriedFunction(roomId, index, collection, filters);
+  return this.kuzzle.dsl.addSubscription(roomId, index, collection, filters);
 }
 
 /**

--- a/lib/api/dsl/index.js
+++ b/lib/api/dsl/index.js
@@ -1,6 +1,6 @@
 var
-  // Basic methods that DSL will curry for build complex custom filters
   methods = require('./methods'),
+  operators = require('./operators'),
   BadRequestError = require('kuzzle-common-objects').Errors.badRequestError,
   NotFoundError = require('kuzzle-common-objects').Errors.notFoundError,
   async = require('async'),
@@ -10,20 +10,20 @@ var
 
 module.exports = function Dsl (kuzzle) {
   /**
-   *
    * A tree where we have an entry by collection, an entry by tag and
-   * an entry by filter (curried function) with the rooms list
+   * an entry by filter, with the rooms list and the corresponding operator arguments
+   *
    * @example
    * Example for chat-room-kuzzle (see above)
    *  filtersTree = {
-   *    app : { // -> index name
-   *      message : { // -> collection name
+   *    index : { // -> index name
+   *      collection : { // -> collection name
    *        rooms: [] // -> global room to test each time (for a a subscribe on a whole collection, or if 'not exists' filter (see issue #1 on github)
    *        fields: {
    *          subject : { // -> attribute where a filter exists
    *            termSubjectKuzzle : {
    *              rooms: [ 'f45de4d8ef4f3ze4ffzer85d4fgkzm41'], // -> room id that match this filter
-   *              fn: function () {} // -> function to execute on collection message, on field subject
+   *              args: {operator, not, field, value}
    *            }
    *          }
    *        }
@@ -38,36 +38,35 @@ module.exports = function Dsl (kuzzle) {
   this.kuzzle = kuzzle;
 
   /**
-   * Create a currified function with methods and operators. Will create a new filter on a specific field for a collection
+   * Creates new entries in the filtersTree with the provided filters
+   *
    * @param {string} roomId
    * @param {string} index
    * @param {string} collection
    * @param {Object} filters
    * @returns {promise} the generated method
    */
-  this.addCurriedFunction = function (roomId, index, collection, filters) {
+  this.addSubscription = function (roomId, index, collection, filters) {
     var
-      deferred = q.defer(),
       filterName,
       privateFilterName;
+    
     if (filters === undefined) {
-      deferred.reject(new BadRequestError('Filters parameter can\'t be undefined'));
-      return deferred.promise;
+      return q.reject(new BadRequestError('Filters parameter can\'t be undefined'));
     }
 
     filterName = Object.keys(filters)[0];
 
     if (filterName === undefined) {
-      deferred.reject(new BadRequestError('Undefined filters'));
-      return deferred.promise;
+      return q.reject(new BadRequestError('Undefined filters'));
     }
 
     privateFilterName = _.camelCase(filterName);
 
     if (!methods[privateFilterName]) {
-      deferred.reject(new NotFoundError('Unknown filter with name '+ privateFilterName));
-      return deferred.promise;
+      return q.reject(new NotFoundError('Unknown filter with name '+ privateFilterName));
     }
+    
     return this.methods[privateFilterName](roomId, index, collection, filters[filterName]);
   };
 
@@ -79,9 +78,6 @@ module.exports = function Dsl (kuzzle) {
    * @param collection
    */
   this.addCollectionSubscription = function (roomId, index, collection) {
-    var
-      deferred = q.defer();
-
     if (!this.filtersTree[index]) {
       this.filtersTree[index] = {};
     }
@@ -98,8 +94,7 @@ module.exports = function Dsl (kuzzle) {
       this.filtersTree[index][collection].rooms.push(roomId);
     }
 
-    deferred.resolve();
-    return deferred.promise;
+    return q();
   };
 
   /**
@@ -312,7 +307,7 @@ function testFieldFilters(index, collection, flattenBody, cachedResults) {
         cachePath = index + '.' + collection + '.' + field + '.' + cleanFunctionName;
 
       if (cachedResults[cachePath] === undefined) {
-        cachedResults[cachePath] = filter.fn(flattenBody);
+        cachedResults[cachePath] = evalFilterArguments(filter.args, flattenBody);
       }
 
       if (!cachedResults[cachePath]) {
@@ -417,10 +412,10 @@ function testGlobalsFilters(index, collection, flattenBody, cachedResults) {
 
 /**
  *
- * @param {Object} flattenBody the new flatten document
- * @param {Object} filters filters that we have to test for check if the document match the room
- * @param {Object} cachedResults an object with all already tested curried function for the document
- * @param {String} upperOperand represent the operand (and/or) on the upper level
+ * @param {Object} flattenBody - the new flatten document
+ * @param {Object} filters - filters that we have to test for check if the document match the room
+ * @param {Object} cachedResults - an object with all already tested filters for the document
+ * @param {String} upperOperand - represent the operand (and/or) on the upper level
  * @returns {Boolean} true if the document match a room filters
  */
 function testFilterRecursively(flattenBody, filters, cachedResults, upperOperand) {
@@ -445,7 +440,7 @@ function testFilterRecursively(flattenBody, filters, cachedResults, upperOperand
     }
     else {
       if (cachedResults[key] === undefined) {
-        cachedResults[key] = filters[key].fn(flattenBody);
+        cachedResults[key] = evalFilterArguments(filters[key].args, flattenBody);
       }
 
       subBool = cachedResults[key];
@@ -553,7 +548,7 @@ function removeFilterPath(room, filterPath) {
     }
   }
 
-  // If the current entry is the curried function (that contains the room list and the function definition)
+  // If the current entry is the filter containing the room list and the operator arguments
   if (parent[subPath] && parent[subPath].rooms) {
     index = parent[subPath].rooms.indexOf(room.id);
     if (index > -1) {
@@ -619,4 +614,18 @@ function getFiltersPathsRecursively(filters) {
   });
 
   return paths;
+}
+
+/**
+ * Evaluates a flattened document content against the operator
+ * arguments stored in the filtersTree
+ *
+ * @param args - operator arguments
+ * @param flattenBody - flattened document content
+ * @returns {boolean}
+ */
+function evalFilterArguments(args, flattenBody) {
+  var result = operators[args.operator](args.field, args.value, flattenBody);
+
+  return args.not ? !result : result;
 }

--- a/lib/api/dsl/methods.js
+++ b/lib/api/dsl/methods.js
@@ -1,4 +1,3 @@
-
 var
   _ = require('lodash'),
   async = require('async'),
@@ -75,15 +74,15 @@ module.exports = methods = {
     async.each(Object.keys(filter[field]), function (fn, callback) {
       var
         value = filter[field][fn],
-        curriedFunctionName = '',
+        encodedFunctionName = '',
         result;
 
       if (not) {
-        curriedFunctionName += 'not';
+        encodedFunctionName += 'not';
       }
-      curriedFunctionName += 'range' + field + fn + value;
+      encodedFunctionName += 'range' + field + fn + value;
 
-      result = buildCurriedFunction(index, collection, field, fn, value, curriedFunctionName, roomId, not);
+      result = addToFiltersTree(index, collection, field, fn, value, encodedFunctionName, roomId, not);
       if (util.isError(result)) {
         callback(result);
         return false;
@@ -301,7 +300,7 @@ module.exports = methods = {
       deferred = q.defer(),
       fieldName,
       formattedFilters,
-      curriedFunctionName = '',
+      encodedFunctionName = '',
       inGlobals = false,
       result;
 
@@ -325,13 +324,13 @@ module.exports = methods = {
     formattedFilters = {};
 
     if (not) {
-      curriedFunctionName += 'not';
+      encodedFunctionName += 'not';
       inGlobals = true;
     }
     // Clean the field in function name because can contains '.' and we don't want it in the function name
-    curriedFunctionName += 'exists' + fieldName.split('.').join('');
+    encodedFunctionName += 'exists' + fieldName.split('.').join('');
 
-    result = buildCurriedFunction(index, collection, fieldName, 'exists', fieldName, curriedFunctionName, roomId, not, inGlobals);
+    result = addToFiltersTree(index, collection, fieldName, 'exists', fieldName, encodedFunctionName, roomId, not, inGlobals);
     if (util.isError(result)) {
       deferred.reject(result);
       return deferred.promise;
@@ -357,7 +356,7 @@ module.exports = methods = {
     var
       deferred = q.defer(),
       formattedFilters,
-      curriedFunctionName = '',
+      encodedFunctionName = '',
       result;
 
     if (_.isEmpty(filter)) {
@@ -378,13 +377,13 @@ module.exports = methods = {
     formattedFilters = {};
 
     if (not) {
-      curriedFunctionName += 'not';
+      encodedFunctionName += 'not';
     }
 
-    curriedFunctionName += 'ids_id' + filter.values;
+    encodedFunctionName += 'ids_id' + filter.values;
 
     // We can use the 'terms' operators because is the same behaviour: check if the value in document match one of values in the filter
-    result = buildCurriedFunction(index, collection, '_id', 'terms', filter.values, curriedFunctionName, roomId, not, false);
+    result = addToFiltersTree(index, collection, '_id', 'terms', filter.values, encodedFunctionName, roomId, not, false);
 
     if (util.isError(result)) {
       deferred.reject(result);
@@ -409,7 +408,7 @@ module.exports = methods = {
    */
   geoBoundingBox: function (roomId, index, collection, filter, not) {
     var
-      curriedFunctionName,
+      encodedFunctionName,
       deferred = q.defer(),
       fieldName,
       formattedFilters = {},
@@ -454,18 +453,18 @@ module.exports = methods = {
       return deferred.promise;
     }
 
-    curriedFunctionName = [fieldName, 'geoBoundingBox', geohash.encode(left, top), geohash.encode(right, bottom)].join('');
+    encodedFunctionName = [fieldName, 'geoBoundingBox', geohash.encode(left, top), geohash.encode(right, bottom)].join('');
     if (not) {
-      curriedFunctionName += 'not';
+      encodedFunctionName += 'not';
     }
 
-    result = buildCurriedFunction(
+    result = addToFiltersTree(
       index,
       collection,
       fieldName,
       'geoBoundingBox',
       {top: top, left: left, right: right, bottom: bottom},
-      curriedFunctionName,
+      encodedFunctionName,
       roomId,
       not
     );
@@ -492,7 +491,7 @@ module.exports = methods = {
    */
   geoDistance: function (roomId, index, collection, filter, not) {
     var
-      curriedFunctionName,
+      encodedFunctionName,
       deferred = q.defer(),
       fieldName,
       formattedFilters = {},
@@ -546,18 +545,18 @@ module.exports = methods = {
       return deferred.promise;
     }
 
-    curriedFunctionName = [fieldName, 'geoDistance', geohash.encode(lat, lon), distance].join('');
+    encodedFunctionName = [fieldName, 'geoDistance', geohash.encode(lat, lon), distance].join('');
     if (not) {
-      curriedFunctionName += 'not';
+      encodedFunctionName += 'not';
     }
 
-    result = buildCurriedFunction(
+    result = addToFiltersTree(
       index,
       collection,
       fieldName,
       'geoDistance',
       {lat: lat, lon: lon, distance: distance},
-      curriedFunctionName,
+      encodedFunctionName,
       roomId,
       not
     );
@@ -584,7 +583,7 @@ module.exports = methods = {
    */
   geoDistanceRange: function (roomId, index, collection, filter, not) {
     var
-      curriedFunctionName,
+      encodedFunctionName,
       deferred = q.defer(),
       fieldName,
       formattedFilters = {},
@@ -643,18 +642,18 @@ module.exports = methods = {
       return deferred.promise;
     }
 
-    curriedFunctionName = [fieldName, 'geoDistanceRange', geohash.encode(lat, lon), from, to].join('');
+    encodedFunctionName = [fieldName, 'geoDistanceRange', geohash.encode(lat, lon), from, to].join('');
     if (not) {
-      curriedFunctionName += 'not';
+      encodedFunctionName += 'not';
     }
 
-    result = buildCurriedFunction(
+    result = addToFiltersTree(
       index,
       collection,
       fieldName,
       'geoDistanceRange',
       {lat: lat, lon: lon, from: from, to: to},
-      curriedFunctionName,
+      encodedFunctionName,
       roomId,
       not
     );
@@ -681,7 +680,7 @@ module.exports = methods = {
    */
   geoPolygon: function (roomId, index, collection, filter, not) {
     var
-      curriedFunctionName,
+      encodedFunctionName,
       deferred = q.defer(),
       fieldName,
       formattedFilters = {},
@@ -713,18 +712,18 @@ module.exports = methods = {
       geoHashPolygon.push(geohash.encode(point.lat, point.lon));
     });
 
-    curriedFunctionName = [fieldName, 'geoPolygon', geoHashPolygon.join('')].join('');
+    encodedFunctionName = [fieldName, 'geoPolygon', geoHashPolygon.join('')].join('');
     if (not) {
-      curriedFunctionName += 'not';
+      encodedFunctionName += 'not';
     }
 
-    result = buildCurriedFunction(
+    result = addToFiltersTree(
       index,
       collection,
       fieldName,
       'geoPolygon',
       polygon,
-      curriedFunctionName,
+      encodedFunctionName,
       roomId,
       not
     );
@@ -775,7 +774,7 @@ module.exports = methods = {
       deferred = q.defer(),
       fieldName,
       formattedFilters,
-      curriedFunctionName = '',
+      encodedFunctionName = '',
       inGlobals = false,
       result;
 
@@ -794,13 +793,13 @@ module.exports = methods = {
     formattedFilters = {};
 
     if (not) {
-      curriedFunctionName += 'not';
+      encodedFunctionName += 'not';
       inGlobals = true;
     }
     // Clean the field in function name because can contains '.' and we don't want it in the function name
-    curriedFunctionName += 'missing' + fieldName.split('.').join('');
+    encodedFunctionName += 'missing' + fieldName.split('.').join('');
 
-    result = buildCurriedFunction(index, collection, fieldName, 'missing', fieldName, curriedFunctionName, roomId, not, inGlobals);
+    result = addToFiltersTree(index, collection, fieldName, 'missing', fieldName, encodedFunctionName, roomId, not, inGlobals);
     if (util.isError(result)) {
       deferred.reject(result);
       return deferred.promise;
@@ -820,25 +819,21 @@ module.exports = methods = {
  * @param {String} index the index name
  * @param {String} collection the collection name
  * @param {String} field the field where we need to apply the filter
- * @param {String} operatorName the operator name that the user wants to execute against the document (defined in operator.js)
+ * @param {String} operator the operator name that the user wants to execute against the document (defined in operator.js)
  * @param {*} value the value to test on the field
- * @param {String} curriedFunctionName
+ * @param {String} encodedFunctionName
  * @param {String} roomId
  * @param {Boolean} not
- * @param {Boolean} inGlobals true if the roomId must be added in global room for the collection (eg, for 'not exists' filter)
+ * @param {Boolean} [inGlobals] true if the roomId must be added in global room for the collection (eg, for 'not exists' filter)
  * @returns {Object} an object with the path and the new filter
  */
-function buildCurriedFunction(index, collection, field, operatorName, value, curriedFunctionName, roomId, not, inGlobals) {
+function addToFiltersTree(index, collection, field, operator, value, encodedFunctionName, roomId, not, inGlobals) {
   var
-    curriedFunction,
-    fnSource,
-    path;
+    hashedFunctionName = md5(encodedFunctionName),
+    path = index + '.' + collection + '.' + field + '.' + hashedFunctionName;
 
-  curriedFunctionName = md5(curriedFunctionName);
-  path = index + '.' + collection + '.' + field + '.' + curriedFunctionName;
-
-  if (operators[operatorName] === undefined) {
-    return new BadRequestError('Operator ' + operatorName + ' doesn\'t exist');
+  if (operators[operator] === undefined) {
+    return new BadRequestError(`Operator ${operator} doesn't exist`);
   }
 
   if (!methods.dsl.filtersTree[index]) {
@@ -857,22 +852,15 @@ function buildCurriedFunction(index, collection, field, operatorName, value, cur
     methods.dsl.filtersTree[index][collection].fields[field] = {};
   }
 
-  if (!methods.dsl.filtersTree[index][collection].fields[field][curriedFunctionName]) {
-    // we need the ugly eval code to make sure the function can later on be serialized and
-    // reused without having to keep a closure context in memory
-    /* eslint-disable no-eval */
-    fnSource = 'd => ' + (not ? '!' : '') + `operators['${operatorName}'](${JSON.stringify(field)}, ${JSON.stringify(value)}, d);`;
-    curriedFunction = eval(fnSource);
-    /* eslint-enable no-eval */
-
-    methods.dsl.filtersTree[index][collection].fields[field][curriedFunctionName] = {
+  if (!methods.dsl.filtersTree[index][collection].fields[field][hashedFunctionName]) {
+    methods.dsl.filtersTree[index][collection].fields[field][hashedFunctionName] = {
       rooms: [],
-      fn: curriedFunction
+      args: {operator, not, field, value}
     };
   }
 
-  if (methods.dsl.filtersTree[index][collection].fields[field][curriedFunctionName].rooms.indexOf(roomId) === -1) {
-    methods.dsl.filtersTree[index][collection].fields[field][curriedFunctionName].rooms.push(roomId);
+  if (methods.dsl.filtersTree[index][collection].fields[field][hashedFunctionName].rooms.indexOf(roomId) === -1) {
+    methods.dsl.filtersTree[index][collection].fields[field][hashedFunctionName].rooms.push(roomId);
   }
 
   if (inGlobals) {
@@ -887,7 +875,7 @@ function buildCurriedFunction(index, collection, field, operatorName, value, cur
 
   return {
     path: path,
-    filter: methods.dsl.filtersTree[index][collection].fields[field][curriedFunctionName]
+    filter: methods.dsl.filtersTree[index][collection].fields[field][hashedFunctionName]
   };
 }
 
@@ -1044,16 +1032,14 @@ function deepExtend(filters1, filters2) {
  */
 function termFunction(termType, roomId, index, collection, filter, not) {
   var
-    deferred = q.defer(),
     field,
     value,
     formattedFilters,
-    curriedFunctionName = '',
+    encodedFunctionName = '',
     result;
 
   if (_.isEmpty(filter)) {
-    deferred.reject(new BadRequestError('A filter can\'t be empty'));
-    return deferred.promise;
+    return q.reject(new BadRequestError('A filter can\'t be empty'));
   }
 
   field = Object.keys(filter)[0];
@@ -1061,24 +1047,21 @@ function termFunction(termType, roomId, index, collection, filter, not) {
   formattedFilters = {};
 
   if (termType === 'terms' && !Array.isArray(value)) {
-    deferred.reject(new BadRequestError('Filter terms must contains an array'));
-    return deferred.promise;
+    return q.reject(new BadRequestError('Filter terms must contains an array'));
   }
 
   if (not) {
-    curriedFunctionName += 'not';
+    encodedFunctionName += 'not';
   }
   // Clean the field in function name because can contains '.' and we don't want it in the function name
-  curriedFunctionName += termType + field.split('.').join('') + value;
+  encodedFunctionName += termType + field.split('.').join('') + value;
 
-  result = buildCurriedFunction(index, collection, field, termType, value, curriedFunctionName, roomId, not);
+  result = addToFiltersTree(index, collection, field, termType, value, encodedFunctionName, roomId, not);
   if (util.isError(result)) {
-    deferred.reject(result);
-    return deferred.promise;
+    return q.reject(result);
   }
 
   formattedFilters[result.path] = result.filter;
 
-  deferred.resolve(formattedFilters);
-  return deferred.promise;
+  return q(formattedFilters);
 }

--- a/lib/api/dsl/methods.js
+++ b/lib/api/dsl/methods.js
@@ -71,18 +71,18 @@ module.exports = methods = {
     field = Object.keys(filter)[0];
     formattedFilters = {};
 
-    async.each(Object.keys(filter[field]), function (fn, callback) {
+    async.each(Object.keys(filter[field]), function (rangeOperator, callback) {
       var
-        value = filter[field][fn],
+        value = filter[field][rangeOperator],
         encodedFunctionName = '',
         result;
 
       if (not) {
         encodedFunctionName += 'not';
       }
-      encodedFunctionName += 'range' + field + fn + value;
+      encodedFunctionName += 'range' + field + rangeOperator + value;
 
-      result = addToFiltersTree(index, collection, field, fn, value, encodedFunctionName, roomId, not);
+      result = addToFiltersTree(index, collection, field, rangeOperator, value, encodedFunctionName, roomId, not);
       if (util.isError(result)) {
         callback(result);
         return false;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cli-color": "^1.1.0",
     "commander": "2.9.0",
     "crypto-md5": "^1.0.0",
-    "easy-circular-list": "^1.0.11",
+    "easy-circular-list": "^1.0.13",
     "elasticsearch": "11.0.1",
     "eventemitter2": "^1.0.0",
     "finalhandler": "0.4.1",

--- a/test/api/dsl/index/addSubscription.test.js
+++ b/test/api/dsl/index/addSubscription.test.js
@@ -2,7 +2,7 @@ var
   should = require('should'),
   Dsl = require.main.require('lib/api/dsl/index');
 
-describe('Test: dsl.addCurriedFunction', function () {
+describe('Test: dsl.addSubscription', function () {
 
   var
     dsl,
@@ -26,19 +26,19 @@ describe('Test: dsl.addCurriedFunction', function () {
 
 
   it('should return an error when the filter is undefined', function () {
-    return should(dsl.addCurriedFunction(roomId, index, collection, undefined)).be.rejected();
+    return should(dsl.addSubscription(roomId, index, collection, undefined)).be.rejected();
   });
 
   it('should return an error when the filter doesn\'t exist', function () {
-    return should(dsl.addCurriedFunction(roomId, index, collection, fakeFilter)).be.rejected();
+    return should(dsl.addSubscription(roomId, index, collection, fakeFilter)).be.rejected();
   });
 
   it('should return an error when the filter is empty', function () {
-    return should(dsl.addCurriedFunction(roomId, index, collection, {})).be.rejected();
+    return should(dsl.addSubscription(roomId, index, collection, {})).be.rejected();
   });
 
   it('should resolve a promise when the filter exists', function () {
-    return should(dsl.addCurriedFunction(roomId, index, collection, filter)).not.be.rejected();
+    return should(dsl.addSubscription(roomId, index, collection, filter)).not.be.rejected();
   });
 
 });

--- a/test/api/dsl/index/testFieldFilters.test.js
+++ b/test/api/dsl/index/testFieldFilters.test.js
@@ -87,8 +87,11 @@ describe('Test: dsl.testFieldFilters', function () {
         'foo.bar': {
           testFoobar: {
             rooms: rooms,
-            fn: function () {
-              return true;
+            args: {
+              operator: 'term',
+              not: false,
+              field: 'foo.bar',
+              value: 'bar'
             }
           }
         }
@@ -110,8 +113,11 @@ describe('Test: dsl.testFieldFilters', function () {
         'foo.bar': {
           testFoobar: {
             rooms: rooms,
-            fn: function () {
-              return true;
+            args: {
+              operator: 'term',
+              not: false,
+              field: 'foo.bar',
+              value: 'bar'
             }
           }
         }

--- a/test/api/dsl/methods/addToFiltersTree.test.js
+++ b/test/api/dsl/methods/addToFiltersTree.test.js
@@ -4,17 +4,17 @@ var
   md5 = require('crypto-md5');
   methods = rewire('../../../../lib/api/dsl/methods');
 
-describe('Test: dsl.buildCurriedFunction method', function () {
+describe('Test: dsl.addToFiltersTree method', function () {
   var
-    buildCurriedFunction = methods.__get__('buildCurriedFunction'),
-    hasedFilter = md5('filter');
+    addToFiltersTree = methods.__get__('addToFiltersTree'),
+    hashedFilter = md5('filter');
 
   beforeEach(function () {
     methods.dsl = { filtersTree: {} };
   });
 
   it('should return an error if the provided operator is not supported', function () {
-    var result = buildCurriedFunction('', '', '', 'foobar', '', '', '', false, false);
+    var result = addToFiltersTree('', '', '', 'foobar', '', '', '', false, false);
     should(result).be.an.Object();
     should(result.status).be.exactly(400);
     should(result.message).not.be.empty();
@@ -22,37 +22,47 @@ describe('Test: dsl.buildCurriedFunction method', function () {
   });
 
   it('should initializes the filter tree using the provided arguments', function () {
-    var result = buildCurriedFunction.call(methods, 'index', 'collection', 'field', 'gte', 42, 'filter', 'roomId');
+    var result = addToFiltersTree.call(methods, 'index', 'collection', 'field', 'gte', 42, 'filter', 'roomId');
 
     should.not.exist(result.error);
     should(result.path).be.exactly('index.collection.field.' + md5('filter'));
     should.exist(result.filter);
     should(result.filter.rooms).be.an.Array().and.match(['roomId']);
     should(result.filter.rooms.length).be.eql(1);
-    should(result.filter.fn).be.a.Function();
+    should(result.filter.args).be.an.Object().and.match({
+      operator: 'gte',
+      not: undefined,
+      field: 'field',
+      value: 42
+    });
 
     should.exist(methods.dsl.filtersTree.index.collection);
     should.exist(methods.dsl.filtersTree.index.collection.fields);
     should.exist(methods.dsl.filtersTree.index.collection.fields.field);
-    should.exist(methods.dsl.filtersTree.index.collection.fields.field[hasedFilter]);
-    should(methods.dsl.filtersTree.index.collection.fields.field[hasedFilter].rooms).be.an.Array().and.match(['roomId']);
+    should.exist(methods.dsl.filtersTree.index.collection.fields.field[hashedFilter]);
+    should(methods.dsl.filtersTree.index.collection.fields.field[hashedFilter].rooms).be.an.Array().and.match(['roomId']);
     should(result.filter.rooms.length).be.eql(1);
-    should(methods.dsl.filtersTree.index.collection.fields.field[hasedFilter].fn).be.a.Function();
+    should(methods.dsl.filtersTree.index.collection.fields.field[hashedFilter].args).be.an.Object().and.match({
+      operator: 'gte',
+      not: undefined,
+      field: 'field',
+      value: 42
+    });
 
     should.not.exist(methods.dsl.filtersTree.index.collection.rooms);
   });
 
   it('should not add a room to the same filter if it is already assigned to it', function () {
-    buildCurriedFunction.call(methods, 'index', 'collection', 'field', 'gte', 42, 'filter', 'roomId');
-    buildCurriedFunction.call(methods, 'index', 'collection', 'field', 'gte', 42, 'filter', 'roomId');
+    addToFiltersTree.call(methods, 'index', 'collection', 'field', 'gte', 42, 'filter', 'roomId');
+    addToFiltersTree.call(methods, 'index', 'collection', 'field', 'gte', 42, 'filter', 'roomId');
 
-    should(methods.dsl.filtersTree.index.collection.fields.field[hasedFilter].rooms).be.an.Array().and.match(['roomId']);
-    should(methods.dsl.filtersTree.index.collection.fields.field[hasedFilter].rooms.length).be.eql(1);
+    should(methods.dsl.filtersTree.index.collection.fields.field[hashedFilter].rooms).be.an.Array().and.match(['roomId']);
+    should(methods.dsl.filtersTree.index.collection.fields.field[hashedFilter].rooms.length).be.eql(1);
   });
 
   it('should also add the room to the global rooms list if the filter is global', function () {
-    buildCurriedFunction.call(methods, 'index', 'collection', 'field', 'gte', 42, 'filter', 'roomId', false, true);
-    buildCurriedFunction.call(methods, 'index', 'collection', 'field', 'gte', 42, 'filter', 'roomId', false, true);
+    addToFiltersTree.call(methods, 'index', 'collection', 'field', 'gte', 42, 'filter', 'roomId', false, true);
+    addToFiltersTree.call(methods, 'index', 'collection', 'field', 'gte', 42, 'filter', 'roomId', false, true);
 
     should.exist(methods.dsl.filtersTree.index.collection.rooms);
     should(methods.dsl.filtersTree.index.collection.rooms).be.an.Array().and.match(['roomId']);

--- a/test/api/dsl/methods/and.test.js
+++ b/test/api/dsl/methods/and.test.js
@@ -5,24 +5,11 @@ var
   md5 = require('crypto-md5'),
   methods = rewire('../../../../lib/api/dsl/methods');
 
-describe('Test and method', function () {
-
+describe('Test "and" method', function () {
   var
     roomId = 'roomId',
     index = 'index',
     collection = 'collection',
-    documentGrace = {
-      firstName: 'Grace',
-      lastName: 'Hopper',
-      city: 'NYC',
-      hobby: 'computer'
-    },
-    documentAda = {
-      firstName: 'Ada',
-      lastName: 'Lovelace',
-      city: 'London',
-      hobby: 'computer'
-    },
     filter = [
       {
         term: {
@@ -30,13 +17,15 @@ describe('Test and method', function () {
         }
       },
       {
-        term: {
-          hobby: 'computer'
+        not: {
+          term: {
+            hobby: 'computer'
+          }
         }
       }
     ],
     termCity = md5('termcityNYC'),
-    termHobby = md5('termhobbycomputer');
+    termHobby = md5('nottermhobbycomputer');
 
 
   before(function () {
@@ -53,7 +42,7 @@ describe('Test and method', function () {
     should(methods.dsl.filtersTree[index][collection].fields.hobby).not.be.empty();
   });
 
-  it('should construct the filterTree with correct curried function name', function () {
+  it('should construct the filterTree with correct encoded function name', function () {
     should(methods.dsl.filtersTree[index][collection].fields.city[termCity]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection].fields.hobby[termHobby]).not.be.empty();
   });
@@ -72,18 +61,20 @@ describe('Test and method', function () {
     should(rooms[0]).be.exactly(roomId);
   });
 
-  it('should construct the filterTree with correct functions', function () {
-    var result;
+  it('should construct the filterTree with correct operator arguments', function () {
+    should(methods.dsl.filtersTree[index][collection].fields.city[termCity].args).match({
+      operator: 'term',
+      not: undefined,
+      field: 'city',
+      value: 'NYC'
+    });
 
-    result = methods.dsl.filtersTree[index][collection].fields.city[termCity].fn(documentGrace);
-    should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.city[termCity].fn(documentAda);
-    should(result).be.exactly(false);
-
-    result = methods.dsl.filtersTree[index][collection].fields.hobby[termHobby].fn(documentGrace);
-    should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.hobby[termHobby].fn(documentAda);
-    should(result).be.exactly(true);
+    should(methods.dsl.filtersTree[index][collection].fields.hobby[termHobby].args).match({
+      operator: 'term',
+      not: true,
+      field: 'hobby',
+      value: 'computer'
+    });
   });
 
   it('should return a rejected promise if getFormattedFilters fails', function () {

--- a/test/api/dsl/methods/bool.test.js
+++ b/test/api/dsl/methods/bool.test.js
@@ -7,25 +7,10 @@ var
   BadRequestError = require.main.require('kuzzle-common-objects').Errors.badRequestError;
 
 describe('Test bool method', function () {
-
   var
     roomId = 'roomId',
     index = 'test',
     collection = 'collection',
-    documentGrace = {
-      firstName: 'Grace',
-      lastName: 'Hopper',
-      age: 85,
-      city: 'NYC',
-      hobby: 'computer'
-    },
-    documentAda = {
-      firstName: 'Ada',
-      lastName: 'Lovelace',
-      age: 36,
-      city: 'London',
-      hobby: 'computer'
-    },
     filter = {
       must : [
         {
@@ -127,38 +112,48 @@ describe('Test bool method', function () {
     should(rooms[0]).be.exactly(roomId);
   });
 
-  it('should construct the filterTree with correct functions', function () {
-    var result;
+  it('should construct the filterTree with correct arguments', function () {
+    should(methods.dsl.filtersTree[index][collection].fields.firstName[md5('termsfirstNameGrace,Ada')].args).match({
+      operator: 'terms',
+      not: undefined,
+      field: 'firstName',
+      value: ['Grace', 'Ada']
+    });
 
-    result = methods.dsl.filtersTree[index][collection].fields.firstName[md5('termsfirstNameGrace,Ada')].fn(documentGrace);
-    should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.firstName[md5('termsfirstNameGrace,Ada')].fn(documentAda);
-    should(result).be.exactly(true);
+    should(methods.dsl.filtersTree[index][collection].fields.age[rangeagegte36].args).match({
+      operator: 'gte',
+      not: undefined,
+      field: 'age',
+      value: 36
+    });
 
-    result = methods.dsl.filtersTree[index][collection].fields.age[rangeagegte36].fn(documentGrace);
-    should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.age[rangeagegte36].fn(documentAda);
-    should(result).be.exactly(true);
+    should(methods.dsl.filtersTree[index][collection].fields.age[rangeagelt85].args).match({
+      operator: 'lt',
+      not: undefined,
+      field: 'age',
+      value: 85
+    });
 
-    result = methods.dsl.filtersTree[index][collection].fields.age[rangeagelt85].fn(documentGrace);
-    should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[index][collection].fields.age[rangeagelt85].fn(documentAda);
-    should(result).be.exactly(true);
+    should(methods.dsl.filtersTree[index][collection].fields.city[nottermcityNYC].args).match({
+      operator: 'term',
+      not: true,
+      field: 'city',
+      value: 'NYC'
+    });
 
-    result = methods.dsl.filtersTree[index][collection].fields.city[nottermcityNYC].fn(documentGrace);
-    should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[index][collection].fields.city[nottermcityNYC].fn(documentAda);
-    should(result).be.exactly(true);
+    should(methods.dsl.filtersTree[index][collection].fields.hobby[termhobbycomputer].args).match({
+      operator: 'term',
+      not: undefined,
+      field: 'hobby',
+      value: 'computer'
+    });
 
-    result = methods.dsl.filtersTree[index][collection].fields.hobby[termhobbycomputer].fn(documentGrace);
-    should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.hobby[termhobbycomputer].fn(documentAda);
-    should(result).be.exactly(true);
-
-    result = methods.dsl.filtersTree[index][collection].fields.lastName[existslastName].fn(documentGrace);
-    should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.lastName[existslastName].fn(documentAda);
-    should(result).be.exactly(true);
+    should(methods.dsl.filtersTree[index][collection].fields.lastName[existslastName].args).match({
+      operator: 'exists',
+      not: undefined,
+      field: 'lastName',
+      value: 'lastName'
+    });
   });
 
   it('should return a rejected promise if an empty filter is provided', function () {

--- a/test/api/dsl/methods/exists.test.js
+++ b/test/api/dsl/methods/exists.test.js
@@ -7,23 +7,14 @@ var
   InternalError = require.main.require('kuzzle-common-objects').Errors.internalError;
 
 describe('Test exists method', function () {
-
   var
     roomId = 'roomId',
     index = 'test',
     collection = 'collection',
-    documentGrace = {
-      firstName: 'Grace',
-      lastName: 'Hopper'
-    },
-    documentAda = {
-      firstName: 'Ada'
-    },
     filter = {
       field: 'lastName'
     },
     existslastName = md5('existslastName');
-
 
   before(function () {
     methods.dsl.filtersTree = {};
@@ -52,13 +43,13 @@ describe('Test exists method', function () {
     should(rooms[0]).be.exactly(roomId);
   });
 
-  it('should construct the filterTree with correct functions exists', function () {
-    var result;
-
-    result = methods.dsl.filtersTree[index][collection].fields.lastName[existslastName].fn(documentGrace);
-    should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.lastName[existslastName].fn(documentAda);
-    should(result).be.exactly(false);
+  it('should construct the filterTree with correct exists arguments', function () {
+    should(methods.dsl.filtersTree[index][collection].fields.lastName[existslastName].args).match({
+      operator: 'exists',
+      not: undefined,
+      field: 'lastName',
+      value: 'lastName'
+    });
   });
 
   it('should return a rejected promise if the filter argument is empty', function () {

--- a/test/api/dsl/methods/geoDistance.test.js
+++ b/test/api/dsl/methods/geoDistance.test.js
@@ -6,19 +6,11 @@ var
   BadRequestError = require.main.require('kuzzle-common-objects').Errors.badRequestError,
   InternalError = require.main.require('kuzzle-common-objects').Errors.internalError;
 
-
-
 describe('Test geoDistance method', function () {
   var
     roomId = 'roomId',
     index = 'test',
     collection = 'collection',
-    document = {
-      name: 'Zero',
-      'location.lat': 0, // we can't test with nested document here
-      'location.lon': 0
-    },
-
     filterExact = {
       location: {
         lat: 0,
@@ -73,8 +65,8 @@ describe('Test geoDistance method', function () {
     should(methods.dsl.filtersTree[index][collection].fields.location).not.be.empty();
   });
 
-  it('should construct the filterTree with correct curried function name', function () {
-    // Coord are geoashed for build the curried function name
+  it('should construct the filterTree with correct encoded function name', function () {
+    // Coordinates are geohashed to encode the function name
     // because we have many times the same coord in filters,
     // we must have only four functions
     
@@ -109,25 +101,34 @@ describe('Test geoDistance method', function () {
     should(rooms[0]).be.exactly(roomId);
   });
 
-  it('should construct the filterTree with correct functions geodistance', function () {
-    var result;
+  it('should construct the filterTree with correct geodistance arguments', function () {
+    should(methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistancekpbxyzbpv111318].args).match({
+      operator: 'geoDistance',
+      not: undefined,
+      field: 'location',
+      value: { lat: 0, lon: 1, distance: 111318 }
+    });
 
-    // test exact
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistancekpbxyzbpv111318].fn(document);
-    should(result).be.exactly(true);
+    should(methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistancekpbxyzbpv111320].args).match({
+      operator: 'geoDistance',
+      not: undefined,
+      field: 'location',
+      value: { lat: 0, lon: 1, distance: 111320 }
+    });
 
-    // test ok
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistancekpbxyzbpv111320].fn(document);
-    should(result).be.exactly(true);
+    should(methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistancekpbxyzbpv111317].args).match({
+      operator: 'geoDistance',
+      not: undefined,
+      field: 'location',
+      value: { lat: 0, lon: 1, distance: 111317 }
+    });
 
-    // test too far
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistancekpbxyzbpv111317].fn(document);
-    should(result).be.exactly(false);
-
-    // test human readable distance
-    result = methods.dsl.filtersTree[index][collection].fields.location[md5('locationgeoDistancekpbxyzbpv111318.9999168')].fn(document);
-    should(result).be.exactly(true);
-
+    should(methods.dsl.filtersTree[index][collection].fields.location[md5('locationgeoDistancekpbxyzbpv111318.9999168')].args).match({
+      operator: 'geoDistance',
+      not: undefined,
+      field: 'location',
+      value: { lat: 0, lon: 1, distance: 111318.9999168 }
+    });
   });
 
   it('should return a rejected promise if an empty filter is provided', function () {
@@ -225,9 +226,9 @@ describe('Test geoDistance method', function () {
     return should(methods.geoDistance(roomId, index, collection, invalidFilter)).be.rejectedWith(BadRequestError, { message: 'Unable to parse the distance filter parameter' });
   });
 
-  it('should return a rejected promise if buildCurriedFunction fails', function () {
+  it('should return a rejected promise if addToFiltersTree fails', function () {
     return methods.__with__({
-      buildCurriedFunction: function () { return new InternalError('rejected'); }
+      addToFiltersTree: function () { return new InternalError('rejected'); }
     })(function () {
       return should(methods.geoDistance(roomId, index, collection, filterOK)).be.rejectedWith('rejected');
     });

--- a/test/api/dsl/methods/geoDistanceRange.test.js
+++ b/test/api/dsl/methods/geoDistanceRange.test.js
@@ -6,34 +6,11 @@ var
   BadRequestError = require.main.require('kuzzle-common-objects').Errors.badRequestError,
   InternalError = require.main.require('kuzzle-common-objects').Errors.internalError;
 
-
-
 describe('Test geoDistanceRange method', function () {
   var
     roomId = 'roomId',
     index = 'test',
     collection = 'collection',
-    document = {
-      name: 'Zero',
-      'location.lat': 0, // we can't test with nested document here
-      'location.lon': 0
-    },
-    documentBad = {
-      name: 'Bad',
-      'location.lol': 0, // we can't test with nested document here
-      'location.cat': 0
-    },
-    documentBadLat = {
-      name: 'Bad',
-      'location.lon': 0, // we can't test with nested document here
-      'location.cat': 0
-    },
-    documentBadLon = {
-      name: 'Bad',
-      'location.lol': 0, // we can't test with nested document here
-      'location.lat': 0
-    },
-
     filterOK = {
       location: {
         lat: 0,
@@ -99,8 +76,8 @@ describe('Test geoDistanceRange method', function () {
     should(methods.dsl.filtersTree[index][collection].fields.location).not.be.empty();
   });
 
-  it('should construct the filterTree with correct curried function name', function () {
-    // Coord are geoashed for build the curried function name
+  it('should construct the filterTree with correct encoded function name', function () {
+    // Coordinates are geohashed to encode the function name
     // because we have many times the same coord in filters,
     // we must have only four functions
     
@@ -136,35 +113,35 @@ describe('Test geoDistanceRange method', function () {
   });
 
   it('should construct the filterTree with correct functions geoDistanceRange', function () {
-    var result;
+    should(methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv111320111317].args).match({
+      operator: 'geoDistanceRange',
+      not: undefined,
+      field: 'location',
+      value: { lat: 0, lon: 1, from: 111320, to: 111317 }
+    });
 
-    // test ok
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv111320111317].fn(document);
-    should(result).be.exactly(true);
+    should(methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv110].args).match({
+      operator: 'geoDistanceRange',
+      not: undefined,
+      field: 'location',
+      value: { lat: 0, lon: 1, from: 1, to: 10 }
+    });
 
-    // test not ok
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv110].fn(document);
-    should(result).be.exactly(false);
+    should(methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv111318111318].args).match({
+      operator: 'geoDistanceRange',
+      not: undefined,
+      field: 'location',
+      value: { lat: 0, lon: 1, from: 111318, to: 111318 }
+    });
 
-    // test human readable distance
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv111318111318].fn(document);
-    should(result).be.exactly(true);
-
-    // test from == to
-    result = methods.dsl.filtersTree[index][collection].fields.location[md5('locationgeoDistanceRangekpbxyzbpv111312.96111319.05600000001')].fn(document);
-    should(result).be.exactly(true);
-
+    should(methods.dsl.filtersTree[index][collection].fields.location[md5('locationgeoDistanceRangekpbxyzbpv111312.96111319.05600000001')].args).match({
+      operator: 'geoDistanceRange',
+      not: undefined,
+      field: 'location',
+      value: {lat: 0, lon: 1, from: 111312.96, to: 111319.05600000001}
+    });
   });
 
-  it('should return false if no lat or lon members exists for the location member of the document', function () {
-    // test ok
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv111320111317].fn(documentBad);
-    should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv111320111317].fn(documentBadLon);
-    should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv111320111317].fn(documentBadLat);
-    should(result).be.exactly(false);
-  });
 
   it('should return a rejected promise if an empty filter is provided', function () {
     return should(methods.geoDistanceRange('foo', index, 'bar', {})).be.rejectedWith(BadRequestError, { message: 'Missing filter' });
@@ -267,9 +244,9 @@ describe('Test geoDistanceRange method', function () {
     return should(methods.geoDistanceRange(roomId, index, collection, invalidFilter)).be.rejectedWith(BadRequestError, { message: 'Unable to parse the distance filter parameter' });
   });
 
-  it('should return a rejected promise if buildCurriedFunction fails', function () {
+  it('should return a rejected promise if addToFiltersTree fails', function () {
     return methods.__with__({
-      buildCurriedFunction: function () { return new InternalError('rejected'); }
+      addToFiltersTree: function () { return new InternalError('rejected'); }
     })(function () {
       return should(methods.geoDistanceRange(roomId, index, collection, filterOK)).be.rejectedWith('rejected');
     });

--- a/test/api/dsl/methods/getFormattedFilters.test.js
+++ b/test/api/dsl/methods/getFormattedFilters.test.js
@@ -6,8 +6,6 @@ var
   methods = rewire('../../../../lib/api/dsl/methods'),
   BadRequestError = require.main.require('kuzzle-common-objects').Errors.badRequestError;
 
-
-
 describe('Test: dsl.getFormattedFilters method', function () {
   var
     getFormattedFilters = methods.__get__('getFormattedFilters'),
@@ -28,7 +26,7 @@ describe('Test: dsl.getFormattedFilters method', function () {
     return should(getFormattedFilters('roomId', 'index', 'collection', { foo: 'bar'})).be.rejectedWith(BadRequestError, { message: 'Function foo doesn\'t exist' });
   });
 
-  it('should return a resolved promise containing 1 formatted filter', function (done) {
+  it('should return a resolved promise containing 1 formatted filter', function () {
     var
       filter = {
         exists: {
@@ -36,52 +34,43 @@ describe('Test: dsl.getFormattedFilters method', function () {
         }
       };
 
-    getFormattedFilters('roomId', 'index', 'collection', filter)
+    return getFormattedFilters('roomId', 'index', 'collection', filter)
       .then(function (formattedFilter) {
         should.exist(formattedFilter['index.collection.foo.' + existsfoo]);
         should(formattedFilter['index.collection.foo.' + existsfoo]).be.an.Object();
         should.exist(formattedFilter['index.collection.foo.' + existsfoo].rooms);
         should(formattedFilter['index.collection.foo.' + existsfoo].rooms).be.an.Array().and.match(['roomId']);
         should(formattedFilter['index.collection.foo.' + existsfoo].rooms.length).eql(1);
-        should.exist(formattedFilter['index.collection.foo.' + existsfoo].fn);
-        done();
-      })
-      .catch(function (error) {
-        done(error);
+        should.exist(formattedFilter['index.collection.foo.' + existsfoo].args);
       });
   });
 
-  it('should be able to handle an array of filters', function (done) {
+  it('should be able to handle an array of filters', function () {
     var
       filters = [
         { exists: { field: 'foo' } },
         { exists: { field: 'bar' } }
       ];
 
-    getFormattedFilters('roomId', 'index', 'collection', filters)
+    return getFormattedFilters('roomId', 'index', 'collection', filters)
       .then(function (formattedFilter) {
         should.exist(formattedFilter['index.collection.foo.' + existsfoo]);
         should(formattedFilter['index.collection.foo.' + existsfoo]).be.an.Object();
         should.exist(formattedFilter['index.collection.foo.' + existsfoo].rooms);
         should(formattedFilter['index.collection.foo.' + existsfoo].rooms).be.an.Array().and.match(['roomId']);
         should(formattedFilter['index.collection.foo.' + existsfoo].rooms.length).eql(1);
-        should.exist(formattedFilter['index.collection.foo.' + existsfoo].fn);
+        should.exist(formattedFilter['index.collection.foo.' + existsfoo].args);
 
         should.exist(formattedFilter['index.collection.bar.' + existsbar]);
         should(formattedFilter['index.collection.bar.' + existsbar]).be.an.Object();
         should.exist(formattedFilter['index.collection.bar.' + existsbar].rooms);
         should(formattedFilter['index.collection.bar.' + existsbar].rooms).be.an.Array().and.match(['roomId']);
         should(formattedFilter['index.collection.bar.' + existsbar].rooms.length).eql(1);
-        should.exist(formattedFilter['index.collection.bar.' + existsbar].fn);
-
-        done();
-      })
-      .catch(function (error) {
-        done(error);
+        should.exist(formattedFilter['index.collection.bar.' + existsbar].args);
       });
   });
 
-  it('should ignore empty filters when an array of filters is provided', function (done) {
+  it('should ignore empty filters when an array of filters is provided', function () {
     var
       filters = [
         { exists: { field: 'foo' } },
@@ -89,30 +78,25 @@ describe('Test: dsl.getFormattedFilters method', function () {
         { exists: { field: 'bar' } }
       ];
 
-    getFormattedFilters('roomId', 'index', 'collection', filters)
+    return getFormattedFilters('roomId', 'index', 'collection', filters)
       .then(function (formattedFilter) {
         should.exist(formattedFilter['index.collection.foo.' + existsfoo]);
         should(formattedFilter['index.collection.foo.' + existsfoo]).be.an.Object();
         should.exist(formattedFilter['index.collection.foo.' + existsfoo].rooms);
         should(formattedFilter['index.collection.foo.' + existsfoo].rooms).be.an.Array().and.match(['roomId']);
         should(formattedFilter['index.collection.foo.' + existsfoo].rooms.length).eql(1);
-        should.exist(formattedFilter['index.collection.foo.' + existsfoo].fn);
+        should.exist(formattedFilter['index.collection.foo.' + existsfoo].args);
 
         should.exist(formattedFilter['index.collection.bar.' + existsbar]);
         should(formattedFilter['index.collection.bar.' + existsbar]).be.an.Object();
         should.exist(formattedFilter['index.collection.bar.' + existsbar].rooms);
         should(formattedFilter['index.collection.bar.' + existsbar].rooms).be.an.Array().and.match(['roomId']);
         should(formattedFilter['index.collection.bar.' + existsbar].rooms.length).eql(1);
-        should.exist(formattedFilter['index.collection.bar.' + existsbar].fn);
-
-        done();
-      })
-      .catch(function (error) {
-        done(error);
+        should.exist(formattedFilter['index.collection.bar.' + existsbar].args);
       });
   });
 
-  it('should invert the filter if the "not" argument is set to true', function (done) {
+  it('should invert the filter if the "not" argument is set to true', function () {
     var
       filter = {
         exists: {
@@ -120,18 +104,14 @@ describe('Test: dsl.getFormattedFilters method', function () {
         }
       };
 
-    getFormattedFilters('roomId', 'index', 'collection', filter, true)
+    return getFormattedFilters('roomId', 'index', 'collection', filter, true)
       .then(function (formattedFilter) {
         should.exist(formattedFilter['index.collection.foo.' + notexistsfoo]);
         should(formattedFilter['index.collection.foo.' + notexistsfoo]).be.an.Object();
         should.exist(formattedFilter['index.collection.foo.' + notexistsfoo].rooms);
         should(formattedFilter['index.collection.foo.' + notexistsfoo].rooms).be.an.Array().and.match(['roomId']);
         should(formattedFilter['index.collection.foo.' + notexistsfoo].rooms.length).eql(1);
-        should.exist(formattedFilter['index.collection.foo.' + notexistsfoo].fn);
-        done();
-      })
-      .catch(function (error) {
-        done(error);
+        should.exist(formattedFilter['index.collection.foo.' + notexistsfoo].args);
       });
   });
 

--- a/test/api/dsl/methods/ids.test.js
+++ b/test/api/dsl/methods/ids.test.js
@@ -6,31 +6,17 @@ var
   BadRequestError = require.main.require('kuzzle-common-objects').Errors.badRequestError,
   InternalError = require.main.require('kuzzle-common-objects').Errors.internalError;
 
-
-
 describe('Test ids method', function () {
-
   var
     roomIdMatch = 'roomIdMatch',
     roomIdNot = 'roomIdNotMatch',
     index = 'test',
     collection = 'collection',
-    documentGrace = {
-      _id: 'idGrace',
-      firstName: 'Grace',
-      lastName: 'Hopper'
-    },
-    documentAda = {
-      _id: 'idAda',
-      firstName: 'Ada',
-      lastName: 'Lovelace'
-    },
     filter = {
       values: ['idGrace']
     },
     idsIdidGrace = md5('ids_ididGrace'),
     notidsIdidGrace = md5('notids_ididGrace');
-
 
   before(function () {
     methods.dsl.filtersTree = {};
@@ -72,18 +58,19 @@ describe('Test ids method', function () {
 
   it('should construct the filterTree with correct functions ids', function () {
     /* jshint camelcase:false */
-    var
-      resultMatch = methods.dsl.filtersTree[index][collection].fields._id[idsIdidGrace].fn(documentGrace),
-      resultNotMatch = methods.dsl.filtersTree[index][collection].fields._id[idsIdidGrace].fn(documentAda);
+    should(methods.dsl.filtersTree[index][collection].fields._id[idsIdidGrace].args).match({
+      operator: 'terms',
+      not: false,
+      field: '_id',
+      value: [ 'idGrace' ]
+    });
 
-    should(resultMatch).be.exactly(true);
-    should(resultNotMatch).be.exactly(false);
-
-    resultMatch = methods.dsl.filtersTree[index][collection].fields._id[notidsIdidGrace].fn(documentAda);
-    resultNotMatch = methods.dsl.filtersTree[index][collection].fields._id[notidsIdidGrace].fn(documentGrace);
-
-    should(resultMatch).be.exactly(true);
-    should(resultNotMatch).be.exactly(false);
+    should(methods.dsl.filtersTree[index][collection].fields._id[notidsIdidGrace].args).match({
+      operator: 'terms',
+      not: true,
+      field: '_id',
+      value: [ 'idGrace' ]
+    });
   });
 
   it('should reject a promise if the filter is empty', function () {
@@ -102,9 +89,9 @@ describe('Test ids method', function () {
     return should(methods.ids(roomIdMatch, index, collection, {values: []})).be.rejectedWith(BadRequestError);
   });
 
-  it('should return a rejected promise if buildCurriedFunction fails', function () {
+  it('should return a rejected promise if addToFiltersTree fails', function () {
     return methods.__with__({
-      buildCurriedFunction: function () { return new InternalError('rejected'); }
+      addToFiltersTree: function () { return new InternalError('rejected'); }
     })(function () {
       return should(methods.ids(roomIdMatch, index, collection, filter, false)).be.rejectedWith('rejected');
     });

--- a/test/api/dsl/methods/missing.test.js
+++ b/test/api/dsl/methods/missing.test.js
@@ -6,10 +6,7 @@ var
   BadRequestError = require.main.require('kuzzle-common-objects').Errors.badRequestError,
   InternalError = require.main.require('kuzzle-common-objects').Errors.internalError;
 
-
-
 describe('Test missing method', function () {
-
   var
     roomId = 'roomId',
     index = 'index',
@@ -18,14 +15,10 @@ describe('Test missing method', function () {
       firstName: 'Grace',
       lastName: 'Hopper'
     },
-    documentAda = {
-      firstName: 'Ada'
-    },
     filter = {
       field: 'lastName'
     },
     missinglastName = md5('missinglastName');
-
 
   before(function () {
     methods.dsl.filtersTree = {};
@@ -55,12 +48,12 @@ describe('Test missing method', function () {
   });
 
   it('should construct the filterTree with correct functions missing', function () {
-    var result;
-
-    result = methods.dsl.filtersTree[index][collection].fields.lastName[missinglastName].fn(documentAda);
-    should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.lastName[missinglastName].fn(documentGrace);
-    should(result).be.exactly(false);
+    should(methods.dsl.filtersTree[index][collection].fields.lastName[missinglastName].args).match({
+      operator: 'missing',
+      not: false,
+      field: 'lastName',
+      value: 'lastName'
+    });
   });
 
   it('should return a rejected promise if the filter argument is empty', function () {
@@ -71,9 +64,9 @@ describe('Test missing method', function () {
     return should(methods.missing('foo', index, 'bar', { foo: 'bar' }, false)).be.rejectedWith(BadRequestError, { message: 'Filter \'missing\' must contains \'field\' attribute' });
   });
 
-  it('should return a rejected promise if buildCurriedFunction fails', function () {
+  it('should return a rejected promise if addToFiltersTree fails', function () {
     return methods.__with__({
-      buildCurriedFunction: function () { return new InternalError('rejected'); }
+      addToFiltersTree: function () { return new InternalError('rejected'); }
     })(function () {
       return should(methods.missing('foo', index, 'bar', { field: 'foo' }, false));
     });

--- a/test/api/dsl/methods/not.test.js
+++ b/test/api/dsl/methods/not.test.js
@@ -3,21 +3,11 @@ var
   md5 = require('crypto-md5'),
   methods = require.main.require('lib/api/dsl/methods');
 
-describe('Test not method', function () {
+describe('Test "not" method', function () {
   var
     roomId = 'roomId',
     index = 'index',
     collection = 'collection',
-    documentGrace = {
-      firstName: 'Grace',
-      lastName: 'Hopper',
-      city: 'NYC'
-    },
-    documentAda = {
-      firstName: 'Ada',
-      lastName: 'Lovelace',
-      city: 'London'
-    },
     filter = {
       term: {
         city: 'London'
@@ -53,12 +43,9 @@ describe('Test not method', function () {
   });
 
   it('should construct the filterTree with correct functions', function () {
-    var result;
-
-    result = methods.dsl.filtersTree[index][collection].fields.city[nottermcityLondon].fn(documentGrace);
-    should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.city[nottermcityLondon].fn(documentAda);
-    should(result).be.exactly(false);
+    should(methods.dsl.filtersTree[index][collection].fields.city[nottermcityLondon].args).match({
+      operator: 'term', not: true, field: 'city', value: 'London'
+    });
   });
 
   it('should pass an inverted "not" argument to the must function', function () {

--- a/test/api/dsl/methods/or.test.js
+++ b/test/api/dsl/methods/or.test.js
@@ -12,18 +12,6 @@ describe('Test or method', function () {
     roomId = 'roomId',
     index = 'index',
     collection = 'collection',
-    documentGrace = {
-      firstName: 'Grace',
-      lastName: 'Hopper',
-      city: 'NYC',
-      hobby: 'computer'
-    },
-    documentAda = {
-      firstName: 'Ada',
-      lastName: 'Lovelace',
-      city: 'London',
-      hobby: 'computer'
-    },
     filter = [
       {
         term: {
@@ -88,28 +76,25 @@ describe('Test or method', function () {
     should(rooms[0]).be.exactly(roomId);
   });
 
-  it('should construct the filterTree with correct functions', function () {
-    var result;
+  it('should construct the filterTree with correct arguments', function () {
+    should(methods.dsl.filtersTree[index][collection].fields.city[termcityNYC].args).match({
+      operator: 'term', not: undefined, field: 'city', value: 'NYC'
+    });
 
-    result = methods.dsl.filtersTree[index][collection].fields.city[termcityNYC].fn(documentGrace);
-    should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.city[termcityNYC].fn(documentAda);
-    should(result).be.exactly(false);
+    should(methods.dsl.filtersTree[index][collection].fields.city[termcityLondon].args).match({
+      operator: 'term',
+      not: undefined,
+      field: 'city',
+      value: 'London'
+    });
 
-    result = methods.dsl.filtersTree[index][collection].fields.city[termcityLondon].fn(documentGrace);
-    should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[index][collection].fields.city[termcityLondon].fn(documentAda);
-    should(result).be.exactly(true);
+    should(methods.dsl.filtersTree[index][collection].fields.city[nottermcityNYC].args).match({
+      operator: 'term', not: true, field: 'city', value: 'NYC'
+    });
 
-    result = methods.dsl.filtersTree[index][collection].fields.city[nottermcityNYC].fn(documentGrace);
-    should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[index][collection].fields.city[nottermcityNYC].fn(documentAda);
-    should(result).be.exactly(true);
-
-    result = methods.dsl.filtersTree[index][collection].fields.city[nottermcityLondon].fn(documentGrace);
-    should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.city[nottermcityLondon].fn(documentAda);
-    should(result).be.exactly(false);
+    should(methods.dsl.filtersTree[index][collection].fields.city[nottermcityLondon].args).match({
+      operator: 'term', not: true, field: 'city', value: 'London'
+    });
   });
 
   it('should return a rejected promise if getFormattedFilters fails', function () {

--- a/test/api/dsl/methods/range.test.js
+++ b/test/api/dsl/methods/range.test.js
@@ -6,29 +6,14 @@ var
   BadRequestError = require.main.require('kuzzle-common-objects').Errors.badRequestError,
   InternalError = require.main.require('kuzzle-common-objects').Errors.internalError;
 
-
-
 describe('Test range method', function () {
-
   var
     roomIdFilterGrace = 'roomIdGrace',
     roomIdFilterAda = 'roomIdAda',
     roomIdFilterAll = 'roomIdAll',
     roomIdFilterNobody = 'roomIdNobody',
-
     index = 'index',
     collection = 'collection',
-    documentGrace = {
-      firstName: 'Grace',
-      lastName: 'Hopper',
-      age: 85
-    },
-    documentAda = {
-      firstName: 'Ada',
-      lastName: 'Lovelace',
-      age: 36
-    },
-
     filterGrace = {
       age: {
         gt: 36,
@@ -77,7 +62,7 @@ describe('Test range method', function () {
     should(methods.dsl.filtersTree[index][collection].fields.age).not.be.empty();
   });
 
-  it('should construct the filterTree with correct curried function name', function () {
+  it('should construct the filterTree with correct encoded function name', function () {
     should(methods.dsl.filtersTree[index][collection].fields.age[rangeagegt36]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection].fields.age[rangeagelte85]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection].fields.age[rangeagegte36]).not.be.empty();
@@ -129,46 +114,38 @@ describe('Test range method', function () {
   });
 
   it('should construct the filterTree with correct functions range', function () {
-    var result;
+    should(methods.dsl.filtersTree[index][collection].fields.age[rangeagegt36].args).match({
+      operator: 'gt', not: undefined, field: 'age', value: 36
+    });
 
-    result = methods.dsl.filtersTree[index][collection].fields.age[rangeagegt36].fn(documentGrace);
-    should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.age[rangeagegt36].fn(documentAda);
-    should(result).be.exactly(false);
+    should(methods.dsl.filtersTree[index][collection].fields.age[rangeagelte85].args).match({
+      operator: 'lte', not: undefined, field: 'age', value: 85
+    });
 
-    result = methods.dsl.filtersTree[index][collection].fields.age[rangeagelte85].fn(documentGrace);
-    should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.age[rangeagelte85].fn(documentAda);
-    should(result).be.exactly(true);
+    should(methods.dsl.filtersTree[index][collection].fields.age[rangeagegte36].args).match({
+      operator: 'gte', not: undefined, field: 'age', value: 36
+    });
 
-    result = methods.dsl.filtersTree[index][collection].fields.age[rangeagegte36].fn(documentGrace);
-    should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.age[rangeagegte36].fn(documentAda);
-    should(result).be.exactly(true);
+    should(methods.dsl.filtersTree[index][collection].fields.age[rangeagelt85].args).match({
+      operator: 'lt', not: undefined, field: 'age', value: 85
+    });
 
-    result = methods.dsl.filtersTree[index][collection].fields.age[rangeagelt85].fn(documentGrace);
-    should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[index][collection].fields.age[rangeagelt85].fn(documentAda);
-    should(result).be.exactly(true);
+    should(methods.dsl.filtersTree[index][collection].fields.age[notrangeagegte36].args).match({
+      operator: 'gte', not: true, field: 'age', value: 36
+    });
 
-    result = methods.dsl.filtersTree[index][collection].fields.age[notrangeagegte36].fn(documentGrace);
-    should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[index][collection].fields.age[notrangeagegte36].fn(documentAda);
-    should(result).be.exactly(false);
-
-    result = methods.dsl.filtersTree[index][collection].fields.age[notrangeagelte85].fn(documentGrace);
-    should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[index][collection].fields.age[notrangeagelte85].fn(documentAda);
-    should(result).be.exactly(false);
+    should(methods.dsl.filtersTree[index][collection].fields.age[notrangeagelte85].args).match({
+      operator: 'lte', not: true, field: 'age', value: 85
+    });
   });
 
   it('should return a rejected promise if the filter is empty', function () {
     return should(methods.range(roomIdFilterGrace, index, collection, {})).be.rejectedWith(BadRequestError, { message: 'A filter can\'t be empty' });
   });
 
-  it('should return a rejected promise if buildCurriedFunction fails', function () {
+  it('should return a rejected promise if addToFiltersTree fails', function () {
     return methods.__with__({
-      buildCurriedFunction: function () { return new InternalError('rejected'); }
+      addToFiltersTree: function () { return new InternalError('rejected'); }
     })(function () {
       return should(methods.range(roomIdFilterGrace, index, collection, filterGrace)).be.rejectedWith('rejected');
     });

--- a/test/api/dsl/methods/term.test.js
+++ b/test/api/dsl/methods/term.test.js
@@ -4,20 +4,11 @@ var
   methods = require.main.require('lib/api/dsl/methods');
 
 describe('Test term method', function () {
-
   var
     roomIdMatch = 'roomIdMatch',
     roomIdNot = 'roomIdNotMatch',
     index = 'index',
     collection = 'collection',
-    documentGrace = {
-      firstName: 'Grace',
-      lastName: 'Hopper'
-    },
-    documentAda = {
-      firstName: 'Ada',
-      lastName: 'Lovelace'
-    },
     filter = {
       firstName: 'Grace'
     },
@@ -41,9 +32,20 @@ describe('Test term method', function () {
     should(methods.dsl.filtersTree[index][collection].fields.firstName).not.be.empty();
   });
 
-  it('should construct the filterTree with correct curried function name', function () {
-    should(methods.dsl.filtersTree[index][collection].fields.firstName[termfirstNameGrace]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.firstName[nottermfirstNameGrace]).not.be.empty();
+  it('should construct the filterTree with correct arguments', function () {
+    should(methods.dsl.filtersTree[index][collection].fields.firstName[termfirstNameGrace].args).match({
+      operator: 'term',
+      not: undefined,
+      field: 'firstName',
+      value: 'Grace'
+    });
+
+    should(methods.dsl.filtersTree[index][collection].fields.firstName[nottermfirstNameGrace].args).match({
+      operator: 'term',
+      not: true,
+      field: 'firstName',
+      value: 'Grace'
+    });
   });
 
   it('should construct the filterTree with correct room list', function () {
@@ -60,20 +62,4 @@ describe('Test term method', function () {
     should(rooms[0]).be.exactly(roomIdMatch);
     should(roomsNot[0]).be.exactly(roomIdNot);
   });
-
-  it('should construct the filterTree with correct functions term', function () {
-    var
-      resultMatch = methods.dsl.filtersTree[index][collection].fields.firstName[termfirstNameGrace].fn(documentGrace),
-      resultNotMatch = methods.dsl.filtersTree[index][collection].fields.firstName[termfirstNameGrace].fn(documentAda);
-
-    should(resultMatch).be.exactly(true);
-    should(resultNotMatch).be.exactly(false);
-
-    resultMatch = methods.dsl.filtersTree[index][collection].fields.firstName[nottermfirstNameGrace].fn(documentAda);
-    resultNotMatch = methods.dsl.filtersTree[index][collection].fields.firstName[nottermfirstNameGrace].fn(documentGrace);
-
-    should(resultMatch).be.exactly(true);
-    should(resultNotMatch).be.exactly(false);
-  });
-
 });

--- a/test/api/dsl/methods/termFunction.test.js
+++ b/test/api/dsl/methods/termFunction.test.js
@@ -6,8 +6,6 @@ var
   BadRequestError = require.main.require('kuzzle-common-objects').Errors.badRequestError,
   InternalError = require.main.require('kuzzle-common-objects').Errors.internalError;
 
-
-
 describe('Test: dsl.termFunction method', function () {
   var
     termFunction = methods.__get__('termFunction'),
@@ -33,86 +31,84 @@ describe('Test: dsl.termFunction method', function () {
     return should(termFunction('terms', 'roomId', 'index', 'collection', filter)).be.rejectedWith(BadRequestError, { message: 'Filter terms must contains an array' });
   });
 
-  it('should create a valid "term" filter', function (done) {
+  it('should create a valid "term" filter', function () {
     var
       filter = {
         foo: 'bar'
       };
 
-    termFunction('term', 'roomId', 'index', 'collection', filter)
+    return termFunction('term', 'roomId', 'index', 'collection', filter)
       .then(function (formattedFilter) {
         should.exist(formattedFilter['index.collection.foo.' + termfoobar]);
         should(formattedFilter['index.collection.foo.' + termfoobar].rooms).be.an.Array().and.match(['roomId']);
-        should(formattedFilter['index.collection.foo.' + termfoobar].fn).be.a.Function();
-        done();
-      })
-      .catch(function (error) {
-        done(error);
+        should(formattedFilter['index.collection.foo.' + termfoobar].args).match({
+          operator: 'term', not: undefined, field: 'foo', value: 'bar'
+        });
       });
   });
 
-  it('should create a valid "terms" filter', function (done) {
+  it('should create a valid "terms" filter', function () {
     var
       filter = {
         foo: ['bar', 'baz']
       };
 
-    termFunction('terms', 'roomId', 'index', 'collection', filter)
+    return termFunction('terms', 'roomId', 'index', 'collection', filter)
       .then(function (formattedFilter) {
         should.exist(formattedFilter['index.collection.foo.' + termsfoobarbaz]);
         should(formattedFilter['index.collection.foo.' + termsfoobarbaz].rooms).be.an.Array().and.match(['roomId']);
-        should(formattedFilter['index.collection.foo.' + termsfoobarbaz].fn).be.a.Function();
-        done();
-      })
-      .catch(function (error) {
-        done(error);
+        should(formattedFilter['index.collection.foo.' + termsfoobarbaz].args).match({
+          operator: 'terms',
+          not: undefined,
+          field: 'foo',
+          value: [ 'bar', 'baz' ]
+        });
       });
   });
 
-  it('should create a valid "not-term" filter', function (done) {
+  it('should create a valid "not-term" filter', function () {
     var
       filter = {
         foo: 'bar'
       };
 
-    termFunction('term', 'roomId', 'index', 'collection', filter, true)
+    return termFunction('term', 'roomId', 'index', 'collection', filter, true)
       .then(function (formattedFilter) {
         should.exist(formattedFilter['index.collection.foo.' + nottermfoobar]);
         should(formattedFilter['index.collection.foo.' + nottermfoobar].rooms).be.an.Array().and.match(['roomId']);
-        should(formattedFilter['index.collection.foo.' + nottermfoobar].fn).be.a.Function();
-        done();
-      })
-      .catch(function (error) {
-        done(error);
+        should(formattedFilter['index.collection.foo.' + nottermfoobar].args).match({
+          operator: 'term', not: true, field: 'foo', value: 'bar'
+        });
       });
   });
 
-  it('should create a valid "not-terms" filter', function (done) {
+  it('should create a valid "not-terms" filter', function () {
     var
       filter = {
         foo: ['bar', 'baz']
       };
 
-    termFunction('terms', 'roomId', 'index', 'collection', filter, true)
+    return termFunction('terms', 'roomId', 'index', 'collection', filter, true)
       .then(function (formattedFilter) {
         should.exist(formattedFilter['index.collection.foo.' + nottermsfoobarbaz]);
         should(formattedFilter['index.collection.foo.' + nottermsfoobarbaz].rooms).be.an.Array().and.match(['roomId']);
-        should(formattedFilter['index.collection.foo.' + nottermsfoobarbaz].fn).be.a.Function();
-        done();
-      })
-      .catch(function (error) {
-        done(error);
+        should(formattedFilter['index.collection.foo.' + nottermsfoobarbaz].args).match({
+          operator: 'terms',
+          not: true,
+          field: 'foo',
+          value: [ 'bar', 'baz' ]
+        });
       });
   });
 
-  it('should return a rejected promise if buildCurriedFunction fails', function () {
+  it('should return a rejected promise if addToFiltersTree fails', function () {
     var
       filter = {
         foo: ['bar', 'baz']
       };
 
     return methods.__with__({
-      buildCurriedFunction: function () { return new InternalError('rejected'); }
+      addToFiltersTree: function () { return new InternalError('rejected'); }
     })(function () {
       return should(termFunction('terms', 'roomId', 'index', 'collection', filter)).be.rejectedWith('rejected');
     });

--- a/test/api/dsl/methods/terms.test.js
+++ b/test/api/dsl/methods/terms.test.js
@@ -3,21 +3,12 @@ var
   md5 = require('crypto-md5'),
   methods = require.main.require('lib/api/dsl/methods');
 
-describe('Test terms method', function () {
-
+describe('Test "terms" method', function () {
   var
     roomIdMatch = 'roomIdMatch',
     roomIdNot = 'roomIdNotMatch',
     index = 'index',
     collection = 'collection',
-    documentGrace = {
-      firstName: 'Grace',
-      lastName: 'Hopper'
-    },
-    documentAda = {
-      firstName: 'Ada',
-      lastName: 'Lovelace'
-    },
     filter = {
       firstName: ['Grace', 'Jean']
     },
@@ -61,18 +52,19 @@ describe('Test terms method', function () {
   });
 
   it('should construct the filterTree with correct functions terms', function () {
-    var
-      resultMatch = methods.dsl.filtersTree[index][collection].fields.firstName[termsfirstNameGraceJean].fn(documentGrace),
-      resultNotMatch = methods.dsl.filtersTree[index][collection].fields.firstName[termsfirstNameGraceJean].fn(documentAda);
+    should(methods.dsl.filtersTree[index][collection].fields.firstName[termsfirstNameGraceJean].args).match({
+      operator: 'terms',
+      not: false,
+      field: 'firstName',
+      value: [ 'Grace', 'Jean' ]
+    });
 
-    should(resultMatch).be.exactly(true);
-    should(resultNotMatch).be.exactly(false);
-
-    resultMatch = methods.dsl.filtersTree[index][collection].fields.firstName[nottermsfirstNameGraceJean].fn(documentAda);
-    resultNotMatch = methods.dsl.filtersTree[index][collection].fields.firstName[nottermsfirstNameGraceJean].fn(documentGrace);
-
-    should(resultMatch).be.exactly(true);
-    should(resultNotMatch).be.exactly(false);
+    should(methods.dsl.filtersTree[index][collection].fields.firstName[nottermsfirstNameGraceJean].args).match({
+      operator: 'terms',
+      not: true,
+      field: 'firstName',
+      value: [ 'Grace', 'Jean' ]
+    });
   });
 
 });

--- a/test/api/dsl/operators/geoDistance.test.js
+++ b/test/api/dsl/operators/geoDistance.test.js
@@ -1,0 +1,57 @@
+var
+  should = require('should'),
+  operators = require.main.require('lib/api/dsl/operators');
+
+describe('Test "geoDistance" operator', function () {
+  var
+    field = 'location',
+    document = {
+      name: 'Zero',
+      'location.lat': 0,
+      'location.lon': 0
+    },
+    valueExact = {
+      lat: 0,
+      lon: 1,
+      distance: 111318
+    },
+    valueOK = {
+      lat: 0,
+      lon: 1,
+      distance: 111320
+    },
+    valueTooFar = {
+      lat: 0,
+      lon: 1,
+      distance: 111317
+    };
+
+  it('should test geodistance correctly', function () {
+    // exact distance
+    should(operators.geoDistance(field, valueExact, document)).be.true();
+
+    // ok
+    should(operators.geoDistance(field, valueOK, document)).be.true();
+
+    // too far
+    should(operators.geoDistance(field, valueTooFar, document)).be.false();
+  });
+
+  it('should ignore documents without latitude coordinate', function () {
+    var doc = {
+      name: 'Zero',
+      'location.lon': 0
+    };
+
+    should(operators.geoDistance(field, valueOK, doc)).be.false();
+  });
+
+  it('should ignore documents without longitude coordinate', function () {
+    var doc = {
+      name: 'Zero',
+      'location.lat': 0
+    };
+
+    should(operators.geoDistance(field, valueOK, doc)).be.false();
+  });
+});

--- a/test/api/dsl/operators/geoDistanceRange.test.js
+++ b/test/api/dsl/operators/geoDistanceRange.test.js
@@ -1,0 +1,58 @@
+var
+  should = require('should'),
+  operators = require.main.require('lib/api/dsl/operators');
+
+describe('Test "geoDistanceRange" operator', function () {
+  var
+    field = 'location',
+    valueOK = {
+      lat: 0,
+      lon: 1,
+      from: 111320,
+      to: 111317
+    },
+    valueNOK = {
+      lat: 0,
+      lon: 1,
+      from: 1,
+      to: 10
+    },
+    valueEqual = {
+      lat: 0,
+      lon: 1,
+      from: 111318,
+      to: 111318
+    },
+    document = {
+      name: 'Zero',
+      'location.lat': 0,
+      'location.lon': 0
+    };
+
+
+  it('should return false if no lat or lon members exists for the location member of the document', function () {
+    should(operators.geoDistanceRange(field, valueOK, {
+      name: 'Bad',
+      'location.lol': 0,
+      'location.cat': 0
+    })).be.false();
+
+    should(operators.geoDistanceRange(field, valueOK, {
+      name: 'Bad',
+      'location.lol': 0,
+      'location.lat': 0
+    })).be.false();
+
+    should(operators.geoDistanceRange(field, valueOK, {
+      name: 'Bad',
+      'location.lon': 0,
+      'location.cat': 0
+    })).be.false();
+  });
+
+  it('should test distance ranges correctly', function () {
+    should(operators.geoDistanceRange(field, valueOK, document)).be.true();
+    should(operators.geoDistanceRange(field, valueNOK, document)).be.false();
+    should(operators.geoDistanceRange(field, valueEqual, document)).be.true();
+  });
+});

--- a/test/api/dsl/operators/geoPolygon.test.js
+++ b/test/api/dsl/operators/geoPolygon.test.js
@@ -1,0 +1,48 @@
+var
+  should = require('should'),
+  operators = require.main.require('lib/api/dsl/operators');
+
+describe('Test "geoPolygon" operator', function () {
+  var
+    field = 'location',
+    valueInside = [
+      { lat: -1, lon: 1 },
+      { lat: 1, lon: 1 },
+      { lat: 1, lon: -1 },
+      { lat: -1, lon: -1 } ],
+    valueOutside = [
+      { lat: 10, lon: 11 },
+      { lat: 11, lon: 11 },
+      { lat: 11, lon: 10 },
+      { lat: 10, lon: 10 }
+    ],
+    valueExact = [
+      { lat: 0, lon: 1 },
+      { lat: 1, lon: 1 },
+      { lat: 1, lon: 0 },
+      { lat: 0, lon: 0 }
+    ],
+    document = {
+      name: 'Zero',
+      'location.lat': 0, // we can't test with nested document here
+      'location.lon': 0
+    };
+
+  it('should ignore documents without latitude or longitude', () => {
+    should(operators.geoPolygon(field, valueInside, {
+      name: 'No',
+      'location.lat': 0
+    })).be.false();
+
+    should(operators.geoPolygon(field, valueInside, {
+      name: 'Just... No',
+      'location.lon': 0
+    })).be.false();
+  });
+
+  it('should test polygons correctly', () => {
+    should(operators.geoPolygon(field, valueInside, document)).be.true();
+    should(operators.geoPolygon(field, valueExact, document)).be.true();
+    should(operators.geoPolygon(field, valueOutside, document)).be.false();
+  });
+});


### PR DESCRIPTION
Following up #285, where DSL functions currified with lodash have been replaced with "eval" to allow sharing across Kuzzle instances, it has been decided with @benoitvidis that this solution could still be upgraded.

The proposed solution is to simply store operators arguments instead of currified functions.
These arguments can easily be shared between instances, and instead of calling the currified function, the correct operator will be invoked with the stored arguments instead.

The memory imprint might be a bit larger than with the "eval" solution (to be proved), but performances should be better with the removal of "eval" and of 2 x "JSON.stringify" calls.

# CHANGELOG

* removed all occurences of the word "currified" in the code
* replaced operator function evaluation with operator arguments storage in the DSL
* adapted unit tests
* split some geolocation unit tests between `dsl/methods` and `dsl/operators` tests, as these test files were testing both parts of the code
* replaced some uses of `q.defer()` with `q()` or `q.reject()`