### PR TITLE
KUZ-490 Multi Profile Implementation

### DIFF
--- a/.kuzzlerc
+++ b/.kuzzlerc
@@ -86,13 +86,13 @@
   // Default user profiles
   "userProfiles": {
     "admin": {
-      "policies": [ {"_id": "admin", "allowInternalIndex": true} ]
+      "policies": [ {"roleId": "admin", "allowInternalIndex": true} ]
     },
     "default": {
-      "policies": [ {"_id": "default"} ]
+      "policies": [ {"roleId": "default"} ]
     },
     "anonymous": {
-      "policies": [ {"_id": "anonymous"} ]
+      "policies": [ {"roleId": "anonymous"} ]
     }
   },
   // role template for all users before creating the first admin

--- a/bin/commands/createFirstAdmin.js
+++ b/bin/commands/createFirstAdmin.js
@@ -116,7 +116,7 @@ var createAdminUser = () => {
   var data = {
     _id: name,
     password: password,
-    profileId: 'admin'
+    profilesIds: ['admin']
   };
 
   return request({

--- a/bin/commands/createFirstAdmin.js
+++ b/bin/commands/createFirstAdmin.js
@@ -155,15 +155,15 @@ var nextStep = (message) => {
     createAdminUser()
       .then(() =>{
         console.log(ok('[✔] "' + name + '" user created with admin rights'));
-        return resetProfile('default', {_id: 'default'});
+        return resetProfile('default', {roleId: 'default'});
       })
       .then(() => {
         console.log(ok('[✔] "default" profile reset'));
-        return resetProfile('admin', {_id: 'admin', allowInternalIndex: true});
+        return resetProfile('admin', {roleId: 'admin', allowInternalIndex: true});
       })
       .then(() => {
         console.log(ok('[✔] "admin" profile reset'));
-        return resetProfile('anonymous', {_id: 'anonymous'});
+        return resetProfile('anonymous', {roleId: 'anonymous'});
       })
       .then(() => {
         console.log(ok('[✔] "anonymous" profile reset'));

--- a/features/AMQP.feature
+++ b/features/AMQP.feature
@@ -323,26 +323,26 @@ Feature: Test AMQP API
     And I create a new user "useradmin" with id "useradmin-id"
     And I create a user "user2" with id "user2-id"
     And I can't create a new user "user2" with id "useradmin-id"
-    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profileId":"admin"}}
-    Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profileId":"#prefix#profile2"}}
+    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
+    Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profilesIds":["#prefix#profile2"]}}
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 2 users
     Then I delete the user "user2-id"
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 1 users matching {"_id":"#prefix#useradmin-id","_source":{"name":{"first":"David","last":"Bowie"}}}
     When I log in as useradmin-id:testpwd expiring in 1h
-    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profileId":"admin"}}
+    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
     Then I log out
-    Then I am getting the current user, which matches {"_id":-1,"_source":{"profileId":"anonymous"}}
+    Then I am getting the current user, which matches {"_id":-1,"_source":{"profilesIds":["anonymous"]}}
 
   @usingAMQP @cleanSecurity
   Scenario: user updateSelf
     When I create a new user "useradmin" with id "useradmin-id"
-    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profileId":"admin"}}
+    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
     When I log in as useradmin-id:testpwd expiring in 1h
-    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profileId":"admin"}}
+    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
     Then I update current user with data {"foo":"bar"}
-    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profileId":"admin"}}
+    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
     Then I log out
-    Then I am getting the current user, which matches {"_id":-1,"_source":{"profileId":"anonymous"}}
+    Then I am getting the current user, which matches {"_id":-1,"_source":{"profilesIds":["anonymous"]}}
 
   @usingAMQP @cleanSecurity
   Scenario: user permissions

--- a/features/MQTT.feature
+++ b/features/MQTT.feature
@@ -323,26 +323,26 @@ Feature: Test MQTT API
     And I create a new user "useradmin" with id "useradmin-id"
     And I create a user "user2" with id "user2-id"
     And I can't create a new user "user2" with id "useradmin-id"
-    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profileId":"admin"}}
-    Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profileId":"#prefix#profile2"}}
+    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
+    Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profilesIds":["#prefix#profile2"]}}
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 2 users
     Then I delete the user "user2-id"
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 1 users matching {"_id":"#prefix#useradmin-id","_source":{"name":{"first":"David","last":"Bowie"}}}
     When I log in as useradmin-id:testpwd expiring in 1h
-    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profileId":"admin"}}
+    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
     Then I log out
-    Then I am getting the current user, which matches {"_id":-1,"_source":{"profileId":"anonymous"}}
+    Then I am getting the current user, which matches {"_id":-1,"_source":{"profilesIds":["anonymous"]}}
 
   @usingMQTT @cleanSecurity
   Scenario: user updateSelf
     When I create a new user "useradmin" with id "useradmin-id"
-    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profileId":"admin"}}
+    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
     When I log in as useradmin-id:testpwd expiring in 1h
-    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profileId":"admin"}}
+    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
     Then I update current user with data {"foo":"bar"}
-    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profileId":"admin","foo":"bar"}}
+    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"],"foo":"bar"}}
     Then I log out
-    Then I am getting the current user, which matches {"_id":-1,"_source":{"profileId":"anonymous"}}
+    Then I am getting the current user, which matches {"_id":-1,"_source":{"profilesIds":["anonymous"]}}
 
   @usingMQTT @cleanSecurity
   Scenario: user permissions

--- a/features/REST.feature
+++ b/features/REST.feature
@@ -210,26 +210,26 @@ Feature: Test REST API
     And I create a new user "useradmin" with id "useradmin-id"
     And I create a user "user2" with id "user2-id"
     And I can't create a new user "user2" with id "useradmin-id"
-    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profileId":"admin"}}
-    Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profileId":"#prefix#profile2"}}
+    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
+    Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profilesIds":["#prefix#profile2"]}}
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 2 users
     Then I delete the user "user2-id"
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 1 users matching {"_id":"#prefix#useradmin-id","_source":{"name":{"first":"David","last":"Bowie"}}}
     When I log in as useradmin-id:testpwd expiring in 1h
-    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profileId":"admin"}}
+    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
     Then I log out
-    Then I am getting the current user, which matches {"_id":-1,"_source":{"profileId":"anonymous"}}
+    Then I am getting the current user, which matches {"_id":-1,"_source":{"profilesIds":["anonymous"]}}
 
   @usingREST @cleanSecurity
   Scenario: user updateSelf
     When I create a new user "useradmin" with id "useradmin-id"
-    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profileId":"admin"}}
+    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
     When I log in as useradmin-id:testpwd expiring in 1h
-    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profileId":"admin"}}
+    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
     Then I update current user with data {"foo":"bar"}
-    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profileId":"admin","foo":"bar"}}
+    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"],"foo":"bar"}}
     Then I log out
-    Then I am getting the current user, which matches {"_id":-1,"_source":{"profileId":"anonymous"}}
+    Then I am getting the current user, which matches {"_id":-1,"_source":{"profilesIds":["anonymous"]}}
 
   @usingREST @cleanSecurity
   Scenario: user permissions

--- a/features/STOMP.feature
+++ b/features/STOMP.feature
@@ -323,26 +323,26 @@ Feature: Test STOMP API
     And I create a new user "useradmin" with id "useradmin-id"
     And I create a user "user2" with id "user2-id"
     And I can't create a new user "user2" with id "useradmin-id"
-    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profileId":"admin"}}
-    Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profileId":"#prefix#profile2"}}
+    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
+    Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profilesIds":["#prefix#profile2"]}}
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 2 users
     Then I delete the user "user2-id"
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 1 users matching {"_id":"#prefix#useradmin-id","_source":{"name":{"first":"David","last":"Bowie"}}}
     When I log in as useradmin-id:testpwd expiring in 1h
-    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profileId":"admin"}}
+    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
     Then I log out
-    Then I am getting the current user, which matches {"_id":-1,"_source":{"profileId":"anonymous"}}
+    Then I am getting the current user, which matches {"_id":-1,"_source":{"profilesIds":["anonymous"]}}
 
   @usingSTOMP @cleanSecurity
   Scenario: user updateSelf
     When I create a new user "useradmin" with id "useradmin-id"
-    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profileId":"admin"}}
+    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
     When I log in as useradmin-id:testpwd expiring in 1h
-    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profileId":"admin"}}
+    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
     Then I update current user with data {"foo":"bar"}
-    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profileId":"admin","foo":"bar"}}
+    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"],"foo":"bar"}}
     Then I log out
-    Then I am getting the current user, which matches {"_id":-1,"_source":{"profileId":"anonymous"}}
+    Then I am getting the current user, which matches {"_id":-1,"_source":{"profilesIds":["anonymous"]}}
 
   @usingSTOMP @cleanSecurity
   Scenario: user permissions

--- a/features/Websocket.feature
+++ b/features/Websocket.feature
@@ -323,26 +323,26 @@ Feature: Test websocket API
     And I create a new user "useradmin" with id "useradmin-id"
     And I create a user "user2" with id "user2-id"
     And I can't create a new user "user2" with id "useradmin-id"
-    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profileId":"admin"}}
-    Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profileId":"#prefix#profile2"}}
+    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
+    Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profilesIds":["#prefix#profile2"]}}
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 2 users
     Then I delete the user "user2-id"
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 1 users matching {"_id":"#prefix#useradmin-id","_source":{"name":{"first":"David","last":"Bowie"}}}
     When I log in as useradmin-id:testpwd expiring in 1h
-    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profileId":"admin"}}
+    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
     Then I log out
-    Then I am getting the current user, which matches {"_id":-1,"_source":{"profileId":"anonymous"}}
+    Then I am getting the current user, which matches {"_id":-1,"_source":{"profilesIds":["anonymous"]}}
 
   @usingWebsocket @cleanSecurity
   Scenario: user updateSelf
     When I create a new user "useradmin" with id "useradmin-id"
-    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profileId":"admin"}}
+    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
     When I log in as useradmin-id:testpwd expiring in 1h
-    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profileId":"admin"}}
+    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
     Then I update current user with data {"foo":"bar"}
-    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profileId":"admin","foo":"bar"}}
+    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"],"foo":"bar"}}
     Then I log out
-    Then I am getting the current user, which matches {"_id":-1,"_source":{"profileId":"anonymous"}}
+    Then I am getting the current user, which matches {"_id":-1,"_source":{"profilesIds":["anonymous"]}}
 
   @usingWebsocket @cleanSecurity @unsubscribe
   Scenario: token expiration

--- a/features/step_definitions/profiles.js
+++ b/features/step_definitions/profiles.js
@@ -221,7 +221,7 @@ var apiSteps = function () {
     profileId = this.idPrefix + profileId;
 
     this.api.createOrReplaceProfile(profileId, {
-      policies: [{_id: roleId}]
+      policies: [{roleId: roleId}]
     })
     .then(response => {
       if (response.error) {

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -117,44 +117,44 @@ module.exports = function () {
 
     this.profiles = {
       profile1: {
-        policies: [{_id: this.idPrefix + 'role1'}]
+        policies: [{roleId: this.idPrefix + 'role1'}]
       },
       profile2: {
         policies: [
           {
-            _id: this.idPrefix + 'role1',
+            roleId: this.idPrefix + 'role1',
             restrictedTo: [{index: this.fakeIndex}]
           },
           {
-            _id: this.idPrefix + 'role2'
+            roleId: this.idPrefix + 'role2'
           }
         ]
       },
       profile3: {
         policies: [{
-          _id: this.idPrefix + 'role2',
+          roleId: this.idPrefix + 'role2',
           restrictedTo: [{index: this.fakeAltIndex, collections:[this.fakeCollection]}]
         }]
       },
       profile4: {
         policies: [{
-          _id: this.idPrefix + 'role3'
+          roleId: this.idPrefix + 'role3'
         }]
       },
       profile5: {
         policies: [{
-          _id: this.idPrefix + 'role3',
+          roleId: this.idPrefix + 'role3',
           restrictedTo: [{index: this.fakeIndex}]
         }]
       },
       profile6: {
         policies: [{
-          _id: this.idPrefix + 'role3',
+          roleId: this.idPrefix + 'role3',
           restrictedTo: [{index: this.fakeIndex, collections:[this.fakeCollection]}]
         }]
       },
       invalidProfile: {
-        policies: [{_id: 'unexisting-role'}]
+        policies: [{roleId: 'unexisting-role'}]
       },
       emptyProfile: {
         policies: []

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -168,11 +168,11 @@ module.exports = function () {
           last: 'Bowie',
           real: 'David Robert Jones'
         },
-        profileId: 'admin',
+        profilesIds: ['admin'],
         password: 'testpwd'
       },
       user1: {
-        profileId: this.idPrefix + 'profile1',
+        profilesIds: [this.idPrefix + 'profile1'],
         password: 'testpwd1'
       },
       user2: {
@@ -181,32 +181,32 @@ module.exports = function () {
           last: 'Wozniak'
         },
         hobby: 'Segway Polo',
-        profileId: this.idPrefix + 'profile2',
+        profilesIds: [this.idPrefix + 'profile2'],
         password: 'testpwd2'
       },
       user3: {
-        profileId: this.idPrefix + 'profile3',
+        profilesIds: [this.idPrefix + 'profile3'],
         password: 'testpwd3'
       },
       user4: {
-        profileId: this.idPrefix + 'profile4',
+        profilesIds: [this.idPrefix + 'profile4'],
         password: 'testpwd4'
       },
       user5: {
-        profileId: this.idPrefix + 'profile5',
+        profilesIds: [this.idPrefix + 'profile5'],
         password: 'testpwd5'
       },
       user6: {
-        profileId: this.idPrefix + 'profile6',
+        profilesIds: [this.idPrefix + 'profile6'],
         password: 'testpwd6'
       },
       unexistingprofile: {
         name: 'John Doe',
-        profileId: this.idPrefix + 'i-dont-exist'
+        profilesIds: [this.idPrefix + 'i-dont-exist']
       },
       invalidprofileType: {
         name: 'John Doe',
-        profileId: null
+        profilesIds: [null]
       }
     };
 

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -141,7 +141,7 @@ function AuthController (kuzzle) {
           return q.reject(new UnauthorizedError('User must be connected in order to call updateSelf'));
         }
 
-        if (modifiedRequestObject.data.body.profileId) {
+        if (modifiedRequestObject.data.body.profilesIds) {
           return q.reject(new BadRequestError('profile can not be provided in updateSelf'));
         }
 

--- a/lib/api/controllers/remoteActions/prepareDb.js
+++ b/lib/api/controllers/remoteActions/prepareDb.js
@@ -424,10 +424,6 @@ function createUserCollection(kuzzle) {
     collection: 'users',
     body: {
       properties: {
-        profileId: {
-          index: 'not_analyzed',
-          type: 'string'
-        },
         password: {
           index: 'no',
           type: 'string'

--- a/lib/api/controllers/remoteActions/prepareDb.js
+++ b/lib/api/controllers/remoteActions/prepareDb.js
@@ -359,7 +359,7 @@ function createProfileCollection(kuzzle) {
       properties: {
         policies: {
           properties: {
-            _id: {
+            roleId: {
               index: 'not_analyzed',
               type: 'string'
             }
@@ -380,11 +380,11 @@ function createProfileCollection(kuzzle) {
     .then(() => {
       kuzzle.indexCache.add(kuzzle.config.internalIndex, 'profiles');
       kuzzle.pluginsManager.trigger('log:info', '== Creating default profile for default...');
-
+      
       requestObject = new RequestObject({
         controller: 'security',
         action: 'createOrReplaceProfile',
-        body: {_id: 'default', policies: [ {_id: 'default', allowInternalIndex: true} ]}
+        body: {_id: 'default', policies: [ {roleId: 'default', allowInternalIndex: true} ]}
       });
 
       return kuzzle.funnel.controllers.security.createOrReplaceProfile(requestObject, {});
@@ -395,7 +395,7 @@ function createProfileCollection(kuzzle) {
       requestObject = new RequestObject({
         controller: 'security',
         action: 'createOrReplaceProfile',
-        body: {_id: 'anonymous', policies: [ {_id:'anonymous', allowInternalIndex: true} ]}
+        body: {_id: 'anonymous', policies: [ {roleId:'anonymous', allowInternalIndex: true} ]}
       });
 
       return kuzzle.funnel.controllers.security.createOrReplaceProfile(requestObject, {});
@@ -406,7 +406,7 @@ function createProfileCollection(kuzzle) {
       requestObject = new RequestObject({
         controller: 'security',
         action: 'createOrReplaceProfile',
-        body: {_id: 'admin', policies: [ {_id:'admin', allowInternalIndex: true} ]}
+        body: {_id: 'admin', policies: [ {roleId:'admin', allowInternalIndex: true} ]}
       });
 
       return kuzzle.funnel.controllers.security.createOrReplaceProfile(requestObject, {});

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -445,8 +445,8 @@ function SecurityController (kuzzle) {
 
         modifiedRequestObject = newRequestObject;
 
-        if (!modifiedRequestObject.data.body || !modifiedRequestObject.data.body.profileId) {
-          return q.reject(new BadRequestError('Invalid user object. No profileId property found.'));
+        if (!modifiedRequestObject.data.body || !modifiedRequestObject.data.body.profilesIds) {
+          return q.reject(new BadRequestError('Invalid user object. No profilesIds property found.'));
         }
 
         pojoUser = modifiedRequestObject.data.body;
@@ -579,7 +579,7 @@ function SecurityController (kuzzle) {
       .then(newRequestObject => {
         modifiedRequestObject = newRequestObject;
 
-        if (!modifiedRequestObject.data.body || !modifiedRequestObject.data.body.profileId) {
+        if (!modifiedRequestObject.data.body || !modifiedRequestObject.data.body.profilesIds) {
           return q.reject(new BadRequestError('Invalid user object. No profile property found.'));
         }
 

--- a/lib/api/core/models/repositories/profileRepository.js
+++ b/lib/api/core/models/repositories/profileRepository.js
@@ -8,13 +8,12 @@ module.exports = function (kuzzle) {
     NotFoundError = require('kuzzle-common-objects').Errors.notFoundError,
     Repository = require('./repository');
 
-  var extractRoleIds = function (policies) {
-    return policies.map(policy => {
-      if (typeof policy === 'string') {
-        return policy;
+  var extractRoleIds = policiesOrRoles => {
+    return policiesOrRoles.map(element => {
+      if (element.roleId) {
+        return element.roleId;
       }
-
-      return policy._id;
+      return element._id;
     });
   };
 
@@ -58,12 +57,12 @@ module.exports = function (kuzzle) {
   /**
    * Loads a Profile object given its id.
    *
-   * @param {array} profilesId
+   * @param {array} Array of profiles ids
    * @returns {Promise} Resolves to the matching Profile object if found, null if not.
    */
   ProfileRepository.prototype.loadProfiles = function (profilesIds) {
     var promises = [];
-    
+
     if (!profilesIds) {
       return q.reject(new BadRequestError('Missing profilesIds'));
     }
@@ -108,15 +107,9 @@ module.exports = function (kuzzle) {
     if (!requestObject.data._id) {
       return q.reject(new BadRequestError('Missing profile id'));
     }
+    _.assign(profile, requestObject.data.body);
 
     profile._id = requestObject.data._id;
-
-    Object.keys(requestObject.data.body).forEach((key) => {
-      if (key !== '_id') {
-        profile[key] = requestObject.data.body[key];
-      }
-    });
-
     return q(profile);
   };
 
@@ -132,8 +125,8 @@ module.exports = function (kuzzle) {
 
     if (roles && Array.isArray(roles) && roles.length) {
       filter.or = [];
-      roles.forEach(role => {
-        filter.or.push({terms: { 'policies._id': [ role ] }});
+      roles.forEach(roleId => {
+        filter.or.push({terms: { 'policies.roleId': [ roleId ] }});
       });
     }
 
@@ -148,7 +141,9 @@ module.exports = function (kuzzle) {
    * @returns Promise Resolves to the hydrated Profile object.
    */
   ProfileRepository.prototype.hydrate = function (profile, data) {
-    var source;
+    var 
+      source, 
+      policiesRoles;
 
     if (data._source) {
       source = data._source;
@@ -160,21 +155,21 @@ module.exports = function (kuzzle) {
       Object.assign(data, source);
     }
 
-    // force "default" role if the profile does not have any role in it
+    // force "default" role/policy if the profile does not have any role in it
     if (!profile.policies || profile.policies.length === 0) {
-      profile.policies = [ {_id: 'default'} ];
+      profile.policies = [ {roleId: 'default'} ];
     }
 
     _.assignIn(profile, data);
+    policiesRoles = extractRoleIds(profile.policies);
 
-    return kuzzle.repositories.role.loadRoles(extractRoleIds(profile.policies))
+    return kuzzle.repositories.role.loadRoles(policiesRoles)
       .then(roles => {
-        var
-          rolesNotFound = _.difference(extractRoleIds(profile.policies), extractRoleIds(roles));
+        var rolesNotFound = _.difference(policiesRoles, extractRoleIds(roles));
 
         // Fail if not all roles are found
         if (rolesNotFound.length) {
-          return q.reject(new NotFoundError(`Unable to hydrate the profile ${data._id}. The following roles don't exist: ${rolesNotFound}`));
+          return q.reject(new NotFoundError(`Unable to hydrate the profile ${data._id}. The following role(s) don't exist: ${rolesNotFound}`));
         }
 
         return profile;
@@ -230,11 +225,10 @@ module.exports = function (kuzzle) {
   /**
    * Given a Profile object, validates its definition and if OK, persist it to the database.
    * @param {Profile} profile
-   * @param {object} context - user's context
    * @param {Object} opts The persistence options
    * @returns Promise<Profile>
    **/
-  ProfileRepository.prototype.validateAndSaveProfile = function (profile, context, opts) {
+  ProfileRepository.prototype.validateAndSaveProfile = function (profile, opts) {
     if (!profile._id) {
       return q.reject(new BadRequestError('Missing profile id'));
     }

--- a/lib/api/core/models/repositories/profileRepository.js
+++ b/lib/api/core/models/repositories/profileRepository.js
@@ -86,10 +86,14 @@ module.exports = function (kuzzle) {
 
     return q.all(promises)
       .then(results => {
+        var profiles = [];
         results.forEach(profile => {
-          this.profiles[profile._id] = profile;
+          if (profile !== null) {
+            this.profiles[profile._id] = profile;
+            profiles.push(profile);
+          }
         });
-        return q(results);
+        return q(profiles);
       });
   };
 

--- a/lib/api/core/models/repositories/profileRepository.js
+++ b/lib/api/core/models/repositories/profileRepository.js
@@ -45,13 +45,51 @@ module.exports = function (kuzzle) {
     }
 
     return this.load(profileId)
-      .then((result) => {
+      .then(result => {
         if (result) {
           return result;
         }
 
         // no profile found
         return null;
+      });
+  };
+
+  /**
+   * Loads a Profile object given its id.
+   *
+   * @param {array} profilesId
+   * @returns {Promise} Resolves to the matching Profile object if found, null if not.
+   */
+  ProfileRepository.prototype.loadProfiles = function (profilesIds) {
+    var promises = [];
+    
+    if (!profilesIds) {
+      return q.reject(new BadRequestError('Missing profilesIds'));
+    }
+
+    if (!_.isArray(profilesIds)) {
+      return q.reject(new BadRequestError('An array of strings must be provided as profilesIds'));
+    }
+
+    if (profilesIds.length === 0) {
+      return q([]);
+    }
+
+    profilesIds.forEach(profileId => {
+      if (typeof profileId !== 'string') {
+        return q.reject(new BadRequestError('An array of strings must be provided as profilesIds'));
+      }
+
+      promises.push(this.load(profileId));
+    });
+
+    return q.all(promises)
+      .then(results => {
+        results.forEach(profile => {
+          this.profiles[profile._id] = profile;
+        });
+        return q(results);
       });
   };
 

--- a/lib/api/core/models/repositories/roleRepository.js
+++ b/lib/api/core/models/repositories/roleRepository.js
@@ -41,9 +41,10 @@ module.exports = function (kuzzle) {
     });
 
     if (keys.length === 0) {
-      Object.keys(buffer).forEach((key) => {
+      Object.keys(buffer).forEach(key => {
         result.push(buffer[key]);
       });
+
       deferred.resolve(result);
     }
     else {

--- a/lib/api/core/models/repositories/userRepository.js
+++ b/lib/api/core/models/repositories/userRepository.js
@@ -5,7 +5,7 @@ module.exports = function (kuzzle) {
     uuid = require('node-uuid'),
     User = require('../security/user'),
     Repository = require('./repository'),
-    InternalError = require('kuzzle-common-objects').Errors.internalError;
+    NotFoundError = require('kuzzle-common-objects').Errors.notFoundError;
 
 
   function UserRepository (opts) {
@@ -49,7 +49,7 @@ module.exports = function (kuzzle) {
 
     return this.persistToDatabase(user, databaseOptions)
       .then(() => this.persistToCache(user, cacheOptions))
-      .then(() => q(user));
+      .then(() => user);
   };
 
 
@@ -60,12 +60,12 @@ module.exports = function (kuzzle) {
     return q(_.assignIn(user, {
       _id: -1,
       name: 'Anonymous',
-      profileId: 'anonymous'
+      profilesIds: ['anonymous']
     }));
   };
 
   UserRepository.prototype.hydrate = function (user, data) {
-    var source;
+    var source, dataProfilesIds;
 
     if (!_.isObject(data)) {
       return q(user);
@@ -77,7 +77,13 @@ module.exports = function (kuzzle) {
       Object.assign(data, source);
     }
 
+    if (data.profilesIds) {
+      dataProfilesIds = data.profilesIds;
+      delete data.profilesIds;
+    }
+
     _.assignIn(user, data);
+    _.assign(user.profilesIds, dataProfilesIds);
 
     if (user._id === undefined || user._id === null) {
       return this.anonymous();
@@ -85,14 +91,18 @@ module.exports = function (kuzzle) {
 
     // if the user exists (have an _id) but no profile
     // set it to default
-    if (!user.profileId) {
-      user.profileId = 'default';
+    if (user.profilesIds.length === 0) {
+      user.profilesIds = ['default'];
     }
 
-    return kuzzle.repositories.profile.loadProfile(user.profileId)
-      .then(profile => {
-        if (!profile) {
-          return q.reject(new InternalError('Could not find profile: ' + user.profileId));
+    return kuzzle.repositories.profile.loadProfiles(user.profilesIds)
+      .then(profiles => {
+        var profilesIds = profiles.map(profile => profile._id),
+          profilesNotFound = _.difference(user.profilesIds, profilesIds);
+
+        // Fail if not all roles are found
+        if (profilesNotFound.length) {
+          return q.reject(new NotFoundError(`Unable to hydrate the user ${data._id}. The following profiles don't exist: ${profilesNotFound}`));
         }
 
         return user;

--- a/lib/api/core/models/security/profile.js
+++ b/lib/api/core/models/security/profile.js
@@ -19,10 +19,9 @@ function Profile () {
 
 Profile.prototype.getRoles = function (kuzzle) {
   var promises;
-
-  promises = this.policies.map(role => {
-    return kuzzle.repositories.role.loadRole(role._id)
-      .then(loadedRole => _.assignIn(new Role(), loadedRole, role));
+  promises = this.policies.map(policy => {
+    return kuzzle.repositories.role.loadRole(policy.roleId)
+      .then(loadedRole => _.assignIn(new Role(), loadedRole, policy));
   });
 
   return q.all(promises)

--- a/lib/api/core/models/security/user.js
+++ b/lib/api/core/models/security/user.js
@@ -1,9 +1,14 @@
+var
+  q = require('q'),
+  async = require('async'),
+  _ = require('lodash');
+
 /**
  * @constructor
  */
 function User () {
   this._id = null;
-  this.profileId = null;
+  this.profilesIds = [];
 }
 
 /**
@@ -11,21 +16,59 @@ function User () {
  *
  * @return {Promise}
  */
-User.prototype.getProfile = function (kuzzle) {
-  return kuzzle.repositories.profile.loadProfile(this.profileId);
+User.prototype.getProfiles = function (kuzzle) {
+  return kuzzle.repositories.profile.loadProfiles(this.profilesIds);
 };
 
 /**
  * @return {Promise}
  */
 User.prototype.getRights = function (kuzzle) {
-  return this.getProfile(kuzzle)
-    .then(profile => profile.getRights(kuzzle));
+  var
+    promises = [],
+    rights = {};
+
+  return this.getProfiles(kuzzle)
+    .then(profiles => {
+      profiles.forEach(profile => {
+        promises.push(profile.getRights(kuzzle));
+      });
+      
+      return q.all(promises)
+        .then(results => {
+          results.forEach(right => {
+            _.assign(rights, right);
+          });
+          return q(rights);
+        });
+    });
 };
 
 User.prototype.isActionAllowed = function (requestObject, context, kuzzle) {
-  return this.getProfile(kuzzle)
-    .then(profile => profile.isActionAllowed(requestObject, context, kuzzle));
+  var deferred;
+  
+  if (this.profilesIds === undefined || this.profilesIds.length === 0) {
+    return q(false);
+  }
+
+  deferred = q.defer();
+
+  this.getProfiles(kuzzle)
+    .then(profiles => {
+      async.some(profiles, (profile, callback) => {
+        profile.isActionAllowed(requestObject, context, kuzzle)
+          .then(isAllowed => {
+            callback(isAllowed);
+          });
+      }, result => {
+        deferred.resolve(result);
+      });
+    })
+    .catch(error => {
+      deferred.reject(error);
+    });
+
+  return deferred.promise;  
 };
 
 module.exports = User;

--- a/lib/api/core/models/security/user.js
+++ b/lib/api/core/models/security/user.js
@@ -24,18 +24,16 @@ User.prototype.getProfiles = function (kuzzle) {
  * @return {Promise}
  */
 User.prototype.getRights = function (kuzzle) {
-  var
-    promises = [],
-    rights = {};
-
   return this.getProfiles(kuzzle)
     .then(profiles => {
-      profiles.forEach(profile => {
-        promises.push(profile.getRights(kuzzle));
+      var promises = profiles.map(profile => {
+        return profile.getRights(kuzzle);
       });
       
       return q.all(promises)
         .then(results => {
+          var rights = {};
+
           results.forEach(right => {
             _.assign(rights, right);
           });
@@ -64,9 +62,7 @@ User.prototype.isActionAllowed = function (requestObject, context, kuzzle) {
         deferred.resolve(result);
       });
     })
-    .catch(error => {
-      deferred.reject(error);
-    });
+    .catch(error => deferred.reject(error));
 
   return deferred.promise;  
 };

--- a/lib/api/core/models/security/user.js
+++ b/lib/api/core/models/security/user.js
@@ -35,7 +35,7 @@ User.prototype.getRights = function (kuzzle) {
           var rights = {};
 
           results.forEach(right => {
-            _.assign(rights, right);
+            _.assignWith(rights, right);
           });
           return q(rights);
         });

--- a/test/api/controllers/adminController.test.js
+++ b/test/api/controllers/adminController.test.js
@@ -280,7 +280,7 @@ describe('Test: admin controller', function () {
       context.token.userId = 'deleteIndex';
       role.restrictedTo = [{index: '%text1'},{index: '%text2'}];
       profile._id = 'deleteIndex';
-      profile.policies = [{_id: role._id, restrictedTo: role.restrictedTo}];
+      profile.policies = [{roleId: role._id, restrictedTo: role.restrictedTo}];
 
       sandbox.stub(kuzzle.repositories.user, 'load').resolves(user);
       sandbox.stub(kuzzle.repositories.profile, 'loadProfile').resolves(profile);

--- a/test/api/controllers/adminController.test.js
+++ b/test/api/controllers/adminController.test.js
@@ -265,7 +265,7 @@ describe('Test: admin controller', function () {
       role;
 
     before(() => {
-      user = _.assignIn(new User(), {_id:'deleteIndex', profileId: 'deleteIndex'});
+      user = _.assignIn(new User(), {_id:'deleteIndex', profilesIds: ['deleteIndex']});
       profile = new Profile();
       role = new Role();
 

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -89,7 +89,7 @@ describe('Test the auth controller', function () {
           }
           return q({
             _id: t,
-            profileId: t
+            profilesIds: [t]
           });
         };
       });
@@ -319,7 +319,7 @@ describe('Test the auth controller', function () {
       kuzzle.funnel.controllers.auth.getCurrentUser(rq, token)
         .then(response => {
           should(response.data.body._id).be.exactly('admin');
-          should(response.data.body._source.profileId).be.exactly('admin');
+          should(response.data.body._source.profilesIds).be.eql(['admin']);
 
           done();
         })
@@ -409,7 +409,7 @@ describe('Test the auth controller', function () {
               return anotherKuzzle.repositories.user.anonymous();
             }
             if (id === 'admin') {
-              return {_id: 'admin', _source: { profileID: 'admin' }};
+              return {_id: 'admin', _source: { profilesId: ['admin'] }};
             }
 
             return q(null);
@@ -444,7 +444,7 @@ describe('Test the auth controller', function () {
 
     it('should reject if profile is specified', () => {
       should(anotherKuzzle.funnel.controllers.auth.updateSelf(new RequestObject({
-        body: { foo: 'bar', profileId: 'test' }
+        body: { foo: 'bar', profilesIds: ['test'] }
       }), { token: { userId: 'admin', _id: 'admin' }}))
         .be.rejected();
     });

--- a/test/api/controllers/remoteActionsController/prepareDb.test.js
+++ b/test/api/controllers/remoteActionsController/prepareDb.test.js
@@ -508,10 +508,10 @@ describe('Test: Prepare database', function () {
           funnel: {
             controllers: {
               security: {
-                createOrReplaceRole: (requestObject) => {
+                createOrReplaceRole: requestObject => {
                   requests.push(requestObject);
                 },
-                createOrReplaceProfile: (requestObject) => {
+                createOrReplaceProfile: requestObject => {
                   requests.push(requestObject);
                 }
               }

--- a/test/api/controllers/routerController/routerController.test.js
+++ b/test/api/controllers/routerController/routerController.test.js
@@ -106,7 +106,7 @@ describe('Test: routerController', () => {
               getProfile: () => {
                 return q({
                   _id: 'profile',
-                  policies: ['role'],
+                  policies: [{roleId: 'role'}],
                   getRoles: sinon.stub().resolves([role]),
                   isActionAllowed: sinon.stub().resolves(true)
                 });

--- a/test/api/controllers/routerController/routerController.test.js
+++ b/test/api/controllers/routerController/routerController.test.js
@@ -101,7 +101,7 @@ describe('Test: routerController', () => {
             
             user = {
               _id: 'user',
-              profileId: 'profile',
+              profilesIds: ['profile'],
               isActionAllowed: sinon.stub().resolves(true),
               getProfile: () => {
                 return q({

--- a/test/api/controllers/securityController.test.js
+++ b/test/api/controllers/securityController.test.js
@@ -41,7 +41,7 @@ describe('Test: security controller', function () {
 
   it('should be rejected if creating a profile with bad roles property form', () => {
     var promise = kuzzle.funnel.controllers.security.createOrReplaceProfile(new RequestObject({
-      body: { _id: 'test', policies: 'not-an-array-roleIds' }
+      body: { roleId: 'test', policies: 'not-an-array-roleIds' }
     }));
 
     return should(promise).be.rejected();

--- a/test/api/controllers/securityController/profiles.test.js
+++ b/test/api/controllers/securityController/profiles.test.js
@@ -34,7 +34,7 @@ describe('Test: security controller - profiles', function () {
     it('should resolve to a responseObject on a createOrReplaceProfile call', () => {
       sandbox.stub(kuzzle.repositories.profile, 'validateAndSaveProfile').resolves({_id: 'test', _source: {}});
       return kuzzle.funnel.controllers.security.createOrReplaceProfile(new RequestObject({
-        body: {_id: 'test', policies: [{_id: 'role1'}]}
+        body: {_id: 'test', policies: [{roleId: 'role1'}]}
       }))
         .then(result => {
           should(result).be.an.instanceOf(ResponseObject);
@@ -61,7 +61,7 @@ describe('Test: security controller - profiles', function () {
     it('should resolve to a responseObject on a createProfile call', () => {
       sandbox.stub(kuzzle.repositories.profile, 'validateAndSaveProfile').resolves({_id: 'test', _source: {}});
       return should(kuzzle.funnel.controllers.security.createProfile(new RequestObject({
-        body: {_id: 'test', policies: ['role1']}
+        body: {_id: 'test', policies: [{roleId:'role1'}]}
       }))).be.fulfilled();
     });
   });
@@ -103,7 +103,7 @@ describe('Test: security controller - profiles', function () {
     });
 
     it('should resolve to a responseObject on a mGetProfiles call', () => {
-      sandbox.stub(kuzzle.repositories.profile, 'loadMultiFromDatabase').resolves([{_id: 'test', policies: [{_id: 'role'}]}]);
+      sandbox.stub(kuzzle.repositories.profile, 'loadMultiFromDatabase').resolves([{_id: 'test', policies: [{roleId: 'role'}]}]);
       return kuzzle.funnel.controllers.security.mGetProfiles(new RequestObject({
         body: {ids: ['test']}
       }))
@@ -114,7 +114,7 @@ describe('Test: security controller - profiles', function () {
           should(result.data.body.hits[0]).be.an.Object();
           should(result.data.body.hits[0]._source.policies).be.an.Array();
           should(result.data.body.hits[0]._source.policies[0]).be.an.Object();
-          should(result.data.body.hits[0]._source.policies[0]._id).be.an.String();
+          should(result.data.body.hits[0]._source.policies[0].roleId).be.an.String();
         });
     });
 
@@ -148,7 +148,7 @@ describe('Test: security controller - profiles', function () {
     });
 
     it('should return a ResponseObject containing an array of profiles on searchProfile call with hydrate', () => {
-      sandbox.stub(kuzzle.repositories.profile, 'searchProfiles').resolves({total: 1, hits: [{_id: 'test', policies: [ {_id: 'default'} ]}]});
+      sandbox.stub(kuzzle.repositories.profile, 'searchProfiles').resolves({total: 1, hits: [{_id: 'test', policies: [ {roleId: 'default'} ]}]});
       return kuzzle.funnel.controllers.security.searchProfiles(new RequestObject({
         body: {
           policies: ['role1']
@@ -161,7 +161,7 @@ describe('Test: security controller - profiles', function () {
           should(jsonResponse.result.hits).be.an.Array();
           should(jsonResponse.result.hits[0]._id).be.exactly('test');
           should(jsonResponse.result.hits[0]._source.policies).be.an.Array();
-          should(jsonResponse.result.hits[0]._source.policies[0]._id).be.exactly('default');
+          should(jsonResponse.result.hits[0]._source.policies[0].roleId).be.exactly('default');
         });
     });
 

--- a/test/api/controllers/securityController/users.test.js
+++ b/test/api/controllers/securityController/users.test.js
@@ -90,7 +90,7 @@ describe('Test: security controller - users', function () {
       }))
         .then(response => {
           should(response).be.an.instanceOf(ResponseObject);
-          should(response.data.body).match({hits: [{_id: 'admin'}], total: 4});
+          should(response.data.body).match({hits: [{_id: 'admin'}], total: 2});
         });
     });
 

--- a/test/api/controllers/securityController/users.test.js
+++ b/test/api/controllers/securityController/users.test.js
@@ -22,7 +22,7 @@ describe('Test: security controller - users', function () {
         // Mock
         kuzzle.services.list.readEngine.search = () => {
           return q({
-            hits: [{_id: 'admin', _source: { profileId: 'admin' }}],
+            hits: [{_id: 'admin', _source: { profilesIds: ['admin'] }}],
             total: 1
           });
         };
@@ -76,7 +76,7 @@ describe('Test: security controller - users', function () {
 
   describe('#searchUsers', function () {
     it('should return a valid responseObject', () => {
-      sandbox.stub(kuzzle.repositories.user, 'search').resolves({hits: [{_id: 'admin', _source: {profileId: 'admin'}}]});
+      sandbox.stub(kuzzle.repositories.user, 'search').resolves({hits: [{_id: 'admin', _source: {profilesIds: ['admin']}}]});
       return kuzzle.funnel.controllers.security.searchUsers(new RequestObject({
         body: {
           filter: {},
@@ -129,7 +129,7 @@ describe('Test: security controller - users', function () {
       sandbox.stub(kuzzle.repositories.user, 'hydrate').resolves();
 
       return kuzzle.funnel.controllers.security.createUser(new RequestObject({
-        body: { _id: 'test', name: 'John Doe', profileId: 'anonymous' }
+        body: { _id: 'test', name: 'John Doe', profilesIds: ['anonymous'] }
       }))
         .then(response => {
           mock.verify();
@@ -144,7 +144,7 @@ describe('Test: security controller - users', function () {
         mockHydrate = sandbox.mock(kuzzle.repositories.user).expects('hydrate').once().resolves();
 
       return kuzzle.funnel.controllers.security.createUser(new RequestObject({
-        body: { name: 'John Doe', profileId: 'anonymous' }
+        body: { name: 'John Doe', profilesIds: ['anonymous'] }
       }))
         .then(response => {
           mockHydrate.verify();
@@ -195,7 +195,7 @@ describe('Test: security controller - users', function () {
 
       return kuzzle.funnel.controllers.security.updateUser(new RequestObject({
         _id: 'test',
-        body: {profileId: 'anonymous', foo: 'bar'}
+        body: {profilesIds: ['anonymous'], foo: 'bar'}
       }))
         .then(response => {
           should(response).be.an.instanceOf(ResponseObject);
@@ -214,7 +214,7 @@ describe('Test: security controller - users', function () {
       return kuzzle.funnel.controllers.security.createOrReplaceUser(new RequestObject({
         body: {
           _id: 'test',
-          profileId: 'admin'
+          profilesIds: ['admin']
         }
       }))
         .then(response => {

--- a/test/api/core/models/repositories/profileRepository.test.js
+++ b/test/api/core/models/repositories/profileRepository.test.js
@@ -112,6 +112,25 @@ describe('Test: repositories/profileRepository', () => {
     });
   });
 
+  describe('#loadProfiles', () => {
+    it('should not load a not existing profile', () => {
+      var
+        existingProfile = new Profile(),
+        stub = sandbox.stub(kuzzle.services.list.readEngine, 'get');
+
+      existingProfile._id = 'existingProfile';
+      stub.onCall(0).rejects(new NotFoundError('Not found'));
+      stub.onCall(1).resolves(existingProfile);
+
+      return kuzzle.repositories.profile.loadProfiles(['idontexist', 'existingProfile'])
+        .then(result => {
+          should(result).be.an.Array();
+          should(result.length).be.eql(1);
+          should(result[0]._id).be.eql('existingProfile');
+        });
+    });
+  });
+
   describe('#buildProfileFromRequestObject', () => {
     it('should reject when no id is provided', () => {
       var invalidProfileObject = new RequestObject({

--- a/test/api/core/models/repositories/profileRepository.test.js
+++ b/test/api/core/models/repositories/profileRepository.test.js
@@ -21,8 +21,8 @@ describe('Test: repositories/profileRepository', () => {
     testProfilePlain = {
       _id: 'testprofile',
       policies: [
-        {_id: 'test', restrictedTo: [{index: 'index'}]},
-        {_id: 'test2'}
+        {roleId: 'test', restrictedTo: [{index: 'index'}]},
+        {roleId: 'test2'}
       ]
     },
     stubs = {
@@ -178,7 +178,7 @@ describe('Test: repositories/profileRepository', () => {
     it('should throw if the profile contains unexisting roles', () => {
       var p = new Profile();
       sandbox.stub(kuzzle.repositories.role, 'loadRoles').resolves([]);
-      return should(kuzzle.repositories.profile.hydrate(p, { policies: [{_id: 'notExistingRole' }] })).be.rejectedWith(NotFoundError);
+      return should(kuzzle.repositories.profile.hydrate(p, { policies: [{roleId: 'notExistingRole' }] })).be.rejectedWith(NotFoundError);
     });
   });
 
@@ -198,7 +198,7 @@ describe('Test: repositories/profileRepository', () => {
       sandbox.stub(kuzzle.repositories.profile, 'profiles', {
         'test': {
           _id: 'test',
-          policies: ['test']
+          policies: [{roleId:'test'}]
         }
       });
 
@@ -220,7 +220,7 @@ describe('Test: repositories/profileRepository', () => {
     it('should reject when trying to delete admin', () => {
       var profile = {
         _id: 'admin',
-        policies: [ {_id: 'admin'} ]
+        policies: [ {roleId: 'admin'} ]
       };
 
       return should(kuzzle.repositories.profile.deleteProfile(profile))
@@ -230,7 +230,7 @@ describe('Test: repositories/profileRepository', () => {
     it('should reject when trying to delete default', () => {
       var profile = {
         _id: 'default',
-        policies: [ {_id: 'default'} ]
+        policies: [ {roleId: 'default'} ]
       };
 
       return should(kuzzle.repositories.profile.deleteProfile(profile))
@@ -240,7 +240,7 @@ describe('Test: repositories/profileRepository', () => {
     it('should reject when trying to delete anonymous', () => {
       var profile = {
         _id: 'anonymous',
-        policies: [ {_id: 'anonymous'} ]
+        policies: [ {roleId: 'anonymous'} ]
       };
 
       return should(kuzzle.repositories.profile.deleteProfile(profile))
@@ -253,9 +253,8 @@ describe('Test: repositories/profileRepository', () => {
       sandbox.stub(kuzzle.services.list.readEngine, 'get').resolves(testProfilePlain);
       sandbox.stub(kuzzle.repositories.role, 'loadRoles', stubs.roleRepository.loadRoles);
       return kuzzle.repositories.profile.loadProfile('testprofile')
-        .then(function (profile) {
+        .then(profile => {
           var result = kuzzle.repositories.profile.serializeToDatabase(profile);
-
           should(result).not.be.an.instanceOf(Profile);
           should(result).be.an.Object();
           should(profile._id).be.exactly('testprofile');
@@ -263,11 +262,11 @@ describe('Test: repositories/profileRepository', () => {
           should(result.policies).have.length(2);
           should(result.policies[0]).be.an.Object();
           should(result.policies[0]).not.be.an.instanceOf(Role);
-          should(result.policies[0]._id).be.exactly('test');
+          should(result.policies[0].roleId).be.exactly('test');
           should(result.policies[0].restrictedTo).be.an.Array();
           should(result.policies[1]).be.an.Object();
           should(result.policies[1]).not.be.an.instanceOf(Role);
-          should(result.policies[1]._id).be.exactly('test2');
+          should(result.policies[1].roleId).be.exactly('test2');
           should(result.policies[1].restrictedTo).be.empty();
         });
     });
@@ -306,9 +305,9 @@ describe('Test: repositories/profileRepository', () => {
           should(result.filter).have.ownProperty('or');
           should(result.filter.or).be.an.Array();
           should(result.filter.or[0]).have.ownProperty('terms');
-          should(result.filter.or[0].terms).have.ownProperty('policies._id');
-          should(result.filter.or[0].terms['policies._id']).be.an.Array();
-          should(result.filter.or[0].terms['policies._id'][0]).be.exactly('role1');
+          should(result.filter.or[0].terms).have.ownProperty('policies.roleId');
+          should(result.filter.or[0].terms['policies.roleId']).be.an.Array();
+          should(result.filter.or[0].terms['policies.roleId'][0]).be.exactly('role1');
         });
     });
   });
@@ -328,7 +327,7 @@ describe('Test: repositories/profileRepository', () => {
 
       return kuzzle.repositories.profile.validateAndSaveProfile(testProfile)
         .then((result) => {
-          should(kuzzle.repositories.profile.profiles[testProfile._id]).match({policies: [{_id: 'test'}]});
+          should(kuzzle.repositories.profile.profiles[testProfile._id]).match({policies: [{roleId: 'test'}]});
           should(result).be.an.Object();
           should(result._id).be.eql(testProfile._id);
         });
@@ -338,11 +337,11 @@ describe('Test: repositories/profileRepository', () => {
       sandbox.stub(kuzzle.repositories.profile, 'persistToDatabase', profile => q({_id: profile._id}));
       sandbox.stub(kuzzle.repositories.role, 'loadRoles', stubs.roleRepository.loadRoles);
 
-      testProfile.policies = [{_id: 'anonymous'}];
+      testProfile.policies = [{roleId: 'anonymous'}];
 
       return kuzzle.repositories.profile.validateAndSaveProfile(testProfile)
         .then((result) => {
-          should(kuzzle.repositories.profile.profiles[testProfile._id]).match({policies: [{_id: 'anonymous'}]});
+          should(kuzzle.repositories.profile.profiles[testProfile._id]).match({policies: [{roleId: 'anonymous'}]});
           should(result).be.an.Object();
           should(result._id).be.eql(testProfile._id);
         });
@@ -357,7 +356,7 @@ describe('Test: repositories/profileRepository', () => {
       sandbox.stub(kuzzle.repositories.role, 'loadRoles', stubs.roleRepository.loadRoles);
 
       return kuzzle.repositories.profile.hydrate(profile, {})
-        .then(result => should(result.policies[0]._id).be.eql('default'));
+        .then(result => should(result.policies[0].roleId).be.eql('default'));
     });
   });
 });

--- a/test/api/core/models/repositories/profileRepository.test.js
+++ b/test/api/core/models/repositories/profileRepository.test.js
@@ -129,6 +129,22 @@ describe('Test: repositories/profileRepository', () => {
           should(result[0]._id).be.eql('existingProfile');
         });
     });
+
+    it('should rejects when no profileIds is given', () => {
+      should(kuzzle.repositories.profile.loadProfiles()).be.rejectedWith('Missing profilesIds');
+    });
+
+    it('should respond with an emty array when profileIds is an empty array', () => {
+      return kuzzle.repositories.profile.loadProfiles([])
+        .then(response => {
+          should(response).be.an.Array();
+          should(response).be.eql([]);
+        });
+    });
+
+    it('should rejects when profileIds contains some non string entry', () => {
+      should(kuzzle.repositories.profile.loadProfiles([12])).be.rejectedWith('An array of strings must be provided as profilesIds');
+    });
   });
 
   describe('#buildProfileFromRequestObject', () => {

--- a/test/api/core/models/repositories/profileRepository.test.js
+++ b/test/api/core/models/repositories/profileRepository.test.js
@@ -134,6 +134,10 @@ describe('Test: repositories/profileRepository', () => {
       should(kuzzle.repositories.profile.loadProfiles()).be.rejectedWith('Missing profilesIds');
     });
 
+    it('should rejects when no profileIds is not an Array', () => {
+      should(kuzzle.repositories.profile.loadProfiles(42)).be.rejectedWith('An array of strings must be provided as profilesIds');
+    });
+
     it('should respond with an emty array when profileIds is an empty array', () => {
       return kuzzle.repositories.profile.loadProfiles([])
         .then(response => {

--- a/test/api/core/models/repositories/tokenRepository.test.js
+++ b/test/api/core/models/repositories/tokenRepository.test.js
@@ -56,7 +56,7 @@ beforeEach(function (done) {
     load: function (username) {
       var user = new User();
       user._id = username;
-      user.profileId = 'anonymous';
+      user.profilesIds = ['anonymous'];
 
       return q(user);
     },
@@ -76,7 +76,7 @@ beforeEach(function (done) {
       };
 
       user._id = -1;
-      user.profileId = 'anonymous';
+      user.profilesIds = ['anonymous'];
       profile.policies = [{_id: role._id}];
 
       return q(user);
@@ -97,7 +97,7 @@ beforeEach(function (done) {
       };
 
       user._id = 'admin';
-      user.profileId = 'admin';
+      user.profilesIds = ['admin'];
       profile.policies = [{_id: role._id}];
 
       return q(user);

--- a/test/api/core/models/repositories/tokenRepository.test.js
+++ b/test/api/core/models/repositories/tokenRepository.test.js
@@ -77,7 +77,7 @@ beforeEach(function (done) {
 
       user._id = -1;
       user.profilesIds = ['anonymous'];
-      profile.policies = [{_id: role._id}];
+      profile.policies = [{roleId: role._id}];
 
       return q(user);
     },
@@ -98,7 +98,7 @@ beforeEach(function (done) {
 
       user._id = 'admin';
       user.profilesIds = ['admin'];
-      profile.policies = [{_id: role._id}];
+      profile.policies = [{roleId: role._id}];
 
       return q(user);
     }

--- a/test/api/core/models/repositories/userRepository.test.js
+++ b/test/api/core/models/repositories/userRepository.test.js
@@ -1,4 +1,5 @@
 var
+  _ = require('lodash'),
   q = require('q'),
   should = require('should'),
   params = require('rc')('kuzzle'),
@@ -61,22 +62,36 @@ before(function (done) {
       }
       profile._id = profileKey;
       return q(profile);
+    },
+    loadProfiles: function (profileKeys) {
+      var
+        profile,
+        profiles = [];
+
+      profileKeys.forEach(profileKey => {
+        profile = new Profile();
+        if (profileKey !== 'notfound') {
+          profile._id = profileKey;
+          profiles.push(_.assignIn({}, profile));
+        }
+      });
+      return q(profiles);
     }
   };
   userInCache = {
     _id: 'userInCache',
     name: 'Johnny Cash',
-    profileId: 'userincacheprofile',
+    profilesIds: ['userincacheprofile'],
     password: encryptedPassword
   };
   userInDB = {
     _id: 'userInDB',
     name: 'Debbie Jones',
-    profileId: 'userindbprofile'
+    profilesIds: ['userindbprofile']
   };
   userInvalidProfile = {
     _id: 'userInvalidProfile',
-    profileId: 'notfound'
+    profilesIds: ['notfound']
   };
 
   userRepository = new UserRepository();
@@ -124,7 +139,7 @@ describe('Test: repositories/userRepository', function () {
 
     it('should return the anonymous user if no _id is set', () => {
       var user = new User();
-      user.profileId = 'a profile';
+      user.profilesIds = 'a profile';
 
       return userRepository.hydrate(user, {})
         .then(result => assertIsAnonymous(result));
@@ -134,7 +149,7 @@ describe('Test: repositories/userRepository', function () {
       var user = new User();
 
       return should(userRepository.hydrate(user, userInvalidProfile))
-        .be.rejectedWith(InternalError);
+        .be.rejectedWith(NotFoundError);
     });
   });
 
@@ -152,16 +167,13 @@ describe('Test: repositories/userRepository', function () {
         .catch(error => { done(error); });
     });
 
-  });
-
-  describe('#load', function () {
     it('should resolve to user if good credentials are given', () => {
       return userRepository.load('userInCache')
         .then(user => {
           should(user._id).be.exactly('userInCache');
           should(user.name).be.exactly('Johnny Cash');
-          should(user.profileId).be.a.String();
-          should(user.profileId).be.exactly('userincacheprofile');
+          should(user.profilesIds).be.an.Array();
+          should(user.profilesIds[0]).be.exactly('userincacheprofile');
         });
     });
 
@@ -191,8 +203,8 @@ describe('Test: repositories/userRepository', function () {
           should(result).not.be.an.instanceOf(User);
           should(result).be.an.Object();
           should(result._id).be.exactly(-1);
-          should(result.profileId).be.a.String();
-          should(result.profileId).be.exactly('anonymous');
+          should(result.profilesIds).be.an.Array();
+          should(result.profilesIds[0]).be.exactly('anonymous');
         });
     });
   });
@@ -201,7 +213,7 @@ describe('Test: repositories/userRepository', function () {
     it('should compute a user id if not set', () => {
       var user = new User();
       user.name = 'John Doe';
-      user.profileId = 'a profile';
+      user.profilesIds = ['a profile'];
 
       userRepository.persist(user);
 
@@ -221,7 +233,9 @@ describe('Test: repositories/userRepository', function () {
       user._id = 'NoProfile';
 
       return userRepository.hydrate(user, {})
-        .then(result => should(result.profileId).be.eql('default'));
+        .then(result => {
+          return should(result.profilesIds[0]).be.eql('default');
+        });
     });
   });
 });
@@ -229,6 +243,6 @@ describe('Test: repositories/userRepository', function () {
 function assertIsAnonymous (user) {
   should(user._id).be.exactly(-1);
   should(user.name).be.exactly('Anonymous');
-  should(user.profileId).be.an.instanceOf(String);
-  should(user.profileId).be.exactly('anonymous');
+  should(user.profilesIds).be.an.instanceOf(Array);
+  should(user.profilesIds[0]).be.exactly('anonymous');
 }

--- a/test/api/core/models/security/profile.test.js
+++ b/test/api/core/models/security/profile.test.js
@@ -68,7 +68,7 @@ describe('Test: security/profileTest', function () {
       }
     };
 
-    profile.policies = [{_id: 'disallowAllRole'}];
+    profile.policies = [{roleId: 'disallowAllRole'}];
 
     sandbox.stub(kuzzle.repositories.role, 'loadRole', roleId => q(roles[roleId]));
 
@@ -76,7 +76,7 @@ describe('Test: security/profileTest', function () {
       .then(isAllowed => {
         should(isAllowed).be.false();
 
-        profile.policies.push({_id: 'allowActionRole'});
+        profile.policies.push({roleId: 'allowActionRole'});
         return profile.isActionAllowed(requestObject, context, kuzzle);
       })
       .then(isAllowed => {
@@ -118,7 +118,7 @@ describe('Test: security/profileTest', function () {
       }
     };
 
-    profile.policies.push({_id: role1._id, restrictedTo: [{ index: 'index1', collections: ['collection1', 'collection2'] }]});
+    profile.policies.push({roleId: role1._id, restrictedTo: [{ index: 'index1', collections: ['collection1', 'collection2'] }]});
 
     role2._id = 'role2';
     role2.controllers = {
@@ -127,7 +127,7 @@ describe('Test: security/profileTest', function () {
       }
     };
 
-    profile.policies.push({_id: role2._id, restrictedTo: [{index: 'index2'}]});
+    profile.policies.push({roleId: role2._id, restrictedTo: [{index: 'index2'}]});
 
     role3._id = 'role3';
     role3.controllers = {
@@ -138,7 +138,7 @@ describe('Test: security/profileTest', function () {
         actions: { update: {test: 'return true;'}, create: true, delete: {test: 'return true;'} }
       }
     };
-    profile.policies.push({_id: role3._id});
+    profile.policies.push({roleId: role3._id});
 
     sandbox.stub(kuzzle.repositories.role, 'loadRole', roleId => q(roles[roleId]));
 

--- a/test/api/core/models/security/user.test.js
+++ b/test/api/core/models/security/user.test.js
@@ -76,4 +76,18 @@ describe('Test: security/userTest', () => {
       });
   });
 
+  it('should respond false if the user have no profileIds', () => {
+    user.profilesIds = [];
+    return user.isActionAllowed({}, {}, kuzzle)
+      .then(isActionAllowed => {
+        should(isActionAllowed).be.a.Boolean();
+        should(isActionAllowed).be.false();
+        should(profile.isActionAllowed.called).be.true();
+      });
+  });
+
+  it('should rejects if the loadProfiles throws an error', () => {
+    sandbox.stub(user, 'getProfiles').rejects('error');
+    should(user.isActionAllowed({}, {}, kuzzle)).be.rejectedWith('error');
+  });
 });

--- a/test/api/core/models/security/user.test.js
+++ b/test/api/core/models/security/user.test.js
@@ -18,14 +18,15 @@ describe('Test: security/userTest', () => {
   profile._id = 'profile';
   profile.isActionAllowed = sinon.stub().resolves(true);
   profile._id = 'profile';
-  user.profileId = 'profile';
+  user.profilesIds = ['profile'];
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     kuzzle = new Kuzzle();
     kuzzle.repositories = {
       profile: {
-        loadProfile: sinon.stub().resolves(profile)
+        loadProfile: sinon.stub().resolves(profile),
+        loadProfiles: sinon.stub().resolves([profile])
       }
     };
   });
@@ -47,21 +48,22 @@ describe('Test: security/userTest', () => {
         }
       };
 
-    sandbox.stub(user, 'getProfile').resolves(profile);
+    sandbox.stub(user, 'getProfiles').resolves([profile]);
     sandbox.stub(profile, 'getRights').resolves(profileRights);
 
     return user.getRights(kuzzle)
       .then(rights => {
         should(rights).be.an.Object();
-        should(rights).be.exactly(profileRights);
+        should(rights).match(profileRights);
       });
   });
 
   it('should retrieve the profile', () => {
-    return user.getProfile(kuzzle)
+    return user.getProfiles(kuzzle)
       .then(p => {
-        should(p).be.an.Object();
-        should(p).be.exactly(profile);
+        should(p).be.an.Array();
+        should(p[0]).be.an.Object();
+        should(p[0]).be.exactly(profile);
       });
   });
 


### PR DESCRIPTION
Adds the ability to use more than one profile per user
Changes : 
     

- the ```profileId``` property of the ```user``` business object is now named ```profilesIds``` and is an array of string represening the profiles IDs
- the ```_id``` property of the ```profile```'s ```policies``` entries is now named ```roleId``` to be more clear