### PR TITLE
Kuz 577 lb master election

### DIFF
--- a/lib/services/broker/wsBrokerClient.js
+++ b/lib/services/broker/wsBrokerClient.js
@@ -175,11 +175,11 @@ WSBrokerClient.prototype._connect = function () {
       ==> RECONNECTING IN ${this.client.retryInterval}ms`
     );
 
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
     if (this.reconnect) {
-      if (this.retryTimer) {
-        clearTimeout(this.retryTimer);
-        this.retryTimer = null;
-      }
       this.retryTimer = setTimeout(() => this._connect(), this.client.retryInterval);
     }
   });
@@ -197,11 +197,11 @@ WSBrokerClient.prototype._connect = function () {
 
     this.client.state = 'retrying';
     
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
     if (this.reconnect) {
-      if (this.retryTimer) {
-        clearTimeout(this.retryTimer);
-        this.retryTimer = null;
-      }
       this.retryTimer = setTimeout(() => this._connect(), this.client.retryInterval);
     }
   });

--- a/lib/services/broker/wsBrokerClient.js
+++ b/lib/services/broker/wsBrokerClient.js
@@ -36,6 +36,7 @@ function WSBrokerClient (brokerType, options, pluginsManager, notifyOnListen) {
   
   this.ws = () => new WS(`ws://${this.server.host}:${this.server.port}`, {perMessageDeflate: false});
   
+  this.reconnect = true;
   this.retryTimer = null;
 }
 
@@ -165,7 +166,6 @@ WSBrokerClient.prototype._connect = function () {
     if (this.client.state === 'disconnected') {
       return false;
     }
-
     this.close();
     
     this.onCloseHandlers.forEach(f => f());
@@ -175,11 +175,13 @@ WSBrokerClient.prototype._connect = function () {
       ==> RECONNECTING IN ${this.client.retryInterval}ms`
     );
 
-    if (this.retryTimer) {
-      clearTimeout(this.retryTimer);
-      this.retryTimer = null;
+    if (this.reconnect) {
+      if (this.retryTimer) {
+        clearTimeout(this.retryTimer);
+        this.retryTimer = null;
+      }
+      this.retryTimer = setTimeout(() => this._connect(), this.client.retryInterval);
     }
-    this.retryTimer = setTimeout(() => this._connect(), this.client.retryInterval);
   });
 
   this.client.socket.on('error', err => {
@@ -195,11 +197,13 @@ WSBrokerClient.prototype._connect = function () {
 
     this.client.state = 'retrying';
     
-    if (this.retryTimer) {
-      clearTimeout(this.retryTimer);
-      this.retryTimer = null;
+    if (this.reconnect) {
+      if (this.retryTimer) {
+        clearTimeout(this.retryTimer);
+        this.retryTimer = null;
+      }
+      this.retryTimer = setTimeout(() => this._connect(), this.client.retryInterval);
     }
-    this.retryTimer = setTimeout(() => this._connect(), this.client.retryInterval);
   });
   
 };

--- a/test/services/implementations/broker.test.js
+++ b/test/services/implementations/broker.test.js
@@ -320,6 +320,19 @@ describe('Test: Internal broker', function () {
         should(client.client.socket).be.an.instanceOf(WSClientMock);
       });
 
+      it('on close should not try to reconnect if explicitly asked so', () => {
+        var socket = client.client.socket;
+
+        client.reconnect = false;
+        client.state = 'connected';
+        client.retryTimer = 'something';
+
+        socket.emit('close', 1);
+
+        should(client.client.socket).be.null();
+        should(client.retryTimer).be.null();
+      });
+
       it('on close should try reconnecting if :close was not explicitly called', () => {
         var
           connectSpy = sandbox.spy(client, '_connect'),
@@ -365,6 +378,18 @@ describe('Test: Internal broker', function () {
         should(client.onErrorHandlers[0]).be.calledThrice();
       });
 
+      it('on error should not try to reconnect if asked so', () => {
+        var socket = client.client.socket;
+        
+        client.reconnect = false;
+        client.retryTimer = 'something';
+        
+        socket.emit('error', 1);
+        
+        should(client.client.socket).be.null();
+        should(client.retryTimer).be.null();
+      });
+      
     });
 
   });


### PR DESCRIPTION
Allows Kuzzle broker client to not try to reconnect on `close` or `error` events.

Typical use case is when the server is down and a new one was popped up.