### PR TITLE
Fix: use getPathPlugin instead of require.resolve

### DIFF
--- a/bin/commands/plugins.js
+++ b/bin/commands/plugins.js
@@ -590,22 +590,14 @@ function removePlugin(plugin, db, cfg) {
     .then(result => {
       // Plugins imported using --path should not be deleted
       installedLocally = (result._source.npmVersion || result._source.gitUrl);
-
       return db.delete(cfg.pluginsManager.dataCollection, plugin);
     })
     .then(() => {
-      var
-        moduleDirectory;
-
       console.log('███ kuzzle-plugins: Plugin configuration deleted');
 
       if (installedLocally) {
         try {
-          moduleDirectory = require.resolve(plugin);
-
-          // instead of the module entry file, we need its installation directory
-          moduleDirectory = moduleDirectory.substr(0, moduleDirectory.indexOf(plugin)) + '/' + plugin;
-          return q.denodeify(rimraf)(moduleDirectory);
+          return q.denodeify(rimraf)(getPathPlugin({}, plugin));
         }
         catch (err) {
           return q.reject(new Error('Unable to remove the plugin module: ' + err));


### PR DESCRIPTION
Invoking `kuzzle plugins --remove <plugin name>` will make the CLI use `require.resolve` to get the directory path of the plugin, in order to delete it.
As seen with @dbengsch, using `require.resolve` is a bad idea as the entry file of the plugin is not necessarily located in its root directory.

This PR replaces `require.resolve` with the already existing `getPathPlugin` function.