### PR TITLE
[beta] fix #302: unable to remove filters with nested attributes

### DIFF
--- a/lib/api/dsl/index.js
+++ b/lib/api/dsl/index.js
@@ -4,26 +4,31 @@ var
   BadRequestError = require('../core/errors/badRequestError'),
   NotFoundError = require('../core/errors/notFoundError'),
   async = require('async'),
+  md5 = require('crypto-md5'),
   _ = require('lodash'),
   q = require('q');
 
 
 module.exports = function Dsl (kuzzle) {
   /**
-   *
    * A tree where we have an entry by collection, an entry by tag and
-   * an entry by filter (curried function) with the rooms list
+   * an entry by filter part.
+   *
+   * A filter part is a filter component potentially shared by multiple filters.
+   * A filter part references the filter IDs using this filter part, and the
+   * operator arguments used to test this part against documents data.
+   *
    * @example
-   * Example for chat-room-kuzzle (see above)
+   * Example:
    *  filtersTree = {
-   *    app : { // -> index name
-   *      message : { // -> collection name
-   *        rooms: [] // -> global room to test each time (for a a subscribe on a whole collection, or if 'not exists' filter (see issue #1 on github)
+   *    index : { // -> index name
+   *      collection : { // -> collection name
+   *        globalFilterIds: [] // -> global filters to test each time (for a a subscribe on a whole collection, or if 'not exists' filter (see issue #1 on github)
    *        fields: {
-   *          subject : { // -> attribute where a filter exists
-   *            termSubjectKuzzle : {
-   *              rooms: [ 'f45de4d8ef4f3ze4ffzer85d4fgkzm41'], // -> room id that match this filter
-   *              fn: function () {} // -> function to execute on collection message, on field subject
+   *          encodedFieldName : { // -> attribute where a filter part exists, encoded with MD5
+   *            encodedFieldFilter : { // -> field+filter part name, encoded with MD5
+   *              ids: [ 'f45de4d8ef4f3ze4ffzer85d4fgkzm41'], // -> ids of filters using this test
+   *              args: {operator, not, field, value}
    *            }
    *          }
    *        }
@@ -50,6 +55,7 @@ module.exports = function Dsl (kuzzle) {
       deferred = q.defer(),
       filterName,
       privateFilterName;
+    
     if (filters === undefined) {
       deferred.reject(new BadRequestError('Filters parameter can\'t be undefined'));
       return deferred.promise;
@@ -116,6 +122,7 @@ module.exports = function Dsl (kuzzle) {
       // the document can be either in _source if it comes from ES or directly in body
       flattenBody = flattenObject(modelObject.data.body._source || modelObject.data.body),
       that = this;
+
     if (!modelObject.index) {
       deferred.reject(new NotFoundError('The data doesn\'t contain an index'));
       return deferred.promise;
@@ -289,17 +296,19 @@ function testFieldFilters(modelObject, flattenBody, cachedResults) {
 
   // Loop on all document attributes
   async.each(documentKeys, function (field, callbackField) {
-    var fieldFilters;
+    var
+      fieldFilters,
+      hashedFieldName = md5(field);
 
     if (!this.filtersTree[modelObject.index] ||
       !this.filtersTree[modelObject.index][modelObject.collection] ||
       !this.filtersTree[modelObject.index][modelObject.collection].fields ||
-      !this.filtersTree[modelObject.index][modelObject.collection].fields[field]) {
+      !this.filtersTree[modelObject.index][modelObject.collection].fields[hashedFieldName]) {
       callbackField();
       return false;
     }
 
-    fieldFilters = this.filtersTree[modelObject.index][modelObject.collection].fields[field];
+    fieldFilters = this.filtersTree[modelObject.index][modelObject.collection].fields[hashedFieldName];
 
     // For each attribute, loop on all saved filters
     async.each(Object.keys(fieldFilters), function (functionName, callbackFilter) {
@@ -307,7 +316,7 @@ function testFieldFilters(modelObject, flattenBody, cachedResults) {
       // Clean function name of potential '.' characters
         cleanFunctionName = functionName.split('.').join(''),
         filter = fieldFilters[functionName],
-        cachePath = modelObject.index + '.' + modelObject.collection + '.' + field + '.' + cleanFunctionName;
+        cachePath = modelObject.index + '.' + modelObject.collection + '.' + hashedFieldName + '.' + cleanFunctionName;
 
       if (cachedResults[cachePath] === undefined) {
         cachedResults[cachePath] = filter.fn(flattenBody);

--- a/lib/api/dsl/methods.js
+++ b/lib/api/dsl/methods.js
@@ -830,10 +830,11 @@ module.exports = methods = {
 function buildCurriedFunction(index, collection, field, operatorName, value, curriedFunctionName, roomId, not, inGlobals) {
   var
     curriedFunction,
+    hashedFieldName = md5(field),
     path;
 
   curriedFunctionName = md5(curriedFunctionName);
-  path = index + '.' + collection + '.' + field + '.' + curriedFunctionName;
+  path = index + '.' + collection + '.' + hashedFieldName + '.' + curriedFunctionName;
 
   if (operators[operatorName] === undefined) {
     return new BadRequestError('Operator ' + operatorName + ' doesn\'t exist');
@@ -851,25 +852,25 @@ function buildCurriedFunction(index, collection, field, operatorName, value, cur
     methods.dsl.filtersTree[index][collection].fields = {};
   }
 
-  if (!methods.dsl.filtersTree[index][collection].fields[field]) {
-    methods.dsl.filtersTree[index][collection].fields[field] = {};
+  if (!methods.dsl.filtersTree[index][collection].fields[hashedFieldName]) {
+    methods.dsl.filtersTree[index][collection].fields[hashedFieldName] = {};
   }
 
-  if (!methods.dsl.filtersTree[index][collection].fields[field][curriedFunctionName]) {
+  if (!methods.dsl.filtersTree[index][collection].fields[hashedFieldName][curriedFunctionName]) {
     curriedFunction = _.curry(operators[operatorName]);
     curriedFunction = _.curry(curriedFunction(field, value));
     if (not) {
       curriedFunction = _.negate(curriedFunction);
     }
 
-    methods.dsl.filtersTree[index][collection].fields[field][curriedFunctionName] = {
+    methods.dsl.filtersTree[index][collection].fields[hashedFieldName][curriedFunctionName] = {
       rooms: [],
       fn: curriedFunction
     };
   }
 
-  if (methods.dsl.filtersTree[index][collection].fields[field][curriedFunctionName].rooms.indexOf(roomId) === -1) {
-    methods.dsl.filtersTree[index][collection].fields[field][curriedFunctionName].rooms.push(roomId);
+  if (methods.dsl.filtersTree[index][collection].fields[hashedFieldName][curriedFunctionName].rooms.indexOf(roomId) === -1) {
+    methods.dsl.filtersTree[index][collection].fields[hashedFieldName][curriedFunctionName].rooms.push(roomId);
   }
 
   if (inGlobals) {
@@ -884,7 +885,7 @@ function buildCurriedFunction(index, collection, field, operatorName, value, cur
 
   return {
     path: path,
-    filter: methods.dsl.filtersTree[index][collection].fields[field][curriedFunctionName]
+    filter: methods.dsl.filtersTree[index][collection].fields[hashedFieldName][curriedFunctionName]
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "apiVersion": "1.0",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",

--- a/test/api/dsl/index/testFieldFilters.test.js
+++ b/test/api/dsl/index/testFieldFilters.test.js
@@ -2,6 +2,7 @@ var
   should = require('should'),
   q = require('q'),
   rewire = require('rewire'),
+  md5 = require('crypto-md5'),
   RequestObject = require.main.require('lib/api/core/models/requestObject'),
   Dsl = rewire('../../../../lib/api/dsl/index');
 
@@ -84,15 +85,12 @@ describe('Test: dsl.testFieldFilters', function () {
       rooms = [ 'foo', 'bar', 'baz' ];
 
     dsl.filtersTree[requestObject.index] = {};
-    dsl.filtersTree[requestObject.index][requestObject.collection] = {
-      fields: {
-        'foo.bar': {
-          testFoobar: {
-            rooms: rooms,
-            fn: function () {
-              return true;
-            }
-          }
+    dsl.filtersTree[requestObject.index][requestObject.collection] = {fields: {}};
+    dsl.filtersTree[requestObject.index][requestObject.collection].fields[md5('foo.bar')] = {
+      testFoobar: {
+        rooms: rooms,
+        fn: function () {
+          return true;
         }
       }
     };
@@ -107,15 +105,12 @@ describe('Test: dsl.testFieldFilters', function () {
       rooms = [ 'foo', 'bar', 'baz' ];
 
     dsl.filtersTree[requestObject.index] = {};
-    dsl.filtersTree[requestObject.index][requestObject.collection] = {
-      fields: {
-        'foo.bar': {
-          testFoobar: {
-            rooms: rooms,
-            fn: function () {
-              return true;
-            }
-          }
+    dsl.filtersTree[requestObject.index][requestObject.collection] = {fields: {}};
+    dsl.filtersTree[requestObject.index][requestObject.collection].fields[md5('foo.bar')] = {
+      testFoobar: {
+        rooms: rooms,
+        fn: function () {
+          return true;
         }
       }
     };

--- a/test/api/dsl/methods/and.test.js
+++ b/test/api/dsl/methods/and.test.js
@@ -36,7 +36,9 @@ describe('Test and method', function () {
       }
     ],
     termCity = md5('termcityNYC'),
-    termHobby = md5('termhobbycomputer');
+    termHobby = md5('termhobbycomputer'),
+    encodedCity = md5('city'),
+    encodedHobby = md5('hobby');
 
 
   before(function () {
@@ -49,24 +51,24 @@ describe('Test and method', function () {
     should(methods.dsl.filtersTree[index]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.city).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.hobby).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedCity]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedHobby]).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
-    should(methods.dsl.filtersTree[index][collection].fields.city[termCity]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.hobby[termHobby]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedCity][termCity]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedHobby][termHobby]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var rooms;
 
-    rooms = methods.dsl.filtersTree[index][collection].fields.city[termCity].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedCity][termCity].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[index][collection].fields.hobby[termHobby].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedHobby][termHobby].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
@@ -75,14 +77,14 @@ describe('Test and method', function () {
   it('should construct the filterTree with correct functions', function () {
     var result;
 
-    result = methods.dsl.filtersTree[index][collection].fields.city[termCity].fn(documentGrace);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedCity][termCity].fn(documentGrace);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.city[termCity].fn(documentAda);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedCity][termCity].fn(documentAda);
     should(result).be.exactly(false);
 
-    result = methods.dsl.filtersTree[index][collection].fields.hobby[termHobby].fn(documentGrace);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedHobby][termHobby].fn(documentGrace);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.hobby[termHobby].fn(documentAda);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedHobby][termHobby].fn(documentAda);
     should(result).be.exactly(true);
   });
 

--- a/test/api/dsl/methods/bool.test.js
+++ b/test/api/dsl/methods/bool.test.js
@@ -66,7 +66,12 @@ describe('Test bool method', function () {
     rangeagelt85 = md5('rangeagelt85'),
     nottermcityNYC = md5('nottermcityNYC'),
     termhobbycomputer = md5('termhobbycomputer'),
-    existslastName = md5('existslastName');
+    existslastName = md5('existslastName'),
+    encodedFirstName = md5('firstName'),
+    encodedAge = md5('age'),
+    encodedCity = md5('city'),
+    encodedHobby = md5('hobby'),
+    encodedLastName = md5('lastName');
 
   before(function () {
     methods.dsl.filtersTree = {};
@@ -78,50 +83,50 @@ describe('Test bool method', function () {
     should(methods.dsl.filtersTree[index]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.firstName).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.age).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.city).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.hobby).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.lastName).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedFirstName]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedAge]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedCity]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedHobby]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedLastName]).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
-    should(methods.dsl.filtersTree[index][collection].fields.firstName[md5('termsfirstNameGrace,Ada')]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.age[rangeagegte36]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.age[rangeagelt85]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.city[nottermcityNYC]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.hobby[termhobbycomputer]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.lastName[existslastName]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedFirstName][md5('termsfirstNameGrace,Ada')]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedAge][rangeagegte36]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedAge][rangeagelt85]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedCity][nottermcityNYC]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedHobby][termhobbycomputer]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedLastName][existslastName]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var rooms;
 
-    rooms = methods.dsl.filtersTree[index][collection].fields.firstName[md5('termsfirstNameGrace,Ada')].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedFirstName][md5('termsfirstNameGrace,Ada')].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[index][collection].fields.age[rangeagegte36].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedAge][rangeagegte36].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
-    rooms = methods.dsl.filtersTree[index][collection].fields.age[rangeagelt85].rooms;
-    should(rooms).be.an.Array();
-    should(rooms).have.length(1);
-    should(rooms[0]).be.exactly(roomId);
-
-    rooms = methods.dsl.filtersTree[index][collection].fields.city[nottermcityNYC].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedAge][rangeagelt85].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[index][collection].fields.hobby[termhobbycomputer].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedCity][nottermcityNYC].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[index][collection].fields.lastName[existslastName].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedHobby][termhobbycomputer].rooms;
+    should(rooms).be.an.Array();
+    should(rooms).have.length(1);
+    should(rooms[0]).be.exactly(roomId);
+
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedLastName][existslastName].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
@@ -130,34 +135,34 @@ describe('Test bool method', function () {
   it('should construct the filterTree with correct functions', function () {
     var result;
 
-    result = methods.dsl.filtersTree[index][collection].fields.firstName[md5('termsfirstNameGrace,Ada')].fn(documentGrace);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedFirstName][md5('termsfirstNameGrace,Ada')].fn(documentGrace);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.firstName[md5('termsfirstNameGrace,Ada')].fn(documentAda);
-    should(result).be.exactly(true);
-
-    result = methods.dsl.filtersTree[index][collection].fields.age[rangeagegte36].fn(documentGrace);
-    should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.age[rangeagegte36].fn(documentAda);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedFirstName][md5('termsfirstNameGrace,Ada')].fn(documentAda);
     should(result).be.exactly(true);
 
-    result = methods.dsl.filtersTree[index][collection].fields.age[rangeagelt85].fn(documentGrace);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedAge][rangeagegte36].fn(documentGrace);
+    should(result).be.exactly(true);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedAge][rangeagegte36].fn(documentAda);
+    should(result).be.exactly(true);
+
+    result = methods.dsl.filtersTree[index][collection].fields[encodedAge][rangeagelt85].fn(documentGrace);
     should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[index][collection].fields.age[rangeagelt85].fn(documentAda);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedAge][rangeagelt85].fn(documentAda);
     should(result).be.exactly(true);
 
-    result = methods.dsl.filtersTree[index][collection].fields.city[nottermcityNYC].fn(documentGrace);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedCity][nottermcityNYC].fn(documentGrace);
     should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[index][collection].fields.city[nottermcityNYC].fn(documentAda);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedCity][nottermcityNYC].fn(documentAda);
     should(result).be.exactly(true);
 
-    result = methods.dsl.filtersTree[index][collection].fields.hobby[termhobbycomputer].fn(documentGrace);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedHobby][termhobbycomputer].fn(documentGrace);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.hobby[termhobbycomputer].fn(documentAda);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedHobby][termhobbycomputer].fn(documentAda);
     should(result).be.exactly(true);
 
-    result = methods.dsl.filtersTree[index][collection].fields.lastName[existslastName].fn(documentGrace);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLastName][existslastName].fn(documentGrace);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.lastName[existslastName].fn(documentAda);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLastName][existslastName].fn(documentAda);
     should(result).be.exactly(true);
   });
 

--- a/test/api/dsl/methods/buildCurriedFunction.test.js
+++ b/test/api/dsl/methods/buildCurriedFunction.test.js
@@ -7,7 +7,8 @@ var
 describe('Test: dsl.buildCurriedFunction method', function () {
   var
     buildCurriedFunction = methods.__get__('buildCurriedFunction'),
-    hasedFilter = md5('filter');
+    hashedFilter = md5('filter'),
+    hashedField = md5('field');
 
   beforeEach(function () {
     methods.dsl = { filtersTree: {} };
@@ -25,7 +26,7 @@ describe('Test: dsl.buildCurriedFunction method', function () {
     var result = buildCurriedFunction.call(methods, 'index', 'collection', 'field', 'gte', 42, 'filter', 'roomId');
 
     should.not.exist(result.error);
-    should(result.path).be.exactly('index.collection.field.' + md5('filter'));
+    should(result.path).be.exactly(`index.collection.${hashedField}.${hashedFilter}`);
     should.exist(result.filter);
     should(result.filter.rooms).be.an.Array().and.match(['roomId']);
     should(result.filter.rooms.length).be.eql(1);
@@ -33,11 +34,11 @@ describe('Test: dsl.buildCurriedFunction method', function () {
 
     should.exist(methods.dsl.filtersTree.index.collection);
     should.exist(methods.dsl.filtersTree.index.collection.fields);
-    should.exist(methods.dsl.filtersTree.index.collection.fields.field);
-    should.exist(methods.dsl.filtersTree.index.collection.fields.field[hasedFilter]);
-    should(methods.dsl.filtersTree.index.collection.fields.field[hasedFilter].rooms).be.an.Array().and.match(['roomId']);
+    should.exist(methods.dsl.filtersTree.index.collection.fields[hashedField]);
+    should.exist(methods.dsl.filtersTree.index.collection.fields[hashedField][hashedFilter]);
+    should(methods.dsl.filtersTree.index.collection.fields[hashedField][hashedFilter].rooms).be.an.Array().and.match(['roomId']);
     should(result.filter.rooms.length).be.eql(1);
-    should(methods.dsl.filtersTree.index.collection.fields.field[hasedFilter].fn).be.a.Function();
+    should(methods.dsl.filtersTree.index.collection.fields[hashedField][hashedFilter].fn).be.a.Function();
 
     should.not.exist(methods.dsl.filtersTree.index.collection.rooms);
   });
@@ -46,8 +47,8 @@ describe('Test: dsl.buildCurriedFunction method', function () {
     buildCurriedFunction.call(methods, 'index', 'collection', 'field', 'gte', 42, 'filter', 'roomId');
     buildCurriedFunction.call(methods, 'index', 'collection', 'field', 'gte', 42, 'filter', 'roomId');
 
-    should(methods.dsl.filtersTree.index.collection.fields.field[hasedFilter].rooms).be.an.Array().and.match(['roomId']);
-    should(methods.dsl.filtersTree.index.collection.fields.field[hasedFilter].rooms.length).be.eql(1);
+    should(methods.dsl.filtersTree.index.collection.fields[hashedField][hashedFilter].rooms).be.an.Array().and.match(['roomId']);
+    should(methods.dsl.filtersTree.index.collection.fields[hashedField][hashedFilter].rooms.length).be.eql(1);
   });
 
   it('should also add the room to the global rooms list if the filter is global', function () {

--- a/test/api/dsl/methods/exists.test.js
+++ b/test/api/dsl/methods/exists.test.js
@@ -22,7 +22,8 @@ describe('Test exists method', function () {
     filter = {
       field: 'lastName'
     },
-    existslastName = md5('existslastName');
+    existslastName = md5('existslastName'),
+    encodedLastName = md5('lastName');
 
 
   before(function () {
@@ -35,18 +36,18 @@ describe('Test exists method', function () {
     should(methods.dsl.filtersTree[index]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.lastName).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedLastName]).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
-    should(methods.dsl.filtersTree[index][collection].fields.lastName[existslastName]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedLastName][existslastName]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var rooms;
 
     // Test gt from filterGrace
-    rooms = methods.dsl.filtersTree[index][collection].fields.lastName[existslastName].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedLastName][existslastName].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
@@ -55,9 +56,9 @@ describe('Test exists method', function () {
   it('should construct the filterTree with correct functions exists', function () {
     var result;
 
-    result = methods.dsl.filtersTree[index][collection].fields.lastName[existslastName].fn(documentGrace);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLastName][existslastName].fn(documentGrace);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.lastName[existslastName].fn(documentAda);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLastName][existslastName].fn(documentAda);
     should(result).be.exactly(false);
   });
 

--- a/test/api/dsl/methods/geoBoundingBox.test.js
+++ b/test/api/dsl/methods/geoBoundingBox.test.js
@@ -65,7 +65,8 @@ describe('Test geoboundingbox method', function () {
     },
     locationgeoBoundingBoxgcmfj457fu10ffy7m4 = md5('locationgeoBoundingBoxgcmfj457fu10ffy7m4'),
     locationgeoBoundingBoxj042p0j0phsc9wnc4v = md5('locationgeoBoundingBoxj042p0j0phsc9wnc4v'),
-    locationgeoBoundingBoxc0x5c7zzzds7jw7zzz = md5('locationgeoBoundingBoxc0x5c7zzzds7jw7zzz');
+    locationgeoBoundingBoxc0x5c7zzzds7jw7zzz = md5('locationgeoBoundingBoxc0x5c7zzzds7jw7zzz'),
+    encodedLocation = md5('location');
 
 
   before(function () {
@@ -90,7 +91,7 @@ describe('Test geoboundingbox method', function () {
     should(methods.dsl.filtersTree[index]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.location).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedLocation]).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
@@ -98,26 +99,26 @@ describe('Test geoboundingbox method', function () {
     // because we have many times the same coord in filters,
     // we must have only three functions (one for filterEngland, and two for filterUSA)
 
-    should(Object.keys(methods.dsl.filtersTree[index][collection].fields.location)).have.length(3);
-    should(methods.dsl.filtersTree[index][collection].fields.location[locationgeoBoundingBoxgcmfj457fu10ffy7m4]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.location[locationgeoBoundingBoxj042p0j0phsc9wnc4v]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.location[locationgeoBoundingBoxc0x5c7zzzds7jw7zzz]).not.be.empty();
+    should(Object.keys(methods.dsl.filtersTree[index][collection].fields[encodedLocation])).have.length(3);
+    should(methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoBoundingBoxgcmfj457fu10ffy7m4]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoBoundingBoxj042p0j0phsc9wnc4v]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoBoundingBoxc0x5c7zzzds7jw7zzz]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var rooms;
 
-    rooms = methods.dsl.filtersTree[index][collection].fields.location[locationgeoBoundingBoxgcmfj457fu10ffy7m4].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoBoundingBoxgcmfj457fu10ffy7m4].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[index][collection].fields.location[locationgeoBoundingBoxj042p0j0phsc9wnc4v].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoBoundingBoxj042p0j0phsc9wnc4v].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[index][collection].fields.location[locationgeoBoundingBoxc0x5c7zzzds7jw7zzz].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoBoundingBoxc0x5c7zzzds7jw7zzz].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
@@ -127,21 +128,21 @@ describe('Test geoboundingbox method', function () {
     var result;
 
     // test filterEngland
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoBoundingBoxgcmfj457fu10ffy7m4].fn(documentGrace);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoBoundingBoxgcmfj457fu10ffy7m4].fn(documentGrace);
     should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoBoundingBoxgcmfj457fu10ffy7m4].fn(documentAda);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoBoundingBoxgcmfj457fu10ffy7m4].fn(documentAda);
     should(result).be.exactly(true);
 
     // test filterUSA
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoBoundingBoxj042p0j0phsc9wnc4v].fn(documentGrace);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoBoundingBoxj042p0j0phsc9wnc4v].fn(documentGrace);
     should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoBoundingBoxj042p0j0phsc9wnc4v].fn(documentAda);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoBoundingBoxj042p0j0phsc9wnc4v].fn(documentAda);
     should(result).be.exactly(false);
 
     // test filterUSA2
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoBoundingBoxc0x5c7zzzds7jw7zzz].fn(documentGrace);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoBoundingBoxc0x5c7zzzds7jw7zzz].fn(documentGrace);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoBoundingBoxc0x5c7zzzds7jw7zzz].fn(documentAda);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoBoundingBoxc0x5c7zzzds7jw7zzz].fn(documentAda);
     should(result).be.exactly(false);
   });
 

--- a/test/api/dsl/methods/geoDistance.test.js
+++ b/test/api/dsl/methods/geoDistance.test.js
@@ -49,7 +49,8 @@ describe('Test geoDistance method', function () {
     },
     locationgeoDistancekpbxyzbpv111318 = md5('locationgeoDistancekpbxyzbpv111318'),
     locationgeoDistancekpbxyzbpv111320 = md5('locationgeoDistancekpbxyzbpv111320'),
-    locationgeoDistancekpbxyzbpv111317 = md5('locationgeoDistancekpbxyzbpv111317');
+    locationgeoDistancekpbxyzbpv111317 = md5('locationgeoDistancekpbxyzbpv111317'),
+    encodedLocation = md5('location');
 
   before(function () {
     methods.dsl.filtersTree = {};
@@ -70,7 +71,7 @@ describe('Test geoDistance method', function () {
     should(methods.dsl.filtersTree[index]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.location).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedLocation]).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
@@ -78,32 +79,32 @@ describe('Test geoDistance method', function () {
     // because we have many times the same coord in filters,
     // we must have only four functions
     
-    should(Object.keys(methods.dsl.filtersTree[index][collection].fields.location)).have.length(4);
-    should(methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistancekpbxyzbpv111318]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistancekpbxyzbpv111320]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistancekpbxyzbpv111317]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.location[md5('locationgeoDistancekpbxyzbpv111318.9999168')]).not.be.empty();
+    should(Object.keys(methods.dsl.filtersTree[index][collection].fields[encodedLocation])).have.length(4);
+    should(methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoDistancekpbxyzbpv111318]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoDistancekpbxyzbpv111320]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoDistancekpbxyzbpv111317]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedLocation][md5('locationgeoDistancekpbxyzbpv111318.9999168')]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var rooms;
 
-    rooms = methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistancekpbxyzbpv111318].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoDistancekpbxyzbpv111318].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistancekpbxyzbpv111320].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoDistancekpbxyzbpv111320].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistancekpbxyzbpv111317].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoDistancekpbxyzbpv111317].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[index][collection].fields.location[md5('locationgeoDistancekpbxyzbpv111318.9999168')].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedLocation][md5('locationgeoDistancekpbxyzbpv111318.9999168')].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
@@ -113,19 +114,19 @@ describe('Test geoDistance method', function () {
     var result;
 
     // test exact
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistancekpbxyzbpv111318].fn(document);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoDistancekpbxyzbpv111318].fn(document);
     should(result).be.exactly(true);
 
     // test ok
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistancekpbxyzbpv111320].fn(document);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoDistancekpbxyzbpv111320].fn(document);
     should(result).be.exactly(true);
 
     // test too far
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistancekpbxyzbpv111317].fn(document);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoDistancekpbxyzbpv111317].fn(document);
     should(result).be.exactly(false);
 
     // test human readable distance
-    result = methods.dsl.filtersTree[index][collection].fields.location[md5('locationgeoDistancekpbxyzbpv111318.9999168')].fn(document);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLocation][md5('locationgeoDistancekpbxyzbpv111318.9999168')].fn(document);
     should(result).be.exactly(true);
 
   });

--- a/test/api/dsl/methods/geoDistanceRange.test.js
+++ b/test/api/dsl/methods/geoDistanceRange.test.js
@@ -68,7 +68,8 @@ describe('Test geoDistanceRange method', function () {
     },
     locationgeoDistanceRangekpbxyzbpv111320111317 = md5('locationgeoDistanceRangekpbxyzbpv111320111317'),
     locationgeoDistanceRangekpbxyzbpv110 = md5('locationgeoDistanceRangekpbxyzbpv110'),
-    locationgeoDistanceRangekpbxyzbpv111318111318 = md5('locationgeoDistanceRangekpbxyzbpv111318111318');
+    locationgeoDistanceRangekpbxyzbpv111318111318 = md5('locationgeoDistanceRangekpbxyzbpv111318111318'),
+    encodedLocation = md5('location');
 
   before(function () {
     methods.dsl.filtersTree = {};
@@ -89,14 +90,14 @@ describe('Test geoDistanceRange method', function () {
     should(methods.dsl.filtersTree[index]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.location).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedLocation]).not.be.empty();
   });
   it('should ', function () {
     should(methods.dsl.filtersTree).not.be.empty();
     should(methods.dsl.filtersTree[index]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.location).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedLocation]).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
@@ -104,32 +105,32 @@ describe('Test geoDistanceRange method', function () {
     // because we have many times the same coord in filters,
     // we must have only four functions
     
-    should(Object.keys(methods.dsl.filtersTree[index][collection].fields.location)).have.length(4);
-    should(methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv111320111317]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv110]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv111318111318]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.location[md5('locationgeoDistanceRangekpbxyzbpv111312.96111319.05600000001')]).not.be.empty();
+    should(Object.keys(methods.dsl.filtersTree[index][collection].fields[encodedLocation])).have.length(4);
+    should(methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoDistanceRangekpbxyzbpv111320111317]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoDistanceRangekpbxyzbpv110]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoDistanceRangekpbxyzbpv111318111318]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedLocation][md5('locationgeoDistanceRangekpbxyzbpv111312.96111319.05600000001')]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var rooms;
 
-    rooms = methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv111320111317].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoDistanceRangekpbxyzbpv111320111317].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv110].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoDistanceRangekpbxyzbpv110].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv111318111318].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoDistanceRangekpbxyzbpv111318111318].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[index][collection].fields.location[md5('locationgeoDistanceRangekpbxyzbpv111312.96111319.05600000001')].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedLocation][md5('locationgeoDistanceRangekpbxyzbpv111312.96111319.05600000001')].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
@@ -139,30 +140,30 @@ describe('Test geoDistanceRange method', function () {
     var result;
 
     // test ok
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv111320111317].fn(document);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoDistanceRangekpbxyzbpv111320111317].fn(document);
     should(result).be.exactly(true);
 
     // test not ok
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv110].fn(document);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoDistanceRangekpbxyzbpv110].fn(document);
     should(result).be.exactly(false);
 
     // test human readable distance
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv111318111318].fn(document);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoDistanceRangekpbxyzbpv111318111318].fn(document);
     should(result).be.exactly(true);
 
     // test from == to
-    result = methods.dsl.filtersTree[index][collection].fields.location[md5('locationgeoDistanceRangekpbxyzbpv111312.96111319.05600000001')].fn(document);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLocation][md5('locationgeoDistanceRangekpbxyzbpv111312.96111319.05600000001')].fn(document);
     should(result).be.exactly(true);
 
   });
 
   it('should return false if no lat or lon members exists for the location member of the document', function () {
     // test ok
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv111320111317].fn(documentBad);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoDistanceRangekpbxyzbpv111320111317].fn(documentBad);
     should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv111320111317].fn(documentBadLon);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoDistanceRangekpbxyzbpv111320111317].fn(documentBadLon);
     should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoDistanceRangekpbxyzbpv111320111317].fn(documentBadLat);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoDistanceRangekpbxyzbpv111320111317].fn(documentBadLat);
     should(result).be.exactly(false);
   });
 

--- a/test/api/dsl/methods/geoPolygon.test.js
+++ b/test/api/dsl/methods/geoPolygon.test.js
@@ -51,7 +51,8 @@ describe('Test geoPolygon method', function () {
     },
     locationgeoPolygonkpbdqcbnts00twy01mebpm9npc67zz631zyd = md5('locationgeoPolygonkpbdqcbnts00twy01mebpm9npc67zz631zyd'),
     locationgeoPolygonkpbxyzbpvs00twy01mebpvxypcr7zzzzzzzz = md5('locationgeoPolygonkpbxyzbpvs00twy01mebpvxypcr7zzzzzzzz'),
-    locationgeoPolygons1zbfk3yns1zyd63zws1zned3z8s1z0gs3y0 = md5('locationgeoPolygons1zbfk3yns1zyd63zws1zned3z8s1z0gs3y0');
+    locationgeoPolygons1zbfk3yns1zyd63zws1zned3z8s1z0gs3y0 = md5('locationgeoPolygons1zbfk3yns1zyd63zws1zned3z8s1z0gs3y0'),
+    encodedLocation = md5('location');
 
   before(function () {
     methods.dsl.filtersTree = {};
@@ -69,7 +70,7 @@ describe('Test geoPolygon method', function () {
     should(methods.dsl.filtersTree[index]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.location).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedLocation]).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
@@ -77,26 +78,26 @@ describe('Test geoPolygon method', function () {
     // because we have many times the same coord in filters,
     // we must have only four functions
     
-    should(Object.keys(methods.dsl.filtersTree[index][collection].fields.location)).have.length(3);
-    should(methods.dsl.filtersTree[index][collection].fields.location[locationgeoPolygonkpbdqcbnts00twy01mebpm9npc67zz631zyd]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.location[locationgeoPolygonkpbxyzbpvs00twy01mebpvxypcr7zzzzzzzz]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.location[locationgeoPolygons1zbfk3yns1zyd63zws1zned3z8s1z0gs3y0]).not.be.empty();
+    should(Object.keys(methods.dsl.filtersTree[index][collection].fields[encodedLocation])).have.length(3);
+    should(methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoPolygonkpbdqcbnts00twy01mebpm9npc67zz631zyd]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoPolygonkpbxyzbpvs00twy01mebpvxypcr7zzzzzzzz]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoPolygons1zbfk3yns1zyd63zws1zned3z8s1z0gs3y0]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var rooms;
 
-    rooms = methods.dsl.filtersTree[index][collection].fields.location[locationgeoPolygonkpbdqcbnts00twy01mebpm9npc67zz631zyd].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoPolygonkpbdqcbnts00twy01mebpm9npc67zz631zyd].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[index][collection].fields.location[locationgeoPolygonkpbxyzbpvs00twy01mebpvxypcr7zzzzzzzz].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoPolygonkpbxyzbpvs00twy01mebpvxypcr7zzzzzzzz].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[index][collection].fields.location[locationgeoPolygons1zbfk3yns1zyd63zws1zned3z8s1z0gs3y0].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoPolygons1zbfk3yns1zyd63zws1zned3z8s1z0gs3y0].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
@@ -107,15 +108,15 @@ describe('Test geoPolygon method', function () {
     var result;
 
     // test exact
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoPolygonkpbdqcbnts00twy01mebpm9npc67zz631zyd].fn(document);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoPolygonkpbdqcbnts00twy01mebpm9npc67zz631zyd].fn(document);
     should(result).be.exactly(true);
 
     // test outside
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoPolygonkpbxyzbpvs00twy01mebpvxypcr7zzzzzzzz].fn(document);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoPolygonkpbxyzbpvs00twy01mebpvxypcr7zzzzzzzz].fn(document);
     should(result).be.exactly(true);
 
     // test on limit
-    result = methods.dsl.filtersTree[index][collection].fields.location[locationgeoPolygons1zbfk3yns1zyd63zws1zned3z8s1z0gs3y0].fn(document);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLocation][locationgeoPolygons1zbfk3yns1zyd63zws1zned3z8s1z0gs3y0].fn(document);
     should(result).be.exactly(false);
 
   });

--- a/test/api/dsl/methods/getFormattedFilters.test.js
+++ b/test/api/dsl/methods/getFormattedFilters.test.js
@@ -14,7 +14,9 @@ describe('Test: dsl.getFormattedFilters method', function () {
     existsfoo = md5('existsfoo'),
     notexistsfoo = md5('notexistsfoo'),
     existsbar = md5('existsbar'),
-    notexistsbar = md5('notexistsbar');
+    notexistsbar = md5('notexistsbar'),
+    encodedFoo = md5('foo'),
+    encodedBar = md5('bar');
 
   beforeEach(function () {
     methods.dsl = { filtersTree: {} };
@@ -38,12 +40,12 @@ describe('Test: dsl.getFormattedFilters method', function () {
 
     getFormattedFilters('roomId', 'index', 'collection', filter)
       .then(function (formattedFilter) {
-        should.exist(formattedFilter['index.collection.foo.' + existsfoo]);
-        should(formattedFilter['index.collection.foo.' + existsfoo]).be.an.Object();
-        should.exist(formattedFilter['index.collection.foo.' + existsfoo].rooms);
-        should(formattedFilter['index.collection.foo.' + existsfoo].rooms).be.an.Array().and.match(['roomId']);
-        should(formattedFilter['index.collection.foo.' + existsfoo].rooms.length).eql(1);
-        should.exist(formattedFilter['index.collection.foo.' + existsfoo].fn);
+        should.exist(formattedFilter[`index.collection.${encodedFoo}.${existsfoo}`]);
+        should(formattedFilter[`index.collection.${encodedFoo}.${existsfoo}`]).be.an.Object();
+        should.exist(formattedFilter[`index.collection.${encodedFoo}.${existsfoo}`].rooms);
+        should(formattedFilter[`index.collection.${encodedFoo}.${existsfoo}`].rooms).be.an.Array().and.match(['roomId']);
+        should(formattedFilter[`index.collection.${encodedFoo}.${existsfoo}`].rooms.length).eql(1);
+        should.exist(formattedFilter[`index.collection.${encodedFoo}.${existsfoo}`].fn);
         done();
       })
       .catch(function (error) {
@@ -60,19 +62,19 @@ describe('Test: dsl.getFormattedFilters method', function () {
 
     getFormattedFilters('roomId', 'index', 'collection', filters)
       .then(function (formattedFilter) {
-        should.exist(formattedFilter['index.collection.foo.' + existsfoo]);
-        should(formattedFilter['index.collection.foo.' + existsfoo]).be.an.Object();
-        should.exist(formattedFilter['index.collection.foo.' + existsfoo].rooms);
-        should(formattedFilter['index.collection.foo.' + existsfoo].rooms).be.an.Array().and.match(['roomId']);
-        should(formattedFilter['index.collection.foo.' + existsfoo].rooms.length).eql(1);
-        should.exist(formattedFilter['index.collection.foo.' + existsfoo].fn);
+        should.exist(formattedFilter[`index.collection.${encodedFoo}.${existsfoo}`]);
+        should(formattedFilter[`index.collection.${encodedFoo}.${existsfoo}`]).be.an.Object();
+        should.exist(formattedFilter[`index.collection.${encodedFoo}.${existsfoo}`].rooms);
+        should(formattedFilter[`index.collection.${encodedFoo}.${existsfoo}`].rooms).be.an.Array().and.match(['roomId']);
+        should(formattedFilter[`index.collection.${encodedFoo}.${existsfoo}`].rooms.length).eql(1);
+        should.exist(formattedFilter[`index.collection.${encodedFoo}.${existsfoo}`].fn);
 
-        should.exist(formattedFilter['index.collection.bar.' + existsbar]);
-        should(formattedFilter['index.collection.bar.' + existsbar]).be.an.Object();
-        should.exist(formattedFilter['index.collection.bar.' + existsbar].rooms);
-        should(formattedFilter['index.collection.bar.' + existsbar].rooms).be.an.Array().and.match(['roomId']);
-        should(formattedFilter['index.collection.bar.' + existsbar].rooms.length).eql(1);
-        should.exist(formattedFilter['index.collection.bar.' + existsbar].fn);
+        should.exist(formattedFilter[`index.collection.${encodedBar}.${existsbar}`]);
+        should(formattedFilter[`index.collection.${encodedBar}.${existsbar}`]).be.an.Object();
+        should.exist(formattedFilter[`index.collection.${encodedBar}.${existsbar}`].rooms);
+        should(formattedFilter[`index.collection.${encodedBar}.${existsbar}`].rooms).be.an.Array().and.match(['roomId']);
+        should(formattedFilter[`index.collection.${encodedBar}.${existsbar}`].rooms.length).eql(1);
+        should.exist(formattedFilter[`index.collection.${encodedBar}.${existsbar}`].fn);
 
         done();
       })
@@ -91,19 +93,19 @@ describe('Test: dsl.getFormattedFilters method', function () {
 
     getFormattedFilters('roomId', 'index', 'collection', filters)
       .then(function (formattedFilter) {
-        should.exist(formattedFilter['index.collection.foo.' + existsfoo]);
-        should(formattedFilter['index.collection.foo.' + existsfoo]).be.an.Object();
-        should.exist(formattedFilter['index.collection.foo.' + existsfoo].rooms);
-        should(formattedFilter['index.collection.foo.' + existsfoo].rooms).be.an.Array().and.match(['roomId']);
-        should(formattedFilter['index.collection.foo.' + existsfoo].rooms.length).eql(1);
-        should.exist(formattedFilter['index.collection.foo.' + existsfoo].fn);
+        should.exist(formattedFilter[`index.collection.${encodedFoo}.${existsfoo}`]);
+        should(formattedFilter[`index.collection.${encodedFoo}.${existsfoo}`]).be.an.Object();
+        should.exist(formattedFilter[`index.collection.${encodedFoo}.${existsfoo}`].rooms);
+        should(formattedFilter[`index.collection.${encodedFoo}.${existsfoo}`].rooms).be.an.Array().and.match(['roomId']);
+        should(formattedFilter[`index.collection.${encodedFoo}.${existsfoo}`].rooms.length).eql(1);
+        should.exist(formattedFilter[`index.collection.${encodedFoo}.${existsfoo}`].fn);
 
-        should.exist(formattedFilter['index.collection.bar.' + existsbar]);
-        should(formattedFilter['index.collection.bar.' + existsbar]).be.an.Object();
-        should.exist(formattedFilter['index.collection.bar.' + existsbar].rooms);
-        should(formattedFilter['index.collection.bar.' + existsbar].rooms).be.an.Array().and.match(['roomId']);
-        should(formattedFilter['index.collection.bar.' + existsbar].rooms.length).eql(1);
-        should.exist(formattedFilter['index.collection.bar.' + existsbar].fn);
+        should.exist(formattedFilter[`index.collection.${encodedBar}.${existsbar}`]);
+        should(formattedFilter[`index.collection.${encodedBar}.${existsbar}`]).be.an.Object();
+        should.exist(formattedFilter[`index.collection.${encodedBar}.${existsbar}`].rooms);
+        should(formattedFilter[`index.collection.${encodedBar}.${existsbar}`].rooms).be.an.Array().and.match(['roomId']);
+        should(formattedFilter[`index.collection.${encodedBar}.${existsbar}`].rooms.length).eql(1);
+        should.exist(formattedFilter[`index.collection.${encodedBar}.${existsbar}`].fn);
 
         done();
       })
@@ -122,12 +124,12 @@ describe('Test: dsl.getFormattedFilters method', function () {
 
     getFormattedFilters('roomId', 'index', 'collection', filter, true)
       .then(function (formattedFilter) {
-        should.exist(formattedFilter['index.collection.foo.' + notexistsfoo]);
-        should(formattedFilter['index.collection.foo.' + notexistsfoo]).be.an.Object();
-        should.exist(formattedFilter['index.collection.foo.' + notexistsfoo].rooms);
-        should(formattedFilter['index.collection.foo.' + notexistsfoo].rooms).be.an.Array().and.match(['roomId']);
-        should(formattedFilter['index.collection.foo.' + notexistsfoo].rooms.length).eql(1);
-        should.exist(formattedFilter['index.collection.foo.' + notexistsfoo].fn);
+        should.exist(formattedFilter[`index.collection.${encodedFoo}.${notexistsfoo}`]);
+        should(formattedFilter[`index.collection.${encodedFoo}.${notexistsfoo}`]).be.an.Object();
+        should.exist(formattedFilter[`index.collection.${encodedFoo}.${notexistsfoo}`].rooms);
+        should(formattedFilter[`index.collection.${encodedFoo}.${notexistsfoo}`].rooms).be.an.Array().and.match(['roomId']);
+        should(formattedFilter[`index.collection.${encodedFoo}.${notexistsfoo}`].rooms.length).eql(1);
+        should.exist(formattedFilter[`index.collection.${encodedFoo}.${notexistsfoo}`].fn);
         done();
       })
       .catch(function (error) {

--- a/test/api/dsl/methods/ids.test.js
+++ b/test/api/dsl/methods/ids.test.js
@@ -29,7 +29,8 @@ describe('Test ids method', function () {
       values: ['idGrace']
     },
     idsIdidGrace = md5('ids_ididGrace'),
-    notidsIdidGrace = md5('notids_ididGrace');
+    notidsIdidGrace = md5('notids_ididGrace'),
+    encodedId = md5('_id');
 
 
   before(function () {
@@ -45,20 +46,20 @@ describe('Test ids method', function () {
     should(methods.dsl.filtersTree[index]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields._id).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedId]).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
     /* jshint camelcase:false */
-    should(methods.dsl.filtersTree[index][collection].fields._id[idsIdidGrace]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields._id[notidsIdidGrace]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedId][idsIdidGrace]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedId][notidsIdidGrace]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     /* jshint camelcase:false */
     var
