### PR TITLE
fix #302: unable to remove filters with nested attributes

### DIFF
--- a/features/AMQP.feature
+++ b/features/AMQP.feature
@@ -23,7 +23,7 @@ Feature: Test AMQP API
 
   @usingAMQP @unsubscribe
   Scenario: Create or Update a document
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.city" having value "NYC"
     When I write the document "documentGrace"
     And I createOrReplace it
     Then I should have updated the document
@@ -80,11 +80,11 @@ Feature: Test AMQP API
     When I write the document "documentAda"
     Then I count 4 documents
     And I count 0 documents in index "kuzzle-test-index-alt"
-    And I count 2 documents with "NYC" in field "city"
+    And I count 2 documents with "NYC" in field "info.city"
     Then I truncate the collection
     And I count 0 documents
 
-  @removeSchema @usingAMQP
+  @usingAMQP
   Scenario: Change mapping
     When I write the document "documentGrace"
     Then I don't find a document with "Grace" in field "firstName"
@@ -95,7 +95,15 @@ Feature: Test AMQP API
 
   @usingAMQP @unsubscribe
   Scenario: Document creation notifications
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.city" having value "NYC"
+    When I write the document "documentGrace"
+    Then I should receive a "create" notification
+    And The notification should have a "_source" member
+    And The notification should have metadata
+
+  @usingAMQP @unsubscribe
+  Scenario: Document creation notifications with not exists
+    Given A room subscription listening field "toto" doesn't exists
     When I write the document "documentGrace"
     Then I should receive a "create" notification
     And The notification should have a "_source" member
@@ -103,7 +111,7 @@ Feature: Test AMQP API
 
   @usingAMQP @unsubscribe
   Scenario: Document delete notifications
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.city" having value "NYC"
     When I write the document "documentGrace"
     Then I remove the document
     Then I should receive a "delete" notification
@@ -112,7 +120,7 @@ Feature: Test AMQP API
 
   @usingAMQP @unsubscribe
   Scenario: Document update: new document notification
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.hobby" having value "computer"
     When I write the document "documentAda"
     Then I update the document with value "Hopper" in field "lastName"
     Then I should receive a "update" notification
@@ -130,7 +138,7 @@ Feature: Test AMQP API
 
   @usingAMQP @unsubscribe
   Scenario: Document replace: new document notification
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.hobby" having value "computer"
     When I write the document "documentAda"
     Then I replace the document with "documentGrace" document
     Then I should receive a "update" notification
@@ -139,19 +147,11 @@ Feature: Test AMQP API
 
   @usingAMQP @unsubscribe
   Scenario: Document replace: removed document notification
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.city" having value "NYC"
     When I write the document "documentGrace"
     Then I replace the document with "documentAda" document
     Then I should receive a "update" notification
     And The notification should not have a "_source" member
-    And The notification should have metadata
-
-  @usingAMQP @unsubscribe
-  Scenario: Document creation notifications with not exists
-    Given A room subscription listening field "toto" doesn't exists
-    When I write the document "documentGrace"
-    Then I should receive a "create" notification
-    And The notification should have a "_source" member
     And The notification should have metadata
 
   @usingAMQP @unsubscribe
@@ -164,11 +164,11 @@ Feature: Test AMQP API
 
   @usingAMQP @unsubscribe
   Scenario: Delete a document with a query
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.city" having value "NYC"
     When I write the document "documentGrace"
     And I write the document "documentAda"
     And I refresh the index
-    Then I remove documents with field "hobby" equals to value "computer"
+    Then I remove documents with field "info.hobby" equals to value "computer"
     Then I should receive a "delete" notification
     And The notification should not have a "_source" member
     And The notification should have metadata
@@ -246,8 +246,8 @@ Feature: Test AMQP API
 
   @usingAMQP @cleanSecurity
   Scenario: login user
-    Given I create a user "useradmin" with id "user1-id"
-    When I log in as user1-id:testpwd expiring in 1h
+    Given I create a user "useradmin" with id "useradmin-id"
+    When I log in as useradmin-id:testpwd expiring in 1h
     Then I write the document
     Then I check the JWT Token
     And The token is valid
@@ -1387,3 +1387,4 @@ Feature: Test AMQP API
     And I write the document "documentGrace"
     When I update the document with value "Josepha" in field "firstName"
     Then I find a document with "josepha" in field "firstName"
+

--- a/features/MQTT.feature
+++ b/features/MQTT.feature
@@ -23,7 +23,7 @@ Feature: Test MQTT API
 
   @usingMQTT @unsubscribe
   Scenario: Create or Update a document
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.city" having value "NYC"
     When I write the document "documentGrace"
     And I createOrReplace it
     Then I should have updated the document
@@ -80,11 +80,11 @@ Feature: Test MQTT API
     When I write the document "documentAda"
     Then I count 4 documents
     And I count 0 documents in index "kuzzle-test-index-alt"
-    And I count 2 documents with "NYC" in field "city"
+    And I count 2 documents with "NYC" in field "info.city"
     Then I truncate the collection
     And I count 0 documents
 
-  @removeSchema @usingMQTT
+  @usingMQTT
   Scenario: Change mapping
     When I write the document "documentGrace"
     Then I don't find a document with "Grace" in field "firstName"
@@ -95,7 +95,15 @@ Feature: Test MQTT API
 
   @usingMQTT @unsubscribe
   Scenario: Document creation notifications
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.city" having value "NYC"
+    When I write the document "documentGrace"
+    Then I should receive a "create" notification
+    And The notification should have a "_source" member
+    And The notification should have metadata
+
+  @usingMQTT @unsubscribe
+  Scenario: Document creation notifications with not exists
+    Given A room subscription listening field "toto" doesn't exists
     When I write the document "documentGrace"
     Then I should receive a "create" notification
     And The notification should have a "_source" member
@@ -103,7 +111,7 @@ Feature: Test MQTT API
 
   @usingMQTT @unsubscribe
   Scenario: Document delete notifications
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.city" having value "NYC"
     When I write the document "documentGrace"
     Then I remove the document
     Then I should receive a "delete" notification
@@ -112,7 +120,7 @@ Feature: Test MQTT API
 
   @usingMQTT @unsubscribe
   Scenario: Document update: new document notification
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.hobby" having value "computer"
     When I write the document "documentAda"
     Then I update the document with value "Hopper" in field "lastName"
     Then I should receive a "update" notification
@@ -130,7 +138,7 @@ Feature: Test MQTT API
 
   @usingMQTT @unsubscribe
   Scenario: Document replace: new document notification
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.hobby" having value "computer"
     When I write the document "documentAda"
     Then I replace the document with "documentGrace" document
     Then I should receive a "update" notification
@@ -139,19 +147,11 @@ Feature: Test MQTT API
 
   @usingMQTT @unsubscribe
   Scenario: Document replace: removed document notification
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.city" having value "NYC"
     When I write the document "documentGrace"
     Then I replace the document with "documentAda" document
     Then I should receive a "update" notification
     And The notification should not have a "_source" member
-    And The notification should have metadata
-
-  @usingMQTT @unsubscribe
-  Scenario: Document creation notifications with not exists
-    Given A room subscription listening field "toto" doesn't exists
-    When I write the document "documentGrace"
-    Then I should receive a "create" notification
-    And The notification should have a "_source" member
     And The notification should have metadata
 
   @usingMQTT @unsubscribe
@@ -164,11 +164,11 @@ Feature: Test MQTT API
 
   @usingMQTT @unsubscribe
   Scenario: Delete a document with a query
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.city" having value "NYC"
     When I write the document "documentGrace"
     And I write the document "documentAda"
     And I refresh the index
-    Then I remove documents with field "hobby" equals to value "computer"
+    Then I remove documents with field "info.hobby" equals to value "computer"
     Then I should receive a "delete" notification
     And The notification should not have a "_source" member
     And The notification should have metadata
@@ -1387,3 +1387,4 @@ Feature: Test MQTT API
     And I write the document "documentGrace"
     When I update the document with value "Josepha" in field "firstName"
     Then I find a document with "josepha" in field "firstName"
+

--- a/features/REST.feature
+++ b/features/REST.feature
@@ -78,7 +78,7 @@ Feature: Test REST API
     When I write the document "documentAda"
     Then I count 4 documents
     And I count 0 documents in index "kuzzle-test-index-alt"
-    And I count 2 documents with "NYC" in field "city"
+    And I count 2 documents with "NYC" in field "info.city"
     Then I truncate the collection
     And I count 0 documents
 

--- a/features/STOMP.feature
+++ b/features/STOMP.feature
@@ -21,20 +21,20 @@ Feature: Test STOMP API
     Then I'm able to get the document
     And I'm not able to get the document in index "kuzzle-test-index-alt"
 
-  @usingSTOMP
-  Scenario: Replace a document
-    When I write the document "documentGrace"
-    Then I replace the document with "documentAda" document
-    Then my document has the value "Ada" in field "firstName"
-
   @usingSTOMP @unsubscribe
   Scenario: Create or Update a document
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.city" having value "NYC"
     When I write the document "documentGrace"
     And I createOrReplace it
     Then I should have updated the document
     And I should receive a "update" notification
     And The notification should have metadata
+
+  @usingSTOMP
+  Scenario: Replace a document
+    When I write the document "documentGrace"
+    Then I replace the document with "documentAda" document
+    Then my document has the value "Ada" in field "firstName"
 
   @usingSTOMP
   Scenario: Update a document
@@ -80,11 +80,11 @@ Feature: Test STOMP API
     When I write the document "documentAda"
     Then I count 4 documents
     And I count 0 documents in index "kuzzle-test-index-alt"
-    And I count 2 documents with "NYC" in field "city"
+    And I count 2 documents with "NYC" in field "info.city"
     Then I truncate the collection
     And I count 0 documents
 
-  @removeSchema @usingSTOMP
+  @usingSTOMP
   Scenario: Change mapping
     When I write the document "documentGrace"
     Then I don't find a document with "Grace" in field "firstName"
@@ -95,7 +95,15 @@ Feature: Test STOMP API
 
   @usingSTOMP @unsubscribe
   Scenario: Document creation notifications
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.city" having value "NYC"
+    When I write the document "documentGrace"
+    Then I should receive a "create" notification
+    And The notification should have a "_source" member
+    And The notification should have metadata
+
+  @usingSTOMP @unsubscribe
+  Scenario: Document creation notifications with not exists
+    Given A room subscription listening field "toto" doesn't exists
     When I write the document "documentGrace"
     Then I should receive a "create" notification
     And The notification should have a "_source" member
