### PR TITLE
remove debug console output

### DIFF
--- a/bin/commands/createFirstAdmin.js
+++ b/bin/commands/createFirstAdmin.js
@@ -3,16 +3,16 @@
 var
   readlineSync = require('readline-sync'),
   clc = require('cli-color'),
-  error = clc.red,
-  question = clc.whiteBright,
-  notice = clc.cyanBright,
-  ok = clc.green.bold,
   request = require('request-promise'),
   rc = require('rc'),
   params = rc('kuzzle'),
   name,
   password,
   resetRoles = false,
+  error,
+  question,
+  notice,
+  ok,
   step = 0,
   // steps definitions
   steps = [
@@ -230,11 +230,22 @@ var checkIfFistAdminNeeded = () => {
 
 process.stdin.setEncoding('utf8');
 
-module.exports = {
-  check: checkIfFistAdminNeeded,
-  action: () => {
-
-    checkIfFistAdminNeeded()
+module.exports = function FirstAdmin (options, run) {
+  if (!(this instanceof FirstAdmin)) {
+    return new FirstAdmin(options);
+  }
+  
+  run = (run === undefined) || run;
+  
+  error = string => options.parent.noColors ? string : clc.red(string);
+  question = string => options.parent.noColors ? string : clc.whiteBright(string);
+  notice = string => options.parent.noColors ? string : clc.cyanBright(string);
+  ok = string => options.parent.noColors ? string : clc.green.bold(string);
+  
+  this.check = checkIfFistAdminNeeded.bind(this);
+  
+  if (run) {
+    this.check()
       .then(() =>{
         // we can access to the admin role, so no admin account have been created yet
         console.log(ok('███ Kuzzle first admin creation'));
@@ -245,3 +256,4 @@ module.exports = {
       });
   }
 };
+

--- a/bin/commands/enable.js
+++ b/bin/commands/enable.js
@@ -8,5 +8,4 @@ module.exports = function () {
   var kuzzle = new Kuzzle();
 
   kuzzle.remoteActions.do('enableServices', params, {enable: true});
-
 };

--- a/bin/commands/plugins.js
+++ b/bin/commands/plugins.js
@@ -3,13 +3,13 @@ var
   childProcess = require('child_process'),
   managePlugins = require('../../lib/api/controllers/remoteActions/managePlugins');
 
-var
-  clcError = clc.red,
-  clcNotice = clc.cyan;
-
 /* eslint-disable no-console */
 
 module.exports = function pluginsManager (plugin, options) {
+  var
+    clcError = string => options.parent.noColors ? string : clc.red(string),
+    clcNotice = string => options.parent.noColors ? string : clc.cyan(string);
+  
   if (!childProcess.hasOwnProperty('execSync')) {
     console.error(clcError('███ kuzzle-plugins: Make sure you\'re using Node version >= 0.12'));
     process.exit(1);

--- a/bin/commands/plugins.js
+++ b/bin/commands/plugins.js
@@ -19,16 +19,8 @@ module.exports = function pluginsManager (plugin, options) {
 
   managePlugins(plugin, options)
     .then(res => {
-      var
-        v;
-      if (res instanceof Array) {
-        for (v in res) {
-          if (res[v] !== undefined) {
-            console.log(res[v]);
-          }
-        }
-      } else {
-        console.log(res);
+      if (options.debug) {
+        console.dir(res, {depth: null, colors: true});
       }
       process.exit(0);
     })

--- a/bin/commands/reset.js
+++ b/bin/commands/reset.js
@@ -6,13 +6,13 @@ var
   Kuzzle = require('../../lib/api'),
   readlineSync = require('readline-sync'),
   fs = require('fs'),
-  clc = require('cli-color'),
-  error = clc.red,
-  warn = clc.yellow,
-  notice = clc.cyanBright;
+  clc = require('cli-color');
 
-module.exports = function () {
-  var 
+module.exports = function (options) {
+  var
+    error = string => options.parent.noColors ? string : clc.red(string),
+    warn = string => options.parent.noColors ? string : clc.yellow(string),
+    notice = string => options.parent.noColors ? string : clc.cyanBright(string),
     userIsSure = false,
     kuzzle = new Kuzzle();
 

--- a/bin/commands/start.js
+++ b/bin/commands/start.js
@@ -6,23 +6,26 @@ var
   params = rc('kuzzle'),
   kuzzle = require('../../lib'),
   RequestObject = require('kuzzle-common-objects').Models.requestObject,
-  firstAdmin = require('./createFirstAdmin'),
+  FirstAdmin = require('./createFirstAdmin'),
   q = require('q'),
   clc = require('cli-color'),
-  error = clc.red,
-  warn = clc.yellow,
-  notice = clc.cyanBright,
-  ok = clc.green.bold,
-  kuz = clc.greenBright.bold,
   coverage;
 
-if (process.env.FEATURE_COVERAGE === '1' || process.env.FEATURE_COVERAGE === 1) {
-  coverage = require('istanbul-middleware');
-  console.log(warn('Hook loader for coverage - ensure this is not production!'));
-  coverage.hookLoader(__dirname+'/../lib');
-}
+module.exports = function (options) {
+  var
+    error = string => options.parent.noColors ? string : clc.red(string),
+    warn = string => options.parent.noColors ? string : clc.yellow(string),
+    notice = string => options.parent.noColors ? string : clc.cyanBright(string),
+    ok = string => options.parent.noColors ? string : clc.green.bold(string),
+    kuz = string => options.parent.noColors ? string : clc.greenBright.bold(string),
+    firstAdmin = new FirstAdmin(options, false);
+  
+  if (process.env.FEATURE_COVERAGE === '1' || process.env.FEATURE_COVERAGE === 1) {
+    coverage = require('istanbul-middleware');
+    console.log(warn('Hook loader for coverage - ensure this is not production!'));
+    coverage.hookLoader(__dirname+'/../lib');
+  }
 
-module.exports = function () {
   console.log(kuz('Starting Kuzzle'), (kuzzle.isServer ? notice('Server') : warn('Worker')));
 
   kuzzle.start(params)

--- a/bin/kuzzle
+++ b/bin/kuzzle
@@ -8,7 +8,9 @@
  */
 var program = require('commander');
 
-program.option('-d, --debug', 'make errors more verbose');
+program
+  .option('-d, --debug', 'make errors more verbose')
+  .option('--noColors', 'do not use ANSI coloring')
 
 // $ kuzzle start
 program
@@ -66,7 +68,7 @@ program
 program
   .command('createFirstAdmin')
   .description('Create the first administrator')
-  .action(require('./commands/createFirstAdmin').action);
+  .action(require('./commands/createFirstAdmin'));
 
 // $ kuzzle likeAvirgin
 program

--- a/lib/api/controllers/remoteActions/managePlugins.js
+++ b/lib/api/controllers/remoteActions/managePlugins.js
@@ -9,21 +9,22 @@ var
   lockfile = require('proper-lockfile'),
   _ = require('lodash'),
   clc = require('cli-color'),
-  ok = clc.green.bold,
   defaultConfig = require('rc')('kuzzle'),
-  DatabaseService = require('../../../services/internalEngine');
-
-var
-  clcError = clc.red,
+  DatabaseService = require('../../../services/internalEngine'),
+  clcOk = clc.green.bold,
   clcNotice = clc.cyan,
-  clcOk = clc.green.bold;
+  clcError = clc.red;
 
 module.exports = function pluginsManager(plugin, options) {
   var
     kuzzleConfiguration = require('../../../config')(defaultConfig),
     dbService = new DatabaseService({config: kuzzleConfiguration}),
     deferred = q.defer();
-
+  
+  if (options.parent && options.parent.noColors) {
+    clcOk = clcNotice = clcError = string => string;
+  }
+  
   dbService.init();
 
   // Prevents multiple 'kuzzle install' to install plugins at the same time.
@@ -110,6 +111,16 @@ module.exports = function pluginsManager(plugin, options) {
             console.log(clcOk('███ kuzzle-plugins: Plugins installed'));
           }
         }
+        else if (options.list) {
+          res.forEach(str => console.log(str));
+        }
+        else if (options.importConfig) {
+          console.log(res);
+        }   
+        else {
+          console.dir(res, {depth: null, colors: !options.parent || !options.parent.noColors});
+        }
+        
         deferred.resolve(res);
       })
       .catch(error => {
@@ -271,9 +282,11 @@ function importPluginConfiguration(db, plugin, filePath, kuzzleConfiguration) {
       res._source.config = content;
       return db.createOrReplace(kuzzleConfiguration.pluginsManager.dataCollection, plugin, res._source);
     }).then(() => {
-      return q(ok('[✔] Successfully imported configuration'));
-    }).catch(() => {
-      return q.reject(new Error('Plugin ' + plugin + ' not found'));
+      return q(clcOk('[✔] Successfully imported configuration'));
+    }).catch(err => {
+      var error = new Error(`Plugin ${plugin} not found`);
+      error.stack = err.stack;
+      return q.reject(error);
     });
 }
 
@@ -296,7 +309,7 @@ function acquirePlugins(plugins) {
 
   _.forEach(plugins, (plugin, name) => {
     if (plugin.path) {
-      console.log('███ kuzzle-plugins: Plugin', name, 'uses local plugin. Config will be overrided with local changes.');
+      console.log('███ kuzzle-plugins: Plugin', name, 'uses local plugin. Config will be overridden with local changes.');
       installViaNpm = false;
     }
     else if (!plugin.gitUrl && !plugin.npmVersion) {

--- a/test/api/controllers/remoteActionsController/managePlugins.test.js
+++ b/test/api/controllers/remoteActionsController/managePlugins.test.js
@@ -8,9 +8,8 @@ var
   InternalEngine = require('../../../../lib/services/internalEngine'),
   lockFile = require('proper-lockfile'),
   path = require('path'),
-  clc = require('cli-color'),
-  clcOk = clc.green.bold,
-  clcNotice = clc.cyan,
+  clcOk = managePlugins.__get__('clcOk'),
+  clcNotice = managePlugins.__get__('clcNotice'),
   sandbox;
 
 require('sinon-as-promised')(q.Promise);
@@ -31,8 +30,13 @@ describe('Test: managePlugins remote action caller', function () {
 
     sandbox.stub(lockFile, 'lock').yields(undefined, () => {});
     managePlugins.__set__({
-      'DatabaseService': function () {
+      DatabaseService: function () {
         return internalEngineStub;
+      },
+      console: {
+        log: sinon.spy(),
+        error: sinon.spy(),
+        dir: sinon.spy()
       }
     });
   });


### PR DESCRIPTION
## Changelog

* options `--noColors` added for all Kuzzle commands in case the end user terminal does not support ANSI colors
* Plugin configurations are now displayed with an infinite depth (fixes #334)