-      rooms = methods.dsl.filtersTree[index][collection].fields._id[idsIdidGrace].rooms,
-      roomsNot = methods.dsl.filtersTree[index][collection].fields._id[notidsIdidGrace].rooms;
+      rooms = methods.dsl.filtersTree[index][collection].fields[encodedId][idsIdidGrace].rooms,
+      roomsNot = methods.dsl.filtersTree[index][collection].fields[encodedId][notidsIdidGrace].rooms;
 
     should(rooms).be.an.Array();
     should(roomsNot).be.an.Array();
@@ -73,14 +74,14 @@ describe('Test ids method', function () {
   it('should construct the filterTree with correct functions ids', function () {
     /* jshint camelcase:false */
     var
-      resultMatch = methods.dsl.filtersTree[index][collection].fields._id[idsIdidGrace].fn(documentGrace),
-      resultNotMatch = methods.dsl.filtersTree[index][collection].fields._id[idsIdidGrace].fn(documentAda);
+      resultMatch = methods.dsl.filtersTree[index][collection].fields[encodedId][idsIdidGrace].fn(documentGrace),
+      resultNotMatch = methods.dsl.filtersTree[index][collection].fields[encodedId][idsIdidGrace].fn(documentAda);
 
     should(resultMatch).be.exactly(true);
     should(resultNotMatch).be.exactly(false);
 
-    resultMatch = methods.dsl.filtersTree[index][collection].fields._id[notidsIdidGrace].fn(documentAda);
-    resultNotMatch = methods.dsl.filtersTree[index][collection].fields._id[notidsIdidGrace].fn(documentGrace);
+    resultMatch = methods.dsl.filtersTree[index][collection].fields[encodedId][notidsIdidGrace].fn(documentAda);
+    resultNotMatch = methods.dsl.filtersTree[index][collection].fields[encodedId][notidsIdidGrace].fn(documentGrace);
 
     should(resultMatch).be.exactly(true);
     should(resultNotMatch).be.exactly(false);

--- a/test/api/dsl/methods/missing.test.js
+++ b/test/api/dsl/methods/missing.test.js
@@ -24,7 +24,8 @@ describe('Test missing method', function () {
     filter = {
       field: 'lastName'
     },
-    missinglastName = md5('missinglastName');
+    missinglastName = md5('missinglastName'),
+    encodedLastName = md5('lastName');
 
 
   before(function () {
@@ -37,18 +38,18 @@ describe('Test missing method', function () {
     should(methods.dsl.filtersTree[index]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.lastName).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedLastName]).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
-    should(methods.dsl.filtersTree[index][collection].fields.lastName[missinglastName]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedLastName][missinglastName]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var rooms;
 
     // Test gt from filterGrace
-    rooms = methods.dsl.filtersTree[index][collection].fields.lastName[missinglastName].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedLastName][missinglastName].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
@@ -57,9 +58,9 @@ describe('Test missing method', function () {
   it('should construct the filterTree with correct functions missing', function () {
     var result;
 
-    result = methods.dsl.filtersTree[index][collection].fields.lastName[missinglastName].fn(documentAda);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLastName][missinglastName].fn(documentAda);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.lastName[missinglastName].fn(documentGrace);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedLastName][missinglastName].fn(documentGrace);
     should(result).be.exactly(false);
   });
 

--- a/test/api/dsl/methods/not.test.js
+++ b/test/api/dsl/methods/not.test.js
@@ -23,7 +23,8 @@ describe('Test not method', function () {
         city: 'London'
       }
     },
-    nottermcityLondon = md5('nottermcityLondon');
+    nottermcityLondon = md5('nottermcityLondon'),
+    encodedCity = md5('city');
 
   before(function () {
     methods.dsl.filtersTree = {};
@@ -35,18 +36,18 @@ describe('Test not method', function () {
     should(methods.dsl.filtersTree[index]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.city).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedCity]).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
-    should(methods.dsl.filtersTree[index][collection].fields.city[nottermcityLondon]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedCity][nottermcityLondon]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var rooms;
 
     // Test gt from filterGrace
-    rooms = methods.dsl.filtersTree[index][collection].fields.city[nottermcityLondon].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedCity][nottermcityLondon].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
@@ -55,9 +56,9 @@ describe('Test not method', function () {
   it('should construct the filterTree with correct functions', function () {
     var result;
 
-    result = methods.dsl.filtersTree[index][collection].fields.city[nottermcityLondon].fn(documentGrace);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedCity][nottermcityLondon].fn(documentGrace);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.city[nottermcityLondon].fn(documentAda);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedCity][nottermcityLondon].fn(documentAda);
     should(result).be.exactly(false);
   });
 

--- a/test/api/dsl/methods/or.test.js
+++ b/test/api/dsl/methods/or.test.js
@@ -39,7 +39,8 @@ describe('Test or method', function () {
     termcityNYC = md5('termcityNYC'),
     termcityLondon = md5('termcityLondon'),
     nottermcityNYC = md5('nottermcityNYC'),
-    nottermcityLondon = md5('nottermcityLondon');
+    nottermcityLondon = md5('nottermcityLondon'),
+    encodedCity = md5('city');
 
   before(function () {
     methods.dsl.filtersTree = {};
@@ -54,35 +55,35 @@ describe('Test or method', function () {
     should(methods.dsl.filtersTree[index]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.city).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedCity]).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
-    should(methods.dsl.filtersTree[index][collection].fields.city[termcityNYC]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.city[termcityLondon]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.city[nottermcityNYC]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.city[nottermcityLondon]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedCity][termcityNYC]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedCity][termcityLondon]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedCity][nottermcityNYC]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedCity][nottermcityLondon]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var rooms;
 
-    rooms = methods.dsl.filtersTree[index][collection].fields.city[termcityNYC].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedCity][termcityNYC].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[index][collection].fields.city[termcityLondon].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedCity][termcityLondon].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[index][collection].fields.city[nottermcityNYC].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedCity][nottermcityNYC].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
 
-    rooms = methods.dsl.filtersTree[index][collection].fields.city[nottermcityLondon].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedCity][nottermcityLondon].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomId);
@@ -91,24 +92,24 @@ describe('Test or method', function () {
   it('should construct the filterTree with correct functions', function () {
     var result;
 
-    result = methods.dsl.filtersTree[index][collection].fields.city[termcityNYC].fn(documentGrace);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedCity][termcityNYC].fn(documentGrace);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.city[termcityNYC].fn(documentAda);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedCity][termcityNYC].fn(documentAda);
     should(result).be.exactly(false);
 
-    result = methods.dsl.filtersTree[index][collection].fields.city[termcityLondon].fn(documentGrace);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedCity][termcityLondon].fn(documentGrace);
     should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[index][collection].fields.city[termcityLondon].fn(documentAda);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedCity][termcityLondon].fn(documentAda);
     should(result).be.exactly(true);
 
-    result = methods.dsl.filtersTree[index][collection].fields.city[nottermcityNYC].fn(documentGrace);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedCity][nottermcityNYC].fn(documentGrace);
     should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[index][collection].fields.city[nottermcityNYC].fn(documentAda);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedCity][nottermcityNYC].fn(documentAda);
     should(result).be.exactly(true);
 
-    result = methods.dsl.filtersTree[index][collection].fields.city[nottermcityLondon].fn(documentGrace);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedCity][nottermcityLondon].fn(documentGrace);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.city[nottermcityLondon].fn(documentAda);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedCity][nottermcityLondon].fn(documentAda);
     should(result).be.exactly(false);
   });
 