@@ -103,7 +111,7 @@ Feature: Test STOMP API
 
   @usingSTOMP @unsubscribe
   Scenario: Document delete notifications
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.city" having value "NYC"
     When I write the document "documentGrace"
     Then I remove the document
     Then I should receive a "delete" notification
@@ -112,7 +120,7 @@ Feature: Test STOMP API
 
   @usingSTOMP @unsubscribe
   Scenario: Document update: new document notification
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.hobby" having value "computer"
     When I write the document "documentAda"
     Then I update the document with value "Hopper" in field "lastName"
     Then I should receive a "update" notification
@@ -130,7 +138,7 @@ Feature: Test STOMP API
 
   @usingSTOMP @unsubscribe
   Scenario: Document replace: new document notification
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.hobby" having value "computer"
     When I write the document "documentAda"
     Then I replace the document with "documentGrace" document
     Then I should receive a "update" notification
@@ -139,19 +147,11 @@ Feature: Test STOMP API
 
   @usingSTOMP @unsubscribe
   Scenario: Document replace: removed document notification
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.city" having value "NYC"
     When I write the document "documentGrace"
     Then I replace the document with "documentAda" document
     Then I should receive a "update" notification
     And The notification should not have a "_source" member
-    And The notification should have metadata
-
-  @usingSTOMP @unsubscribe
-  Scenario: Document creation notifications with not exists
-    Given A room subscription listening field "toto" doesn't exists
-    When I write the document "documentGrace"
-    Then I should receive a "create" notification
-    And The notification should have a "_source" member
     And The notification should have metadata
 
   @usingSTOMP @unsubscribe
@@ -164,11 +164,11 @@ Feature: Test STOMP API
 
   @usingSTOMP @unsubscribe
   Scenario: Delete a document with a query
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.city" having value "NYC"
     When I write the document "documentGrace"
     And I write the document "documentAda"
     And I refresh the index
-    Then I remove documents with field "hobby" equals to value "computer"
+    Then I remove documents with field "info.hobby" equals to value "computer"
     Then I should receive a "delete" notification
     And The notification should not have a "_source" member
     And The notification should have metadata
@@ -280,7 +280,7 @@ Feature: Test STOMP API
   Scenario: get profile without id triggers an error
     Then I cannot a profile without ID
 
-  @usingSTOMP
+  @usingSTOMP @cleanSecurity
   Scenario: creating a profile with an empty set of roles triggers an error
     Then I cannot create a profile with an empty set of roles
 
