### PR TITLE
fix #339: Unsubscription from a subfilter clean all related filters

### DIFF
--- a/lib/api/dsl/filters.js
+++ b/lib/api/dsl/filters.js
@@ -642,10 +642,7 @@ function removeFilterPath(filterId, filterPath) {
     return false;
   }
 
-  /*
-   If there is no another filter using this filter part, we can remove it,
-   unless there is still global filters in it
-   */
+  // If there is no another filter using this filter part, we can remove it
   if (parent.fields) {
     delete parent.fields[subPath];
   }

--- a/lib/api/dsl/filters.js
+++ b/lib/api/dsl/filters.js
@@ -349,61 +349,15 @@ function Filters () {
   };
 
   /**
-   * Removes a global filter
+   * Removes filters corresponding to the provided filter ID from
+   * the filters tree
    *
-   * @param {string} filterId of the filter to remove
+   * @param {string} filterId
+   * @returns {Promise<T>}
    */
-  this.removeGlobalFilter = function (filterId) {
-    var
-      index,
-      filters = this.filters[filterId],
-      treeLink;
-
-    if (!filters || _.isEmpty(this.filtersTree[filters.index][filters.collection].globalFilterIds)) {
-      return false;
-    }
-
-    treeLink = this.filtersTree[filters.index][filters.collection];
-    index = treeLink.globalFilterIds.indexOf(filterId);
-
-    if (index !== -1) {
-      treeLink.globalFilterIds.splice(index, 1);
-    }
-
-    // Check if we can delete the collection
-    if (treeLink.globalFilterIds.length === 0 &&
-      (!treeLink.fields || Object.keys(treeLink.fields).length === 0)) {
-      delete this.filtersTree[filters.index][filters.collection];
-    }
-
-    // Check if we can delete the index
-    if (Object.keys(this.filtersTree[filters.index]).length === 0) {
-      delete this.filtersTree[filters.index];
-    }
-  };
-
-  /**
-   * Removes a non-global filter
-   *
-   * @param {string} filterId of the filter to remove
-   * @returns {Promise}
-   */
-  this.removeFieldFilter = function (filterId) {
-    var
-      deferred = q.defer(),
-      filters = this.filters[filterId];
-
-    if (!filters || !filters.encodedFilters) {
-      deferred.resolve();
-      return deferred.promise;
-    }
-
-    async.each(getFiltersPathsRecursively(filters.encodedFilters), (filterPath, callback) => {
-      removeFilterPath.call(this, filterId, filterPath);
-      callback();
-    }, deferred.makeNodeResolver());
-
-    return deferred.promise;
+  this.removeFilter = function (filterId) {
+    removeGlobalFilter.call(this, filterId);
+    return removeFieldFilter.call(this, filterId);
   };
 
   /**
@@ -438,6 +392,66 @@ function Filters () {
 
     return _.uniq(ids);
   };
+}
+
+/**
+ * Removes a global filter
+ *
+ * @this Filters
+ * @param {string} filterId of the filter to remove
+ */
+function removeGlobalFilter (filterId) {
+  var
+    index,
+    filters = this.filters[filterId],
+    treeLink;
+
+  if (!filters || _.isEmpty(this.filtersTree[filters.index][filters.collection].globalFilterIds)) {
+    return false;
+  }
+
+  treeLink = this.filtersTree[filters.index][filters.collection];
+  index = treeLink.globalFilterIds.indexOf(filterId);
+
+  if (index !== -1) {
+    treeLink.globalFilterIds.splice(index, 1);
+
+    // Check if we can delete the collection
+    if (treeLink.globalFilterIds.length === 0 &&
+      (!treeLink.fields || Object.keys(treeLink.fields).length === 0)) {
+      delete this.filtersTree[filters.index][filters.collection];
+
+      // Check if we can delete the index
+      if (Object.keys(this.filtersTree[filters.index]).length === 0) {
+        delete this.filtersTree[filters.index];
+      }
+    }
+  }
+}
+
+/**
+ * Removes a non-global filter
+ *
+ * @this Filters
+ * @param {string} filterId of the filter to remove
+ * @returns {Promise}
+ */
+function removeFieldFilter (filterId) {
+  var
+    deferred = q.defer(),
+    filters = this.filters[filterId];
+
+  if (!filters || !filters.encodedFilters) {
+    deferred.resolve();
+    return deferred.promise;
+  }
+
+  async.each(getFiltersPathsRecursively(filters.encodedFilters), (filterPath, callback) => {
+    removeFilterPath.call(this, filterId, filterPath);
+    callback();
+  }, deferred.makeNodeResolver());
+
+  return deferred.promise;
 }
 
 /**
@@ -618,12 +632,20 @@ function removeFilterPath(filterId, filterPath) {
     return false;
   }
 
+  // If we're at collection level and there are still global filters stored
+  if (parent[subPath] && parent[subPath].globalFilterIds && parent[subPath].globalFilterIds.length > 0) {
+    return false;
+  }
+
   // If we are at index level and there is other collections stored
   if (subPath === pathArray[0] && !_.isEmpty(parent[subPath])) {
     return false;
   }
 
-  // If there is no another filter using this filter part, we can remove it
+  /*
+   If there is no another filter using this filter part, we can remove it,
+   unless there is still global filters in it
+   */
   if (parent.fields) {
     delete parent.fields[subPath];
   }

--- a/lib/api/dsl/index.js
+++ b/lib/api/dsl/index.js
@@ -109,26 +109,11 @@ function Dsl () {
    * @returns {Promise}
    */
   this.remove = function (filterId) {
-    var
-      deferred = q.defer();
-
     if (typeof filterId !== 'string') {
-      deferred.reject(new BadRequestError(`Expected a filterId, got a ${typeof filterId}`));
-      return deferred.promise;
+      return q.reject(new BadRequestError(`Expected a filterId, got a ${typeof filterId}`));
     }
 
-    // Deletes a filter subscription from the DSL
-    async.parallel([
-      callback => {
-        this.filters.removeGlobalFilter(filterId);
-        callback();
-      },
-      callback => {
-        this.filters.removeFieldFilter(filterId).nodeify(callback);
-      }
-    ], deferred.makeNodeResolver());
-
-    return deferred.promise;
+    return this.filters.removeFilter(filterId);
   };
 
   /**

--- a/test/api/dsl/filters/removeFieldFilter.test.js
+++ b/test/api/dsl/filters/removeFieldFilter.test.js
@@ -12,6 +12,6 @@ describe('Test: dsl.removeFieldFilter', function () {
   });
 
   it('should do nothing if no filters are provided', function () {
-    return should(filters.removeFieldFilter({})).be.fulfilled();
+    return should(DslFilters.__get__('removeFieldFilter').call(filters, null)).be.fulfilled();
   });
 });

--- a/test/api/dsl/filters/removeFilterPath.test.js
+++ b/test/api/dsl/filters/removeFilterPath.test.js
@@ -49,6 +49,17 @@ describe('Test: dsl.removeFilterPath', function () {
     should(filters.filtersTree.anIndex.aCollection.fields.aField.randomFilter.ids).be.an.Array().and.match(['foo']);
   });
 
+  it('should not delete the entire filter if there is still global filters on it', () => {
+    filters.filtersTree.anIndex.aCollection.fields.aField.randomFilter.ids = [ 'foo' ];
+    filters.filtersTree.anIndex.aCollection.globalFilterIds = [ 'bar' ];
+    removeFilterPath.call(filters, 'foo', 'anIndex.aCollection.aField.randomFilter');
+
+    should.exist(filters.filtersTree.anIndex.aCollection);
+    should(filters.filtersTree.anIndex.aCollection.fields).be.empty();
+    should.exist(filters.filtersTree.anIndex.aCollection.globalFilterIds);
+    should(filters.filtersTree.anIndex.aCollection.globalFilterIds).match(['bar']);
+  });
+
   it('should do nothing if the provided filter ID is not listed in the filter path', function () {
     var ids = [ 'foo', 'bar' ];
 

--- a/test/api/dsl/filters/removeGlobalFilter.test.js
+++ b/test/api/dsl/filters/removeGlobalFilter.test.js
@@ -5,25 +5,26 @@ var
 
 describe('Test: dsl.filters.removeGlobalFilter', function () {
   var
-    filters;
+    filters,
+    removeGlobalFilter = DslFilters.__get__('removeGlobalFilter');
 
   beforeEach(function () {
     filters = new DslFilters();
   });
 
   it('should do nothing if the index or the collection does not exist', function () {
-    should(filters.removeGlobalFilter('fake')).be.false();
+    should(removeGlobalFilter.call(filters, 'fake')).be.false();
 
     filters.filtersTree.foobar = {};
-    should(filters.removeGlobalFilter('fake')).be.false();
+    should(removeGlobalFilter.call(filters, 'fake')).be.false();
 
     filters.filtersTree.foobar.globalFilterIds = [];
-    should(filters.removeGlobalFilter('fake')).be.false();
+    should(removeGlobalFilter.call(filters, 'fake')).be.false();
   });
 
   it('should do nothing if the filter ID does not exist', function () {
     filters.addCollectionSubscription('foo', 'index', 'collection');
-    filters.removeGlobalFilter('bar');
+    removeGlobalFilter.call(filters, 'bar');
 
     should(filters.filtersTree.index.collection.globalFilterIds.length).be.exactly(1);
     should(filters.filtersTree.index.collection.globalFilterIds[0]).be.exactly('foo');
@@ -31,7 +32,7 @@ describe('Test: dsl.filters.removeGlobalFilter', function () {
 
   it('should remove the entire index tree if this is the last filter to be removed on it', function () {
     filters.addCollectionSubscription('foo', 'index', 'collection');
-    filters.removeGlobalFilter('foo');
+    removeGlobalFilter.call(filters, 'foo');
 
     should(filters.filtersTree.index).be.undefined();
   });

--- a/test/api/dsl/index/remove.test.js
+++ b/test/api/dsl/index/remove.test.js
@@ -43,7 +43,7 @@ describe('Test: dsl.remove', function () {
   });
 
   it('should return a rejected promise on fail', function () {
-    dsl.filters.removeFieldFilter = () => q.reject(new Error('rejected'));
+    dsl.filters.removeFilter = () => q.reject(new Error('rejected'));
 
     return dsl.register(filterId, index, collection, {})
       .then(() => {


### PR DESCRIPTION
Fixes #339 

# Bug

When the last field filter on a data collection leaves, then the whole DSL filters tree is cleaned up even if there is still subscriptions on global filters.

This causes subscriptions on a data collection to stop working on certain conditions.

# How to reproduce

* on a connection, subscribe to a collection using global filters (whole collection or not exists filter)
* on another connection, subscribe to some field filters (e.g. a "term" filter)
* disconnect the second connection
* the first one does not receive any notification anymore

# Fixes

* the DSL `removeFilterPath` method now checks that there is no global filters left on a collection before removing it from the filters tree
* added a unit test to ensure the bug has been fixed

# Other changes

* simplified a bit how the DSL `index.js` file calls the `filters.js` one to remove filters
* in `removeGlobalFilters`, check if a data collection or a data index can be removed from the filters tree _if and only if_ a global filter has been removed from it