--- a/test/api/dsl/methods/range.test.js
+++ b/test/api/dsl/methods/range.test.js
@@ -52,7 +52,8 @@ describe('Test range method', function () {
     rangeagegte36 = md5('rangeagegte36'),
     rangeagelt85 = md5('rangeagelt85'),
     notrangeagegte36 = md5('notrangeagegte36'),
-    notrangeagelte85 = md5('notrangeagelte85');
+    notrangeagelte85 = md5('notrangeagelte85'),
+    encodedAge = md5('age');
 
 
   before(function () {
@@ -74,55 +75,55 @@ describe('Test range method', function () {
     should(methods.dsl.filtersTree[index]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.age).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedAge]).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
-    should(methods.dsl.filtersTree[index][collection].fields.age[rangeagegt36]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.age[rangeagelte85]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.age[rangeagegte36]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.age[rangeagelt85]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.age[notrangeagegte36]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.age[notrangeagelte85]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedAge][rangeagegt36]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedAge][rangeagelte85]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedAge][rangeagegte36]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedAge][rangeagelt85]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedAge][notrangeagegte36]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedAge][notrangeagelte85]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var rooms;
 
     // Test gt from filterGrace
-    rooms = methods.dsl.filtersTree[index][collection].fields.age[rangeagegt36].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedAge][rangeagegt36].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomIdFilterGrace);
 
     // Test lte from filterGrace and filterAll