@@ -1370,7 +1370,6 @@ Feature: Test STOMP API
       """
     Then The ms result should match the json 11
 
-
   @usingSTOMP
   Scenario: autorefresh
     When I check the autoRefresh status
@@ -1388,3 +1387,4 @@ Feature: Test STOMP API
     And I write the document "documentGrace"
     When I update the document with value "Josepha" in field "firstName"
     Then I find a document with "josepha" in field "firstName"
+

--- a/features/Websocket.feature
+++ b/features/Websocket.feature
@@ -23,7 +23,7 @@ Feature: Test websocket API
 
   @usingWebsocket @unsubscribe
   Scenario: Create or Update a document
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.city" having value "NYC"
     When I write the document "documentGrace"
     And I createOrReplace it
     Then I should have updated the document
@@ -80,7 +80,7 @@ Feature: Test websocket API
     When I write the document "documentAda"
     Then I count 4 documents
     And I count 0 documents in index "kuzzle-test-index-alt"
-    And I count 2 documents with "NYC" in field "city"
+    And I count 2 documents with "NYC" in field "info.city"
     Then I truncate the collection
     And I count 0 documents
 
@@ -95,7 +95,7 @@ Feature: Test websocket API
 
   @usingWebsocket @unsubscribe
   Scenario: Document creation notifications
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.city" having value "NYC"
     When I write the document "documentGrace"
     Then I should receive a "create" notification
     And The notification should have a "_source" member
@@ -111,7 +111,7 @@ Feature: Test websocket API
 
   @usingWebsocket @unsubscribe
   Scenario: Document delete notifications
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.city" having value "NYC"
     When I write the document "documentGrace"
     Then I remove the document
     Then I should receive a "delete" notification
@@ -120,7 +120,7 @@ Feature: Test websocket API
 
   @usingWebsocket @unsubscribe
   Scenario: Document update: new document notification
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.hobby" having value "computer"
     When I write the document "documentAda"
     Then I update the document with value "Hopper" in field "lastName"
     Then I should receive a "update" notification
@@ -138,7 +138,7 @@ Feature: Test websocket API
 
   @usingWebsocket @unsubscribe
   Scenario: Document replace: new document notification
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.hobby" having value "computer"
     When I write the document "documentAda"
     Then I replace the document with "documentGrace" document
     Then I should receive a "update" notification
@@ -147,7 +147,7 @@ Feature: Test websocket API
 
   @usingWebsocket @unsubscribe
   Scenario: Document replace: removed document notification
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.city" having value "NYC"
     When I write the document "documentGrace"
     Then I replace the document with "documentAda" document
     Then I should receive a "update" notification
@@ -164,11 +164,11 @@ Feature: Test websocket API
 
   @usingWebsocket @unsubscribe
   Scenario: Delete a document with a query
-    Given A room subscription listening to "lastName" having value "Hopper"
+    Given A room subscription listening to "info.city" having value "NYC"
     When I write the document "documentGrace"
     And I write the document "documentAda"
     And I refresh the index
-    Then I remove documents with field "hobby" equals to value "computer"
+    Then I remove documents with field "info.hobby" equals to value "computer"
     Then I should receive a "delete" notification
     And The notification should not have a "_source" member
     And The notification should have metadata

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -19,24 +19,28 @@ module.exports = function () {
     this.documentGrace = {
       firstName: 'Grace',
       lastName: 'Hopper',
-      age: 85,
+      info: {
+        age: 85,
+        city: 'NYC',
+        hobby: 'computer'
+      },
       location: {
         lat: 32.692742,
         lon: -97.114127
-      },
-      city: 'NYC',
-      hobby: 'computer'
+      }
     };
     this.documentAda = {
       firstName: 'Ada',
       lastName: 'Lovelace',
-      age: 36,
+      info: {
+        age: 36,
+        city: 'London',
+        hobby: 'computer'
+      },
       location: {
         lat: 51.519291,
         lon: -0.149817
-      },
-      city: 'London',
-      hobby: 'computer'
+      }
     };
     this.bulk = [
       { index:  {_id: 1 } },

--- a/lib/api/dsl/filters.js
+++ b/lib/api/dsl/filters.js
@@ -29,8 +29,8 @@ module.exports = function Filters() {
    *      collection : { // -> collection name
    *        globalFilterIds: [] // -> global filters to test each time (for a a subscribe on a whole collection, or if 'not exists' filter (see issue #1 on github)
    *        fields: {
-   *          subject : { // -> attribute where a filter part exists
-   *            termSubjectKuzzle : { // -> encoded field+filter part name
+   *          encodedFieldName : { // -> attribute where a filter part exists, encoded with MD5
+   *            encodedFieldFilter : { // -> field+filter part name, encoded with MD5
    *              ids: [ 'f45de4d8ef4f3ze4ffzer85d4fgkzm41'], // -> ids of filters using this test
    *              args: {operator, not, field, value}
    *            }
@@ -67,7 +67,7 @@ module.exports = function Filters() {
    *
    * Into an encoded version:
    * {
-   *  subject: { 'termSubjectKuzzle' : { args: {operator, not, field, value}, ids: [] } },
+   *  subject: { 'encodedFieldFilter' : { args: {operator, not, field, value}, ids: [] } },
    * }
    *
    * @param {string} filterId
@@ -152,7 +152,8 @@ module.exports = function Filters() {
   this.add = function (index, collection, field, operator, value, encodedFunctionName, filterId, not, inGlobals) {
     var
       hashedFunctionName = md5(encodedFunctionName),
-      path = index + '.' + collection + '.' + field + '.' + hashedFunctionName;
+      hashedFieldName = md5(field),
+      path = index + '.' + collection + '.' + hashedFieldName + '.' + hashedFunctionName;
 
     if (operators[operator] === undefined) {
       return new BadRequestError(`Operator ${operator} doesn't exist`);
@@ -170,19 +171,19 @@ module.exports = function Filters() {
       this.filtersTree[index][collection].fields = {};
     }
 
-    if (!this.filtersTree[index][collection].fields[field]) {
-      this.filtersTree[index][collection].fields[field] = {};
+    if (!this.filtersTree[index][collection].fields[hashedFieldName]) {
+      this.filtersTree[index][collection].fields[hashedFieldName] = {};
     }
 
-    if (!this.filtersTree[index][collection].fields[field][hashedFunctionName]) {
-      this.filtersTree[index][collection].fields[field][hashedFunctionName] = {
+    if (!this.filtersTree[index][collection].fields[hashedFieldName][hashedFunctionName]) {
+      this.filtersTree[index][collection].fields[hashedFieldName][hashedFunctionName] = {
         ids: [],
         args: {operator, not, field, value}
       };
     }
 
-    if (this.filtersTree[index][collection].fields[field][hashedFunctionName].ids.indexOf(filterId) === -1) {
-      this.filtersTree[index][collection].fields[field][hashedFunctionName].ids.push(filterId);
+    if (this.filtersTree[index][collection].fields[hashedFieldName][hashedFunctionName].ids.indexOf(filterId) === -1) {
+      this.filtersTree[index][collection].fields[hashedFieldName][hashedFunctionName].ids.push(filterId);
     }
 
     if (inGlobals) {
@@ -197,7 +198,7 @@ module.exports = function Filters() {
 
     return {
       path: path,
-      filter: this.filtersTree[index][collection].fields[field][hashedFunctionName]
+      filter: this.filtersTree[index][collection].fields[hashedFieldName][hashedFunctionName]
     };
   };
 
@@ -241,17 +242,19 @@ module.exports = function Filters() {
 
     // Loop on all document attributes
     async.each(documentKeys, (field, callbackField) => {
-      var fieldFilters;
+      var
+        fieldFilters,
+        hashedFieldName = md5(field);
 
       if (!this.filtersTree[index] ||
         !this.filtersTree[index][collection] ||
         !this.filtersTree[index][collection].fields ||
-        !this.filtersTree[index][collection].fields[field]) {
+        !this.filtersTree[index][collection].fields[hashedFieldName]) {
         callbackField();
         return false;
       }
 
-      fieldFilters = this.filtersTree[index][collection].fields[field];
+      fieldFilters = this.filtersTree[index][collection].fields[hashedFieldName];
 
       // For each attribute, loop on all saved filters
       async.each(Object.keys(fieldFilters), (functionName, callbackFilter) => {
@@ -259,7 +262,7 @@ module.exports = function Filters() {
         // Clean function name of potential '.' characters
           cleanFunctionName = functionName.split('.').join(''),
           filter = fieldFilters[functionName],
-          cachePath = index + '.' + collection + '.' + field + '.' + cleanFunctionName;
+          cachePath = index + '.' + collection + '.' + hashedFieldName + '.' + cleanFunctionName;
 
         if (cachedResults[cachePath] === undefined) {
           cachedResults[cachePath] = evalFilterArguments(filter.args, flattenBody);

--- a/test/api/dsl/filters/add.test.js
+++ b/test/api/dsl/filters/add.test.js
@@ -1,12 +1,14 @@
 var
   should = require('should'),
   rewire = require('rewire'),
-  md5 = require('crypto-md5');
+  md5 = require('crypto-md5'),
   DslFilters = rewire('../../../../lib/api/dsl/filters');
 
 describe('Test: dsl.filters.add', function () {
   var
     filters,
+    field = 'some.field',
+    hashedField = md5(field),
     hashedFilter = md5('filter');
 
   beforeEach(function () {
@@ -22,30 +24,30 @@ describe('Test: dsl.filters.add', function () {
   });
 
   it('should initializes the filter tree using the provided arguments', function () {
-    var result = filters.add('index', 'collection', 'field', 'gte', 42, 'filter', 'filterId');
+    var result = filters.add('index', 'collection', field, 'gte', 42, 'filter', 'filterId');
 
     should.not.exist(result.error);
-    should(result.path).be.exactly('index.collection.field.' + md5('filter'));
+    should(result.path).be.exactly(`index.collection.${hashedField}.${hashedFilter}`);
     should.exist(result.filter);
     should(result.filter.ids).be.an.Array().and.match(['filterId']);
     should(result.filter.ids.length).be.eql(1);
     should(result.filter.args).be.an.Object().and.match({
       operator: 'gte',
       not: undefined,
-      field: 'field',
+      field,
       value: 42
     });
 
     should.exist(filters.filtersTree.index.collection);
     should.exist(filters.filtersTree.index.collection.fields);
-    should.exist(filters.filtersTree.index.collection.fields.field);
-    should.exist(filters.filtersTree.index.collection.fields.field[hashedFilter]);
-    should(filters.filtersTree.index.collection.fields.field[hashedFilter].ids).be.an.Array().and.match(['filterId']);
+    should.exist(filters.filtersTree.index.collection.fields[hashedField]);
+    should.exist(filters.filtersTree.index.collection.fields[hashedField][hashedFilter]);
+    should(filters.filtersTree.index.collection.fields[hashedField][hashedFilter].ids).be.an.Array().and.match(['filterId']);
     should(result.filter.ids.length).be.eql(1);
-    should(filters.filtersTree.index.collection.fields.field[hashedFilter].args).be.an.Object().and.match({
+    should(filters.filtersTree.index.collection.fields[hashedField][hashedFilter].args).be.an.Object().and.match({
       operator: 'gte',
       not: undefined,
-      field: 'field',
+      field,
       value: 42
     });
 
@@ -53,16 +55,16 @@ describe('Test: dsl.filters.add', function () {
   });
 
   it('should not add a room to the same filter if it is already assigned to it', function () {
-    filters.add('index', 'collection', 'field', 'gte', 42, 'filter', 'filterId');
-    filters.add('index', 'collection', 'field', 'gte', 42, 'filter', 'filterId');
+    filters.add('index', 'collection', field, 'gte', 42, 'filter', 'filterId');
+    filters.add('index', 'collection', field, 'gte', 42, 'filter', 'filterId');
 
-    should(filters.filtersTree.index.collection.fields.field[hashedFilter].ids).be.an.Array().and.match(['filterId']);
-    should(filters.filtersTree.index.collection.fields.field[hashedFilter].ids.length).be.eql(1);
+    should(filters.filtersTree.index.collection.fields[hashedField][hashedFilter].ids).be.an.Array().and.match(['filterId']);
+    should(filters.filtersTree.index.collection.fields[hashedField][hashedFilter].ids.length).be.eql(1);
   });
 
   it('should also add the room to the global rooms list if the filter is global', function () {
-    filters.add('index', 'collection', 'field', 'gte', 42, 'filter', 'filterId', false, true);
-    filters.add('index', 'collection', 'field', 'gte', 42, 'filter', 'filterId', false, true);
+    filters.add('index', 'collection', field, 'gte', 42, 'filter', 'filterId', false, true);
+    filters.add('index', 'collection', field, 'gte', 42, 'filter', 'filterId', false, true);
 
     should.exist(filters.filtersTree.index.collection.globalFilterIds);
     should(filters.filtersTree.index.collection.globalFilterIds).be.an.Array().and.match(['filterId']);

--- a/test/api/dsl/filters/testFieldFilters.test.js
+++ b/test/api/dsl/filters/testFieldFilters.test.js
@@ -2,6 +2,7 @@ var
   should = require('should'),
   q = require('q'),
   rewire = require('rewire'),
+  md5 = require('crypto-md5'),
   DslFilters = rewire('../../../../lib/api/dsl/filters'),
   Dsl = rewire('../../../../lib/api/dsl/index');
 
@@ -63,10 +64,8 @@ describe('Test: dsl.filters.testFieldFilters', function () {
       fields: {
         foobar: {
           testFoobar: {
-            rooms: [ 'foo', 'bar', 'baz' ],
-            fn: function () {
-              return false;
-            }
+            ids: [ 'foo', 'bar', 'baz' ],
+            args: {}
           }
         }
       }
@@ -79,21 +78,19 @@ describe('Test: dsl.filters.testFieldFilters', function () {
   it('should resolve to a list of filter IDs to notify if a document matches registered filters', function () {
     var
       result,
+      hashedFieldName = md5('foo.bar'),
       ids = [ 'foo', 'bar', 'baz' ];
 
     filters.filtersTree[index] = {};
-    filters.filtersTree[index][collection] = {
-      fields: {
-        'foo.bar': {
-          testFoobar: {
-            ids: ids,
-            args: {
-              operator: 'term',
-              not: false,
-              field: 'foo.bar',
-              value: 'bar'
-            }
-          }
+    filters.filtersTree[index][collection] = {fields: {}};
+    filters.filtersTree[index][collection].fields[hashedFieldName] = {
+      testFoobar: {
+        ids: ids,
+        args: {
+          operator: 'term',
+          not: false,
+          field: 'foo.bar',
+          value: 'bar'
         }
       }
     };
@@ -105,21 +102,19 @@ describe('Test: dsl.filters.testFieldFilters', function () {
   it('should return a rejected promise if findMatchingFilters fails', function () {
     var
       result,
+      hashedFieldName = md5('foo.bar'),
       ids = [ 'foo', 'bar', 'baz' ];
 
     filters.filtersTree[index] = {};
-    filters.filtersTree[index][collection] = {
-      fields: {
-        'foo.bar': {
-          testFoobar: {
-            ids: ids,
-            args: {
-              operator: 'term',
-              not: false,
-              field: 'foo.bar',
-              value: 'bar'
-            }
-          }
+    filters.filtersTree[index][collection] = {fields: {}};
+    filters.filtersTree[index][collection].fields[hashedFieldName] = {
+      testFoobar: {
+        ids: ids,
+        args: {
+          operator: 'term',
+          not: false,
+          field: 'foo.bar',
+          value: 'bar'
         }
       }
     };

--- a/test/api/dsl/methods/and.test.js
+++ b/test/api/dsl/methods/and.test.js
@@ -27,8 +27,9 @@ describe('Test "and" method', function () {
       }
     ],
     termCity = md5('termcityNYC'),
-    termHobby = md5('nottermhobbycomputer');
-
+    termHobby = md5('nottermhobbycomputer'),
+    fieldCity = md5('city'),
+    fieldHobby = md5('hobby');
 
   before(function () {
     methods = new Methods(new Filters());
@@ -40,38 +41,38 @@ describe('Test "and" method', function () {
     should(methods.filters.filtersTree[index]).not.be.empty();
     should(methods.filters.filtersTree[index][collection]).not.be.empty();
     should(methods.filters.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.city).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.hobby).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldCity]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldHobby]).not.be.empty();
   });
 
   it('should construct the filterTree with correct encoded function name', function () {
-    should(methods.filters.filtersTree[index][collection].fields.city[termCity]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.hobby[termHobby]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldCity][termCity]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldHobby][termHobby]).not.be.empty();
   });
 
   it('should construct the filterTree with the correct filter IDs list', function () {
     var ids;
 
-    ids = methods.filters.filtersTree[index][collection].fields.city[termCity].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldCity][termCity].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
 
-    ids = methods.filters.filtersTree[index][collection].fields.hobby[termHobby].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldHobby][termHobby].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
   });
 
   it('should construct the filterTree with correct operator arguments', function () {
-    should(methods.filters.filtersTree[index][collection].fields.city[termCity].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldCity][termCity].args).match({
       operator: 'term',
       not: undefined,
       field: 'city',
       value: 'NYC'
     });
 
-    should(methods.filters.filtersTree[index][collection].fields.hobby[termHobby].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldHobby][termHobby].args).match({
       operator: 'term',
       not: true,
       field: 'hobby',

--- a/test/api/dsl/methods/bool.test.js
+++ b/test/api/dsl/methods/bool.test.js
@@ -53,7 +53,12 @@ describe('Test bool method', function () {
     rangeagelt85 = md5('rangeagelt85'),
     nottermcityNYC = md5('nottermcityNYC'),
     termhobbycomputer = md5('termhobbycomputer'),
-    existslastName = md5('existslastName');
+    existslastName = md5('existslastName'),
+    fieldFirstName = md5('firstName'),
+    fieldAge = md5('age'),
+    fieldCity = md5('city'),
+    fieldHobby = md5('hobby'),
+    fieldLastName = md5('lastName');
 
   before(function () {
     /*
@@ -71,92 +76,92 @@ describe('Test bool method', function () {
     should(methods.filters.filtersTree[index]).not.be.empty();
     should(methods.filters.filtersTree[index][collection]).not.be.empty();
     should(methods.filters.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.firstName).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.age).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.city).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.hobby).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.lastName).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldFirstName]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldAge]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldCity]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldHobby]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldLastName]).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
-    should(methods.filters.filtersTree[index][collection].fields.firstName[md5('termsfirstNameGrace,Ada')]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.age[rangeagegte36]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.age[rangeagelt85]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.city[nottermcityNYC]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.hobby[termhobbycomputer]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.lastName[existslastName]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldFirstName][md5('termsfirstNameGrace,Ada')]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldAge][rangeagegte36]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldAge][rangeagelt85]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldCity][nottermcityNYC]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldHobby][termhobbycomputer]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldLastName][existslastName]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var ids;
 
-    ids = methods.filters.filtersTree[index][collection].fields.firstName[md5('termsfirstNameGrace,Ada')].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldFirstName][md5('termsfirstNameGrace,Ada')].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
 
-    ids = methods.filters.filtersTree[index][collection].fields.age[rangeagegte36].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldAge][rangeagegte36].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
-    ids = methods.filters.filtersTree[index][collection].fields.age[rangeagelt85].ids;
-    should(ids).be.an.Array();
-    should(ids).have.length(1);
-    should(ids[0]).be.exactly(filterId);
-
-    ids = methods.filters.filtersTree[index][collection].fields.city[nottermcityNYC].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldAge][rangeagelt85].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
 
-    ids = methods.filters.filtersTree[index][collection].fields.hobby[termhobbycomputer].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldCity][nottermcityNYC].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
 
-    ids = methods.filters.filtersTree[index][collection].fields.lastName[existslastName].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldHobby][termhobbycomputer].ids;
+    should(ids).be.an.Array();
+    should(ids).have.length(1);
+    should(ids[0]).be.exactly(filterId);
+
+    ids = methods.filters.filtersTree[index][collection].fields[fieldLastName][existslastName].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
   });
 
   it('should construct the filterTree with correct arguments', function () {
-    should(methods.filters.filtersTree[index][collection].fields.firstName[md5('termsfirstNameGrace,Ada')].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldFirstName][md5('termsfirstNameGrace,Ada')].args).match({
       operator: 'terms',
       not: undefined,
       field: 'firstName',
       value: ['Grace', 'Ada']
     });
 
-    should(methods.filters.filtersTree[index][collection].fields.age[rangeagegte36].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldAge][rangeagegte36].args).match({
       operator: 'gte',
       not: undefined,
       field: 'age',
       value: 36
     });
 
-    should(methods.filters.filtersTree[index][collection].fields.age[rangeagelt85].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldAge][rangeagelt85].args).match({
       operator: 'lt',
       not: undefined,
       field: 'age',
       value: 85
     });
 
-    should(methods.filters.filtersTree[index][collection].fields.city[nottermcityNYC].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldCity][nottermcityNYC].args).match({
       operator: 'term',
       not: true,
       field: 'city',
       value: 'NYC'
     });
 
-    should(methods.filters.filtersTree[index][collection].fields.hobby[termhobbycomputer].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldHobby][termhobbycomputer].args).match({
       operator: 'term',
       not: undefined,
       field: 'hobby',
       value: 'computer'
     });
 
-    should(methods.filters.filtersTree[index][collection].fields.lastName[existslastName].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldLastName][existslastName].args).match({
       operator: 'exists',
       not: undefined,
       field: 'lastName',

--- a/test/api/dsl/methods/exists.test.js
+++ b/test/api/dsl/methods/exists.test.js
@@ -16,7 +16,8 @@ describe('Test exists method', function () {
     filter = {
       field: 'lastName'
     },
-    existslastName = md5('existslastName');
+    existslastName = md5('existslastName'),
+    fieldLastName = md5('lastName');
 
   beforeEach(function () {
     methods = new Methods(new Filters());
@@ -28,25 +29,25 @@ describe('Test exists method', function () {
     should(methods.filters.filtersTree[index]).not.be.empty();
     should(methods.filters.filtersTree[index][collection]).not.be.empty();
     should(methods.filters.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.lastName).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldLastName]).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
-    should(methods.filters.filtersTree[index][collection].fields.lastName[existslastName]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldLastName][existslastName]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var ids;
 
     // Test gt from filterGrace
-    ids = methods.filters.filtersTree[index][collection].fields.lastName[existslastName].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldLastName][existslastName].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
   });
 
   it('should construct the filterTree with correct exists arguments', function () {
-    should(methods.filters.filtersTree[index][collection].fields.lastName[existslastName].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldLastName][existslastName].args).match({
       operator: 'exists',
       not: undefined,
       field: 'lastName',

--- a/test/api/dsl/methods/geoBoundingBox.test.js
+++ b/test/api/dsl/methods/geoBoundingBox.test.js
@@ -54,7 +54,8 @@ describe('Test geoboundingbox method', function () {
     },
     locationgeoBoundingBoxgcmfj457fu10ffy7m4 = md5('locationgeoBoundingBoxgcmfj457fu10ffy7m4'),
     locationgeoBoundingBoxj042p0j0phsc9wnc4v = md5('locationgeoBoundingBoxj042p0j0phsc9wnc4v'),
-    locationgeoBoundingBoxc0x5c7zzzds7jw7zzz = md5('locationgeoBoundingBoxc0x5c7zzzds7jw7zzz');
+    locationgeoBoundingBoxc0x5c7zzzds7jw7zzz = md5('locationgeoBoundingBoxc0x5c7zzzds7jw7zzz'),
+    fieldLocation = md5('location');
 
   beforeEach(() => {
     methods = new Methods(new Filters());
@@ -70,7 +71,7 @@ describe('Test geoboundingbox method', function () {
     should(methods.filters.filtersTree[index]).not.be.empty();
     should(methods.filters.filtersTree[index][collection]).not.be.empty();
     should(methods.filters.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.location).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation]).not.be.empty();
   });
 
   it('should construct the filterTree with correct encoded function name', function () {
@@ -78,26 +79,26 @@ describe('Test geoboundingbox method', function () {
     // because we have many times the same coord in filters,
     // we must have only three functions (one for filterEngland, and two for filterUSA)
 
-    should(Object.keys(methods.filters.filtersTree[index][collection].fields.location)).have.length(3);
-    should(methods.filters.filtersTree[index][collection].fields.location[locationgeoBoundingBoxgcmfj457fu10ffy7m4]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.location[locationgeoBoundingBoxj042p0j0phsc9wnc4v]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.location[locationgeoBoundingBoxc0x5c7zzzds7jw7zzz]).not.be.empty();
+    should(Object.keys(methods.filters.filtersTree[index][collection].fields[fieldLocation])).have.length(3);
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoBoundingBoxgcmfj457fu10ffy7m4]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoBoundingBoxj042p0j0phsc9wnc4v]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoBoundingBoxc0x5c7zzzds7jw7zzz]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var ids;
 
-    ids = methods.filters.filtersTree[index][collection].fields.location[locationgeoBoundingBoxgcmfj457fu10ffy7m4].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoBoundingBoxgcmfj457fu10ffy7m4].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
 
-    ids = methods.filters.filtersTree[index][collection].fields.location[locationgeoBoundingBoxj042p0j0phsc9wnc4v].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoBoundingBoxj042p0j0phsc9wnc4v].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
 
-    ids = methods.filters.filtersTree[index][collection].fields.location[locationgeoBoundingBoxc0x5c7zzzds7jw7zzz].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoBoundingBoxc0x5c7zzzds7jw7zzz].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
@@ -105,7 +106,7 @@ describe('Test geoboundingbox method', function () {
 
   it('should construct the filterTree with correct geoboundingbox arguments', function () {
     // test filterEngland
-    should(methods.filters.filtersTree[index][collection].fields.location[locationgeoBoundingBoxgcmfj457fu10ffy7m4].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoBoundingBoxgcmfj457fu10ffy7m4].args).match({
       operator: 'geoBoundingBox',
       not: undefined,
       field: 'location',
@@ -118,7 +119,7 @@ describe('Test geoboundingbox method', function () {
     });
 
     // test filterUSA
-    should(methods.filters.filtersTree[index][collection].fields.location[locationgeoBoundingBoxj042p0j0phsc9wnc4v].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoBoundingBoxj042p0j0phsc9wnc4v].args).match({
       operator: 'geoBoundingBox',
       not: undefined,
       field: 'location',
@@ -131,7 +132,7 @@ describe('Test geoboundingbox method', function () {
     });
 
     // test filterUSA2
-    should(methods.filters.filtersTree[index][collection].fields.location[locationgeoBoundingBoxc0x5c7zzzds7jw7zzz].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoBoundingBoxc0x5c7zzzds7jw7zzz].args).match({
       operator: 'geoBoundingBox',
       not: undefined,
       field: 'location',

--- a/test/api/dsl/methods/geoDistance.test.js
+++ b/test/api/dsl/methods/geoDistance.test.js
@@ -43,7 +43,8 @@ describe('Test geoDistance method', function () {
     },
     locationgeoDistancekpbxyzbpv111318 = md5('locationgeoDistancekpbxyzbpv111318'),
     locationgeoDistancekpbxyzbpv111320 = md5('locationgeoDistancekpbxyzbpv111320'),
-    locationgeoDistancekpbxyzbpv111317 = md5('locationgeoDistancekpbxyzbpv111317');
+    locationgeoDistancekpbxyzbpv111317 = md5('locationgeoDistancekpbxyzbpv111317'),
+    fieldLocation = md5('location');
 
   beforeEach(function () {
     methods = new Methods(new Filters());
@@ -58,7 +59,7 @@ describe('Test geoDistance method', function () {
     should(methods.filters.filtersTree[index]).not.be.empty();
     should(methods.filters.filtersTree[index][collection]).not.be.empty();
     should(methods.filters.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.location).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation]).not.be.empty();
   });
 
   it('should construct the filterTree with correct encoded function name', function () {
@@ -66,60 +67,60 @@ describe('Test geoDistance method', function () {
     // because we have many times the same coord in filters,
     // we must have only four functions
     
-    should(Object.keys(methods.filters.filtersTree[index][collection].fields.location)).have.length(4);
-    should(methods.filters.filtersTree[index][collection].fields.location[locationgeoDistancekpbxyzbpv111318]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.location[locationgeoDistancekpbxyzbpv111320]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.location[locationgeoDistancekpbxyzbpv111317]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.location[md5('locationgeoDistancekpbxyzbpv111318.9999168')]).not.be.empty();
+    should(Object.keys(methods.filters.filtersTree[index][collection].fields[fieldLocation])).have.length(4);
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoDistancekpbxyzbpv111318]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoDistancekpbxyzbpv111320]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoDistancekpbxyzbpv111317]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][md5('locationgeoDistancekpbxyzbpv111318.9999168')]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var ids;
 
-    ids = methods.filters.filtersTree[index][collection].fields.location[locationgeoDistancekpbxyzbpv111318].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoDistancekpbxyzbpv111318].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
 
-    ids = methods.filters.filtersTree[index][collection].fields.location[locationgeoDistancekpbxyzbpv111320].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoDistancekpbxyzbpv111320].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
 
-    ids = methods.filters.filtersTree[index][collection].fields.location[locationgeoDistancekpbxyzbpv111317].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoDistancekpbxyzbpv111317].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
 
-    ids = methods.filters.filtersTree[index][collection].fields.location[md5('locationgeoDistancekpbxyzbpv111318.9999168')].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldLocation][md5('locationgeoDistancekpbxyzbpv111318.9999168')].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
   });
 
   it('should construct the filterTree with correct geodistance arguments', function () {
-    should(methods.filters.filtersTree[index][collection].fields.location[locationgeoDistancekpbxyzbpv111318].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoDistancekpbxyzbpv111318].args).match({
       operator: 'geoDistance',
       not: undefined,
       field: 'location',
       value: { lat: 0, lon: 1, distance: 111318 }
     });
 
-    should(methods.filters.filtersTree[index][collection].fields.location[locationgeoDistancekpbxyzbpv111320].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoDistancekpbxyzbpv111320].args).match({
       operator: 'geoDistance',
       not: undefined,
       field: 'location',
       value: { lat: 0, lon: 1, distance: 111320 }
     });
 
-    should(methods.filters.filtersTree[index][collection].fields.location[locationgeoDistancekpbxyzbpv111317].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoDistancekpbxyzbpv111317].args).match({
       operator: 'geoDistance',
       not: undefined,
       field: 'location',
       value: { lat: 0, lon: 1, distance: 111317 }
     });
 
-    should(methods.filters.filtersTree[index][collection].fields.location[md5('locationgeoDistancekpbxyzbpv111318.9999168')].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][md5('locationgeoDistancekpbxyzbpv111318.9999168')].args).match({
       operator: 'geoDistance',
       not: undefined,
       field: 'location',

--- a/test/api/dsl/methods/geoDistanceRange.test.js
+++ b/test/api/dsl/methods/geoDistanceRange.test.js
@@ -47,7 +47,8 @@ describe('Test geoDistanceRange method', function () {
     },
     locationgeoDistanceRangekpbxyzbpv111320111317 = md5('locationgeoDistanceRangekpbxyzbpv111320111317'),
     locationgeoDistanceRangekpbxyzbpv110 = md5('locationgeoDistanceRangekpbxyzbpv110'),
-    locationgeoDistanceRangekpbxyzbpv111318111318 = md5('locationgeoDistanceRangekpbxyzbpv111318111318');
+    locationgeoDistanceRangekpbxyzbpv111318111318 = md5('locationgeoDistanceRangekpbxyzbpv111318111318'),
+    fieldLocation = md5('location');
 
   beforeEach(function () {
     methods = new Methods(new Filters());
@@ -62,14 +63,14 @@ describe('Test geoDistanceRange method', function () {
     should(methods.filters.filtersTree[index]).not.be.empty();
     should(methods.filters.filtersTree[index][collection]).not.be.empty();
     should(methods.filters.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.location).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation]).not.be.empty();
   });
   it('should ', function () {
     should(methods.filters.filtersTree).not.be.empty();
     should(methods.filters.filtersTree[index]).not.be.empty();
     should(methods.filters.filtersTree[index][collection]).not.be.empty();
     should(methods.filters.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.location).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation]).not.be.empty();
   });
 
   it('should construct the filterTree with correct encoded function name', function () {
@@ -77,60 +78,60 @@ describe('Test geoDistanceRange method', function () {
     // because we have many times the same coord in filters,
     // we must have only four functions
     
-    should(Object.keys(methods.filters.filtersTree[index][collection].fields.location)).have.length(4);
-    should(methods.filters.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv111320111317]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv110]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv111318111318]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.location[md5('locationgeoDistanceRangekpbxyzbpv111312.96111319.05600000001')]).not.be.empty();
+    should(Object.keys(methods.filters.filtersTree[index][collection].fields[fieldLocation])).have.length(4);
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoDistanceRangekpbxyzbpv111320111317]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoDistanceRangekpbxyzbpv110]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoDistanceRangekpbxyzbpv111318111318]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][md5('locationgeoDistanceRangekpbxyzbpv111312.96111319.05600000001')]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var ids;
 
-    ids = methods.filters.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv111320111317].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoDistanceRangekpbxyzbpv111320111317].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
 
-    ids = methods.filters.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv110].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoDistanceRangekpbxyzbpv110].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
 
-    ids = methods.filters.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv111318111318].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoDistanceRangekpbxyzbpv111318111318].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
 
-    ids = methods.filters.filtersTree[index][collection].fields.location[md5('locationgeoDistanceRangekpbxyzbpv111312.96111319.05600000001')].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldLocation][md5('locationgeoDistanceRangekpbxyzbpv111312.96111319.05600000001')].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
   });
 
   it('should construct the filterTree with correct functions geoDistanceRange', function () {
-    should(methods.filters.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv111320111317].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoDistanceRangekpbxyzbpv111320111317].args).match({
       operator: 'geoDistanceRange',
       not: undefined,
       field: 'location',
       value: { lat: 0, lon: 1, from: 111320, to: 111317 }
     });
 
-    should(methods.filters.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv110].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoDistanceRangekpbxyzbpv110].args).match({
       operator: 'geoDistanceRange',
       not: undefined,
       field: 'location',
       value: { lat: 0, lon: 1, from: 1, to: 10 }
     });
 
-    should(methods.filters.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv111318111318].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoDistanceRangekpbxyzbpv111318111318].args).match({
       operator: 'geoDistanceRange',
       not: undefined,
       field: 'location',
       value: { lat: 0, lon: 1, from: 111318, to: 111318 }
     });
 
-    should(methods.filters.filtersTree[index][collection].fields.location[md5('locationgeoDistanceRangekpbxyzbpv111312.96111319.05600000001')].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][md5('locationgeoDistanceRangekpbxyzbpv111312.96111319.05600000001')].args).match({
       operator: 'geoDistanceRange',
       not: undefined,
       field: 'location',

--- a/test/api/dsl/methods/geoPolygon.test.js
+++ b/test/api/dsl/methods/geoPolygon.test.js
@@ -45,7 +45,8 @@ describe('Test "geoPolygon" method', function () {
     },
     locationgeoPolygonkpbdqcbnts00twy01mebpm9npc67zz631zyd = md5('locationgeoPolygonkpbdqcbnts00twy01mebpm9npc67zz631zyd'),
     locationgeoPolygonkpbxyzbpvs00twy01mebpvxypcr7zzzzzzzz = md5('locationgeoPolygonkpbxyzbpvs00twy01mebpvxypcr7zzzzzzzz'),
-    locationgeoPolygons1zbfk3yns1zyd63zws1zned3z8s1z0gs3y0 = md5('locationgeoPolygons1zbfk3yns1zyd63zws1zned3z8s1z0gs3y0');
+    locationgeoPolygons1zbfk3yns1zyd63zws1zned3z8s1z0gs3y0 = md5('locationgeoPolygons1zbfk3yns1zyd63zws1zned3z8s1z0gs3y0'),
+    fieldLocation = md5('location');
 
   beforeEach(function () {
     methods = new Methods(new Filters());
@@ -60,7 +61,7 @@ describe('Test "geoPolygon" method', function () {
     should(methods.filters.filtersTree[index]).not.be.empty();
     should(methods.filters.filtersTree[index][collection]).not.be.empty();
     should(methods.filters.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.location).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation]).not.be.empty();
   });
 
   it('should construct the filterTree with correct encoded function name', function () {
@@ -68,26 +69,26 @@ describe('Test "geoPolygon" method', function () {
     // because we have many times the same coord in filters,
     // we must have only four functions
     
-    should(Object.keys(methods.filters.filtersTree[index][collection].fields.location)).have.length(3);
-    should(methods.filters.filtersTree[index][collection].fields.location[locationgeoPolygonkpbdqcbnts00twy01mebpm9npc67zz631zyd]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.location[locationgeoPolygonkpbxyzbpvs00twy01mebpvxypcr7zzzzzzzz]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.location[locationgeoPolygons1zbfk3yns1zyd63zws1zned3z8s1z0gs3y0]).not.be.empty();
+    should(Object.keys(methods.filters.filtersTree[index][collection].fields[fieldLocation])).have.length(3);
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoPolygonkpbdqcbnts00twy01mebpm9npc67zz631zyd]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoPolygonkpbxyzbpvs00twy01mebpvxypcr7zzzzzzzz]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoPolygons1zbfk3yns1zyd63zws1zned3z8s1z0gs3y0]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var ids;
 
-    ids = methods.filters.filtersTree[index][collection].fields.location[locationgeoPolygonkpbdqcbnts00twy01mebpm9npc67zz631zyd].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoPolygonkpbdqcbnts00twy01mebpm9npc67zz631zyd].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
 
-    ids = methods.filters.filtersTree[index][collection].fields.location[locationgeoPolygonkpbxyzbpvs00twy01mebpvxypcr7zzzzzzzz].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoPolygonkpbxyzbpvs00twy01mebpvxypcr7zzzzzzzz].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
 
-    ids = methods.filters.filtersTree[index][collection].fields.location[locationgeoPolygons1zbfk3yns1zyd63zws1zned3z8s1z0gs3y0].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoPolygons1zbfk3yns1zyd63zws1zned3z8s1z0gs3y0].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
@@ -96,7 +97,7 @@ describe('Test "geoPolygon" method', function () {
 
   it('should construct the filterTree with correct functions geoPolygon', function () {
     // test exact
-    should(methods.filters.filtersTree[index][collection].fields.location[locationgeoPolygonkpbdqcbnts00twy01mebpm9npc67zz631zyd].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoPolygonkpbdqcbnts00twy01mebpm9npc67zz631zyd].args).match({
       operator: 'geoPolygon',
       not: undefined,
       field: 'location',
@@ -108,7 +109,7 @@ describe('Test "geoPolygon" method', function () {
     });
 
     // test outside
-    should(methods.filters.filtersTree[index][collection].fields.location[locationgeoPolygonkpbxyzbpvs00twy01mebpvxypcr7zzzzzzzz].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoPolygonkpbxyzbpvs00twy01mebpvxypcr7zzzzzzzz].args).match({
       operator: 'geoPolygon',
       not: undefined,
       field: 'location',
@@ -120,7 +121,7 @@ describe('Test "geoPolygon" method', function () {
     });
 
     // test on limit
-    should(methods.filters.filtersTree[index][collection].fields.location[locationgeoPolygons1zbfk3yns1zyd63zws1zned3z8s1z0gs3y0].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldLocation][locationgeoPolygons1zbfk3yns1zyd63zws1zned3z8s1z0gs3y0].args).match({
       operator: 'geoPolygon',
       not: undefined,
       field: 'location',

--- a/test/api/dsl/methods/getFormattedFilters.test.js
+++ b/test/api/dsl/methods/getFormattedFilters.test.js
@@ -14,7 +14,8 @@ describe('Test: dsl.getFormattedFilters method', function () {
     existsfoo = md5('existsfoo'),
     notexistsfoo = md5('notexistsfoo'),
     existsbar = md5('existsbar'),
-    notexistsbar = md5('notexistsbar');
+    fieldFoo = md5('foo'),
+    fieldBar = md5('bar');
 
   beforeEach(function () {
     methods = new Methods(new Filters());
@@ -38,12 +39,12 @@ describe('Test: dsl.getFormattedFilters method', function () {
 
     return getFormattedFilters.call(methods, 'roomId', 'index', 'collection', filter)
       .then(function (formattedFilter) {
-        should.exist(formattedFilter['index.collection.foo.' + existsfoo]);
-        should(formattedFilter['index.collection.foo.' + existsfoo]).be.an.Object();
-        should.exist(formattedFilter['index.collection.foo.' + existsfoo].ids);
-        should(formattedFilter['index.collection.foo.' + existsfoo].ids).be.an.Array().and.match(['roomId']);
-        should(formattedFilter['index.collection.foo.' + existsfoo].ids.length).eql(1);
-        should.exist(formattedFilter['index.collection.foo.' + existsfoo].args);
+        should.exist(formattedFilter[`index.collection.${fieldFoo}.${existsfoo}`]);
+        should(formattedFilter[`index.collection.${fieldFoo}.${existsfoo}`]).be.an.Object();
+        should.exist(formattedFilter[`index.collection.${fieldFoo}.${existsfoo}`].ids);
+        should(formattedFilter[`index.collection.${fieldFoo}.${existsfoo}`].ids).be.an.Array().and.match(['roomId']);
+        should(formattedFilter[`index.collection.${fieldFoo}.${existsfoo}`].ids.length).eql(1);
+        should.exist(formattedFilter[`index.collection.${fieldFoo}.${existsfoo}`].args);
       });
   });
 
@@ -56,19 +57,19 @@ describe('Test: dsl.getFormattedFilters method', function () {
 
     return getFormattedFilters.call(methods, 'roomId', 'index', 'collection', filters)
       .then(function (formattedFilter) {
-        should.exist(formattedFilter['index.collection.foo.' + existsfoo]);
-        should(formattedFilter['index.collection.foo.' + existsfoo]).be.an.Object();
-        should.exist(formattedFilter['index.collection.foo.' + existsfoo].ids);
-        should(formattedFilter['index.collection.foo.' + existsfoo].ids).be.an.Array().and.match(['roomId']);
-        should(formattedFilter['index.collection.foo.' + existsfoo].ids.length).eql(1);
-        should.exist(formattedFilter['index.collection.foo.' + existsfoo].args);
+        should.exist(formattedFilter[`index.collection.${fieldFoo}.${existsfoo}`]);
+        should(formattedFilter[`index.collection.${fieldFoo}.${existsfoo}`]).be.an.Object();
+        should.exist(formattedFilter[`index.collection.${fieldFoo}.${existsfoo}`].ids);
+        should(formattedFilter[`index.collection.${fieldFoo}.${existsfoo}`].ids).be.an.Array().and.match(['roomId']);
+        should(formattedFilter[`index.collection.${fieldFoo}.${existsfoo}`].ids.length).eql(1);
+        should.exist(formattedFilter[`index.collection.${fieldFoo}.${existsfoo}`].args);
 
-        should.exist(formattedFilter['index.collection.bar.' + existsbar]);
-        should(formattedFilter['index.collection.bar.' + existsbar]).be.an.Object();
-        should.exist(formattedFilter['index.collection.bar.' + existsbar].ids);
-        should(formattedFilter['index.collection.bar.' + existsbar].ids).be.an.Array().and.match(['roomId']);
-        should(formattedFilter['index.collection.bar.' + existsbar].ids.length).eql(1);
-        should.exist(formattedFilter['index.collection.bar.' + existsbar].args);
+        should.exist(formattedFilter[`index.collection.${fieldBar}.${existsbar}`]);
+        should(formattedFilter[`index.collection.${fieldBar}.${existsbar}`]).be.an.Object();
+        should.exist(formattedFilter[`index.collection.${fieldBar}.${existsbar}`].ids);
+        should(formattedFilter[`index.collection.${fieldBar}.${existsbar}`].ids).be.an.Array().and.match(['roomId']);
+        should(formattedFilter[`index.collection.${fieldBar}.${existsbar}`].ids.length).eql(1);
+        should.exist(formattedFilter[`index.collection.${fieldBar}.${existsbar}`].args);
       });
   });
 
@@ -82,19 +83,19 @@ describe('Test: dsl.getFormattedFilters method', function () {
 
     return getFormattedFilters.call(methods, 'roomId', 'index', 'collection', filters)
       .then(function (formattedFilter) {
-        should.exist(formattedFilter['index.collection.foo.' + existsfoo]);
-        should(formattedFilter['index.collection.foo.' + existsfoo]).be.an.Object();
-        should.exist(formattedFilter['index.collection.foo.' + existsfoo].ids);
-        should(formattedFilter['index.collection.foo.' + existsfoo].ids).be.an.Array().and.match(['roomId']);
-        should(formattedFilter['index.collection.foo.' + existsfoo].ids.length).eql(1);
-        should.exist(formattedFilter['index.collection.foo.' + existsfoo].args);
+        should.exist(formattedFilter[`index.collection.${fieldFoo}.${existsfoo}`]);
+        should(formattedFilter[`index.collection.${fieldFoo}.${existsfoo}`]).be.an.Object();
+        should.exist(formattedFilter[`index.collection.${fieldFoo}.${existsfoo}`].ids);
+        should(formattedFilter[`index.collection.${fieldFoo}.${existsfoo}`].ids).be.an.Array().and.match(['roomId']);
+        should(formattedFilter[`index.collection.${fieldFoo}.${existsfoo}`].ids.length).eql(1);
+        should.exist(formattedFilter[`index.collection.${fieldFoo}.${existsfoo}`].args);
 
-        should.exist(formattedFilter['index.collection.bar.' + existsbar]);
-        should(formattedFilter['index.collection.bar.' + existsbar]).be.an.Object();
-        should.exist(formattedFilter['index.collection.bar.' + existsbar].ids);
-        should(formattedFilter['index.collection.bar.' + existsbar].ids).be.an.Array().and.match(['roomId']);
-        should(formattedFilter['index.collection.bar.' + existsbar].ids.length).eql(1);
-        should.exist(formattedFilter['index.collection.bar.' + existsbar].args);
+        should.exist(formattedFilter[`index.collection.${fieldBar}.${existsbar}`]);
+        should(formattedFilter[`index.collection.${fieldBar}.${existsbar}`]).be.an.Object();
+        should.exist(formattedFilter[`index.collection.${fieldBar}.${existsbar}`].ids);
+        should(formattedFilter[`index.collection.${fieldBar}.${existsbar}`].ids).be.an.Array().and.match(['roomId']);
+        should(formattedFilter[`index.collection.${fieldBar}.${existsbar}`].ids.length).eql(1);
+        should.exist(formattedFilter[`index.collection.${fieldBar}.${existsbar}`].args);
       });
   });
 
@@ -108,12 +109,12 @@ describe('Test: dsl.getFormattedFilters method', function () {
 
     return getFormattedFilters.call(methods, 'roomId', 'index', 'collection', filter, true)
       .then(function (formattedFilter) {
-        should.exist(formattedFilter['index.collection.foo.' + notexistsfoo]);
-        should(formattedFilter['index.collection.foo.' + notexistsfoo]).be.an.Object();
-        should.exist(formattedFilter['index.collection.foo.' + notexistsfoo].ids);
-        should(formattedFilter['index.collection.foo.' + notexistsfoo].ids).be.an.Array().and.match(['roomId']);
-        should(formattedFilter['index.collection.foo.' + notexistsfoo].ids.length).eql(1);
-        should.exist(formattedFilter['index.collection.foo.' + notexistsfoo].args);
+        should.exist(formattedFilter[`index.collection.${fieldFoo}.${notexistsfoo}`]);
+        should(formattedFilter[`index.collection.${fieldFoo}.${notexistsfoo}`]).be.an.Object();
+        should.exist(formattedFilter[`index.collection.${fieldFoo}.${notexistsfoo}`].ids);
+        should(formattedFilter[`index.collection.${fieldFoo}.${notexistsfoo}`].ids).be.an.Array().and.match(['roomId']);
+        should(formattedFilter[`index.collection.${fieldFoo}.${notexistsfoo}`].ids.length).eql(1);
+        should.exist(formattedFilter[`index.collection.${fieldFoo}.${notexistsfoo}`].args);
       });
   });
 

--- a/test/api/dsl/methods/ids.test.js
+++ b/test/api/dsl/methods/ids.test.js
@@ -18,7 +18,8 @@ describe('Test ids method', function () {
       values: ['idGrace']
     },
     idsIdidGrace = md5('ids_ididGrace'),
-    notidsIdidGrace = md5('notids_ididGrace');
+    notidsIdidGrace = md5('notids_ididGrace'),
+    fieldId = md5('_id');
 
   beforeEach(function () {
     methods = new Methods(new Filters());
@@ -31,20 +32,20 @@ describe('Test ids method', function () {
     should(methods.filters.filtersTree[index]).not.be.empty();
     should(methods.filters.filtersTree[index][collection]).not.be.empty();
     should(methods.filters.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields._id).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldId]).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
     /* jshint camelcase:false */
-    should(methods.filters.filtersTree[index][collection].fields._id[idsIdidGrace]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields._id[notidsIdidGrace]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldId][idsIdidGrace]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldId][notidsIdidGrace]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     /* jshint camelcase:false */
     var
-      ids = methods.filters.filtersTree[index][collection].fields._id[idsIdidGrace].ids,
-      idsNot = methods.filters.filtersTree[index][collection].fields._id[notidsIdidGrace].ids;
+      ids = methods.filters.filtersTree[index][collection].fields[fieldId][idsIdidGrace].ids,
+      idsNot = methods.filters.filtersTree[index][collection].fields[fieldId][notidsIdidGrace].ids;
 
     should(ids).be.an.Array();
     should(idsNot).be.an.Array();
@@ -58,14 +59,14 @@ describe('Test ids method', function () {
 
   it('should construct the filterTree with correct functions ids', function () {
     /* jshint camelcase:false */
-    should(methods.filters.filtersTree[index][collection].fields._id[idsIdidGrace].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldId][idsIdidGrace].args).match({
       operator: 'terms',
       not: false,
       field: '_id',
       value: [ 'idGrace' ]
     });
 
-    should(methods.filters.filtersTree[index][collection].fields._id[notidsIdidGrace].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldId][notidsIdidGrace].args).match({
       operator: 'terms',
       not: true,
       field: '_id',

--- a/test/api/dsl/methods/missing.test.js
+++ b/test/api/dsl/methods/missing.test.js
@@ -20,7 +20,8 @@ describe('Test missing method', function () {
     filter = {
       field: 'lastName'
     },
-    missinglastName = md5('missinglastName');
+    missinglastName = md5('missinglastName'),
+    fieldLastName = md5('lastName');
 
   beforeEach(function () {
     methods = new Methods(new Filters());
@@ -32,25 +33,25 @@ describe('Test missing method', function () {
     should(methods.filters.filtersTree[index]).not.be.empty();
     should(methods.filters.filtersTree[index][collection]).not.be.empty();
     should(methods.filters.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.lastName).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldLastName]).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
-    should(methods.filters.filtersTree[index][collection].fields.lastName[missinglastName]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldLastName][missinglastName]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var ids;
 
     // Test gt from filterGrace
-    ids = methods.filters.filtersTree[index][collection].fields.lastName[missinglastName].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldLastName][missinglastName].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
   });
 
   it('should construct the filterTree with correct functions missing', function () {
-    should(methods.filters.filtersTree[index][collection].fields.lastName[missinglastName].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldLastName][missinglastName].args).match({
       operator: 'missing',
       not: false,
       field: 'lastName',

--- a/test/api/dsl/methods/not.test.js
+++ b/test/api/dsl/methods/not.test.js
@@ -15,7 +15,8 @@ describe('Test "not" method', function () {
         city: 'London'
       }
     },
-    nottermcityLondon = md5('nottermcityLondon');
+    nottermcityLondon = md5('nottermcityLondon'),
+    fieldCity = md5('city');
 
   beforeEach(function () {
     methods = new Methods(new Filters());
@@ -27,25 +28,25 @@ describe('Test "not" method', function () {
     should(methods.filters.filtersTree[index]).not.be.empty();
     should(methods.filters.filtersTree[index][collection]).not.be.empty();
     should(methods.filters.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.city).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldCity]).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
-    should(methods.filters.filtersTree[index][collection].fields.city[nottermcityLondon]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldCity][nottermcityLondon]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var ids;
 
     // Test gt from filterGrace
-    ids = methods.filters.filtersTree[index][collection].fields.city[nottermcityLondon].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldCity][nottermcityLondon].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
   });
 
   it('should construct the filterTree with correct functions', function () {
-    should(methods.filters.filtersTree[index][collection].fields.city[nottermcityLondon].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldCity][nottermcityLondon].args).match({
       operator: 'term', not: true, field: 'city', value: 'London'
     });
   });

--- a/test/api/dsl/methods/or.test.js
+++ b/test/api/dsl/methods/or.test.js
@@ -28,7 +28,8 @@ describe('Test or method', function () {
     termcityNYC = md5('termcityNYC'),
     termcityLondon = md5('termcityLondon'),
     nottermcityNYC = md5('nottermcityNYC'),
-    nottermcityLondon = md5('nottermcityLondon');
+    nottermcityLondon = md5('nottermcityLondon'),
+    fieldCity = md5('city');
 
   beforeEach(function () {
     methods = new Methods(new Filters());
@@ -42,57 +43,57 @@ describe('Test or method', function () {
     should(methods.filters.filtersTree[index]).not.be.empty();
     should(methods.filters.filtersTree[index][collection]).not.be.empty();
     should(methods.filters.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.city).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldCity]).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
-    should(methods.filters.filtersTree[index][collection].fields.city[termcityNYC]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.city[termcityLondon]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.city[nottermcityNYC]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.city[nottermcityLondon]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldCity][termcityNYC]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldCity][termcityLondon]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldCity][nottermcityNYC]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldCity][nottermcityLondon]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var ids;
 
-    ids = methods.filters.filtersTree[index][collection].fields.city[termcityNYC].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldCity][termcityNYC].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
 
-    ids = methods.filters.filtersTree[index][collection].fields.city[termcityLondon].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldCity][termcityLondon].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
 
-    ids = methods.filters.filtersTree[index][collection].fields.city[nottermcityNYC].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldCity][nottermcityNYC].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
 
-    ids = methods.filters.filtersTree[index][collection].fields.city[nottermcityLondon].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldCity][nottermcityLondon].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterId);
   });
 
   it('should construct the filterTree with correct arguments', function () {
-    should(methods.filters.filtersTree[index][collection].fields.city[termcityNYC].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldCity][termcityNYC].args).match({
       operator: 'term', not: undefined, field: 'city', value: 'NYC'
     });
 
-    should(methods.filters.filtersTree[index][collection].fields.city[termcityLondon].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldCity][termcityLondon].args).match({
       operator: 'term',
       not: undefined,
       field: 'city',
       value: 'London'
     });
 
-    should(methods.filters.filtersTree[index][collection].fields.city[nottermcityNYC].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldCity][nottermcityNYC].args).match({
       operator: 'term', not: true, field: 'city', value: 'NYC'
     });
 
-    should(methods.filters.filtersTree[index][collection].fields.city[nottermcityLondon].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldCity][nottermcityLondon].args).match({
       operator: 'term', not: true, field: 'city', value: 'London'
     });
   });

--- a/test/api/dsl/methods/range.test.js
+++ b/test/api/dsl/methods/range.test.js
@@ -39,7 +39,8 @@ describe('Test range method', function () {
     rangeagegte36 = md5('rangeagegte36'),
     rangeagelt85 = md5('rangeagelt85'),
     notrangeagegte36 = md5('notrangeagegte36'),
-    notrangeagelte85 = md5('notrangeagelte85');
+    notrangeagelte85 = md5('notrangeagelte85'),
+    fieldAge = md5('age');
 
   beforeEach(function () {
     methods = new Methods(new Filters());
@@ -55,82 +56,82 @@ describe('Test range method', function () {
     should(methods.filters.filtersTree[index]).not.be.empty();
     should(methods.filters.filtersTree[index][collection]).not.be.empty();
     should(methods.filters.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.age).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldAge]).not.be.empty();
   });
 
   it('should construct the filterTree with correct encoded function name', function () {
-    should(methods.filters.filtersTree[index][collection].fields.age[rangeagegt36]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.age[rangeagelte85]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.age[rangeagegte36]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.age[rangeagelt85]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.age[notrangeagegte36]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.age[notrangeagelte85]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldAge][rangeagegt36]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldAge][rangeagelte85]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldAge][rangeagegte36]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldAge][rangeagelt85]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldAge][notrangeagegte36]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldAge][notrangeagelte85]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var ids;
 
     // Test gt from filterGrace
-    ids = methods.filters.filtersTree[index][collection].fields.age[rangeagegt36].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldAge][rangeagegt36].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterIdFilterGrace);
 
     // Test lte from filterGrace and filterAll
-    ids = methods.filters.filtersTree[index][collection].fields.age[rangeagelte85].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldAge][rangeagelte85].ids;
     should(ids).be.an.Array();
     should(ids).have.length(2);
     should(ids).containEql(filterIdFilterGrace);
     should(ids).containEql(filterIdFilterAll);
 
     // Test gte from filterAda and filterAll
-    ids = methods.filters.filtersTree[index][collection].fields.age[rangeagegte36].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldAge][rangeagegte36].ids;
     should(ids).be.an.Array();
     should(ids).have.length(2);
     should(ids).containEql(filterIdFilterAda);
     should(ids).containEql(filterIdFilterAll);
 
     // Test lt from filterAda
-    ids = methods.filters.filtersTree[index][collection].fields.age[rangeagelt85].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldAge][rangeagelt85].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterIdFilterAda);
 
     // Test not gte from negative filterAll
-    ids = methods.filters.filtersTree[index][collection].fields.age[notrangeagegte36].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldAge][notrangeagegte36].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterIdFilterNobody);
 
     // Test not lte from negative filterAll
-    ids = methods.filters.filtersTree[index][collection].fields.age[notrangeagelte85].ids;
+    ids = methods.filters.filtersTree[index][collection].fields[fieldAge][notrangeagelte85].ids;
     should(ids).be.an.Array();
     should(ids).have.length(1);
     should(ids[0]).be.exactly(filterIdFilterNobody);
   });
 
   it('should construct the filterTree with correct functions range', function () {
-    should(methods.filters.filtersTree[index][collection].fields.age[rangeagegt36].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldAge][rangeagegt36].args).match({
       operator: 'gt', not: undefined, field: 'age', value: 36
     });
 
-    should(methods.filters.filtersTree[index][collection].fields.age[rangeagelte85].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldAge][rangeagelte85].args).match({
       operator: 'lte', not: undefined, field: 'age', value: 85
     });
 
-    should(methods.filters.filtersTree[index][collection].fields.age[rangeagegte36].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldAge][rangeagegte36].args).match({
       operator: 'gte', not: undefined, field: 'age', value: 36
     });
 
-    should(methods.filters.filtersTree[index][collection].fields.age[rangeagelt85].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldAge][rangeagelt85].args).match({
       operator: 'lt', not: undefined, field: 'age', value: 85
     });
 
-    should(methods.filters.filtersTree[index][collection].fields.age[notrangeagegte36].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldAge][notrangeagegte36].args).match({
       operator: 'gte', not: true, field: 'age', value: 36
     });
 
-    should(methods.filters.filtersTree[index][collection].fields.age[notrangeagelte85].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldAge][notrangeagelte85].args).match({
       operator: 'lte', not: true, field: 'age', value: 85
     });
   });

--- a/test/api/dsl/methods/term.test.js
+++ b/test/api/dsl/methods/term.test.js
@@ -15,7 +15,8 @@ describe('Test term method', function () {
       firstName: 'Grace'
     },
     termfirstNameGrace = md5('termfirstNameGrace'),
-    nottermfirstNameGrace = md5('nottermfirstNameGrace');
+    nottermfirstNameGrace = md5('nottermfirstNameGrace'),
+    fieldFirstName = md5('firstName');
 
 
   before(function () {
@@ -29,18 +30,18 @@ describe('Test term method', function () {
     should(methods.filters.filtersTree[index]).not.be.empty();
     should(methods.filters.filtersTree[index][collection]).not.be.empty();
     should(methods.filters.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.firstName).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldFirstName]).not.be.empty();
   });
 
   it('should construct the filterTree with correct arguments', function () {
-    should(methods.filters.filtersTree[index][collection].fields.firstName[termfirstNameGrace].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldFirstName][termfirstNameGrace].args).match({
       operator: 'term',
       not: undefined,
       field: 'firstName',
       value: 'Grace'
     });
 
-    should(methods.filters.filtersTree[index][collection].fields.firstName[nottermfirstNameGrace].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldFirstName][nottermfirstNameGrace].args).match({
       operator: 'term',
       not: true,
       field: 'firstName',
@@ -50,8 +51,8 @@ describe('Test term method', function () {
 
   it('should construct the filterTree with correct room list', function () {
     var
-      ids = methods.filters.filtersTree[index][collection].fields.firstName[termfirstNameGrace].ids,
-      idsNot = methods.filters.filtersTree[index][collection].fields.firstName[nottermfirstNameGrace].ids;
+      ids = methods.filters.filtersTree[index][collection].fields[fieldFirstName][termfirstNameGrace].ids,
+      idsNot = methods.filters.filtersTree[index][collection].fields[fieldFirstName][nottermfirstNameGrace].ids;
 
     should(ids).be.an.Array();
     should(idsNot).be.an.Array();

--- a/test/api/dsl/methods/termFunction.test.js
+++ b/test/api/dsl/methods/termFunction.test.js
@@ -14,7 +14,8 @@ describe('Test: dsl.termFunction method', function () {
     termfoobar = md5('termfoobar'),
     termsfoobarbaz = md5('termsfoobar,baz'),
     nottermfoobar = md5('nottermfoobar'),
-    nottermsfoobarbaz = md5('nottermsfoobar,baz');
+    nottermsfoobarbaz = md5('nottermsfoobar,baz'),
+    fieldFoo = md5('foo');
 
   beforeEach(function () {
     methods = new Methods(new Filters());
@@ -42,9 +43,9 @@ describe('Test: dsl.termFunction method', function () {
 
     return termFunction('term', 'roomId', 'index', 'collection', filter)
       .then(function (formattedFilter) {
-        should.exist(formattedFilter['index.collection.foo.' + termfoobar]);
-        should(formattedFilter['index.collection.foo.' + termfoobar].ids).be.an.Array().and.match(['roomId']);
-        should(formattedFilter['index.collection.foo.' + termfoobar].args).match({
+        should.exist(formattedFilter[`index.collection.${fieldFoo}.${termfoobar}`]);
+        should(formattedFilter[`index.collection.${fieldFoo}.${termfoobar}`].ids).be.an.Array().and.match(['roomId']);
+        should(formattedFilter[`index.collection.${fieldFoo}.${termfoobar}`].args).match({
           operator: 'term', not: undefined, field: 'foo', value: 'bar'
         });
       });
@@ -58,9 +59,9 @@ describe('Test: dsl.termFunction method', function () {
 
     return termFunction('terms', 'roomId', 'index', 'collection', filter)
       .then(function (formattedFilter) {
-        should.exist(formattedFilter['index.collection.foo.' + termsfoobarbaz]);
-        should(formattedFilter['index.collection.foo.' + termsfoobarbaz].ids).be.an.Array().and.match(['roomId']);
-        should(formattedFilter['index.collection.foo.' + termsfoobarbaz].args).match({
+        should.exist(formattedFilter[`index.collection.${fieldFoo}.${termsfoobarbaz}`]);
+        should(formattedFilter[`index.collection.${fieldFoo}.${termsfoobarbaz}`].ids).be.an.Array().and.match(['roomId']);
+        should(formattedFilter[`index.collection.${fieldFoo}.${termsfoobarbaz}`].args).match({
           operator: 'terms',
           not: undefined,
           field: 'foo',
@@ -77,9 +78,9 @@ describe('Test: dsl.termFunction method', function () {
 
     return termFunction('term', 'roomId', 'index', 'collection', filter, true)
       .then(function (formattedFilter) {
-        should.exist(formattedFilter['index.collection.foo.' + nottermfoobar]);
-        should(formattedFilter['index.collection.foo.' + nottermfoobar].ids).be.an.Array().and.match(['roomId']);
-        should(formattedFilter['index.collection.foo.' + nottermfoobar].args).match({
+        should.exist(formattedFilter[`index.collection.${fieldFoo}.${nottermfoobar}`]);
+        should(formattedFilter[`index.collection.${fieldFoo}.${nottermfoobar}`].ids).be.an.Array().and.match(['roomId']);
+        should(formattedFilter[`index.collection.${fieldFoo}.${nottermfoobar}`].args).match({
           operator: 'term', not: true, field: 'foo', value: 'bar'
         });
       });
@@ -93,9 +94,9 @@ describe('Test: dsl.termFunction method', function () {
 
     return termFunction('terms', 'roomId', 'index', 'collection', filter, true)
       .then(function (formattedFilter) {
-        should.exist(formattedFilter['index.collection.foo.' + nottermsfoobarbaz]);
-        should(formattedFilter['index.collection.foo.' + nottermsfoobarbaz].ids).be.an.Array().and.match(['roomId']);
-        should(formattedFilter['index.collection.foo.' + nottermsfoobarbaz].args).match({
+        should.exist(formattedFilter[`index.collection.${fieldFoo}.${nottermsfoobarbaz}`]);
+        should(formattedFilter[`index.collection.${fieldFoo}.${nottermsfoobarbaz}`].ids).be.an.Array().and.match(['roomId']);
+        should(formattedFilter[`index.collection.${fieldFoo}.${nottermsfoobarbaz}`].args).match({
           operator: 'terms',
           not: true,
           field: 'foo',

--- a/test/api/dsl/methods/terms.test.js
+++ b/test/api/dsl/methods/terms.test.js
@@ -15,7 +15,8 @@ describe('Test "terms" method', function () {
       firstName: ['Grace', 'Jean']
     },
     termsfirstNameGraceJean = md5('termsfirstNameGrace,Jean'),
-    nottermsfirstNameGraceJean = md5('nottermsfirstNameGrace,Jean');
+    nottermsfirstNameGraceJean = md5('nottermsfirstNameGrace,Jean'),
+    fieldFirstName = md5('firstName');
 
   beforeEach(function () {
     methods = new Methods(new Filters());
@@ -29,18 +30,18 @@ describe('Test "terms" method', function () {
     should(methods.filters.filtersTree[index]).not.be.empty();
     should(methods.filters.filtersTree[index][collection]).not.be.empty();
     should(methods.filters.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.firstName).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldFirstName]).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
-    should(methods.filters.filtersTree[index][collection].fields.firstName[termsfirstNameGraceJean]).not.be.empty();
-    should(methods.filters.filtersTree[index][collection].fields.firstName[nottermsfirstNameGraceJean]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldFirstName][termsfirstNameGraceJean]).not.be.empty();
+    should(methods.filters.filtersTree[index][collection].fields[fieldFirstName][nottermsfirstNameGraceJean]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var
-      ids = methods.filters.filtersTree[index][collection].fields.firstName[termsfirstNameGraceJean].ids,
-      idsNot = methods.filters.filtersTree[index][collection].fields.firstName[nottermsfirstNameGraceJean].ids;
+      ids = methods.filters.filtersTree[index][collection].fields[fieldFirstName][termsfirstNameGraceJean].ids,
+      idsNot = methods.filters.filtersTree[index][collection].fields[fieldFirstName][nottermsfirstNameGraceJean].ids;
 
     should(ids).be.an.Array();
     should(idsNot).be.an.Array();
@@ -53,14 +54,14 @@ describe('Test "terms" method', function () {
   });
 
   it('should construct the filterTree with correct functions terms', function () {
-    should(methods.filters.filtersTree[index][collection].fields.firstName[termsfirstNameGraceJean].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldFirstName][termsfirstNameGraceJean].args).match({
       operator: 'terms',
       not: false,
       field: 'firstName',
       value: [ 'Grace', 'Jean' ]
     });
 
-    should(methods.filters.filtersTree[index][collection].fields.firstName[nottermsfirstNameGraceJean].args).match({
+    should(methods.filters.filtersTree[index][collection].fields[fieldFirstName][nottermsfirstNameGraceJean].args).match({
       operator: 'terms',
       not: true,
       field: 'firstName',


### PR DESCRIPTION
This pull request fixes issue #302 :

* the filters structure in `dsl/filters` now uses MD5-encoded field names instead of user-provided ones
* updated unit tests
* introduced nested attributes in some functional tests to ensure this bug never happens again

If this pull request is validated, I'll merge it onto the `master` branch and I'll then backport this fix to the `beta` version of Kuzzle