### PR TITLE
KUZ-613: repositories in plugincontext

### DIFF
--- a/.kuzzlerc
+++ b/.kuzzlerc
@@ -179,7 +179,7 @@
         "activated": true
       },
       "kuzzle-plugin-auth-passport-local": {
-        "npmVersion": "2.0.1",
+        "npmVersion": "2.0.2",
         "activated": true
       }
     }

--- a/.kuzzlerc
+++ b/.kuzzlerc
@@ -179,8 +179,9 @@
         "activated": true
       },
       "kuzzle-plugin-auth-passport-local": {
-        "npmVersion": "2.0.2",
-        "activated": true
+        "npmVersion": "2.0.3",
+        "activated": true,
+        "loadedBy": "server"
       }
     }
   },

--- a/features/step_definitions/authentication.js
+++ b/features/step_definitions/authentication.js
@@ -26,7 +26,7 @@ var apiSteps = function () {
         callback();
       })
       .catch(function (error) {
-        callback(error);
+        callback(error.message);
       });
   });
 

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -1,7 +1,6 @@
 var
   q = require('q'),
   _ = require('lodash'),
-  PassportWrapper = require('../core/auth/passportWrapper'),
   BadRequestError= require('kuzzle-common-objects').Errors.badRequestError,
   UnauthorizedError = require('kuzzle-common-objects').Errors.unauthorizedError,
   ResponseObject = require('kuzzle-common-objects').Models.responseObject,