-    rooms = methods.dsl.filtersTree[index][collection].fields.age[rangeagelte85].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedAge][rangeagelte85].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(2);
     should(rooms).containEql(roomIdFilterGrace);
     should(rooms).containEql(roomIdFilterAll);
 
     // Test gte from filterAda and filterAll
-    rooms = methods.dsl.filtersTree[index][collection].fields.age[rangeagegte36].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedAge][rangeagegte36].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(2);
     should(rooms).containEql(roomIdFilterAda);
     should(rooms).containEql(roomIdFilterAll);
 
     // Test lt from filterAda
-    rooms = methods.dsl.filtersTree[index][collection].fields.age[rangeagelt85].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedAge][rangeagelt85].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomIdFilterAda);
 
     // Test not gte from negative filterAll
-    rooms = methods.dsl.filtersTree[index][collection].fields.age[notrangeagegte36].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedAge][notrangeagegte36].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomIdFilterNobody);
 
     // Test not lte from negative filterAll
-    rooms = methods.dsl.filtersTree[index][collection].fields.age[notrangeagelte85].rooms;
+    rooms = methods.dsl.filtersTree[index][collection].fields[encodedAge][notrangeagelte85].rooms;
     should(rooms).be.an.Array();
     should(rooms).have.length(1);
     should(rooms[0]).be.exactly(roomIdFilterNobody);
@@ -131,34 +132,34 @@ describe('Test range method', function () {
   it('should construct the filterTree with correct functions range', function () {
     var result;
 
-    result = methods.dsl.filtersTree[index][collection].fields.age[rangeagegt36].fn(documentGrace);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedAge][rangeagegt36].fn(documentGrace);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.age[rangeagegt36].fn(documentAda);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedAge][rangeagegt36].fn(documentAda);
     should(result).be.exactly(false);
 
-    result = methods.dsl.filtersTree[index][collection].fields.age[rangeagelte85].fn(documentGrace);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedAge][rangeagelte85].fn(documentGrace);
     should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.age[rangeagelte85].fn(documentAda);
-    should(result).be.exactly(true);
-
-    result = methods.dsl.filtersTree[index][collection].fields.age[rangeagegte36].fn(documentGrace);
-    should(result).be.exactly(true);
-    result = methods.dsl.filtersTree[index][collection].fields.age[rangeagegte36].fn(documentAda);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedAge][rangeagelte85].fn(documentAda);
     should(result).be.exactly(true);
 
-    result = methods.dsl.filtersTree[index][collection].fields.age[rangeagelt85].fn(documentGrace);
-    should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[index][collection].fields.age[rangeagelt85].fn(documentAda);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedAge][rangeagegte36].fn(documentGrace);
+    should(result).be.exactly(true);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedAge][rangeagegte36].fn(documentAda);
     should(result).be.exactly(true);
 