@@ -12,8 +11,6 @@ var
  * @constructor
  */
 function AuthController (kuzzle) {
-  this.passport = new PassportWrapper(kuzzle);
-
   /**
    * Logs the current user out
    *
@@ -46,7 +43,7 @@ function AuthController (kuzzle) {
         modifiedContext = modifiedData.context;
         modifiedRequestObject = modifiedData.requestObject;
 
-        return this.passport.authenticate({query: modifiedRequestObject.data.body}, strategy);
+        return kuzzle.passport.authenticate({query: modifiedRequestObject.data.body}, strategy);
       })
       .then((userObject) => {
         if (!userObject.headers) {

--- a/lib/api/core/auth/passportWrapper.js
+++ b/lib/api/core/auth/passportWrapper.js
@@ -7,19 +7,12 @@ var
   InternalError = require('kuzzle-common-objects').Errors.internalError;
 
 /**
- * @param kuzzle
  * @constructor
  */
-function PassportWrapper (kuzzle) {
-  var
-    scope = [];
+function PassportWrapper () {
+  this.scope = {};
 
-  kuzzle.pluginsManager.trigger('passport:loadScope', {scope: scope})
-    .then(function(modifiedRequestObject) {
-      scope = modifiedRequestObject;
-    });
-
-  this.authenticate = function(request, strategy) {
+  this.authenticate = function (request, strategy) {
     var
       deferred = q.defer(),
       response = new PassportResponse(deferred),
@@ -29,8 +22,7 @@ function PassportWrapper (kuzzle) {
       if (!passport._strategy(strategy)) {
         return q.reject(new BadRequestError('Unknown authentication strategy "' + strategy + '"'));
       }
-      passport.authenticate(strategy, {scope: scope[strategy]}, function(err, user, info) {
-        kuzzle.pluginsManager.trigger('log:silly', 'Authenticate Info : ' + info);
+      passport.authenticate(strategy, {scope: this.scope[strategy]}, (err, user, info) => {
         if (err !== null) {
           deferred.reject(err);
         }
@@ -51,7 +43,16 @@ function PassportWrapper (kuzzle) {
     return deferred.promise;
   };
 
-  kuzzle.pluginsManager.trigger('auth:loadStrategies', passport);
+  /**
+   * Adds a scope for a strategy in this.scope
+   * Used by passport.authenticate
+   *
+   * @param {string} strategy name
+   * @param {Array} scope - list of fields in the strategy's scope
+   */
+  this.injectScope = (strategy, scope) => {
+    this.scope[strategy] = scope;
+  };
 }
 
 module.exports = PassportWrapper;

--- a/lib/api/core/auth/passportWrapper.js
+++ b/lib/api/core/auth/passportWrapper.js
@@ -53,6 +53,12 @@ function PassportWrapper () {
   this.injectScope = (strategy, scope) => {
     this.scope[strategy] = scope;
   };
+
+  /**
+   * Exposes passport.use function
+   * Mainly used by the plugin context
+   */
+  this.use = passport.use.bind(passport);
 }
 
 module.exports = PassportWrapper;

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -22,6 +22,15 @@ function PluginContext (kuzzle) {
    a Kuzzle Server instance
     */
   if (kuzzle.isServer) {
+    Object.defineProperty(this.accessors, 'passport', {
+      enumerable: true,
+      get: function () {
+        return {
+          use: kuzzle.passport.use
+        }
+      }
+    });
+
     Object.defineProperty(this.accessors, 'router', {
       enumerable: true,
       get: function () {

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -1,5 +1,7 @@
 var
-  _ = require('lodash');
+  _ = require('lodash'),
+  q = require('q'),
+  PluginImplementationError = require('kuzzle-common-objects').Errors.pluginImplementationError;
 
 function PluginContext (kuzzle) {
   this.accessors = {};
@@ -31,10 +33,16 @@ function PluginContext (kuzzle) {
       }
     });
 
-    Object.defineProperty(this.accessors, 'repositories', {
+    /*
+     Sharing only a handful user functions as wrappers for the repositories object
+     */
+    Object.defineProperty(this.accessors, 'users', {
       enumerable: true,
       get: function () {
-        return kuzzle.repositories;
+        return {
+          load: userId => kuzzle.repositories.user.load(userId),
+          create: user => createUser(kuzzle.repositories.user, user)
+        };
       }
     });
 
@@ -45,6 +53,35 @@ function PluginContext (kuzzle) {
       }
     });
   }
+}
+
+/**
+ * UserRepositories wrapper to expose user creation to plugins.
+ * If "userInfo" does not contain a profile attribute, this function
+ * will add one with the value "default"
+ *
+ * @param {Object} userRepository - Kuzzle's user repositories
+ * @param {Object} userInfo - the user to be created
+ * @returns {Promise<T>}
+ */
+function createUser(userRepository, userInfo) {
+  var userConstructor = new userRepository.ObjectConstructor();
+
+  if (!userInfo || typeof userInfo !== 'object' || Array.isArray(userInfo)) {
+    return q.reject(new PluginImplementationError('Cannot create user: invalid "user" argument (expected an object)'));
+  }
+
+  if (!userInfo.profile) {
+    userInfo.profile = 'default';
+  }
+
+  return userRepository.hydrate(userConstructor, userInfo)
+    .then(user => userRepository.persist(user, {database: {method: 'create'}}))
+    /*
+      masking the resolved user object to avoid plugin developers having access
+      to an internal Kuzzle object
+     */
+    .then(() => userInfo);
 }
 
 module.exports = PluginContext;

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -41,7 +41,7 @@ function PluginContext (kuzzle) {
       get: function () {
         return {
           load: userId => kuzzle.repositories.user.load(userId),
-          create: user => createUser(kuzzle.repositories.user, user)
+          create: (name, profile, info) => createUser(kuzzle.repositories.user, name, profile, info)
         };
       }
     });
@@ -61,19 +61,35 @@ function PluginContext (kuzzle) {
  * will add one with the value "default"
  *
  * @param {Object} userRepository - Kuzzle's user repositories
- * @param {Object} userInfo - the user to be created
+ * @param {string} name - user name
+ * @param {string} [profile] - profile name
+ * @param {Object} [userInfo] - the user to be created
  * @returns {Promise<T>}
  */
-function createUser(userRepository, userInfo) {
-  var userConstructor = new userRepository.ObjectConstructor();
+function createUser(userRepository, name, profile, userInfo) {
+  var
+    userConstructor = new userRepository.ObjectConstructor();
 
-  if (!userInfo || typeof userInfo !== 'object' || Array.isArray(userInfo)) {
-    return q.reject(new PluginImplementationError('Cannot create user: invalid "user" argument (expected an object)'));
+  if (!userInfo) {
+    if (profile && typeof profile === 'object') {
+      userInfo = profile;
+      profile = 'default';
+    }
+    else {
+      userInfo = {};
+    }
   }
 
-  if (!userInfo.profile) {
-    userInfo.profile = 'default';
+  if (!name || typeof name !== 'string') {
+    return q.reject(new PluginImplementationError('User creation error: "name" argument invalid or missing'));
   }
+
+  if (typeof userInfo !== 'object' || Array.isArray(userInfo)) {
+    return q.reject(new PluginImplementationError('User creation error: invalid "info" argument (expected an object)'));
+  }
+
+  userInfo._id = name;
+  userInfo.profile = profile || 'default';
 
   return userRepository.hydrate(userConstructor, userInfo)
     .then(user => userRepository.persist(user, {database: {method: 'create'}}))

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -27,7 +27,7 @@ function PluginContext (kuzzle) {
       get: function () {
         return {
           use: kuzzle.passport.use
-        }
+        };
       }
     });
 

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -119,6 +119,10 @@ function PluginsManager (kuzzle) {
         initControllers(this.controllers, this.routes, plugin, pluginName);
       }
 
+      if (plugin.object.scope) {
+        injectScope(plugin.object.scope, kuzzle.passport);
+      }
+
       console.log('Plugin', pluginName, 'started');
       callback();
     }, (err) => {
@@ -578,6 +582,22 @@ function registerPipe(pipes, plugin, warnDelay, timeoutDelay, event, fn) {
 function registerHook(kuzzle, plugin, event, fn) {
   kuzzle.on(event, function (message) {
     plugin.object[fn](message, event);
+  });
+}
+
+
+/**
+ * Injects a plugin's declared scopes into the Kuzzle passport wrapper
+ *
+ * @param {Object} scope to inject, in the following format: {strategy: [scope, fields}, ...}
+ * @param {Object} passport wrapper object
+ */
+function injectScope(scope, passport) {
+  Object.keys(scope).forEach(strategy => {
+    // enforcing scope format
+    if (typeof strategy === 'string' && Array.isArray(scope[strategy])) {
+      passport.injectScope(strategy, scope[strategy]);
+    }
   });
 }
 

--- a/lib/api/start.js
+++ b/lib/api/start.js
@@ -16,6 +16,7 @@ var
   RouterController = require('./controllers/routerController'),
   RemoteActionsController = require('./controllers/remoteActionsController'),
   Dsl = require('./dsl'),
+  PassportWrapper = require('./core/auth/passportWrapper'),
   // Load all configuration files (database, brokers...)
   config = require('../config'),
   PluginsManager = require('./core/plugins/pluginsManager'),
@@ -63,6 +64,8 @@ module.exports = function start (params, feature) {
 
   this.internalEngine = new InternalEngine(this);
   this.internalEngine.init();
+
+  this.passport = new PassportWrapper();
 
   this.pluginsManager = new PluginsManager(this);
   this.pluginsManager.init(this.isServer, feature.dummy)

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -116,36 +116,28 @@ describe('Test the auth controller', function () {
     });
 
     it('should resolve to a valid jwt token if authentication succeed', () => {
-      kuzzle.funnel.controllers.auth.passport = new MockupWrapper('resolve');
+      kuzzle.passport = new MockupWrapper('resolve');
       return kuzzle.funnel.controllers.auth.login(requestObject, {})
         .then(response => {
           var decodedToken = jwt.verify(response.data.body.jwt, params.jsonWebToken.secret);
           should(decodedToken._id).be.equal('jdoe');
-        })
-        .catch(() => {
-          // This case must not raise
-          should(false).be.true();
         });
     });
 
-    it('should resolve to a redirect url', function(done) {
+    it('should resolve to a redirect url', function() {
       this.timeout(50);
 
-      kuzzle.funnel.controllers.auth.passport = new MockupWrapper('oauth');
-      kuzzle.funnel.controllers.auth.login(requestObject, {})
+      kuzzle.passport = new MockupWrapper('oauth');
+      return kuzzle.funnel.controllers.auth.login(requestObject, {})
         .then(function(response) {
           should(response.data.body.headers.Location).be.equal('http://github.com');
-          done();
-        })
-        .catch(function (error) {
-          done(error);
         });
     });
 
     it('should use local strategy if no one is set', function (done) {
       this.timeout(50);
 
-      kuzzle.funnel.controllers.auth.passport = {
+      kuzzle.passport = {
         authenticate: function(data, strategy) {
           should(strategy).be.exactly('local');
           done();
@@ -163,7 +155,7 @@ describe('Test the auth controller', function () {
 
       requestObject.data.body.expiresIn = '1s';
 
-      kuzzle.funnel.controllers.auth.passport = new MockupWrapper('resolve');
+      kuzzle.passport = new MockupWrapper('resolve');
       kuzzle.funnel.controllers.auth.login(requestObject, {connection: {id: 'banana'}})
         .then(function(response) {
           var decodedToken = jwt.verify(response.data.body.jwt, params.jsonWebToken.secret);
@@ -200,7 +192,7 @@ describe('Test the auth controller', function () {
         done();
       };
 
-      kuzzle.funnel.controllers.auth.passport = new MockupWrapper('resolve');
+      kuzzle.passport = new MockupWrapper('resolve');
       kuzzle.funnel.controllers.auth.login(requestObject, context)
         .catch(function (error) {
           done(error);
@@ -209,7 +201,7 @@ describe('Test the auth controller', function () {
 
     it('should reject if authentication failure', function (done) {
       this.timeout(50);
-      kuzzle.funnel.controllers.auth.passport = new MockupWrapper('reject');
+      kuzzle.passport = new MockupWrapper('reject');
       kuzzle.funnel.controllers.auth.login(requestObject)
         .catch((error) => {
           should(error.message).be.exactly('Mockup Wrapper Error');

--- a/test/api/core/pluginContext/pluginContext.test.js
+++ b/test/api/core/pluginContext/pluginContext.test.js
@@ -1,0 +1,143 @@
+var
+  PluginContext = require.main.require('lib/api/core/plugins/pluginContext'),
+  PluginImplementationError = require('kuzzle-common-objects').Errors.pluginImplementationError,
+  params = require('rc')('kuzzle'),
+  Kuzzle = require.main.require('lib/api/Kuzzle'),
+  sinon = require('sinon'),
+  should = require('should'),
+  _ = require('lodash');
+
+require('sinon-as-promised');
+
+describe.only('Plugin Context', () => {
+  var
+    kuzzle,
+    sandbox;
+
+  before(() => {
+    kuzzle = new Kuzzle();
+    return kuzzle.start(params, {dummy: true});
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    kuzzle.isServer = true;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should be an instance of a PluginContext object', () => {
+    should(new PluginContext(kuzzle)).be.instanceOf(PluginContext);
+  });
+
+  it('should expose the right constructors', () => {
+    var
+      context = new PluginContext(kuzzle),
+      Dsl = require.main.require('lib/api/dsl'),
+      RequestObject = require('kuzzle-common-objects').Models.requestObject,
+      ResponseObject = require('kuzzle-common-objects').Models.responseObject;
+
+    should(context.constructors).be.an.Object().and.not.be.empty();
+    should(context.constructors.Dsl).be.a.Function();
+    should(context.constructors.RequestObject).be.a.Function();
+    should(context.constructors.ResponseObject).be.a.Function();
+
+    should(new context.constructors.Dsl).be.instanceOf(Dsl);
+    should(new context.constructors.RequestObject({})).be.instanceOf(RequestObject);
+    should(new context.constructors.ResponseObject).be.instanceOf(ResponseObject);
+  });
+
+  it('should expose all error objects as capitalized constructors', () => {
+    var
+      context = new PluginContext(kuzzle),
+      errors = require('kuzzle-common-objects').Errors;
+
+    should(context.errors).be.an.Object().and.not.be.empty();
+
+    _.forOwn(errors, (constructor, name) => {
+      var capitalized = _.upperFirst(name);
+
+      should(context.errors[capitalized]).be.a.Function();
+      should(new context.errors[capitalized]('foo')).be.instanceOf(constructor);
+    });
+  });
+
+  it('should not expose accessors if not in a kuzzle server instance', () => {
+    var
+      context;
+
+    kuzzle.isServer = false;
+    context = new PluginContext(kuzzle);
+
+    should(context.accessors).be.an.Object().and.be.empty();
+  });
+
+  it('should expose the right accessors', () => {
+    var context = new PluginContext(kuzzle);
+
+    should(context.accessors).be.an.Object().and.not.be.empty();
+    should(context.accessors).have.properties(['router', 'users']);
+  });
+
+  it('should expose a correctly constructed router accessor', () => {
+    var
+      context = new PluginContext(kuzzle),
+      nCnxStub = sandbox.stub(kuzzle.router, 'newConnection'),
+      execStub = sandbox.stub(kuzzle.router, 'execute'),
+      rCnxStub = sandbox.stub(kuzzle.router, 'removeConnection');
+
+    should(context.accessors.router).be.an.Object();
+    should(context.accessors.router.newConnection).be.a.Function();
+    should(context.accessors.router.execute).be.a.Function();
+    should(context.accessors.router.removeConnection).be.a.Function();
+
+    context.accessors.router.newConnection();
+    should(nCnxStub.calledOnce).be.true();
+    should(nCnxStub.calledOn(kuzzle.router)).be.true();
+
+    context.accessors.router.execute();
+    should(execStub.calledOnce).be.true();
+    should(execStub.calledOn(kuzzle.router)).be.true();
+
+    context.accessors.router.removeConnection();
+    should(rCnxStub.calledOnce).be.true();
+    should(rCnxStub.calledOn(kuzzle.router)).be.true();
+  });
+
+  it('should expose a users.load accessor', () => {
+    var
+      context = new PluginContext(kuzzle),
+      loadStub = sandbox.stub(kuzzle.repositories.user, 'load');
+
+    should(context.accessors.users).be.an.Object();
+    should(context.accessors.users.load).be.a.Function();
+
+    context.accessors.users.load();
+    should(loadStub.calledOnce).be.true();
+  });
+
+  it('should allow creating users', () => {
+    var
+      context = new PluginContext(kuzzle),
+      hydrStub = sandbox.stub(kuzzle.repositories.user, 'hydrate').resolves({}),
+      persStub = sandbox.stub(kuzzle.repositories.user, 'persist').resolves({});
+
+    should(context.accessors.users.create).be.a.Function();
+
+    return context.accessors.users.create({foo: 'bar'})
+      .then(userInfo => {
+        should(userInfo).match({foo: 'bar', profile: 'default'});
+        should(hydrStub.calledOnce).be.true();
+        should(persStub.calledOnce).be.true();
+      });
+  });
+
+  it('should reject user creation with incorrect argument', () => {
+    var
+      context = new PluginContext(kuzzle);
+
+    return should(context.accessors.users.create(['incorrect'])).be.rejectedWith(PluginImplementationError);
+  });
+});

--- a/test/api/core/pluginContext/pluginContext.test.js
+++ b/test/api/core/pluginContext/pluginContext.test.js
@@ -9,7 +9,7 @@ var
 
 require('sinon-as-promised');
 
-describe.only('Plugin Context', () => {
+describe('Plugin Context', () => {
   var
     kuzzle,
     sandbox;

--- a/test/api/core/pluginContext/pluginContext.test.js
+++ b/test/api/core/pluginContext/pluginContext.test.js
@@ -126,18 +126,25 @@ describe('Plugin Context', () => {
 
     should(context.accessors.users.create).be.a.Function();
 
-    return context.accessors.users.create({foo: 'bar'})
+    return context.accessors.users.create('foobar', {foo: 'bar'})
       .then(userInfo => {
-        should(userInfo).match({foo: 'bar', profile: 'default'});
+        should(userInfo).match({_id: 'foobar', foo: 'bar', profile: 'default'});
         should(hydrStub.calledOnce).be.true();
         should(persStub.calledOnce).be.true();
       });
   });
 
-  it('should reject user creation with incorrect argument', () => {
+  it('should reject user creation with incorrect name argument', () => {
     var
       context = new PluginContext(kuzzle);
 
     return should(context.accessors.users.create(['incorrect'])).be.rejectedWith(PluginImplementationError);
   });
+
+  it('should reject user creation with incorrect userInfo argument', () => {
+    var
+      context = new PluginContext(kuzzle);
+    return should(context.accessors.users.create('foo', ['incorrect'])).be.rejectedWith(PluginImplementationError);
+  });
+
 });


### PR DESCRIPTION
Instead of the full `repositories` object been exposed in the plugin context, we now expose only a few methods that can be used by plugin developers.
This makes plugin development easier to grasp and to document.

# Changelog 
* replaced `PluginContext.accessors.repositories` with `PluginContext.accessors.users`
* instead of exposing the entire repository system, the new `users` accessor now only exposes the following methods:
  * `load(userId)`: returns a promise resolving to a user object
  * `create({user: 'informations'})`: returns a promise resolving to the updated user object
* added unit tests to the plugin context object
* moved `authController.passport` into `kuzzle.passport`
* plugin context now exposes the `passport.use` method in its accessors
* removed the special `auth:loadStrategies` hook (this hook does not behave like other hooks)
* replaced event `auth:loadScope`: auth plugins now require a `this.scope` variable to manage scope instead