-    result = methods.dsl.filtersTree[index][collection].fields.age[notrangeagegte36].fn(documentGrace);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedAge][rangeagelt85].fn(documentGrace);
     should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[index][collection].fields.age[notrangeagegte36].fn(documentAda);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedAge][rangeagelt85].fn(documentAda);
+    should(result).be.exactly(true);
+
+    result = methods.dsl.filtersTree[index][collection].fields[encodedAge][notrangeagegte36].fn(documentGrace);
+    should(result).be.exactly(false);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedAge][notrangeagegte36].fn(documentAda);
     should(result).be.exactly(false);
 
-    result = methods.dsl.filtersTree[index][collection].fields.age[notrangeagelte85].fn(documentGrace);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedAge][notrangeagelte85].fn(documentGrace);
     should(result).be.exactly(false);
-    result = methods.dsl.filtersTree[index][collection].fields.age[notrangeagelte85].fn(documentAda);
+    result = methods.dsl.filtersTree[index][collection].fields[encodedAge][notrangeagelte85].fn(documentAda);
     should(result).be.exactly(false);
   });
 

--- a/test/api/dsl/methods/term.test.js
+++ b/test/api/dsl/methods/term.test.js
@@ -22,7 +22,8 @@ describe('Test term method', function () {
       firstName: 'Grace'
     },
     termfirstNameGrace = md5('termfirstNameGrace'),
-    nottermfirstNameGrace = md5('nottermfirstNameGrace');
+    nottermfirstNameGrace = md5('nottermfirstNameGrace'),
+    encodedFirstName = md5('firstName');
 
 
   before(function () {
@@ -38,18 +39,18 @@ describe('Test term method', function () {
     should(methods.dsl.filtersTree[index]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.firstName).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedFirstName]).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
-    should(methods.dsl.filtersTree[index][collection].fields.firstName[termfirstNameGrace]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.firstName[nottermfirstNameGrace]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedFirstName][termfirstNameGrace]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedFirstName][nottermfirstNameGrace]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var
-      rooms = methods.dsl.filtersTree[index][collection].fields.firstName[termfirstNameGrace].rooms,
-      roomsNot = methods.dsl.filtersTree[index][collection].fields.firstName[nottermfirstNameGrace].rooms;
+      rooms = methods.dsl.filtersTree[index][collection].fields[encodedFirstName][termfirstNameGrace].rooms,
+      roomsNot = methods.dsl.filtersTree[index][collection].fields[encodedFirstName][nottermfirstNameGrace].rooms;
 
     should(rooms).be.an.Array();
     should(roomsNot).be.an.Array();
@@ -63,14 +64,14 @@ describe('Test term method', function () {
 
   it('should construct the filterTree with correct functions term', function () {
     var
-      resultMatch = methods.dsl.filtersTree[index][collection].fields.firstName[termfirstNameGrace].fn(documentGrace),
-      resultNotMatch = methods.dsl.filtersTree[index][collection].fields.firstName[termfirstNameGrace].fn(documentAda);
+      resultMatch = methods.dsl.filtersTree[index][collection].fields[encodedFirstName][termfirstNameGrace].fn(documentGrace),
+      resultNotMatch = methods.dsl.filtersTree[index][collection].fields[encodedFirstName][termfirstNameGrace].fn(documentAda);
 
     should(resultMatch).be.exactly(true);
     should(resultNotMatch).be.exactly(false);
 
-    resultMatch = methods.dsl.filtersTree[index][collection].fields.firstName[nottermfirstNameGrace].fn(documentAda);
-    resultNotMatch = methods.dsl.filtersTree[index][collection].fields.firstName[nottermfirstNameGrace].fn(documentGrace);
+    resultMatch = methods.dsl.filtersTree[index][collection].fields[encodedFirstName][nottermfirstNameGrace].fn(documentAda);
+    resultNotMatch = methods.dsl.filtersTree[index][collection].fields[encodedFirstName][nottermfirstNameGrace].fn(documentGrace);
 
     should(resultMatch).be.exactly(true);
     should(resultNotMatch).be.exactly(false);

--- a/test/api/dsl/methods/termFunction.test.js
+++ b/test/api/dsl/methods/termFunction.test.js
@@ -14,7 +14,8 @@ describe('Test: dsl.termFunction method', function () {
     termfoobar = md5('termfoobar'),
     termsfoobarbaz = md5('termsfoobar,baz'),
     nottermfoobar = md5('nottermfoobar'),
-    nottermsfoobarbaz = md5('nottermsfoobar,baz');
+    nottermsfoobarbaz = md5('nottermsfoobar,baz'),
+    encodedFoo = md5('foo');
 
   beforeEach(function () {
     methods.dsl = { filtersTree: {} };
@@ -41,9 +42,9 @@ describe('Test: dsl.termFunction method', function () {
 
     termFunction('term', 'roomId', 'index', 'collection', filter)
       .then(function (formattedFilter) {
-        should.exist(formattedFilter['index.collection.foo.' + termfoobar]);
-        should(formattedFilter['index.collection.foo.' + termfoobar].rooms).be.an.Array().and.match(['roomId']);
-        should(formattedFilter['index.collection.foo.' + termfoobar].fn).be.a.Function();
+        should.exist(formattedFilter[`index.collection.${encodedFoo}.${termfoobar}`]);
+        should(formattedFilter[`index.collection.${encodedFoo}.${termfoobar}`].rooms).be.an.Array().and.match(['roomId']);
+        should(formattedFilter[`index.collection.${encodedFoo}.${termfoobar}`].fn).be.a.Function();
         done();
       })
       .catch(function (error) {
@@ -59,9 +60,9 @@ describe('Test: dsl.termFunction method', function () {
 
     termFunction('terms', 'roomId', 'index', 'collection', filter)
       .then(function (formattedFilter) {
-        should.exist(formattedFilter['index.collection.foo.' + termsfoobarbaz]);
-        should(formattedFilter['index.collection.foo.' + termsfoobarbaz].rooms).be.an.Array().and.match(['roomId']);
-        should(formattedFilter['index.collection.foo.' + termsfoobarbaz].fn).be.a.Function();
+        should.exist(formattedFilter[`index.collection.${encodedFoo}.${termsfoobarbaz}`]);
+        should(formattedFilter[`index.collection.${encodedFoo}.${termsfoobarbaz}`].rooms).be.an.Array().and.match(['roomId']);
+        should(formattedFilter[`index.collection.${encodedFoo}.${termsfoobarbaz}`].fn).be.a.Function();
         done();
       })
       .catch(function (error) {
@@ -77,9 +78,9 @@ describe('Test: dsl.termFunction method', function () {
 
     termFunction('term', 'roomId', 'index', 'collection', filter, true)
       .then(function (formattedFilter) {
-        should.exist(formattedFilter['index.collection.foo.' + nottermfoobar]);
-        should(formattedFilter['index.collection.foo.' + nottermfoobar].rooms).be.an.Array().and.match(['roomId']);
-        should(formattedFilter['index.collection.foo.' + nottermfoobar].fn).be.a.Function();
+        should.exist(formattedFilter[`index.collection.${encodedFoo}.${nottermfoobar}`]);
+        should(formattedFilter[`index.collection.${encodedFoo}.${nottermfoobar}`].rooms).be.an.Array().and.match(['roomId']);
+        should(formattedFilter[`index.collection.${encodedFoo}.${nottermfoobar}`].fn).be.a.Function();
         done();
       })
       .catch(function (error) {
@@ -95,9 +96,9 @@ describe('Test: dsl.termFunction method', function () {
 
     termFunction('terms', 'roomId', 'index', 'collection', filter, true)
       .then(function (formattedFilter) {
-        should.exist(formattedFilter['index.collection.foo.' + nottermsfoobarbaz]);
-        should(formattedFilter['index.collection.foo.' + nottermsfoobarbaz].rooms).be.an.Array().and.match(['roomId']);
-        should(formattedFilter['index.collection.foo.' + nottermsfoobarbaz].fn).be.a.Function();
+        should.exist(formattedFilter[`index.collection.${encodedFoo}.${nottermsfoobarbaz}`]);
+        should(formattedFilter[`index.collection.${encodedFoo}.${nottermsfoobarbaz}`].rooms).be.an.Array().and.match(['roomId']);
+        should(formattedFilter[`index.collection.${encodedFoo}.${nottermsfoobarbaz}`].fn).be.a.Function();
         done();
       })
       .catch(function (error) {

--- a/test/api/dsl/methods/terms.test.js
+++ b/test/api/dsl/methods/terms.test.js
@@ -22,7 +22,8 @@ describe('Test terms method', function () {
       firstName: ['Grace', 'Jean']
     },
     termsfirstNameGraceJean = md5('termsfirstNameGrace,Jean'),
-    nottermsfirstNameGraceJean = md5('nottermsfirstNameGrace,Jean');
+    nottermsfirstNameGraceJean = md5('nottermsfirstNameGrace,Jean'),
+    encodedFirstName = md5('firstName');
 
   before(function () {
     methods.dsl.filtersTree = {};
@@ -37,18 +38,18 @@ describe('Test terms method', function () {
     should(methods.dsl.filtersTree[index]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection]).not.be.empty();
     should(methods.dsl.filtersTree[index][collection].fields).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.firstName).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedFirstName]).not.be.empty();
   });
 
   it('should construct the filterTree with correct curried function name', function () {
-    should(methods.dsl.filtersTree[index][collection].fields.firstName[termsfirstNameGraceJean]).not.be.empty();
-    should(methods.dsl.filtersTree[index][collection].fields.firstName[nottermsfirstNameGraceJean]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedFirstName][termsfirstNameGraceJean]).not.be.empty();
+    should(methods.dsl.filtersTree[index][collection].fields[encodedFirstName][nottermsfirstNameGraceJean]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', function () {
     var
-      rooms = methods.dsl.filtersTree[index][collection].fields.firstName[termsfirstNameGraceJean].rooms,
-      roomsNot = methods.dsl.filtersTree[index][collection].fields.firstName[nottermsfirstNameGraceJean].rooms;
+      rooms = methods.dsl.filtersTree[index][collection].fields[encodedFirstName][termsfirstNameGraceJean].rooms,
+      roomsNot = methods.dsl.filtersTree[index][collection].fields[encodedFirstName][nottermsfirstNameGraceJean].rooms;
 
     should(rooms).be.an.Array();
     should(roomsNot).be.an.Array();
@@ -62,14 +63,14 @@ describe('Test terms method', function () {
 
   it('should construct the filterTree with correct functions terms', function () {
     var
-      resultMatch = methods.dsl.filtersTree[index][collection].fields.firstName[termsfirstNameGraceJean].fn(documentGrace),
-      resultNotMatch = methods.dsl.filtersTree[index][collection].fields.firstName[termsfirstNameGraceJean].fn(documentAda);
+      resultMatch = methods.dsl.filtersTree[index][collection].fields[encodedFirstName][termsfirstNameGraceJean].fn(documentGrace),
+      resultNotMatch = methods.dsl.filtersTree[index][collection].fields[encodedFirstName][termsfirstNameGraceJean].fn(documentAda);
 
     should(resultMatch).be.exactly(true);
     should(resultNotMatch).be.exactly(false);
 
-    resultMatch = methods.dsl.filtersTree[index][collection].fields.firstName[nottermsfirstNameGraceJean].fn(documentAda);
-    resultNotMatch = methods.dsl.filtersTree[index][collection].fields.firstName[nottermsfirstNameGraceJean].fn(documentGrace);
+    resultMatch = methods.dsl.filtersTree[index][collection].fields[encodedFirstName][nottermsfirstNameGraceJean].fn(documentAda);
+    resultNotMatch = methods.dsl.filtersTree[index][collection].fields[encodedFirstName][nottermsfirstNameGraceJean].fn(documentGrace);
 
     should(resultMatch).be.exactly(true);
     should(resultNotMatch).be.exactly(false);


### PR DESCRIPTION
This pull request fixes issue #302 and is a backport of the fix proposed in #304 :

* the filters structure in `dsl/filters` now uses MD5-encoded field names instead of user-provided ones
* updated unit tests