### PR TITLE
KUZ-146: performance fixes

### DIFF
--- a/.kuzzlerc
+++ b/.kuzzlerc
@@ -205,6 +205,6 @@
      Requests submitted while the queue is full are discarded with a 503 error
      code ("Service temporary unavailable")
      */
-    "maxRetainedRequests": 2000
+    "maxRetainedRequests": 10000
   }
 }

--- a/bin/commands/start.js
+++ b/bin/commands/start.js
@@ -7,7 +7,7 @@ var
   kuzzle = require('../../lib'),
   RequestObject = require('kuzzle-common-objects').Models.requestObject,
   FirstAdmin = require('./createFirstAdmin'),
-  q = require('q'),
+  Promise = require('bluebird'),
   clc = require('cli-color'),
   coverage;
 
@@ -66,7 +66,7 @@ module.exports = function (options) {
       if (kuzzle.isServer) {
         return kuzzle.services.list.broker.waitForClients(kuzzle.config.queues.workerWriteTaskQueue);
       }
-      return q();
+      return Promise.resolve();
     })
     .then(() => {
       var request;
@@ -83,7 +83,7 @@ module.exports = function (options) {
         }
       }
 
-      return q();
+      return Promise.resolve();
     })
     .then(() => {
       var 
@@ -117,7 +117,7 @@ module.exports = function (options) {
         return kuzzle.remoteActionsController.actions.prepareDb(kuzzle, request);
       }
 
-      return q();
+      return Promise.resolve();
     })
     .then(() => {
       if (kuzzle.isServer) {

--- a/features/step_definitions/countDocuments.js
+++ b/features/step_definitions/countDocuments.js
@@ -4,14 +4,9 @@ var
 var apiSteps = function () {
   this.Then(/^I count ([\d]*) documents(?: in index "([^"]*)")?$/, function (number, index, callback) {
     var main = function (callbackAsync) {
-      setTimeout(function () {
+      setTimeout(() => {
         this.api.count({}, index)
           .then(body => {
-            if (body.error) {
-              callbackAsync(body.error.message);
-              return false;
-            }
-
             if (body.result.count !== parseInt(number)) {
               callbackAsync('No correct value for count. Expected ' + number + ', got ' + body.result.count);
               return false;
@@ -19,16 +14,14 @@ var apiSteps = function () {
 
             callbackAsync();
           })
-          .catch(function (error) {
-            callbackAsync(error);
-          });
-      }.bind(this), 100); // end setTimeout
+          .catch(error => callbackAsync(error));
+      }, 100); // end setTimeout
     };
 
     async.retry(20, main.bind(this), function (err) {
       if (err) {
         if (err.message) {
-          err = err.message;
+          err = `${err.statusCode}: ${err.message}`;
         }
 
         callback(new Error(err));

--- a/features/step_definitions/indexes.js
+++ b/features/step_definitions/indexes.js
@@ -1,6 +1,6 @@
 var
   async = require('async'),
-  q = require('q');
+  Promise = require('bluebird');
 
 var apiSteps = function () {
   this.When(/^I create an index named "([^"]*)"$/, function (index, callback) {
@@ -135,7 +135,7 @@ var apiSteps = function () {
     return this.api.setAutoRefresh(idx, autoRefresh)
       .then(body => {
         if (body.error) {
-          return q.reject(new Error(body.error.message));
+          return Promise.reject(new Error(body.error.message));
         }
 
         this.result = body;
@@ -151,7 +151,7 @@ var apiSteps = function () {
     return this.api.getAutoRefresh(idx)
       .then(body => {
         if (body.error) {
-          return q.reject(body.error);
+          return Promise.reject(body.error);
         }
 
         this.result = body;

--- a/features/step_definitions/memoryStorage.js
+++ b/features/step_definitions/memoryStorage.js
@@ -1,5 +1,5 @@
 var
-  q = require('q'),
+  Promise = require('bluebird'),
   should = require('should');
 
 
@@ -13,14 +13,14 @@ module.exports = function () {
         realArgs = JSON.parse(args.replace(/#prefix#/g, this.idPrefix));
       }
       catch(err) {
-        return q.reject(err);
+        return Promise.reject(err);
       }
     }
 
     return this.api.callMemoryStorage(command, realArgs)
       .then(response => {
         if (response.error) {
-          return q.reject(response.error);
+          return Promise.reject(response.error);
         }
 
         this.memoryStorageResult = response;

--- a/features/step_definitions/readDocument.js
+++ b/features/step_definitions/readDocument.js
@@ -1,6 +1,6 @@
 var
   async = require('async'),
-  q = require('q');
+  Promise = require('bluebird');
 
 var apiSteps = function () {
   this.Then(/^I'm ?(not)* able to get the document(?: in index "([^"]*)")?$/, function (not, index, callback) {
@@ -109,23 +109,23 @@ var apiSteps = function () {
       .then(function (body) {
         if (body.error !== null) {
           if (dont) {
-            return q();
+            return Promise.resolve();
           }
 
-          return q.reject(body.error);
+          return Promise.reject(body.error);
         }
 
         if (body.result && body.result.hits && body.result.total !== 0) {
-          if (dont) { return q.reject('A document exists for the filter'); }
-          return q();
+          if (dont) { return Promise.reject('A document exists for the filter'); }
+          return Promise.resolve();
         }
 
-        if (dont) { return q(); }
-        return q.reject('No result for filter search');
+        if (dont) { return Promise.resolve(); }
+        return Promise.reject('No result for filter search');
       })
       .catch(error => {
-        if (dont) { return q(); }
-        return q.reject(error);
+        if (dont) { return Promise.resolve(); }
+        return Promise.reject(error);
       });
   });
 

--- a/features/step_definitions/writeDocument.js
+++ b/features/step_definitions/writeDocument.js
@@ -1,5 +1,5 @@
 var
-  q = require('q');
+  Promise = require('bluebird');
 
 var apiSteps = function () {
   this.When(/^I ?(can't)* write the document ?(?:"([^"]*)")?(?: in index "([^"]*)")?$/, function (cant, documentName, index, callback) {
@@ -80,10 +80,10 @@ var apiSteps = function () {
     return this.api.update(this.result._id, body, index)
       .then(aBody => {
         if (aBody.error) {
-          return q.reject(aBody.error);
+          return Promise.reject(aBody.error);
         }
         if (!aBody.result) {
-          return q.reject('No result provided');
+          return Promise.reject('No result provided');
         }
       });
   });

--- a/features/support/apiAMQP.js
+++ b/features/support/apiAMQP.js
@@ -34,11 +34,11 @@ ApiAMQP.prototype.init = function (world) {
 ApiAMQP.prototype.disconnect = function () {
   if (this.amqpClient) {
     this.amqpClient
-      .then(connection => connection.close.bind(connection))
-      .catch(err => console.error('error= ', err));
-
-    this.amqpClient = null;
-    this.amqpChannel = null;
+      .then(connection => {
+        connection.close.bind(connection);
+        this.amqpClient = null;
+        this.amqpChannel = null;
+      });
   }
 };
 

--- a/lib/api/controllers/adminController.js
+++ b/lib/api/controllers/adminController.js
@@ -134,27 +134,27 @@ function AdminController (kuzzle) {
 
         return new Promise((resolve, reject) => {
           async.each(indexes, (index, callback) => {
-              kuzzle.repositories.user.load(context.token.userId)
-                .then(user => user.isActionAllowed({
-                  controller: 'admin',
-                  action: 'deleteIndex',
-                  index: index
-                }, context, kuzzle))
-                .then(isAllowed => {
-                  if (isAllowed) {
-                    allowedIndexes.push(index);
-                  }
-                })
-                .then(() => callback())
-                .catch(err => callback(err));
-            },
-            error => {
-              if (error) {
-                reject(error);
-              } else {
-                resolve(allowedIndexes);
-              }
-            });
+            kuzzle.repositories.user.load(context.token.userId)
+              .then(user => user.isActionAllowed({
+                controller: 'admin',
+                action: 'deleteIndex',
+                index: index
+              }, context, kuzzle))
+              .then(isAllowed => {
+                if (isAllowed) {
+                  allowedIndexes.push(index);
+                }
+              })
+              .then(() => callback())
+              .catch(err => callback(err));
+          },
+          error => {
+            if (error) {
+              reject(error);
+            } else {
+              resolve(allowedIndexes);
+            }
+          });
         });
       })
       .then(allowedIndexes => {

--- a/lib/api/controllers/adminController.js
+++ b/lib/api/controllers/adminController.js
@@ -1,6 +1,6 @@
 var
   _ = require('lodash'),
-  q = require('q'),
+  Promise = require('bluebird'),
   async = require('async'),
   ResponseObject = require('kuzzle-common-objects').Models.responseObject,
   BadRequestError = require('kuzzle-common-objects').Errors.badRequestError,
@@ -129,28 +129,33 @@ function AdminController (kuzzle) {
     return kuzzle.services.list.readEngine.listIndexes()
       .then(response => {
         var
-          deferred = q.defer(),
           allowedIndexes = [],
           indexes = response.indexes.filter(index => _.includes(requestObject.data.body.indexes, index));
 
-        async.each(indexes, (index, callback) => {
-          kuzzle.repositories.user.load(context.token.userId)
-            .then(user => user.isActionAllowed({controller: 'admin', action: 'deleteIndex', index: index}, context, kuzzle))
-            .then((isAllowed) => {
-              if (isAllowed) {
-                allowedIndexes.push(index);
+        return new Promise((resolve, reject) => {
+          async.each(indexes, (index, callback) => {
+              kuzzle.repositories.user.load(context.token.userId)
+                .then(user => user.isActionAllowed({
+                  controller: 'admin',
+                  action: 'deleteIndex',
+                  index: index
+                }, context, kuzzle))
+                .then(isAllowed => {
+                  if (isAllowed) {
+                    allowedIndexes.push(index);
+                  }
+                })
+                .then(() => callback())
+                .catch(err => callback(err));
+            },
+            error => {
+              if (error) {
+                reject(error);
+              } else {
+                resolve(allowedIndexes);
               }
-            })
-            .finally(() => callback());
-        },
-        error => {
-          if (error) {
-            deferred.reject(error);
-          } else {
-            deferred.resolve(allowedIndexes);
-          }
+            });
         });
-        return deferred.promise;
       })
       .then(allowedIndexes => {
         requestObject.data.body.indexes = allowedIndexes;

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -1,5 +1,5 @@
 var
-  q = require('q'),
+  Promise = require('bluebird'),
   _ = require('lodash'),
   BadRequestError= require('kuzzle-common-objects').Errors.badRequestError,
   UnauthorizedError = require('kuzzle-common-objects').Errors.unauthorizedError,
@@ -53,7 +53,7 @@ function AuthController (kuzzle) {
           return kuzzle.repositories.token.generateToken(userObject, modifiedContext, options);
         }
 
-        return q(new ResponseObject(modifiedRequestObject, userObject));
+        return Promise.resolve(new ResponseObject(modifiedRequestObject, userObject));
       })
       .then((token) => {
         if (token instanceof ResponseObject) {
@@ -105,7 +105,7 @@ function AuthController (kuzzle) {
     var modifiedRequestObject;
 
     if (!requestObject.data.body || !requestObject.data.body.token) {
-      return q.reject(new BadRequestError('Cannot check token: no token provided'));
+      return Promise.reject(new BadRequestError('Cannot check token: no token provided'));
     }
 
     return kuzzle.pluginsManager.trigger('auth:beforeCheckToken', requestObject)
@@ -117,10 +117,10 @@ function AuthController (kuzzle) {
       .then(token => kuzzle.pluginsManager.trigger('auth:afterCheckToken', new ResponseObject(modifiedRequestObject, {valid: true, expiresAt: token.expiresAt})))
       .catch(invalid => {
         if (invalid.status === 401) {
-          return q(new ResponseObject(modifiedRequestObject || requestObject, {valid: false, state: invalid.message}));
+          return Promise.resolve(new ResponseObject(modifiedRequestObject || requestObject, {valid: false, state: invalid.message}));
         }
 
-        return q.reject(invalid);
+        return Promise.reject(invalid);
       });
   };
 
@@ -138,15 +138,15 @@ function AuthController (kuzzle) {
       .then(newRequestObject => {
         modifiedRequestObject = newRequestObject;
         if (!context.token._id) {
-          return q.reject(new UnauthorizedError('User must be connected in order to call updateSelf'));
+          return Promise.reject(new UnauthorizedError('User must be connected in order to call updateSelf'));
         }
 
         if (modifiedRequestObject.data.body.profileId) {
-          return q.reject(new BadRequestError('profile can not be provided in updateSelf'));
+          return Promise.reject(new BadRequestError('profile can not be provided in updateSelf'));
         }
 
         if (modifiedRequestObject.data.body._id) {
-          return q.reject(new BadRequestError('_id can not be part of the body'));
+          return Promise.reject(new BadRequestError('_id can not be part of the body'));
         }
 
         return kuzzle.repositories.user.load(context.token.userId);

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -1,5 +1,5 @@
 var
-  q = require('q'),
+  Promise = require('bluebird'),
   MemoryStorageController = require('./memoryStorageController'),
   WriteController = require('./writeController'),
   ReadController = require('./readController'),
@@ -124,7 +124,7 @@ function processRequest(kuzzle, controllers, requestObject, context) {
         || !controllers[requestObject.controller][requestObject.action]
         || typeof controllers[requestObject.controller][requestObject.action] !== 'function'
       ) {
-        return q.reject(new BadRequestError('No corresponding action ' + requestObject.action + ' in controller ' + requestObject.controller));
+        return Promise.reject(new BadRequestError('No corresponding action ' + requestObject.action + ' in controller ' + requestObject.controller));
       }
       return kuzzle.repositories.user.load(context.token.userId);
     })
@@ -133,14 +133,14 @@ function processRequest(kuzzle, controllers, requestObject, context) {
       if (!isAllowed) {
         // anonymous user => we throw a 401 (Unauthorised) error
         if (context.token.userId === -1) {
-          return q.reject(new UnauthorizedError('Unauthorized action [' +
+          return Promise.reject(new UnauthorizedError('Unauthorized action [' +
             requestObject.index + '/' +
             requestObject.collection + '/' +
             requestObject.controller + '/' +
             requestObject.action + '] for anonymous user'));
         }
         // logged-in user with insufficient permissions => we throw a 403 (Forbidden) error
-        return q.reject(new ForbiddenError('Forbidden action [' +
+        return Promise.reject(new ForbiddenError('Forbidden action [' +
           requestObject.index + '/' +
           requestObject.collection + '/' +
           requestObject.controller + '/' +
@@ -156,7 +156,7 @@ function processRequest(kuzzle, controllers, requestObject, context) {
     })
     .catch(error => {
       kuzzle.statistics.failedRequest(requestObject);
-      return q.reject(error);
+      return Promise.reject(error);
     });
 }
 

--- a/lib/api/controllers/readController.js
+++ b/lib/api/controllers/readController.js
@@ -1,5 +1,5 @@
 var
-  q = require('q'),
+  Promise = require('bluebird'),
   os = require('os'),
   _ = require('lodash'),
   BadRequestError = require('kuzzle-common-objects').Errors.badRequestError,
@@ -50,7 +50,7 @@ function ReadController (kuzzle) {
       modifiedRequestObject = null;
 
     if (['all', 'stored', 'realtime'].indexOf(type) === -1) {
-      return q.reject(
+      return Promise.reject(
         new ResponseObject(requestObject, new BadRequestError('listCollections: unrecognized type argument: "' + type + '"'))
       );
     }
@@ -186,9 +186,9 @@ function ReadController (kuzzle) {
           return kuzzle.services.list[current].getInfos();
         }
 
-        return q();
+        return Promise.resolve();
       });
-    }, q())
+    }, Promise.resolve())
     .then(serviceInfo => {
       if (serviceInfo) {
         response.services[serviceName] = serviceInfo;

--- a/lib/api/controllers/remoteActions/cleanDb.js
+++ b/lib/api/controllers/remoteActions/cleanDb.js
@@ -1,7 +1,7 @@
 var
   RequestObject = require('kuzzle-common-objects').Models.requestObject,
   BadRequestError = require('kuzzle-common-objects').Errors.badRequestError,
-  q = require('q');
+  Promise = require('bluebird');
 
 /**
  * Removes all indexes from the database
@@ -15,7 +15,7 @@ module.exports = function cleanDb (kuzzle) {
 
   // is a reset has been asked on a worker?
   if (!kuzzle.isServer) {
-    return q.reject(new BadRequestError('Only a Kuzzle Server can reset the database'));
+    return Promise.reject(new BadRequestError('Only a Kuzzle Server can reset the database'));
   }
 
   // @todo : manage internal index properly
@@ -28,10 +28,10 @@ module.exports = function cleanDb (kuzzle) {
     .then(() => {
       kuzzle.indexCache.reset();
       kuzzle.pluginsManager.trigger('cleanDb:done', 'Reset done: Kuzzle is now like a virgin, touched for the very first time !');
-      return q({databaseReset: true});
+      return Promise.resolve({databaseReset: true});
     })
     .catch(err => {
       kuzzle.pluginsManager.trigger('cleanDb:error', err);
-      return q.reject(new BadRequestError(err));
+      return Promise.reject(new BadRequestError(err));
     });
 };

--- a/lib/api/controllers/remoteActions/enableServices.js
+++ b/lib/api/controllers/remoteActions/enableServices.js
@@ -1,6 +1,6 @@
 var
   BadRequestError = require('kuzzle-common-objects').Errors.badRequestError,
-  q = require('q');
+  Promise = require('bluebird');
 
 /**
  * @param {Kuzzle} kuzzle
@@ -9,19 +9,19 @@ var
  */
 module.exports = function EnableServices (kuzzle, request) {
   if (!request.data.body.service) {
-    return q.reject(new BadRequestError('Missing service name'));
+    return Promise.reject(new BadRequestError('Missing service name'));
   }
 
   if (request.data.body.enable === undefined) {
-    return q.reject(new BadRequestError('Missing enable/disable tag'));
+    return Promise.reject(new BadRequestError('Missing enable/disable tag'));
   }
 
   if (!kuzzle.services.list[request.data.body.service]) {
-    return q.reject(new BadRequestError('Unknown or deactivated service: ' + request.data.body.service));
+    return Promise.reject(new BadRequestError('Unknown or deactivated service: ' + request.data.body.service));
   }
 
   if (!kuzzle.services.list[request.data.body.service].toggle) {
-    return q.reject(new BadRequestError('The service ' + request.data.body.service + ' doesn\'t support on-the-fly disabling/enabling'));
+    return Promise.reject(new BadRequestError('The service ' + request.data.body.service + ' doesn\'t support on-the-fly disabling/enabling'));
   }
 
   return kuzzle.services.list[request.data.body.service].toggle(request.data.body.enable);

--- a/lib/api/controllers/remoteActions/managePlugins.js
+++ b/lib/api/controllers/remoteActions/managePlugins.js
@@ -4,7 +4,7 @@ var
   fs = require('fs'),
   rimraf = require('rimraf'),
   path = require('path'),
-  q = require('q'),
+  Promise = require('bluebird'),
   childProcess = require('child_process'),
   lockfile = require('proper-lockfile'),
   _ = require('lodash'),
@@ -19,8 +19,9 @@ module.exports = function pluginsManager(plugin, options) {
   var
     kuzzleConfiguration = require('../../../config')(defaultConfig),
     dbService = new DatabaseService({config: kuzzleConfiguration}),
-    deferred = q.defer();
-  
+    lockPromisified = Promise.promisify(lockfile.lock),
+    releaseLock = null;
+
   if (options.parent && options.parent.noColors) {
     clcOk = clcNotice = clcError = string => string;
   }
@@ -28,116 +29,119 @@ module.exports = function pluginsManager(plugin, options) {
   dbService.init();
 
   // Prevents multiple 'kuzzle install' to install plugins at the same time.
-  lockfile.lock('./node_modules', {retries: 1000, minTimeout: 200, maxTimeout: 1000}, (err, release) => {
-    if (err) {
-      deferred.reject(new Error('kuzzle-plugins: Unable to acquire lock: ', err));
-    }
-
-    initializeInternalIndex(dbService, kuzzleConfiguration)
-      .then(() => {
-        if (options.list) {
-          return getPluginsList(dbService, kuzzleConfiguration)
-            .then(pluginsInfos => {
-              var pluginsList = [];
-              Object.keys(pluginsInfos).forEach(name => {
-                if (pluginsInfos[name].activated) {
-                  pluginsList.push(clcOk(name + ' (activated)'));
-                }
-                else if (needInstall(pluginsInfos[name], name)) {
-                  pluginsList.push(clcNotice(name + ' (not installed)'));
-                }
-                else {
-                  pluginsList.push(clcNotice(name + ' (disabled)'));
-                }
-              });
-              return q(pluginsList);
+  return lockPromisified('./node_modules', {retries: 1000, minTimeout: 200, maxTimeout: 1000})
+    .then(release => {
+      releaseLock = release;
+      return initializeInternalIndex(dbService, kuzzleConfiguration);
+    })
+    .then(() => {
+      if (options.list) {
+        return getPluginsList(dbService, kuzzleConfiguration)
+          .then(pluginsInfos => {
+            var pluginsList = [];
+            Object.keys(pluginsInfos).forEach(name => {
+              if (pluginsInfos[name].activated) {
+                pluginsList.push(clcOk(name + ' (activated)'));
+              }
+              else if (needInstall(pluginsInfos[name], name)) {
+                pluginsList.push(clcNotice(name + ' (not installed)'));
+              }
+              else {
+                pluginsList.push(clcNotice(name + ' (disabled)'));
+              }
             });
-        }
-        if (options.install) {
-          if (plugin) {
-            console.log('███ kuzzle-plugins: Installing plugin ' + plugin + '...');
-          }
-          else {
-            console.log('███ kuzzle-plugins: Starting plugins installation...');
-          }
+            return Promise.resolve(pluginsList);
+          });
+      }
 
-          return installPlugins(plugin, options, dbService, kuzzleConfiguration);
+      if (options.install) {
+        if (plugin) {
+          console.log('███ kuzzle-plugins: Installing plugin ' + plugin + '...');
         }
-
-        if (options.get) {
-          return getPluginConfiguration(plugin, dbService, kuzzleConfiguration);
-        }
-
-        if (options.set) {
-          return setPluginConfiguration(plugin, options.set, dbService, kuzzleConfiguration);
-        }
-
-        if (options.importConfig) {
-          return importPluginConfiguration(dbService, plugin, options.importConfig, kuzzleConfiguration);
-        }
-
-        if (options.unset) {
-          return unsetPluginConfiguration(plugin, options.unset, dbService, kuzzleConfiguration);
-        }
-
-        if (options.replace) {
-          return replacePluginConfiguration(plugin, options.replace, dbService, kuzzleConfiguration);
-        }
-
-        if (options.remove) {
-          return removePlugin(plugin, dbService, kuzzleConfiguration);
-        }
-
-        if (options.activate) {
-          return dbService
-            .update(kuzzleConfiguration.pluginsManager.dataCollection, plugin, {activated: true})
-            .then(() => getPluginConfiguration(plugin, dbService, kuzzleConfiguration));
-        }
-
-        if (options.deactivate) {
-          return dbService
-            .update(kuzzleConfiguration.pluginsManager.dataCollection, plugin, {activated: false})
-            .then(() => getPluginConfiguration(plugin, dbService, kuzzleConfiguration));
-        }
-      })
-      .then((res) => {
-        release();
-
-        if (options.install) {
-          if (plugin) {
-            console.log(clcOk('███ kuzzle-plugins: Plugin ' + plugin + ' installed'));
-          }
-          else {
-            console.log(clcOk('███ kuzzle-plugins: Plugins installed'));
-          }
-        }
-        else if (options.list) {
-          res.forEach(str => console.log(str));
-        }
-        else if (options.importConfig) {
-          console.log(res);
-        }   
         else {
-          console.dir(res, {depth: null, colors: !options.parent || !options.parent.noColors});
+          console.log('███ kuzzle-plugins: Starting plugins installation...');
         }
-        
-        deferred.resolve(res);
-      })
-      .catch(error => {
-        release();
 
-        /*
-         If elasticsearch returns with a "Service temporary unavailable" error,
-         we retry until it's ready
-         */
-        if (error.status === 503) {
-          console.log('The database seems to not be ready yet. Retrying in 5s...');
-          return setTimeout(() => pluginsManager(plugin, options), 5000);
+        return installPlugins(plugin, options, dbService, kuzzleConfiguration);
+      }
+
+      if (options.get) {
+        return getPluginConfiguration(plugin, dbService, kuzzleConfiguration);
+      }
+
+      if (options.set) {
+        return setPluginConfiguration(plugin, options.set, dbService, kuzzleConfiguration);
+      }
+
+      if (options.importConfig) {
+        return importPluginConfiguration(dbService, plugin, options.importConfig, kuzzleConfiguration);
+      }
+
+      if (options.unset) {
+        return unsetPluginConfiguration(plugin, options.unset, dbService, kuzzleConfiguration);
+      }
+
+      if (options.replace) {
+        return replacePluginConfiguration(plugin, options.replace, dbService, kuzzleConfiguration);
+      }
+
+      if (options.remove) {
+        return removePlugin(plugin, dbService, kuzzleConfiguration);
+      }
+
+      if (options.activate) {
+        return dbService
+          .update(kuzzleConfiguration.pluginsManager.dataCollection, plugin, {activated: true})
+          .then(() => getPluginConfiguration(plugin, dbService, kuzzleConfiguration));
+      }
+
+      if (options.deactivate) {
+        return dbService
+          .update(kuzzleConfiguration.pluginsManager.dataCollection, plugin, {activated: false})
+          .then(() => getPluginConfiguration(plugin, dbService, kuzzleConfiguration));
+      }
+    })
+    .then(res => {
+      releaseLock();
+
+      if (options.install) {
+        if (plugin) {
+          console.log(clcOk('███ kuzzle-plugins: Plugin ' + plugin + ' installed'));
         }
-        deferred.reject(error);
-      });
-  });
-  return deferred.promise;
+        else {
+          console.log(clcOk('███ kuzzle-plugins: Plugins installed'));
+        }
+      }
+      else if (options.list) {
+        res.forEach(str => console.log(str));
+      }
+      else if (options.importConfig) {
+        console.log(res);
+      }
+      else {
+        console.dir(res, {depth: null, colors: !options.parent || !options.parent.noColors});
+      }
+
+      return Promise.resolve(res);
+    })
+    .catch(error => {
+      if (!releaseLock) {
+        return Promise.reject(new Error('kuzzle-plugins: Unable to acquire lock: ', error));
+      }
+
+      releaseLock();
+
+      /*
+       If elasticsearch returns with a "Service temporary unavailable" error,
+       we retry until it's ready
+       */
+      if (error.status === 503) {
+        console.log('The database seems to not be ready yet. Retrying in 5s...');
+        return setTimeout(() => pluginsManager(plugin, options), 5000);
+      }
+
+      return Promise.reject(error);
+    });
 };
 
 /**
@@ -169,10 +173,10 @@ function initializeInternalIndex(db, kuzzleConfiguration) {
     .catch(err => {
       // ignoring error if it's raised because the index already exists
       if (err.status === 400) {
-        return q();
+        return Promise.resolve();
       }
 
-      return q.reject(err);
+      return Promise.reject(err);
     });
 }
 
@@ -232,7 +236,7 @@ function installPlugins(plugin, options, dbService, kuzzleConfiguration) {
 
     p[plugin].activated = options.activated;
 
-    pluginsListPromise = q(p);
+    pluginsListPromise = Promise.resolve(p);
   }
   else {
     pluginsListPromise = getPluginsList(dbService, kuzzleConfiguration);
@@ -267,14 +271,14 @@ function importPluginConfiguration(db, plugin, filePath, kuzzleConfiguration) {
   try {
     content = fs.readFileSync(filePath, 'UTF-8');
   } catch (err) {
-    return q.reject(new Error(`Error opening file ${filePath}: ${err.message}`));
+    return Promise.reject(new Error(`Error opening file ${filePath}: ${err.message}`));
   }
 
   try {
     content = JSON.parse(content);
   }
   catch (err) {
-    return q.reject(new Error(`Unable to parse ${filePath}: ${err}`));
+    return Promise.reject(new Error(`Unable to parse ${filePath}: ${err}`));
   }
 
   return db.get(kuzzleConfiguration.pluginsManager.dataCollection, plugin)
@@ -282,11 +286,11 @@ function importPluginConfiguration(db, plugin, filePath, kuzzleConfiguration) {
       res._source.config = content;
       return db.createOrReplace(kuzzleConfiguration.pluginsManager.dataCollection, plugin, res._source);
     }).then(() => {
-      return q(clcOk('[✔] Successfully imported configuration'));
+      return Promise.resolve(clcOk('[✔] Successfully imported configuration'));
     }).catch(err => {
       var error = new Error(`Plugin ${plugin} not found`);
       error.stack = err.stack;
-      return q.reject(error);
+      return Promise.reject(error);
     });
 }
 
@@ -328,7 +332,7 @@ function acquirePlugins(plugins) {
       promises.push(npmInstall(plugin, name));
     }
   });
-  return q.all(promises);
+  return Promise.all(promises);
 }
 
 /**
@@ -340,8 +344,7 @@ function acquirePlugins(plugins) {
  * @returns {Promise}
  */
 function npmInstall(plugin, name) {
-  var deferred = q.defer(),
-    uri;
+  var uri;
 
   if (plugin.gitUrl) {
     uri = plugin.gitUrl;
@@ -352,20 +355,20 @@ function npmInstall(plugin, name) {
   }
   console.log('███ kuzzle-plugins: Downloading plugin: ', uri);
 
-  childProcess.exec('npm install ' + uri, (err, stdout, stderr) => {
-    if (err) {
-      console.error(`Plugin download error. Full log:\n${stderr}`);
-      return deferred.reject(err);
-    }
+  return new Promise((resolve, reject) => {
+    childProcess.exec('npm install ' + uri, (err, stdout, stderr) => {
+      if (err) {
+        console.error(`Plugin download error. Full log:\n${stderr}`);
+        return reject(err);
+      }
 
-    console.log('███ kuzzle-plugins: Plugin', uri, 'downloaded');
-    if (plugin.gitUrl) {
-      createLock(getPathPlugin(plugin, name));
-    }
-    deferred.resolve();
+      console.log('███ kuzzle-plugins: Plugin', uri, 'downloaded');
+      if (plugin.gitUrl) {
+        createLock(getPathPlugin(plugin, name));
+      }
+      resolve();
+    });
   });
-
-  return deferred.promise;
 }
 
 /**
@@ -374,7 +377,7 @@ function npmInstall(plugin, name) {
  * @param db - database service client
  * @param collection in which the plugin configuration must be stored
  * @param plugins list
- * @returns {boolean}
+ * @returns {Promise}
  */
 function updatePluginsConfiguration(db, collection, plugins) {
   var promises = [];
@@ -414,7 +417,7 @@ function updatePluginsConfiguration(db, collection, plugins) {
     promises.push(db.createOrReplace(collection, name, pluginConfiguration));
   });
 
-  return q.all(promises);
+  return Promise.all(promises);
 }
 
 
@@ -509,7 +512,7 @@ function setPluginConfiguration(plugin, property, db, cfg) {
     jsonProperty = JSON.parse(property);
   }
   catch (err) {
-    return q.reject(new Error('Unable to parse ' + property + '. Expected: JSON Object\n' + err));
+    return Promise.reject(new Error('Unable to parse ' + property + '. Expected: JSON Object\n' + err));
   }
 
   return db
@@ -538,7 +541,7 @@ function unsetPluginConfiguration(plugin, property, db, cfg) {
       var config = result._source;
 
       if (!config.config[property]) {
-        return q.reject(new Error('Property ' + property + ' not found in the plugin configuration'));
+        return Promise.reject(new Error('Property ' + property + ' not found in the plugin configuration'));
       }
 
       delete config.config[property];
@@ -563,7 +566,7 @@ function replacePluginConfiguration(plugin, content, db, cfg) {
     jsonProperty = JSON.parse(content);
   }
   catch (err) {
-    return q.reject(new Error('Unable to parse the new plugin configuration. Expected: JSON Object\n' + err));
+    return Promise.reject(new Error('Unable to parse the new plugin configuration. Expected: JSON Object\n' + err));
   }
 
   return db
@@ -584,7 +587,9 @@ function replacePluginConfiguration(plugin, content, db, cfg) {
  * @returns {Promise}
  */
 function removePlugin(plugin, db, cfg) {
-  var installedLocally;
+  var
+    installedLocally,
+    rimrafPromise = Promise.promisify(rimraf);
 
   return db
     .get(cfg.pluginsManager.dataCollection, plugin)
@@ -598,10 +603,10 @@ function removePlugin(plugin, db, cfg) {
 
       if (installedLocally) {
         try {
-          return q.denodeify(rimraf)(getPathPlugin({}, plugin));
+          return rimrafPromise(getPathPlugin({}, plugin));
         }
         catch (err) {
-          return q.reject(new Error('Unable to remove the plugin module: ' + err));
+          return Promise.reject(new Error('Unable to remove the plugin module: ' + err));
         }
       }
     })

--- a/lib/api/controllers/remoteActions/prepareDb.js
+++ b/lib/api/controllers/remoteActions/prepareDb.js
@@ -3,7 +3,7 @@ var
   RequestObject = require('kuzzle-common-objects').Models.requestObject,
   InternalError = require('kuzzle-common-objects').Errors.internalError,
   async = require('async'),
-  q = require('q');
+  Promise = require('bluebird');
 
 /**
  * @typedef {{kuzzle: Kuzzle, defaultRoleDefinition: *, files: {fixtures: *, mapping: *}, data: *}} PrepareDb
@@ -59,7 +59,7 @@ module.exports = function PrepareDb (kuzzle, request) {
       });
   }
 
-  return q({isWorker: true});
+  return Promise.resolve({isWorker: true});
 };
 
 /**
@@ -81,7 +81,7 @@ function readFile(which) {
   if (!this.files[which] || this.files[which] === '') {
     this.kuzzle.pluginsManager.trigger('log:info', '== No default ' + which + ' file specified in env vars: continue.');
     this.data[which] = {};
-    return q();
+    return Promise.resolve();
   }
 
   this.kuzzle.pluginsManager.trigger('log:info', '== Reading default ' + which + ' file ' + this.files[which] + '...');
@@ -89,7 +89,7 @@ function readFile(which) {
   try {
     this.data[which] = JSON.parse(fs.readFileSync(this.files[which], 'utf8'));
     this.kuzzle.pluginsManager.trigger('log:info', '== Reading default ' + which + ' file ' + this.files[which] + ' done.');
-    return q();
+    return Promise.resolve();
   }
   catch (e) {
     this.kuzzle.pluginsManager.trigger('log:info',
@@ -99,7 +99,7 @@ function readFile(which) {
     );
 
     this.kuzzle.pluginsManager.trigger('prepareDb:error', new Error('Error while loading the file ' + this.files[which]));
-    return q.reject(new InternalError('Error while loading the file ' + this.files[which]));
+    return Promise.reject(new InternalError('Error while loading the file ' + this.files[which]));
   }
 }
 
@@ -107,154 +107,143 @@ function readFile(which) {
  * @this {PrepareDb}
  */
 function createIndexes() {
-  var deferred = q.defer();
+  return new Promise((resolve, reject) => {
+    async.map(
+      Object.keys(this.data.mappings).concat(Object.keys(this.data.fixtures)),
+      (index, callback) => {
+        var requestObject = new RequestObject({controller: 'admin', action: 'createIndex', index: index});
 
-  async.map(
-    Object.keys(this.data.mappings).concat(Object.keys(this.data.fixtures)),
-    (index, callback) => {
-      var requestObject = new RequestObject({controller: 'admin', action: 'createIndex', index: index});
+        if (this.kuzzle.indexCache.indexes[index]) {
+          callback(null, true);
 
-      if (this.kuzzle.indexCache.indexes[index]) {
-        callback(null, true);
+        } else {
 
-      } else {
+          this.kuzzle.pluginsManager.trigger('prepareDb:createFixturesIndex', requestObject)
+            .then(newRequestObject => {
+              return this.kuzzle.workerListener.add(newRequestObject);
+            })
+            .then(() => {
+              this.kuzzle.pluginsManager.trigger('log:info', '== index "' + index + '" created.');
+              this.kuzzle.indexCache.add(index);
+              callback(null, true);
+            })
+            .catch((error) => {
+              this.kuzzle.pluginsManager.trigger('log:error', '!! index "' + index + '" not created: ' + JSON.stringify(error));
+              callback(error);
+            });
+        }
 
-        this.kuzzle.pluginsManager.trigger('prepareDb:createFixturesIndex', requestObject)
-          .then(newRequestObject => {
-            return this.kuzzle.workerListener.add(newRequestObject);
-          })
-          .then(() => {
-            this.kuzzle.pluginsManager.trigger('log:info', '== index "' + index + '" created.');
-            this.kuzzle.indexCache.add(index);
-            callback(null, true);
-          })
-          .catch((error) => {
-            this.kuzzle.pluginsManager.trigger('log:error', '!! index "' + index + '" not created: ' + JSON.stringify(error));
-            callback(error);
-          });
+      },
+      error => {
+        this.kuzzle.pluginsManager.trigger('log:info', '== Index creation process terminated.');
+
+        if (error) {
+          this.kuzzle.pluginsManager.trigger('prepareDb:error',
+            '!! An error occured during the indexes creation.\nHere is the original error message:\n' + error.message
+          );
+
+          return reject(new InternalError('An error occured during the indexes creation.\nHere is the original error message:\n' + error.message));
+        }
+
+        resolve();
       }
-
-    },
-    (error) => {
-      this.kuzzle.pluginsManager.trigger('log:info', '== Index creation process terminated.');
-
-      if (error) {
-        this.kuzzle.pluginsManager.trigger('prepareDb:error',
-          '!! An error occured during the indexes creation.\nHere is the original error message:\n'+error.message
-        );
-
-        deferred.reject(new InternalError('An error occured during the indexes creation.\nHere is the original error message:\n'+error.message));
-        return deferred.promise;
-      }
-
-      return deferred.resolve();
-    }
-  );
-
-  return deferred.promise;
+    );
+  });
 }
 
 /**
  * @this {PrepareDb}
  */
 function importMapping() {
-  var
-    deferred = q.defer();
+  return new Promise((resolve, reject) => {
+    async.each(Object.keys(this.data.mappings), (index, callbackIndex) => {
+      async.each(Object.keys(this.data.mappings[index]), (collection, callbackCollection) => {
+        var
+          requestObject,
+          msg;
 
-  async.each(Object.keys(this.data.mappings), (index, callbackIndex) => {
-    async.each(Object.keys(this.data.mappings[index]), (collection, callbackCollection) => {
-      var
-        requestObject,
-        msg;
+        if (!this.data.mappings[index][collection].properties) {
+          msg = '== Invalid mapping detected: missing required "properties" field';
+          this.kuzzle.pluginsManager.trigger('log:err', msg);
+          return callbackCollection(msg);
+        }
 
-      if (!this.data.mappings[index][collection].properties) {
-        msg = '== Invalid mapping detected: missing required "properties" field';
-        this.kuzzle.pluginsManager.trigger('log:err', msg);
-        return callbackCollection(msg);
+        this.kuzzle.pluginsManager.trigger('log:info', '== Importing mapping for ' + index + ':' + collection + '...');
+
+        requestObject = new RequestObject({
+          controller: 'admin',
+          action: 'updateMapping',
+          index: index,
+          collection: collection,
+          body: this.data.mappings[index][collection]
+        });
+
+        this.kuzzle.pluginsManager.trigger('prepareDb:importMapping', requestObject)
+          .then(newRequestObject => this.kuzzle.workerListener.add(newRequestObject))
+          .then(() => callbackCollection())
+          .catch(response => callbackCollection('Mapping import error ' + response.message));
+
+      }, error => callbackIndex(error));
+    }, error => {
+      if (error) {
+        this.kuzzle.pluginsManager.trigger('log:error', 'An error occured during the mappings import.\nHere is the original error object:\n', error);
+        return reject(new InternalError(error));
       }
 
-      this.kuzzle.pluginsManager.trigger('log:info', '== Importing mapping for ' + index + ':' + collection + '...');
-
-      requestObject = new RequestObject({
-        controller: 'admin',
-        action: 'updateMapping',
-        index: index,
-        collection: collection,
-        body: this.data.mappings[index][collection]
-      });
-
-      this.kuzzle.pluginsManager.trigger('prepareDb:importMapping', requestObject)
-        .then(newRequestObject => {
-          return this.kuzzle.workerListener.add(newRequestObject);
-        })
-        .then(() => callbackCollection())
-        .catch(response => callbackCollection('Mapping import error ' + response.message));
-
-    }, error => callbackIndex(error));
-  }, error => {
-    if (error) {
-      this.kuzzle.pluginsManager.trigger('log:error', 'An error occured during the mappings import.\nHere is the original error object:\n', error);
-      return deferred.reject(new InternalError(error));
-    }
-
-    this.kuzzle.pluginsManager.trigger('log:info', '== All mapping imports launched.');
-    return deferred.resolve();
+      this.kuzzle.pluginsManager.trigger('log:info', '== All mapping imports launched.');
+      resolve();
+    });
   });
-
-  return deferred.promise;
 }
 
 /**
  * @this {PrepareDb}
  */
 function importFixtures() {
-  var
-    deferred = q.defer();
+  return new Promise((resolve, reject) => {
+    async.each(Object.keys(this.data.fixtures), (index, callbackIndex) => {
+      async.each(Object.keys(this.data.fixtures[index]), (collection, callback) => {
+        var
+          fixture = {
+            controller: 'bulk',
+            action: 'import',
+            index: index,
+            collection: collection,
+            body: this.data.fixtures[index][collection]
+          },
+          requestObject = new RequestObject(fixture);
 
-  async.each(Object.keys(this.data.fixtures), (index, callbackIndex) => {
-    async.each(Object.keys(this.data.fixtures[index]), (collection, callback) => {
-      var
-        fixture = {
-          controller: 'bulk',
-          action: 'import',
-          index: index,
-          collection: collection,
-          body: this.data.fixtures[index][collection]
-        },
-        requestObject = new RequestObject(fixture);
+        this.kuzzle.pluginsManager.trigger('log:info', '== Importing fixtures for collection ' + index + ':' + collection + '...');
 
-      this.kuzzle.pluginsManager.trigger('log:info', '== Importing fixtures for collection ' + index + ':' + collection + '...');
+        this.kuzzle.pluginsManager.trigger('prepareDb:importFixtures', requestObject)
+          .then(newRequestObject => this.kuzzle.workerListener.add(newRequestObject))
+          .then(() => callback())
+          .catch(response => {
+            // 206 = partial errors
+            if (response.status !== 206) {
+              return callback(response.message);
+            }
 
-      this.kuzzle.pluginsManager.trigger('prepareDb:importFixtures', requestObject)
-        .then(newRequestObject => this.kuzzle.workerListener.add(newRequestObject))
-        .then(() => callback())
-        .catch(response => {
-          // 206 = partial errors
-          if (response.status !== 206) {
-            return callback(response.message);
-          }
+            // We need to filter "Document already exists" errors
+            if (response.errors.filter(e => e.status !== 409).length === 0) {
+              callback();
+            } else {
+              callback(response.message);
+            }
+          });
+      }, function (error) {
+        callbackIndex(error);
+      });
+    }, error => {
+      if (error) {
+        this.kuzzle.pluginsManager.trigger('log:error', '== Fixture import error: ' + error.message);
+        return reject(new InternalError(error));
+      }
 
-          // We need to filter "Document already exists" errors
-          if (response.errors.filter(e => e.status !== 409).length === 0) {
-            callback();
-          } else {
-            callback(response.message);
-          }
-        });
-    }, function (error) {
-      callbackIndex(error);
+      this.kuzzle.pluginsManager.trigger('log:info', '== All fixtures imports launched.');
+      resolve();
     });
-  }, error => {
-    if (error) {
-      this.kuzzle.pluginsManager.trigger('log:error', '== Fixture import error: ' + error.message);
-      return deferred.reject(new InternalError(error));
-    }
-
-    this.kuzzle.pluginsManager.trigger('log:info', '== All fixtures imports launched.');
-    return deferred.resolve();
   });
-
-  return deferred.promise;
 }
 
 /**
@@ -268,7 +257,7 @@ function createInternalIndex(kuzzle) {
   });
 
   if (kuzzle.indexCache && kuzzle.indexCache.indexes && kuzzle.indexCache.indexes[kuzzle.config.internalIndex]) {
-    return q();
+    return Promise.resolve();
   }
 
   kuzzle.pluginsManager.trigger('log:info', '== Creating Kuzzle internal index...');
@@ -297,7 +286,7 @@ function createRoleCollection(kuzzle, defaultRoleDefinition) {
   });
 
   if (kuzzle.indexCache.indexes[kuzzle.config.internalIndex].indexOf('roles') !== -1) {
-    return q();
+    return Promise.resolve();
   }
 
   kuzzle.pluginsManager.trigger('log:info', '== Creating roles collection...');
@@ -370,7 +359,7 @@ function createProfileCollection(kuzzle) {
   });
 
   if (kuzzle.indexCache.indexes[kuzzle.config.internalIndex].indexOf('profiles') !== -1) {
-    return q();
+    return Promise.resolve();
   }
 
   kuzzle.pluginsManager.trigger('log:info', '== Creating profiles collection...');
@@ -437,7 +426,7 @@ function createUserCollection(kuzzle) {
   });
 
   if (kuzzle.indexCache.indexes[kuzzle.config.internalIndex].indexOf('users') !== -1) {
-    return q();
+    return Promise.resolve();
   }
 
   kuzzle.pluginsManager.trigger('log:info', '== Creating users collection...');

--- a/lib/api/controllers/remoteActions/swagger.js
+++ b/lib/api/controllers/remoteActions/swagger.js
@@ -2,7 +2,7 @@ var
   fs = require('fs'),
   path = require('path'),
   InternalError = require('kuzzle-common-objects').Errors.internalError,
-  q = require('q'),
+  Promise = require('bluebird'),
   jsonToYaml = require('json2yaml'),  
   generateSwagger = require('../../core/swagger'),
   writeFiles;
@@ -15,20 +15,20 @@ writeFiles = swagger => {
     fs.writeFileSync(path.join(baseDir, 'kuzzle-swagger.json'), JSON.stringify(swagger));
   }
   catch (e) {
-    return q.reject(new InternalError('Unable to write the kuzzle-swagger.json file'));
+    return Promise.reject(new InternalError('Unable to write the kuzzle-swagger.json file'));
   }
   try {
     fs.writeFileSync(path.join(baseDir, 'kuzzle-swagger.yml'), jsonToYaml.stringify(swagger));
   }
   catch (e) {
-    return q.reject(new InternalError('Unable to write the kuzzle-swagger.yml file'));
+    return Promise.reject(new InternalError('Unable to write the kuzzle-swagger.yml file'));
   }
-  return q(swagger);
+  return Promise.resolve(swagger);
 };
 
 module.exports = function GenerateSwaggerFiles (kuzzle) {
   if (! kuzzle.isServer) {
-    return q({isWorker: true});
+    return Promise.resolve({isWorker: true});
   }
 
   return generateSwagger(kuzzle)

--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -1,6 +1,6 @@
 var
   _ = require('lodash'),
-  q = require('q'),
+  Promise = require('bluebird'),
   url = require('url'),
   stringify = require('json-stable-stringify'),
   jsonToYaml = require('json2yaml'),
@@ -32,7 +32,7 @@ function RouterController (kuzzle) {
    *
    * @param {string} protocol - protocol name
    * @param {string} connectionId - unique connection identifier
-   * @return {promise} connection context, to be used with other router functions
+   * @return {Promise} connection context, to be used with other router functions
    */
   this.newConnection = function (protocol, connectionId) {
     var error;
@@ -40,7 +40,7 @@ function RouterController (kuzzle) {
     if (!connectionId || !protocol || typeof connectionId !== 'string' || typeof protocol !== 'string') {
       error = new PluginImplementationError('Rejected new connection declaration: invalid arguments');
       kuzzle.pluginsManager.trigger('log:error', error);
-      return q.reject(error);
+      return Promise.reject(error);
     }
 
     if (!this.connections[connectionId]) {
@@ -52,7 +52,7 @@ function RouterController (kuzzle) {
 
     kuzzle.statistics.newConnection(this.connections[connectionId]);
 
-    return q(this.connections[connectionId]);
+    return Promise.resolve(this.connections[connectionId]);
   };
 
   /**

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -1,7 +1,7 @@
 var
   _ = require('lodash'),
   uuid = require('node-uuid'),
-  q = require('q'),
+  Promise = require('bluebird'),
   BadRequestError = require('kuzzle-common-objects').Errors.badRequestError,
   ResponseObject = require('kuzzle-common-objects').Models.responseObject,
   NotFoundError = require('kuzzle-common-objects').Errors.notFoundError,
@@ -24,7 +24,7 @@ function SecurityController (kuzzle) {
       })
       .then(role => {
         if (!role) {
-          return q.reject(new NotFoundError(`Role with id ${modifiedRequestObject.data._id} not found`));
+          return Promise.reject(new NotFoundError(`Role with id ${modifiedRequestObject.data._id} not found`));
         }
 
         return kuzzle.pluginsManager.trigger(
@@ -47,7 +47,7 @@ function SecurityController (kuzzle) {
         modifiedRequestObject = newRequestObject;
 
         if (!modifiedRequestObject.data.body || !modifiedRequestObject.data.body.ids || !Array.isArray(modifiedRequestObject.data.body.ids)) {
-          return q.reject(new BadRequestError('Missing role ids'));
+          return Promise.reject(new BadRequestError('Missing role ids'));
         }
 
         return kuzzle.repositories.role.loadMultiFromDatabase(modifiedRequestObject.data.body.ids);
@@ -145,14 +145,14 @@ function SecurityController (kuzzle) {
         modifiedRequestObject = newRequestObject;
 
         if (!modifiedRequestObject.data._id) {
-          return q.reject(new BadRequestError('Missing profile id'));
+          return Promise.reject(new BadRequestError('Missing profile id'));
         }
 
         return kuzzle.repositories.profile.loadProfile(modifiedRequestObject.data._id);
       })
       .then(profile => {
         if (!profile) {
-          return q.reject(new NotFoundError(`Profile with id ${modifiedRequestObject.data._id} not found`));
+          return Promise.reject(new NotFoundError(`Profile with id ${modifiedRequestObject.data._id} not found`));
         }
 
         return kuzzle.pluginsManager.trigger(
@@ -175,7 +175,7 @@ function SecurityController (kuzzle) {
         modifiedRequestObject = newRequestObject;
 
         if (!modifiedRequestObject.data.body || !modifiedRequestObject.data.body.ids || !Array.isArray(modifiedRequestObject.data.body.ids)) {
-          return q.reject(new BadRequestError('Missing profile ids'));
+          return Promise.reject(new BadRequestError('Missing profile ids'));
         }
 
         return kuzzle.repositories.profile.loadMultiFromDatabase(modifiedRequestObject.data.body.ids);
@@ -294,7 +294,7 @@ function SecurityController (kuzzle) {
       })
       .then(user => {
         if (!user) {
-          return q.reject(new NotFoundError(`User with id ${modifiedRequestObject.data.body._id} not found`));
+          return Promise.reject(new NotFoundError(`User with id ${modifiedRequestObject.data.body._id} not found`));
         }
 
         return formatProcessing.formatUserForSerialization(kuzzle, user);
@@ -315,20 +315,20 @@ function SecurityController (kuzzle) {
         modifiedRequestObject = newRequestObject;
 
         if (!modifiedRequestObject.data._id) {
-          return q.reject(new BadRequestError('No profile id given'));
+          return Promise.reject(new BadRequestError('No profile id given'));
         }
 
         return kuzzle.repositories.profile.loadProfile(modifiedRequestObject.data._id);
       })
       .then(profile => {
         if (!profile) {
-          return q.reject(new NotFoundError(`Profile with id ${modifiedRequestObject.data._id} not found`));
+          return Promise.reject(new NotFoundError(`Profile with id ${modifiedRequestObject.data._id} not found`));
         }
 
         return profile.getRights(kuzzle);
       })
       .then(rights => {
-        return q(Object.keys(rights).reduce((array, item) => array.concat(rights[item]), []));
+        return Promise.resolve(Object.keys(rights).reduce((array, item) => array.concat(rights[item]), []));
       })
       .then(rights => {
         var response = {
@@ -351,14 +351,14 @@ function SecurityController (kuzzle) {
         modifiedRequestObject = newRequestObject;
 
         if (!modifiedRequestObject.data._id) {
-          return q.reject(new BadRequestError('No user id given'));
+          return Promise.reject(new BadRequestError('No user id given'));
         }
 
         return kuzzle.repositories.user.load(modifiedRequestObject.data._id);
       })
       .then(user => {
         if (!user) {
-          return q.reject(new NotFoundError(`User with id ${modifiedRequestObject.data._id} not found`));
+          return Promise.reject(new NotFoundError(`User with id ${modifiedRequestObject.data._id} not found`));
         }
 
         return user.getRights(kuzzle);
@@ -396,7 +396,7 @@ function SecurityController (kuzzle) {
           return formatProcessing.formatUserForSerialization(kuzzle, user);
         }));
 
-        return q.all(promises);
+        return Promise.all(promises);
       })
       .then(formattedUsers => {
         return kuzzle.pluginsManager.trigger('security:afterSearchUsers',
@@ -421,7 +421,7 @@ function SecurityController (kuzzle) {
         modifiedRequestObject = newRequestObject;
 
         if (!modifiedRequestObject.data._id) {
-          return q.reject(new BadRequestError('No user id given'));
+          return Promise.reject(new BadRequestError('No user id given'));
         }
 
         return kuzzle.repositories.user.delete(modifiedRequestObject.data._id);
@@ -446,7 +446,7 @@ function SecurityController (kuzzle) {
         modifiedRequestObject = newRequestObject;
 
         if (!modifiedRequestObject.data.body || !modifiedRequestObject.data.body.profileId) {
-          return q.reject(new BadRequestError('Invalid user object. No profileId property found.'));
+          return Promise.reject(new BadRequestError('Invalid user object. No profileId property found.'));
         }
 
         pojoUser = modifiedRequestObject.data.body;
@@ -478,11 +478,11 @@ function SecurityController (kuzzle) {
         modifiedRequestObject = newRequestObject;
 
         if (!modifiedRequestObject.data._id) {
-          return q.reject(new BadRequestError('No user id given'));
+          return Promise.reject(new BadRequestError('No user id given'));
         }
 
         if (modifiedRequestObject.data.body._id) {
-          return q.reject(new BadRequestError('_id can not be part of the body'));
+          return Promise.reject(new BadRequestError('_id can not be part of the body'));
         }
 
         return kuzzle.repositories.user.load(modifiedRequestObject.data._id);
@@ -509,11 +509,11 @@ function SecurityController (kuzzle) {
         modifiedContext = modifiedData.context;
 
         if (!modifiedRequestObject.data._id) {
-          return q.reject(new BadRequestError('No profile id given'));
+          return Promise.reject(new BadRequestError('No profile id given'));
         }
 
         if (modifiedRequestObject.data.body._id) {
-          return q.reject(new BadRequestError('_id can not be part of the body'));
+          return Promise.reject(new BadRequestError('_id can not be part of the body'));
         }
 
         return kuzzle.repositories.profile.loadProfile(modifiedRequestObject.data._id);
@@ -543,18 +543,18 @@ function SecurityController (kuzzle) {
         modifiedContext = modifiedData.context;
 
         if (!modifiedRequestObject.data._id) {
-          return q.reject(new BadRequestError('No role id given'));
+          return Promise.reject(new BadRequestError('No role id given'));
         }
 
         if (modifiedRequestObject.data.body._id) {
-          return q.reject(new BadRequestError('_id can not be part of the body'));
+          return Promise.reject(new BadRequestError('_id can not be part of the body'));
         }
 
         return kuzzle.repositories.role.loadRole(modifiedRequestObject.data._id);
       })
       .then(role => {
         if (!role) {
-          return q.reject(new NotFoundError('Cannot update role "' + modifiedRequestObject.data._id + '": role not found'));
+          return Promise.reject(new NotFoundError('Cannot update role "' + modifiedRequestObject.data._id + '": role not found'));
         }
 
         return kuzzle.repositories.role.validateAndSaveRole(_.extend(role, modifiedRequestObject.data.body), modifiedContext, { method: 'update' });
@@ -580,7 +580,7 @@ function SecurityController (kuzzle) {
         modifiedRequestObject = newRequestObject;
 
         if (!modifiedRequestObject.data.body || !modifiedRequestObject.data.body.profileId) {
-          return q.reject(new BadRequestError('Invalid user object. No profile property found.'));
+          return Promise.reject(new BadRequestError('Invalid user object. No profile property found.'));
         }
 
         if (modifiedRequestObject.data._id !== undefined) {
@@ -617,7 +617,7 @@ function createOrReplaceRole (requestObject, context, opts) {
  */
 function createOrReplaceProfile (requestObject, context, opts) {
   if (!_.isArray(requestObject.data.body.policies)) {
-    return q.reject(new BadRequestError('Policies property must be an array.'));
+    return Promise.reject(new BadRequestError('Policies property must be an array.'));
   }
 
   return this.repositories.profile.buildProfileFromRequestObject(requestObject)

--- a/lib/api/controllers/writeController.js
+++ b/lib/api/controllers/writeController.js
@@ -48,7 +48,7 @@ function WriteController (kuzzle) {
         modifiedRequestObject = newRequestObject;
         return kuzzle.notifier.publish(modifiedRequestObject);
       })
-      .then(response => kuzzle.pluginsManager.trigger('data:afterPublish', new ResponseObject(modifiedRequestObject, response)));
+      .then(response => kuzzle.pluginsManager.trigger('data:afterPublish', new ResponseObject(modifiedRequestObject, {acknowledge: true})));
   };
 
   /**

--- a/lib/api/controllers/writeController.js
+++ b/lib/api/controllers/writeController.js
@@ -48,7 +48,7 @@ function WriteController (kuzzle) {
         modifiedRequestObject = newRequestObject;
         return kuzzle.notifier.publish(modifiedRequestObject);
       })
-      .then(() => kuzzle.pluginsManager.trigger('data:afterPublish', new ResponseObject(modifiedRequestObject, {acknowledge: true})));
+      .then(response => kuzzle.pluginsManager.trigger('data:afterPublish', new ResponseObject(modifiedRequestObject, response)));
   };
 
   /**

--- a/lib/api/controllers/writeController.js
+++ b/lib/api/controllers/writeController.js
@@ -48,7 +48,7 @@ function WriteController (kuzzle) {
         modifiedRequestObject = newRequestObject;
         return kuzzle.notifier.publish(modifiedRequestObject);
       })
-      .then(response => kuzzle.pluginsManager.trigger('data:afterPublish', new ResponseObject(modifiedRequestObject, {acknowledge: true})));
+      .then(() => kuzzle.pluginsManager.trigger('data:afterPublish', new ResponseObject(modifiedRequestObject, {acknowledge: true})));
   };
 
   /**

--- a/lib/api/core/auth/passportResponse.js
+++ b/lib/api/core/auth/passportResponse.js
@@ -5,10 +5,9 @@ HTTP Response Mockup to emulate response objects for Passport Authentication
 */
 
 /**
- * @param {Promise} deferred
  * @constructor
  */
-function PassportResponse (deferred) {
+function PassportResponse () {
 
   this.headers = {};
   this.statusCode = 200;
@@ -21,7 +20,6 @@ function PassportResponse (deferred) {
     if (statusCode) {
       this.statusCode = statusCode;
     }
-    deferred.resolve(this);
   };
 
   this.getHeader = function(key) {

--- a/lib/api/core/auth/passportWrapper.js
+++ b/lib/api/core/auth/passportWrapper.js
@@ -1,5 +1,5 @@
 var
-  q = require('q'),
+  Promise = require('bluebird'),
   passport = require('passport'),
   PassportResponse = require('./passportResponse'),
   BadRequestError = require('kuzzle-common-objects').Errors.badRequestError,
@@ -14,33 +14,34 @@ function PassportWrapper () {
 
   this.authenticate = function (request, strategy) {
     var
-      deferred = q.defer(),
       response = new PassportResponse(deferred),
       error;
 
     try {
       if (!passport._strategy(strategy)) {
-        return q.reject(new BadRequestError('Unknown authentication strategy "' + strategy + '"'));
+        return Promise.reject(new BadRequestError('Unknown authentication strategy "' + strategy + '"'));
       }
-      passport.authenticate(strategy, {scope: this.scope[strategy]}, (err, user, info) => {
-        if (err !== null) {
-          deferred.reject(err);
-        }
-        else if (user === false) {
-          error = new UnauthorizedError(info.message);
-          error.details = {
-            subCode: error.subCodes.AuthenticationError
-          };
-          deferred.reject(error);
-        }
-        else {
-          deferred.resolve(user);
-        }
-      })(request, response);
+
+      return new Promise((resolve, reject) => {
+        passport.authenticate(strategy, {scope: this.scope[strategy]}, (err, user, info) => {
+          if (err !== null) {
+            reject(err);
+          }
+          else if (!user) {
+            error = new UnauthorizedError(info.message);
+            error.details = {
+              subCode: error.subCodes.AuthenticationError
+            };
+            reject(error);
+          }
+          else {
+            resolve(user);
+          }
+        })(request, response);
+      });
     } catch (err) {
-      deferred.reject(new InternalError(err));
+      return Promise.reject(new InternalError(err));
     }
-    return deferred.promise;
   };
 
   /**

--- a/lib/api/core/auth/passportWrapper.js
+++ b/lib/api/core/auth/passportWrapper.js
@@ -14,7 +14,7 @@ function PassportWrapper () {
 
   this.authenticate = function (request, strategy) {
     var
-      response = new PassportResponse(deferred),
+      response = new PassportResponse(),
       error;
 
     try {

--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -1,7 +1,7 @@
 var
   _ = require('lodash'),
   async = require('async'),
-  q = require('q'),
+  Promise = require('bluebird'),
   crypto = require('crypto'),
   RequestObject = require('kuzzle-common-objects').Models.requestObject,
   BadRequestError = require('kuzzle-common-objects').Errors.badRequestError,
@@ -121,7 +121,7 @@ function HotelClerk (kuzzle) {
       connection = context.connection;
 
     if (!requestObject.data.body || !requestObject.data.body.roomId) {
-      return q.reject(new BadRequestError('The room ID is mandatory to unsubcribe to a room'));
+      return Promise.reject(new BadRequestError('The room ID is mandatory to unsubcribe to a room'));
     }
 
     // Remove the room for the customer, don't wait for deletion before continuing
@@ -138,14 +138,14 @@ function HotelClerk (kuzzle) {
    */
   this.countSubscription = function (requestObject) {
     if (!requestObject.data.body || !requestObject.data.body.roomId) {
-      return q.reject(new BadRequestError('The room Id is mandatory to count subscriptions'));
+      return Promise.reject(new BadRequestError('The room Id is mandatory to count subscriptions'));
     }
 
     if (!this.rooms[requestObject.data.body.roomId]) {
-      return q.reject(new NotFoundError('The room Id ' + requestObject.data.body.roomId + ' does not exist'));
+      return Promise.reject(new NotFoundError('The room Id ' + requestObject.data.body.roomId + ' does not exist'));
     }
 
-    return q({count: this.rooms[requestObject.data.body.roomId].customers.length});
+    return Promise.resolve({count: this.rooms[requestObject.data.body.roomId].customers.length});
   };
 
   /**
@@ -159,21 +159,25 @@ function HotelClerk (kuzzle) {
    */
   this.removeCustomerFromAllRooms = function (connection) {
     var
-      deferred = q.defer(),
       rooms;
 
     if (!this.customers[connection.id]) {
-      deferred.reject(new NotFoundError('Unknown user with connection id ' + connection.id));
-      return deferred.promise;
+      return Promise.reject(new NotFoundError('Unknown user with connection id ' + connection.id));
     }
 
     rooms = Object.keys(this.customers[connection.id]);
 
-    async.each(rooms, (roomId, callback) => {
-      removeRoomForCustomer.call(this, connection, roomId).nodeify(callback);
-    }, deferred.makeNodeResolver());
+    return new Promise((resolve, reject) => {
+      async.each(rooms, (roomId, callback) => {
+        removeRoomForCustomer.call(this, connection, roomId).asCallback(callback);
+      }, err => {
+        if (err) {
+          return reject(err);
+        }
 
-    return deferred.promise;
+        resolve();
+      });
+    });
   };
 
   /**
@@ -184,44 +188,41 @@ function HotelClerk (kuzzle) {
    * @returns {Promise} resolve an object with collection, rooms, subscribers
    */
   this.listSubscriptions = function (context) {
-    var
-      list = {},
-      deferred = q.defer(),
-      requestObjectCollection = {
-        action: 'search',
-        controller: 'read'
-      };
+    return new Promise(resolve => {
+      var
+        list = {},
+        requestObjectCollection = {
+          action: 'search',
+          controller: 'read'
+        };
 
-    async.each(Object.keys(this.rooms), (roomId, callback) => {
-      var room = this.rooms[roomId];
+      async.each(Object.keys(this.rooms), (roomId, callback) => {
+        var room = this.rooms[roomId];
 
-      kuzzle.repositories.user.load(context.token.userId)
-        .then(user => {
-          var requestObject = _.assign(requestObjectCollection, {index: room.index, collection: room.collection});
+        kuzzle.repositories.user.load(context.token.userId)
+          .then(user => {
+            var requestObject = _.assign(requestObjectCollection, {index: room.index, collection: room.collection});
 
-          return user.isActionAllowed(requestObject, context, kuzzle);
-        })
-        .then(isAllowed => {
-          if (!isAllowed) {
-            return callback(null);
-          }
+            return user.isActionAllowed(requestObject, context, kuzzle);
+          })
+          .then(isAllowed => {
+            if (!isAllowed) {
+              return callback(null);
+            }
 
-          if (!list[room.index]) {
-            list[room.index] = {};
-          }
+            if (!list[room.index]) {
+              list[room.index] = {};
+            }
 
-          if (!list[room.index][room.collection]) {
-            list[room.index][room.collection] = {};
-          }
+            if (!list[room.index][room.collection]) {
+              list[room.index][room.collection] = {};
+            }
 
-          list[room.index][room.collection][roomId] = room.customers.length;
-          callback(null);
-        });
-    }, () => {
-      deferred.resolve(list);
+            list[room.index][room.collection][roomId] = room.customers.length;
+            callback(null);
+          });
+      }, () => resolve(list));
     });
-
-    return deferred.promise;
   };
 
   /**
@@ -236,10 +237,10 @@ function HotelClerk (kuzzle) {
       roomId = requestObject.data.body.roomId;
 
     if (!this.rooms[roomId]) {
-      return q.reject(new InternalError('No room found for id ' + roomId));
+      return Promise.reject(new InternalError('No room found for id ' + roomId));
     }
 
-    return q(subscribeToRoom.call(this, roomId, requestObject, context))
+    return Promise.resolve(subscribeToRoom.call(this, roomId, requestObject, context))
       .then(response => {
         kuzzle.pluginsManager.trigger('core:hotelClerk:join', response);
         return response.data;
@@ -254,20 +255,20 @@ function HotelClerk (kuzzle) {
    */
   this.removeRooms = function (requestObject) {
     if (!requestObject.index) {
-      return q.reject(new BadRequestError('No index provided'));
+      return Promise.reject(new BadRequestError('No index provided'));
     }
 
     if (!requestObject.collection) {
-      return q.reject(new BadRequestError('No collection provided'));
+      return Promise.reject(new BadRequestError('No collection provided'));
     }
 
     if (!kuzzle.dsl.exists(requestObject.index, requestObject.collection)) {
-      return q.reject(new NotFoundError(`No subscription found on index ${requestObject.index} and collection ${requestObject.collection}`));
+      return Promise.reject(new NotFoundError(`No subscription found on index ${requestObject.index} and collection ${requestObject.collection}`));
     }
 
     if (requestObject.data && requestObject.data.body && requestObject.data.body.rooms) {
       if (!Array.isArray(requestObject.data.body.rooms)) {
-        return q.reject(new BadRequestError('The rooms attribute must be an array'));
+        return Promise.reject(new BadRequestError('The rooms attribute must be an array'));
       }
 
       return removeListRoomsInCollection.call(this, requestObject.index, requestObject.collection, requestObject.data.body.rooms)
@@ -318,12 +319,16 @@ function HotelClerk (kuzzle) {
  */
 function removeAllRoomsInCollection (index, collection) {
   var
-    deferred = q.defer(),
     dslFilters = this.kuzzle.dsl.getFilterIds(index, collection);
 
-  async.each(dslFilters, (id, cb) => removeRoomEverywhere.call(this, id).nodeify(cb), deferred.makeNodeResolver());
-
-  return deferred.promise;
+  return new Promise((resolve, reject) => {
+    async.each(dslFilters, (id, cb) => removeRoomEverywhere.call(this, id).asCallback(cb), err => {
+      if (err) {
+        return reject(err);
+      }
+      resolve();
+    });
+  });
 }
 
 /**
@@ -335,38 +340,37 @@ function removeAllRoomsInCollection (index, collection) {
  */
 function removeListRoomsInCollection (index, collection, rooms) {
   var
-    deferred = q.defer(),
     partialErrors = [];
 
-  async.each(rooms, (roomId, callback) => {
-    if (!this.rooms[roomId]) {
-      // don't stop the loop if error occured but return a partial error to user
-      partialErrors.push(`No room with id ${roomId}`);
-      return callback();
-    }
+  return new Promise((resolve, reject) => {
+    async.each(rooms, (roomId, callback) => {
+      if (!this.rooms[roomId]) {
+        // don't stop the loop if error occured but return a partial error to user
+        partialErrors.push(`No room with id ${roomId}`);
+        return callback();
+      }
 
-    if (this.rooms[roomId].index !== index) {
-      // don't stop the loop if error occured but return a partial error to user
-      partialErrors.push(`The room ${roomId} does not match index ${index}`);
-      return callback();
-    }
+      if (this.rooms[roomId].index !== index) {
+        // don't stop the loop if error occured but return a partial error to user
+        partialErrors.push(`The room ${roomId} does not match index ${index}`);
+        return callback();
+      }
 
-    if (this.rooms[roomId].collection !== collection) {
-      // don't stop the loop if error occured but return a partial error to user
-      partialErrors.push(`The room ${roomId} does not match collection ${collection}`);
-      return callback();
-    }
+      if (this.rooms[roomId].collection !== collection) {
+        // don't stop the loop if error occured but return a partial error to user
+        partialErrors.push(`The room ${roomId} does not match collection ${collection}`);
+        return callback();
+      }
 
-    removeRoomEverywhere.call(this, roomId).nodeify(callback);
-  }, error => {
-    if (error) {
-      return deferred.reject(error);
-    }
+      removeRoomEverywhere.call(this, roomId).asCallback(callback);
+    }, error => {
+      if (error) {
+        return reject(error);
+      }
 
-    deferred.resolve(partialErrors);
+      resolve(partialErrors);
+    });
   });
-
-  return deferred.promise;
 }
 
 /**
@@ -381,61 +385,62 @@ function removeListRoomsInCollection (index, collection, rooms) {
 function createRoom (index, collection, filters) {
   var
     diff,
-    deferred,
     roomId;
 
   if (!index || !collection) {
-    return q.reject(new BadRequestError('Cannot subscribe without an index and a collection'));
+    return Promise.reject(new BadRequestError('Cannot subscribe without an index and a collection'));
   }
 
   roomId = this.kuzzle.dsl.createFilterId(index, collection, filters);
-  deferred = q.defer();
 
-  async.retry(callback => {
-    // if the room is about to be destroyed, we have to delay its re-creation until its destruction has completed
-    if (this.rooms[roomId] && this.rooms[roomId].destroyed) {
-      return callback(new InternalError('Cannot create the room ' + roomId + ' because it has been marked for destruction'));
-    }
+  return Promise.fromNode(asyncCB => async.retry(callback => {
+      // if the room is about to be destroyed, we have to delay its re-creation until its destruction has completed
+      if (this.rooms[roomId] && this.rooms[roomId].destroyed) {
+        return callback(new InternalError('Cannot create the room ' + roomId + ' because it has been marked for destruction'));
+      }
 
-    if (!this.rooms[roomId]) {
-      // If it's a new room, we have to calculate filters to apply on the future documents
-      this.kuzzle.dsl.register(roomId, index, collection, filters)
-        .then(response => {
-          var formattedFilters;
+      if (!this.rooms[roomId]) {
+        // If it's a new room, we have to calculate filters to apply on the future documents
+        this.kuzzle.dsl.register(roomId, index, collection, filters)
+          .then(response => {
+            var formattedFilters;
 
-          if (response && response.filter !== undefined) {
-            formattedFilters = response.filter;
-          }
+            if (response && response.filter !== undefined) {
+              formattedFilters = response.filter;
+            }
 
-          if (response) {
-            diff = response.diff;
-          }
+            if (response) {
+              diff = response.diff;
+            }
 
-          if (this.rooms[roomId]) {
-            return callback(null, roomId);
-          }
+            if (this.rooms[roomId]) {
+              return callback(null, roomId);
+            }
 
-          this.kuzzle.pluginsManager.trigger('room:new', {roomId: roomId, index: index, collection: collection, formattedFilters: formattedFilters})
-            .then(modifiedData => {
-              this.rooms[modifiedData.roomId] = {
-                id: modifiedData.roomId,
-                customers: [],
-                index: modifiedData.index,
-                channels: {},
-                collection: modifiedData.collection
-              };
+            this.kuzzle.pluginsManager.trigger('room:new', {
+              roomId: roomId,
+              index: index,
+              collection: collection,
+              formattedFilters: formattedFilters
+            })
+              .then(modifiedData => {
+                this.rooms[modifiedData.roomId] = {
+                  id: modifiedData.roomId,
+                  customers: [],
+                  index: modifiedData.index,
+                  channels: {},
+                  collection: modifiedData.collection
+                };
 
-              callback(null, { diff, roomId });
-            });
-        })
-        .catch(error => callback(error));
-    }
-    else {
-      callback(null, { roomId });
-    }
-  }, deferred.makeNodeResolver());
-
-  return deferred.promise;
+                callback(null, {diff, roomId});
+              });
+          })
+          .catch(error => callback(error));
+      }
+      else {
+        callback(null, {roomId});
+      }
+    }, asyncCB));
 }
 
 /**
@@ -460,14 +465,14 @@ function addRoomForCustomer (connection, roomId, metadata) {
  * Create a channel object and resolve it
  *
  * @param requestObject
- * @return {promise}
+ * @return {Promise}
  */
 function createChannelConfiguration (requestObject) {
   var
     channel = {};
 
   if (requestObject.state && ['all', 'done', 'pending'].indexOf(requestObject.state) === -1) {
-    return q.reject(new BadRequestError('Incorrect value for the "state" parameter. Expected: all, done or pending. Got: ' + requestObject.state));
+    return Promise.reject(new BadRequestError('Incorrect value for the "state" parameter. Expected: all, done or pending. Got: ' + requestObject.state));
   } else if (!requestObject.state) {
     channel.state = 'done';
   } else {
@@ -475,7 +480,7 @@ function createChannelConfiguration (requestObject) {
   }
 
   if (requestObject.scope && ['all', 'in', 'out', 'none'].indexOf(requestObject.scope) === -1) {
-    return q.reject(new BadRequestError('Incorrect value for the "scope" parameter. Expected: all, in, out or none. Got: ' + requestObject.scope));
+    return Promise.reject(new BadRequestError('Incorrect value for the "scope" parameter. Expected: all, in, out or none. Got: ' + requestObject.scope));
   } else if (!requestObject.scope) {
     channel.scope = 'all';
   } else {
@@ -483,14 +488,14 @@ function createChannelConfiguration (requestObject) {
   }
 
   if (requestObject.users && ['all', 'in', 'out', 'none'].indexOf(requestObject.users) === -1) {
-    return q.reject(new BadRequestError('Incorrect value for the "users" parameter. Expected: all, in, out or none. Got: ' + requestObject.users));
+    return Promise.reject(new BadRequestError('Incorrect value for the "users" parameter. Expected: all, in, out or none. Got: ' + requestObject.users));
   } else if (!requestObject.users) {
     channel.users = 'none';
   } else {
     channel.users = requestObject.users;
   }
 
-  return q(channel);
+  return Promise.resolve(channel);
 }
 
 /**
@@ -516,12 +521,12 @@ function cleanUpRooms (roomId) {
       })
       .catch(error => {
         this.kuzzle.pluginsManager.trigger('log:error', error);
-        throw error;
+        return Promise.reject(error);
       })
       .finally(() => delete this.rooms[roomId]);
   }
 
-  return q(roomId);
+  return Promise.resolve(roomId);
 }
 
 /**
@@ -560,11 +565,11 @@ function removeRoomForCustomer (connection, roomId, notify) {
   }
 
   if (!this.customers[connection.id]) {
-    return q.reject(new NotFoundError(`The user with connection ${connection.id} doesn't exist`));
+    return Promise.reject(new NotFoundError(`The user with connection ${connection.id} doesn't exist`));
   }
 
   if (!this.customers[connection.id][roomId]) {
-    return q.reject(new NotFoundError(`The user with connectionId ${connection.id} doesn't listen the room ${roomId}`));
+    return Promise.reject(new NotFoundError(`The user with connectionId ${connection.id} doesn't listen the room ${roomId}`));
   }
 
   Object.keys(this.rooms[roomId].channels).forEach(channel => {
@@ -611,22 +616,15 @@ function removeRoomForCustomer (connection, roomId, notify) {
  * @returns {Promise} resolve nothing
  */
 function removeRoomForAllCustomers (roomId) {
-  var
-    deferred = q.defer();
-
-  async.each(Object.keys(this.customers), (customerId, callbackCustomer) => {
-    async.each(Object.keys(this.customers[customerId]), (customerRoomId, callbackRoom) => {
+  Object.keys(this.customers).forEach(customerId => {
+    Object.keys(this.customers[customerId]).forEach(customerRoomId => {
       if (customerRoomId === roomId) {
         delete this.customers[customerId][customerRoomId];
       }
-
-      callbackRoom();
-    }, () => {
-      callbackCustomer();
     });
-  }, deferred.makeNodeResolver());
+  });
 
-  return deferred.promise;
+  return Promise.resolve();
 }
 
 /** MANAGE FILTERS TREE **/

--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -343,7 +343,7 @@ function removeListRoomsInCollection (index, collection, rooms) {
   var
     partialErrors = [];
 
-  return new Promise((resolve, reject) => {
+  return new Promise(resolve => {
     async.each(rooms, (roomId, callback) => {
       if (!this.rooms[roomId]) {
         // don't stop the loop if error occured but return a partial error to user

--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -155,14 +155,15 @@ function HotelClerk (kuzzle) {
    * Usually called on a user disconnection event
    *
    * @param {Object} connection information
-   * @returns {Promise} reject an error or resolve nothing
+   * @returns {Promise}
    */
   this.removeCustomerFromAllRooms = function (connection) {
     var
       rooms;
 
     if (!this.customers[connection.id]) {
-      return Promise.reject(new NotFoundError('Unknown user with connection id ' + connection.id));
+      // No need to raise an error if the connection has already been cleaned up
+      return Promise.resolve();
     }
 
     rooms = Object.keys(this.customers[connection.id]);

--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -364,13 +364,7 @@ function removeListRoomsInCollection (index, collection, rooms) {
       }
 
       removeRoomEverywhere.call(this, roomId).asCallback(callback);
-    }, error => {
-      if (error) {
-        return reject(error);
-      }
-
-      resolve(partialErrors);
-    });
+    }, () => resolve(partialErrors));
   });
 }
 

--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -394,53 +394,53 @@ function createRoom (index, collection, filters) {
   roomId = this.kuzzle.dsl.createFilterId(index, collection, filters);
 
   return Promise.fromNode(asyncCB => async.retry(callback => {
-      // if the room is about to be destroyed, we have to delay its re-creation until its destruction has completed
-      if (this.rooms[roomId] && this.rooms[roomId].destroyed) {
-        return callback(new InternalError('Cannot create the room ' + roomId + ' because it has been marked for destruction'));
-      }
+    // if the room is about to be destroyed, we have to delay its re-creation until its destruction has completed
+    if (this.rooms[roomId] && this.rooms[roomId].destroyed) {
+      return callback(new InternalError('Cannot create the room ' + roomId + ' because it has been marked for destruction'));
+    }
 
-      if (!this.rooms[roomId]) {
-        // If it's a new room, we have to calculate filters to apply on the future documents
-        this.kuzzle.dsl.register(roomId, index, collection, filters)
-          .then(response => {
-            var formattedFilters;
+    if (!this.rooms[roomId]) {
+      // If it's a new room, we have to calculate filters to apply on the future documents
+      this.kuzzle.dsl.register(roomId, index, collection, filters)
+        .then(response => {
+          var formattedFilters;
 
-            if (response && response.filter !== undefined) {
-              formattedFilters = response.filter;
-            }
+          if (response && response.filter !== undefined) {
+            formattedFilters = response.filter;
+          }
 
-            if (response) {
-              diff = response.diff;
-            }
+          if (response) {
+            diff = response.diff;
+          }
 
-            if (this.rooms[roomId]) {
-              return callback(null, roomId);
-            }
+          if (this.rooms[roomId]) {
+            return callback(null, roomId);
+          }
 
-            this.kuzzle.pluginsManager.trigger('room:new', {
-              roomId: roomId,
-              index: index,
-              collection: collection,
-              formattedFilters: formattedFilters
-            })
-              .then(modifiedData => {
-                this.rooms[modifiedData.roomId] = {
-                  id: modifiedData.roomId,
-                  customers: [],
-                  index: modifiedData.index,
-                  channels: {},
-                  collection: modifiedData.collection
-                };
-
-                callback(null, {diff, roomId});
-              });
+          this.kuzzle.pluginsManager.trigger('room:new', {
+            roomId: roomId,
+            index: index,
+            collection: collection,
+            formattedFilters: formattedFilters
           })
-          .catch(error => callback(error));
-      }
-      else {
-        callback(null, {roomId});
-      }
-    }, asyncCB));
+            .then(modifiedData => {
+              this.rooms[modifiedData.roomId] = {
+                id: modifiedData.roomId,
+                customers: [],
+                index: modifiedData.index,
+                channels: {},
+                collection: modifiedData.collection
+              };
+
+              callback(null, {diff, roomId});
+            });
+        })
+        .catch(error => callback(error));
+    }
+    else {
+      callback(null, {roomId});
+    }
+  }, asyncCB));
 }
 
 /**

--- a/lib/api/core/models/repositories/profileRepository.js
+++ b/lib/api/core/models/repositories/profileRepository.js
@@ -61,13 +61,13 @@ module.exports = function (kuzzle) {
    * @returns {Promise} Resolves to the matching Profile object if found, null if not.
    */
   ProfileRepository.prototype.loadProfiles = function (profilesIds) {
-    var promises = [];
+    var promises;
 
     if (!profilesIds) {
       return Promise.reject(new BadRequestError('Missing profilesIds'));
     }
 
-    if (!_.isArray(profilesIds)) {
+    if (!_.isArray(profilesIds) || profilesIds.reduce((prev, profile) => (prev || typeof profile !== 'string'), false)) {
       return Promise.reject(new BadRequestError('An array of strings must be provided as profilesIds'));
     }
 
@@ -75,13 +75,7 @@ module.exports = function (kuzzle) {
       return Promise.resolve([]);
     }
 
-    profilesIds.forEach(profileId => {
-      if (typeof profileId !== 'string') {
-        return Promise.reject(new BadRequestError('An array of strings must be provided as profilesIds'));
-      }
-
-      promises.push(this.load(profileId));
-    });
+    promises = profilesIds.map(profileId => this.load(profileId));
 
     return Promise.all(promises)
       .then(results => {
@@ -92,7 +86,7 @@ module.exports = function (kuzzle) {
             profiles.push(profile);
           }
         });
-        
+
         return profiles;
       });
   };

--- a/lib/api/core/models/repositories/profileRepository.js
+++ b/lib/api/core/models/repositories/profileRepository.js
@@ -1,13 +1,13 @@
-module.exports = function (kuzzle) {
-  var
-    _ = require('lodash'),
-    q = require('q'),
-    Profile = require('../security/profile'),
-    BadRequestError = require('kuzzle-common-objects').Errors.badRequestError,
-    ForbiddenError = require('kuzzle-common-objects').Errors.forbiddenError,
-    NotFoundError = require('kuzzle-common-objects').Errors.notFoundError,
-    Repository = require('./repository');
+var
+  _ = require('lodash'),
+  Promise = require('bluebird'),
+  Profile = require('../security/profile'),
+  BadRequestError = require('kuzzle-common-objects').Errors.badRequestError,
+  ForbiddenError = require('kuzzle-common-objects').Errors.forbiddenError,
+  NotFoundError = require('kuzzle-common-objects').Errors.notFoundError,
+  Repository = require('./repository');
 
+module.exports = function (kuzzle) {
   var extractRoleIds = function (policies) {
     return policies.map(policy => {
       if (typeof policy === 'string') {
@@ -37,11 +37,11 @@ module.exports = function (kuzzle) {
    */
   ProfileRepository.prototype.loadProfile = function (profileId) {
     if (!profileId) {
-      return q.reject(new BadRequestError('Missing profileId'));
+      return Promise.reject(new BadRequestError('Missing profileId'));
     }
 
     if (typeof profileId !== 'string') {
-      return q.reject(new BadRequestError('A profileId must be provided'));
+      return Promise.reject(new BadRequestError('A profileId must be provided'));
     }
 
     return this.load(profileId)
@@ -64,7 +64,7 @@ module.exports = function (kuzzle) {
     var profile = new Profile();
 
     if (!requestObject.data._id) {
-      return q.reject(new BadRequestError('Missing profile id'));
+      return Promise.reject(new BadRequestError('Missing profile id'));
     }
 
     profile._id = requestObject.data._id;
@@ -75,7 +75,7 @@ module.exports = function (kuzzle) {
       }
     });
 
-    return q(profile);
+    return Promise.resolve(profile);
   };
 
   /**
@@ -132,7 +132,7 @@ module.exports = function (kuzzle) {
 
         // Fail if not all roles are found
         if (rolesNotFound.length) {
-          return q.reject(new NotFoundError(`Unable to hydrate the profile ${data._id}. The following roles don't exist: ${rolesNotFound}`));
+          return Promise.reject(new NotFoundError(`Unable to hydrate the profile ${data._id}. The following roles don't exist: ${rolesNotFound}`));
         }
 
         return profile;
@@ -148,11 +148,11 @@ module.exports = function (kuzzle) {
     var filter;
 
     if (!profile._id) {
-      return q.reject(new BadRequestError('Missing profile id'));
+      return Promise.reject(new BadRequestError('Missing profile id'));
     }
 
     if (['admin', 'default', 'anonymous'].indexOf(profile._id) > -1) {
-      return q.reject(new BadRequestError(profile._id + ' is one of the basic profiles of Kuzzle, you cannot delete it, but you can edit it.'));
+      return Promise.reject(new BadRequestError(profile._id + ' is one of the basic profiles of Kuzzle, you cannot delete it, but you can edit it.'));
     }
 
     filter = {terms: { 'profiles': [ profile._id ] }};
@@ -160,7 +160,7 @@ module.exports = function (kuzzle) {
     return kuzzle.repositories.user.search(filter, 0, 1, false)
       .then(response => {
         if (response.total > 0) {
-          return q.reject(new ForbiddenError('The profile "' + profile._id + '" cannot be deleted since it is used by some users.'));
+          return Promise.reject(new ForbiddenError('The profile "' + profile._id + '" cannot be deleted since it is used by some users.'));
         }
 
         return this.deleteFromCache(profile._id)
@@ -194,7 +194,7 @@ module.exports = function (kuzzle) {
    **/
   ProfileRepository.prototype.validateAndSaveProfile = function (profile, context, opts) {
     if (!profile._id) {
-      return q.reject(new BadRequestError('Missing profile id'));
+      return Promise.reject(new BadRequestError('Missing profile id'));
     }
 
     return profile.validateDefinition()

--- a/lib/api/core/models/repositories/repository.js
+++ b/lib/api/core/models/repositories/repository.js
@@ -1,6 +1,6 @@
 var
   _ = require('lodash'),
-  q = require('q'),
+  Promise = require('bluebird'),
   InternalError = require('kuzzle-common-objects').Errors.internalError,
   RequestObject = require('kuzzle-common-objects').Models.requestObject;
 
@@ -68,19 +68,19 @@ Repository.prototype.loadOneFromDatabase = function (id) {
       if (response._id) {
         result = new this.ObjectConstructor();
         if (response._source) {
-          return q(_.assignIn(result, response._source, {_id: response._id}));
+          return _.assignIn(result, response._source, {_id: response._id});
         }
-        return q(_.assignIn(result, response));
+        return _.assignIn(result, response);
       }
-      return q(null);
+      return null;
     })
     .catch(error => {
       if (error.status === 404) {
         // no content found, we return null without failing
-        return q(null);
+        return Promise.resolve(null);
       }
 
-      return q.reject(error);
+      return Promise.reject(error);
     });
 };
 
@@ -96,7 +96,7 @@ Repository.prototype.loadMultiFromDatabase = function (_ids) {
     ids = [];
 
   if (!_.isArray(_ids)) {
-    return q.reject(new InternalError('Bad argument: ' + _ids.toString() + ' is not an array.'));
+    return Promise.reject(new InternalError('Bad argument: ' + _ids.toString() + ' is not an array.'));
   }
   _ids.forEach(element => {
     if (!_.isObject(element)) {
@@ -120,7 +120,7 @@ Repository.prototype.loadMultiFromDatabase = function (_ids) {
   return this.readEngine.mget(requestObject)
     .then(response => {
       if (!response.hits || response.hits.length === 0) {
-        return q([]);
+        return Promise.resolve([]);
       }
 
       promises = response.hits
@@ -131,7 +131,7 @@ Repository.prototype.loadMultiFromDatabase = function (_ids) {
           return _.assignIn(object, document._source, {_id: document._id});
         });
 
-      return q.all(promises);
+      return Promise.all(promises);
     });
 };
 
@@ -146,7 +146,6 @@ Repository.prototype.loadMultiFromDatabase = function (_ids) {
  */
 Repository.prototype.search = function (filter, from, size) {
   var
-    deferred = q.defer(),
     requestObject;
 
   requestObject = new RequestObject({
@@ -161,21 +160,19 @@ Repository.prototype.search = function (filter, from, size) {
     }
   });
 
-  this.readEngine.search(requestObject)
+  return this.readEngine.search(requestObject)
     .then(response => {
       if (!response.hits || response.hits.length === 0) {
-        return deferred.resolve({total: 0, hits: []});
+        return {total: 0, hits: []};
       }
 
-      return deferred.resolve({total: response.total, hits: response.hits.map((document) => {
-        return _.assignIn({}, document._source, {_id: document._id});
-      })});
-    })
-    .catch(function (error) {
-      deferred.reject(error);
+      return {
+        total: response.total,
+        hits: response.hits.map((document) => {
+          return _.assignIn({}, document._source, {_id: document._id});
+        })
+      };
     });
-
-  return deferred.promise;
 };
 
 /**
@@ -200,14 +197,14 @@ Repository.prototype.loadFromCache = function (id, opts) {
       var object;
 
       if (response === null) {
-        return q(null);
+        return null;
       }
 
       object = new this.ObjectConstructor();
 
-      return q(_.assignIn(object, JSON.parse(response)));
+      return _.assignIn(object, JSON.parse(response));
     })
-    .catch(err => q.reject(new InternalError(err)));
+    .catch(err => Promise.reject(new InternalError(err)));
 };
 
 /**
@@ -223,7 +220,7 @@ Repository.prototype.loadFromCache = function (id, opts) {
  * In case the key is not provided, it defauls to <collection>/id, i.e.: _kuzzle/users/12
  *
  * @param {String} id The id of the object to get
- * @param {Object} opts Optional options.
+ * @param {Object} [opts] Optional options.
  * @returns {Promise}
  */
 Repository.prototype.load = function (id, opts) {
@@ -244,16 +241,10 @@ Repository.prototype.load = function (id, opts) {
               this.persistToCache(objectFromDatabase);
             }
             return objectFromDatabase;
-          })
-          .catch(err => {
-            return q.reject(err);
           });
       }
       this.refreshCacheTTL(object);
       return object;
-    })
-    .catch(err => {
-      return q.reject(err);
     });
 };
 
@@ -299,7 +290,7 @@ Repository.prototype.delete = function (id, opts) {
     promises.push(this.deleteFromDatabase(id));
   }
 
-  return q.all(promises);
+  return Promise.all(promises);
 };
 
 

--- a/lib/api/core/models/repositories/repository.js
+++ b/lib/api/core/models/repositories/repository.js
@@ -92,7 +92,6 @@ Repository.prototype.loadOneFromDatabase = function (id) {
 Repository.prototype.loadMultiFromDatabase = function (_ids) {
   var
     requestObject,
-    promises,
     ids = [];
 
   if (!_.isArray(_ids)) {
@@ -123,15 +122,13 @@ Repository.prototype.loadMultiFromDatabase = function (_ids) {
         return Promise.resolve([]);
       }
 
-      promises = response.hits
+      return response.hits
         .filter(document => document.found)
         .map(document => {
           var object = new this.ObjectConstructor();
           
           return _.assignIn(object, document._source, {_id: document._id});
         });
-
-      return Promise.all(promises);
     });
 };
 

--- a/lib/api/core/models/repositories/roleRepository.js
+++ b/lib/api/core/models/repositories/roleRepository.js
@@ -1,12 +1,11 @@
+var
+  _ = require('lodash'),
+  Promise = require('bluebird'),
+  BadRequestError = require('kuzzle-common-objects').Errors.badRequestError,
+  Repository = require('./repository'),
+  Role = require('../security/role');
+
 module.exports = function (kuzzle) {
-  var
-    _ = require('lodash'),
-    q = require('q'),
-    BadRequestError = require('kuzzle-common-objects').Errors.badRequestError,
-    Repository = require('./repository'),
-    Role = require('../security/role');
-
-
   function RoleRepository() {
     this.roles = {};
   }
@@ -26,7 +25,6 @@ module.exports = function (kuzzle) {
    */
   RoleRepository.prototype.loadRoles = function (roleKeys) {
     var
-      deferred = q.defer(),
       keys = [],
       buffer = {},
       result = [];
@@ -44,57 +42,50 @@ module.exports = function (kuzzle) {
       Object.keys(buffer).forEach((key) => {
         result.push(buffer[key]);
       });
-      deferred.resolve(result);
+
+      return Promise.resolve(result);
     }
-    else {
-      this.loadMultiFromDatabase(keys)
-        .then(roles => {
-          var promises = [];
 
-          roles.forEach(role => {
-            buffer[role._id] = role;
-            this.roles[role._id] = role;
+    return this.loadMultiFromDatabase(keys)
+      .then(roles => {
+        var promises = [];
+
+        roles.forEach(role => {
+          buffer[role._id] = role;
+          this.roles[role._id] = role;
+        });
+
+        _.difference(roleKeys, Object.keys(buffer)).forEach((key) => {
+          var role;
+
+          if (kuzzle.config.defaultUserRoles[key] !== undefined) {
+            role = new Role();
+            promises.push(_.assignIn(role, kuzzle.config.defaultUserRoles[key]));
+          }
+        });
+
+        if (promises.length === 0) {
+          Object.keys(buffer).forEach((key) => {
+            result.push(buffer[key]);
           });
 
-          _.difference(roleKeys, Object.keys(buffer)).forEach((key) => {
-            var role;
+          return result;
+        }
 
-            if (kuzzle.config.defaultUserRoles[key] !== undefined) {
-              role = new Role();
-              promises.push(_.assignIn(role, kuzzle.config.defaultUserRoles[key]));
-            }
-          });
+        return Promise.all(promises)
+          .then(results => {
+            results.forEach(role => {
+              buffer[role._id] = role;
+              this.roles[role._id] = role;
+            });
 
-          if (promises.length === 0) {
-            Object.keys(buffer).forEach((key) => {
+            Object.keys(buffer).forEach(key => {
               result.push(buffer[key]);
             });
 
-            deferred.resolve(result);
-            return;
-          }
-
-          q.all(promises)
-            .then(results => {
-              results.forEach(role => {
-                buffer[role._id] = role;
-                this.roles[role._id] = role;
-              });
-
-              Object.keys(buffer).forEach(key => {
-                result.push(buffer[key]);
-              });
-
-              deferred.resolve(result);
-            });
-        })
-        .catch((error) => {
-          deferred.reject(error);
-        });
-    }
-
-
-    return deferred.promise;
+            return result;
+          });
+      });
   };
 
   /**
@@ -127,33 +118,26 @@ module.exports = function (kuzzle) {
    * @returns Promise
    */
   RoleRepository.prototype.loadRole = function (roleId) {
-    var deferred = q.defer();
-
     if (!roleId) {
-      deferred.reject(new BadRequestError('Missing role id'));
-      return deferred.promise;
+      return Promise.reject(new BadRequestError('Missing role id'));
     }
 
     if (typeof roleId !== 'string') {
-      deferred.reject(new BadRequestError('A role ID must be provided'));
-      return deferred.promise;
+      return Promise.reject(new BadRequestError('A role ID must be provided'));
     }
 
     if (this.roles[roleId]) {
-      deferred.resolve(this.roles[roleId]);
-    }
-    else {
-      return this.loadOneFromDatabase(roleId)
-        .then(loadedRole => {
-          if (loadedRole) {
-            this.roles[loadedRole._id] = loadedRole;
-          }
-
-          return loadedRole;
-        });
+      return Promise.resolve(this.roles[roleId]);
     }
 
-    return deferred.promise;
+    return this.loadOneFromDatabase(roleId)
+      .then(loadedRole => {
+        if (loadedRole) {
+          this.roles[loadedRole._id] = loadedRole;
+        }
+
+        return loadedRole;
+      });
   };
 
   /**
@@ -193,7 +177,7 @@ module.exports = function (kuzzle) {
    */
   RoleRepository.prototype.validateAndSaveRole = function (role, context, opts) {
     if (!role._id) {
-      return q.reject(new BadRequestError('Missing role id'));
+      return Promise.reject(new BadRequestError('Missing role id'));
     }
 
     return role.validateDefinition(context)
@@ -211,17 +195,17 @@ module.exports = function (kuzzle) {
    */
   RoleRepository.prototype.deleteRole = function (role) {
     if (!role._id) {
-      return q.reject(new BadRequestError('Missing role id'));
+      return Promise.reject(new BadRequestError('Missing role id'));
     }
 
     if (['admin', 'default', 'anonymous'].indexOf(role._id) > -1) {
-      return q.reject(new BadRequestError(role._id + ' is one of the basic roles of Kuzzle, you cannot delete it, but you can edit it.'));
+      return Promise.reject(new BadRequestError(role._id + ' is one of the basic roles of Kuzzle, you cannot delete it, but you can edit it.'));
     }
 
     return kuzzle.repositories.profile.searchProfiles([ role._id ], 0, 1)
       .then(response => {
         if (response.total > 0) {
-          return q.reject(new BadRequestError('The role "' + role._id + '" cannot be deleted since it is used by some profile.'));
+          return Promise.reject(new BadRequestError('The role "' + role._id + '" cannot be deleted since it is used by some profile.'));
         }
 
         return this.deleteFromDatabase(role._id)

--- a/lib/api/core/models/repositories/tokenRepository.js
+++ b/lib/api/core/models/repositories/tokenRepository.js
@@ -158,6 +158,10 @@ module.exports = function (kuzzle) {
         return userToken;
       })
       .catch(err => {
+        if (err instanceof UnauthorizedError) {
+          return Promise.reject(err);
+        }
+
         error = new InternalError('Unknown user');
         error.details = err;
 

--- a/lib/api/core/models/repositories/tokenRepository.js
+++ b/lib/api/core/models/repositories/tokenRepository.js
@@ -1,14 +1,14 @@
-module.exports = function (kuzzle) {
-  var
-    _ = require('lodash'),
-    jwt = require('jsonwebtoken'),
-    ms = require('ms'),
-    q = require('q'),
-    Token = require('../security/token'),
-    Repository = require('./repository'),
-    InternalError = require('kuzzle-common-objects').Errors.internalError,
-    UnauthorizedError = require('kuzzle-common-objects').Errors.unauthorizedError;
+var
+  _ = require('lodash'),
+  jwt = require('jsonwebtoken'),
+  ms = require('ms'),
+  Promise = require('bluebird'),
+  Token = require('../security/token'),
+  Repository = require('./repository'),
+  InternalError = require('kuzzle-common-objects').Errors.internalError,
+  UnauthorizedError = require('kuzzle-common-objects').Errors.unauthorizedError;
 
+module.exports = function (kuzzle) {
   function parseTimespan(time) {
     var milliseconds;
 
@@ -46,23 +46,16 @@ module.exports = function (kuzzle) {
 
   TokenRepository.prototype.expire = function(token) {
     var
-      error,
-      deferred = q.defer();
+      error;
 
-    Repository.prototype.expireFromCache.call(this, token)
-      .then(() => {
-        kuzzle.tokenManager.expire(token);
-
-        deferred.resolve();
-      })
+    return Repository.prototype.expireFromCache.call(this, token)
+      .then(() => kuzzle.tokenManager.expire(token))
       .catch(err => {
         error = new InternalError('Error expiring token');
         error.details = err;
 
-        deferred.reject(error);
+        return Promise.reject(error);
       });
-
-    return deferred.promise;
   };
 
   TokenRepository.prototype.generateToken = function (user, context, opts) {
@@ -75,12 +68,12 @@ module.exports = function (kuzzle) {
 
     if (!user || user._id === null) {
       error = new InternalError('Unknown User : cannot generate token');
-      return q.reject(error);
+      return Promise.reject(error);
     }
 
     if (!context || context.connection === null) {
       error = new InternalError('Unknown context connection : cannot generate token');
-      return q.reject(error);
+      return Promise.reject(error);
     }
 
     if (!options.algorithm) {
@@ -111,21 +104,20 @@ module.exports = function (kuzzle) {
           error = new InternalError('Unable to generate token for unknown user');
           error.details = err.message;
           error.stack = err.stack;
-          return q.reject(error);
+          return Promise.reject(error);
         });
     }
     catch (err) {
       error = new InternalError('Error while generating token');
       error.details = err.message;
       error.stack = err.stack;
-      return q.reject(error);
+      return Promise.reject(error);
     }
   };
 
   TokenRepository.prototype.verifyToken = function (token) {
     var
-      error,
-      deferred;
+      error;
 
     if (token === null) {
       return this.anonymous();
@@ -154,32 +146,28 @@ module.exports = function (kuzzle) {
         error.details = err;
       }
 
-      return q.reject(error);
+      return Promise.reject(error);
     }
 
-    deferred = q.defer();
-
-    this.load(token)
+    return this.load(token)
       .then(userToken => {
         if (userToken === null) {
-          return deferred.reject(new UnauthorizedError('Invalid token', 401));
+          return Promise.reject(new UnauthorizedError('Invalid token', 401));
         }
 
-        return deferred.resolve(userToken);
+        return userToken;
       })
       .catch(err => {
         error = new InternalError('Unknown user');
         error.details = err;
 
-        return deferred.reject(error);
+        return Promise.reject(error);
       });
-
-    return deferred.promise;
   };
 
   TokenRepository.prototype.hydrate = function (userToken, data) {
     if (!_.isObject(data)) {
-      return q(userToken);
+      return Promise.resolve(userToken);
     }
 
     _.assignIn(userToken, data);
@@ -188,7 +176,7 @@ module.exports = function (kuzzle) {
       return this.anonymous();
     }
 
-    return q(userToken);
+    return Promise.resolve(userToken);
   };
 
   TokenRepository.prototype.anonymous = function () {
@@ -198,7 +186,7 @@ module.exports = function (kuzzle) {
     token._id = undefined;
     token.userId = -1;
 
-    return q(token);
+    return Promise.resolve(token);
   };
 
   TokenRepository.prototype.serializeToDatabase = TokenRepository.prototype.serializeToCache;

--- a/lib/api/core/models/repositories/userRepository.js
+++ b/lib/api/core/models/repositories/userRepository.js
@@ -1,13 +1,12 @@
+var
+  _ = require('lodash'),
+  Promise = require('bluebird'),
+  uuid = require('node-uuid'),
+  User = require('../security/user'),
+  Repository = require('./repository'),
+  InternalError = require('kuzzle-common-objects').Errors.internalError;
+
 module.exports = function (kuzzle) {
-  var
-    _ = require('lodash'),
-    q = require('q'),
-    uuid = require('node-uuid'),
-    User = require('../security/user'),
-    Repository = require('./repository'),
-    InternalError = require('kuzzle-common-objects').Errors.internalError;
-
-
   function UserRepository (opts) {
     var options = opts || {};
 
@@ -49,7 +48,7 @@ module.exports = function (kuzzle) {
 
     return this.persistToDatabase(user, databaseOptions)
       .then(() => this.persistToCache(user, cacheOptions))
-      .then(() => q(user));
+      .then(() => user);
   };
 
 
@@ -57,7 +56,7 @@ module.exports = function (kuzzle) {
     var
       user = new User();
 
-    return q(_.assignIn(user, {
+    return Promise.resolve(_.assignIn(user, {
       _id: -1,
       name: 'Anonymous',
       profileId: 'anonymous'
@@ -68,7 +67,7 @@ module.exports = function (kuzzle) {
     var source;
 
     if (!_.isObject(data)) {
-      return q(user);
+      return Promise.resolve(user);
     }
 
     if (data._source) {
@@ -92,7 +91,7 @@ module.exports = function (kuzzle) {
     return kuzzle.repositories.profile.loadProfile(user.profileId)
       .then(profile => {
         if (!profile) {
-          return q.reject(new InternalError('Could not find profile: ' + user.profileId));
+          return Promise.reject(new InternalError('Could not find profile: ' + user.profileId));
         }
 
         return user;

--- a/lib/api/core/models/security/profile.js
+++ b/lib/api/core/models/security/profile.js
@@ -61,7 +61,7 @@ Profile.prototype.validateDefinition = function () {
     return Promise.reject(new BadRequestError('The roles member must be an array'));
   }
 
-  if (_.isEmpty(this.policies)) {
+  if (this.policies.length === 0) {
     return Promise.reject(new BadRequestError('The roles member array cannot be empty'));
   }
 

--- a/lib/api/core/models/security/profile.js
+++ b/lib/api/core/models/security/profile.js
@@ -1,7 +1,7 @@
 var
   BadRequestError = require('kuzzle-common-objects').Errors.badRequestError,
   Role = require('./role'),
-  q = require('q'),
+  Promise = require('bluebird'),
   _ = require('lodash'),
   md5 = require('crypto-md5'),
   async = require('async');
@@ -25,10 +25,7 @@ Profile.prototype.getRoles = function (kuzzle) {
       .then(loadedRole => _.assignIn(new Role(), loadedRole, role));
   });
 
-  return q.all(promises)
-    .then(roles => {
-      return roles;
-    });
+  return Promise.all(promises);
 };
 
 /**
@@ -39,29 +36,19 @@ Profile.prototype.getRoles = function (kuzzle) {
  * @return Promise
  */
 Profile.prototype.isActionAllowed = function (requestObject, context, kuzzle) {
-  var deferred;
   if (this.policies === undefined || this.policies.length === 0) {
-    return q(false);
+    return Promise.resolve(false);
   }
 
-  deferred = q.defer();
-
-  this.getRoles(kuzzle)
+  return this.getRoles(kuzzle)
     .then(roles => {
-      async.some(roles, (role, callback) => {
-        role.isActionAllowed(requestObject, context, kuzzle)
-          .then(isAllowed => {
-            callback(isAllowed);
-          });
-      }, result => {
-        deferred.resolve(result);
+      return new Promise(resolve => {
+        async.some(roles, (role, callback) => {
+          role.isActionAllowed(requestObject, context, kuzzle)
+            .then(isAllowed => callback(isAllowed));
+        }, result => resolve(result));
       });
-    })
-    .catch(error => {
-      deferred.reject(error);
     });
-
-  return deferred.promise;
 };
 
 /**
@@ -71,14 +58,14 @@ Profile.prototype.isActionAllowed = function (requestObject, context, kuzzle) {
  */
 Profile.prototype.validateDefinition = function () {
   if (!_.isArray(this.policies)) {
-    return q.reject(new BadRequestError('The roles member must be an array'));
+    return Promise.reject(new BadRequestError('The roles member must be an array'));
   }
 
   if (_.isEmpty(this.policies)) {
-    return q.reject(new BadRequestError('The roles member array cannot be empty'));
+    return Promise.reject(new BadRequestError('The roles member array cannot be empty'));
   }
 
-  return q(true);
+  return Promise.resolve(true);
 };
 
 /**

--- a/lib/api/core/models/security/role.js
+++ b/lib/api/core/models/security/role.js
@@ -178,11 +178,11 @@ Role.prototype.validateDefinition = function (context) {
               },
               code: '(function (requestObject, context, $currentUserId, args) { ' + actionRights.test + '\nreturn false;\n})(requestObject, context, $currentUserId, args)'
             })
-              .then(result => {
+              .then(response => {
                 var error;
 
-                if (result.result !== undefined && _.isBoolean(result.result)) {
-                  return result.result;
+                if (response.result !== undefined && _.isBoolean(response.result)) {
+                  return response.result;
                 }
 
                 error = new BadRequestError('Invalid definition for ' + [controllerKey, actionKey] + '. Error executing function');
@@ -201,13 +201,8 @@ Role.prototype.validateDefinition = function (context) {
       resolve(promises);
     }
   })
-  .then(promises => {
-    if (promises.length > 0) {
-      return Promise.all(promises);
-    }
-
-    return true;
-  });
+  .then(promises => Promise.all(promises))
+  .then(() => true);
 };
 
 module.exports = Role;

--- a/lib/api/core/models/security/role.js
+++ b/lib/api/core/models/security/role.js
@@ -17,6 +17,9 @@ function Role () {
   this.controllers = {};
   this.closures = {};
   this.allowInternalIndex = false;
+
+  // Injected by Profile.getRoles, contains a profile's policies
+  this.restrictedTo = [];
 }
 
 function doesIndexExist(index, indexes) {
@@ -109,7 +112,7 @@ Role.prototype.validateDefinition = function (context) {
   if (!_.isObject(this.controllers)) {
     return Promise.reject(new BadRequestError('The "controllers" definition must be an object'));
   }
-  if (_.isEmpty(this.controllers)) {
+  if (Object.keys(this.controllers).length === 0) {
     return Promise.reject(new BadRequestError('The "controllers" definition cannot be empty'));
   }
 
@@ -125,7 +128,7 @@ Role.prototype.validateDefinition = function (context) {
         reject(new BadRequestError('Invalid definition for ' + [controllerKey] + '. Must be an object'));
         return false;
       }
-      if (_.isEmpty(controllerRights)) {
+      if (Object.keys(controllerRights).length === 0) {
         reject(new BadRequestError('Invalid definition for ' + [controllerKey] + '. Cannot be empty'));
         return false;
       }
@@ -137,7 +140,7 @@ Role.prototype.validateDefinition = function (context) {
         reject(new BadRequestError('Invalid definition for ' + [controllerKey] + '. `actions` attribute must be an object'));
         return false;
       }
-      if (_.isEmpty(controllerRights.actions)) {
+      if (Object.keys(controllerRights.actions).length === 0) {
         reject(new BadRequestError('Invalid definition for ' + [controllerKey] + '. `actions` attribute cannot be empty'));
         return false;
       }
@@ -238,7 +241,7 @@ function canCreateCollection(index, collection, context, kuzzle) {
  */
 function checkRestrictions(requestObject) {
   // If no restrictions, we allow the action:
-  if (_.isEmpty(this.restrictedTo)) {
+  if (this.restrictedTo.length === 0) {
     return Promise.resolve(true);
   }
 
@@ -267,11 +270,11 @@ function checkIndexRestriction(requestObject, restriction) {
   }
 
   // if no collections given on the restriction, the action is allowed for all collections:
-  if (_.isEmpty(restriction.collections)) {
+  if (!restriction.collections || restriction.collections.length === 0) {
     return true;
   }
 
-  // If the request's action does not refer to a collcetion, the restriction is useless for this action (=> ignored):
+  // If the request's action does not refer to a collection, the restriction is useless for this action (=> ignored):
   if (!requestObject.collection || requestObject.collection === null || requestObject.collection === undefined) {
     return true;
   }
@@ -296,9 +299,9 @@ function executeClosure (kuzzle, path, actionRights, requestObject, context) {
     argsDefinitions = {},
     message;
 
-  if (! _.isString(actionRights.test)) {
-    error = new ParseError('Error parsing rights for role ' + this._id + ' (' + path.join('/') + ') :' + actionRights);
-    error.details = 'Missing or malformed "test" attribute (string requised)';
+  if (typeof actionRights.test !== 'string') {
+    error = new ParseError(`Error parsing rights for role ${this._id} (${path.join('/')}) : ${actionRights}`);
+    error.details = 'Missing or malformed "test" attribute (string required)';
     return Promise.reject(error);
   }
 
@@ -306,7 +309,7 @@ function executeClosure (kuzzle, path, actionRights, requestObject, context) {
     this.closures[path] = {};
   }
 
-  if (actionRights.args && !_.isEmpty(actionRights.args) && !this.closures[path].getArgsDefinitions) {
+  if (actionRights.args && Object.keys(actionRights.args).length > 0 && !this.closures[path].getArgsDefinitions) {
     try {
       /* jshint evil: true */
       /* eslint-disable no-eval */
@@ -389,11 +392,11 @@ function executeClosure (kuzzle, path, actionRights, requestObject, context) {
 
 /**
  * @this {Role}
- * @param argsDefinitions
+ * @param {Object} argsDefinitions
  * @returns {Promise}
  */
 function buildArgsForContext (argsDefinitions) {
-  if (!_.isEmpty(argsDefinitions)) {
+  if (Object.keys(argsDefinitions).length > 0) {
     return buildClosureArgs.call(this, argsDefinitions);
   }
 
@@ -437,7 +440,7 @@ function buildClosureArgs (argsDefinitions) {
 function factoryFunctionClosure (argName, argDefinition) {
   var methodName;
 
-  if (!argDefinition.collection || !argDefinition.index || !argDefinition.action || _.isEmpty(argDefinition.action)) {
+  if (!argDefinition.collection || !argDefinition.index || !argDefinition.action || Object.keys(argDefinition.action).length === 0) {
     this.pluginsManager.trigger('log:error', `Bad format in closure rights for ${argName}`);
     return callback => callback(null, {});
   }

--- a/lib/api/core/models/security/role.js
+++ b/lib/api/core/models/security/role.js
@@ -1,6 +1,6 @@
 var
   _ = require('lodash'),
-  q = require('q'),
+  Promise = require('bluebird'),
   async = require('async'),
   vm = require('vm'),
   BadRequestError = require('kuzzle-common-objects').Errors.badRequestError,
@@ -43,11 +43,11 @@ Role.prototype.isActionAllowed = function (requestObject, context, kuzzle) {
 
   // explicit actions on internalIndex must be denied if no explicit restriction on internalIndex is set:
   if (requestObject.index === internalIndex && !this.allowInternalIndex) {
-    return q(false);
+    return Promise.resolve(false);
   }
 
   if (this.controllers === undefined) {
-    return q(false);
+    return Promise.resolve(false);
   }
 
   if (this.controllers[requestObject.controller] !== undefined) {
@@ -59,11 +59,11 @@ Role.prototype.isActionAllowed = function (requestObject, context, kuzzle) {
     path.push('*');
   }
   else {
-    return q(false);
+    return Promise.resolve(false);
   }
 
   if (controllerRights.actions === undefined) {
-    return q(false);
+    return Promise.resolve(false);
   }
 
   if (controllerRights.actions[requestObject.action] !== undefined) {
@@ -75,7 +75,7 @@ Role.prototype.isActionAllowed = function (requestObject, context, kuzzle) {
     path.push('*');
   }
   else {
-    return q(false);
+    return Promise.resolve(false);
   }
 
   if (requestObject.action === 'createCollection' &&
@@ -89,19 +89,16 @@ Role.prototype.isActionAllowed = function (requestObject, context, kuzzle) {
   }
 
   if (_.isBoolean(actionRights)) {
-    promises.push(q(actionRights));
+    promises.push(Promise.resolve(actionRights));
   } else if (_.isObject(actionRights)) {
     promises.push(executeClosure.call(this, kuzzle, path, actionRights, requestObject, context));
   } else {
-    return q.reject(new InternalError('Invalid rights given for role ' + this._id + '(' + path.join('/') + ') : ' + actionRights));
+    return Promise.reject(new InternalError('Invalid rights given for role ' + this._id + '(' + path.join('/') + ') : ' + actionRights));
   }
 
   promises.push(checkRestrictions.call(this, requestObject));
 
-  return q.all(promises)
-    .then(results => {
-      return q(_.every(results));
-    });
+  return Promise.all(promises).then(results => _.every(results));
 };
 
 /**
@@ -109,113 +106,108 @@ Role.prototype.isActionAllowed = function (requestObject, context, kuzzle) {
  * @returns {Promise}
  */
 Role.prototype.validateDefinition = function (context) {
-  var
-    deferred = q.defer(),
-    promises = [];
-
   if (!_.isObject(this.controllers)) {
-    return q.reject(new BadRequestError('The "controllers" definition must be an object'));
+    return Promise.reject(new BadRequestError('The "controllers" definition must be an object'));
   }
   if (_.isEmpty(this.controllers)) {
-    return q.reject(new BadRequestError('The "controllers" definition cannot be empty'));
+    return Promise.reject(new BadRequestError('The "controllers" definition cannot be empty'));
   }
 
-  Object.keys(this.controllers).every(controllerKey => {
-    var controllerRights = this.controllers[controllerKey];
+  return new Promise((resolve, reject) => {
+    var
+      result,
+      promises = [];
 
-    if (!_.isObject(controllerRights)) {
-      deferred.reject(new BadRequestError('Invalid definition for ' + [controllerKey] + '. Must be an object'));
-      return false;
-    }
-    if (_.isEmpty(controllerRights)) {
-      deferred.reject(new BadRequestError('Invalid definition for ' + [controllerKey] + '. Cannot be empty'));
-      return false;
-    }
-    if (controllerRights.actions === undefined) {
-      deferred.reject(new BadRequestError('Invalid definition for ' + [controllerKey] + '. `actions` attribute missing'));
-      return false;
-    }
-    if (!_.isObject(controllerRights.actions)) {
-      deferred.reject(new BadRequestError('Invalid definition for ' + [controllerKey] + '. `actions` attribute must be an object'));
-      return false;
-    }
-    if (_.isEmpty(controllerRights.actions)) {
-      deferred.reject(new BadRequestError('Invalid definition for ' + [controllerKey] + '. `actions` attribute cannot be empty'));
-      return false;
-    }
+    result = Object.keys(this.controllers).every(controllerKey => {
+      var controllerRights = this.controllers[controllerKey];
 
-    Object.keys(controllerRights.actions).every(actionKey => {
-      var actionRights = controllerRights.actions[actionKey];
-
-      if (!_.isBoolean(actionRights) && !_.isObject(actionRights)) {
-        deferred.reject(new BadRequestError('Invalid definition for ' + [controllerKey, actionKey] + '. Must be a boolean or an object'));
+      if (!_.isObject(controllerRights)) {
+        reject(new BadRequestError('Invalid definition for ' + [controllerKey] + '. Must be an object'));
+        return false;
+      }
+      if (_.isEmpty(controllerRights)) {
+        reject(new BadRequestError('Invalid definition for ' + [controllerKey] + '. Cannot be empty'));
+        return false;
+      }
+      if (controllerRights.actions === undefined) {
+        reject(new BadRequestError('Invalid definition for ' + [controllerKey] + '. `actions` attribute missing'));
+        return false;
+      }
+      if (!_.isObject(controllerRights.actions)) {
+        reject(new BadRequestError('Invalid definition for ' + [controllerKey] + '. `actions` attribute must be an object'));
+        return false;
+      }
+      if (_.isEmpty(controllerRights.actions)) {
+        reject(new BadRequestError('Invalid definition for ' + [controllerKey] + '. `actions` attribute cannot be empty'));
         return false;
       }
 
-      if (_.isObject(actionRights) && actionRights.test) {
+      return Object.keys(controllerRights.actions).every(actionKey => {
+        var actionRights = controllerRights.actions[actionKey];
 
-        promises.push((function () {
-          var
-            sandBox = new Sandbox();
+        if (!_.isBoolean(actionRights) && !_.isObject(actionRights)) {
+          reject(new BadRequestError('Invalid definition for ' + [controllerKey, actionKey] + '. Must be a boolean or an object'));
+          return false;
+        }
 
-          return sandBox.run({
-            sandbox: {
-              requestObject: {
-                index: 'index',
-                collection: 'collection',
-                controller: 'controller',
-                action: 'action',
-                data: {
-                  _id: -1,
-                  body: {
-                    a: true
+        if (_.isObject(actionRights) && actionRights.test) {
+          promises.push((function () {
+            var
+              sandBox = new Sandbox();
+
+            return sandBox.run({
+              sandbox: {
+                requestObject: {
+                  index: 'index',
+                  collection: 'collection',
+                  controller: 'controller',
+                  action: 'action',
+                  data: {
+                    _id: -1,
+                    body: {
+                      a: true
+                    }
                   }
+                },
+                context: {
+                  connection: {type: context.connection.type},
+                  token: context.token
+                },
+                $currentUserId: -1,
+                args: {}
+              },
+              code: '(function (requestObject, context, $currentUserId, args) { ' + actionRights.test + '\nreturn false;\n})(requestObject, context, $currentUserId, args)'
+            })
+              .then(result => {
+                var error;
+
+                if (result.result !== undefined && _.isBoolean(result.result)) {
+                  return result.result;
                 }
-              },
-              context: {
-                connection: {type: context.connection.type},
-                token: context.token
-              },
-              $currentUserId: -1,
-              args: {}
-            },
-            code: '(function (requestObject, context, $currentUserId, args) { ' + actionRights.test + '\nreturn false;\n})(requestObject, context, $currentUserId, args)'
-          })
-          .then(result => {
-            var error;
 
-            if (result.result !== undefined && _.isBoolean(result.result)) {
-              return q(result.result);
-            }
+                error = new BadRequestError('Invalid definition for ' + [controllerKey, actionKey] + '. Error executing function');
+                error.detail = result.err;
 
-            error = new BadRequestError('Invalid definition for '+ [controllerKey, actionKey] + '. Error executing function');
-            error.detail = result.err;
+                return Promise.reject(error);
+              });
+          })());
+        }
 
-            return q.reject(error);
-          });
-        })());
-      }
-
-      return true;
+        return true;
+      });
     });
+
+    if (result === true) {
+      resolve(promises);
+    }
+  })
+  .then(promises => {
+    if (promises.length > 0) {
+      return Promise.all(promises);
+    }
 
     return true;
   });
-
-  if (promises.length > 0) {
-    q.all(promises)
-      .then(() => {
-        deferred.resolve(true);
-      })
-      .catch(error => {
-        deferred.reject(error);
-      });
-  }
-  else {
-    deferred.resolve(true);
-  }
-
-  return deferred.promise;
 };
 
 module.exports = Role;
@@ -250,24 +242,23 @@ function canCreateCollection(index, collection, context, kuzzle) {
  * @returns {Promise|Promise} resolves to a Boolean value
  */
 function checkRestrictions(requestObject) {
-  var deferred = q.defer();
   // If no restrictions, we allow the action:
   if (_.isEmpty(this.restrictedTo)) {
-    return q(true);
+    return Promise.resolve(true);
   }
 
   // If the request's action does not refer to an index, restrictions are useless for this action (=> ignore them):
   if (!requestObject.index || requestObject.index === null || requestObject.index === undefined) {
-    return q(true);
+    return Promise.resolve(true);
   }
 
-  async.some(this.restrictedTo, (restriction, callback) => {
-    callback(checkIndexRestriction(requestObject, restriction));
-  }, result => {
-    deferred.resolve(result);
+  return new Promise(resolve => {
+    async.some(this.restrictedTo, (restriction, callback) => {
+      callback(checkIndexRestriction(requestObject, restriction));
+    }, result => {
+      resolve(result);
+    });
   });
-
-  return deferred.promise;
 }
 
 /**
@@ -313,7 +304,7 @@ function executeClosure (kuzzle, path, actionRights, requestObject, context) {
   if (! _.isString(actionRights.test)) {
     error = new ParseError('Error parsing rights for role ' + this._id + ' (' + path.join('/') + ') :' + actionRights);
     error.details = 'Missing or malformed "test" attribute (string requised)';
-    return q.reject(error);
+    return Promise.reject(error);
   }
 
   if (this.closures[path] === undefined) {
@@ -337,7 +328,7 @@ function executeClosure (kuzzle, path, actionRights, requestObject, context) {
       error = new ParseError('Error parsing rights for role ' + this._id + ' (' + path.join('/') + ') :' + actionRights);
       error.details = err;
 
-      return q.reject(error);
+      return Promise.reject(error);
     }
   }
 
@@ -371,7 +362,7 @@ function executeClosure (kuzzle, path, actionRights, requestObject, context) {
           error = new ParseError(message);
           error.details = err;
 
-          return q.reject(error);
+          return Promise.reject(error);
         }
       }
 
@@ -385,9 +376,10 @@ function executeClosure (kuzzle, path, actionRights, requestObject, context) {
         error = new ParseError(message);
         error.details = `Closure result is not a boolean value: ${result}`;
 
-        return q.reject(error);
+        return Promise.reject(error);
       }
-      return q(result);
+
+      return result;
     })
     .catch((err) => {
       message = `Error during executing rights action closure (${path.join('/')}): ${err.message}`;
@@ -396,7 +388,7 @@ function executeClosure (kuzzle, path, actionRights, requestObject, context) {
       error = new ParseError(message);
       error.details = err;
 
-      return q.reject(error);
+      return Promise.reject(error);
     });
 }
 
@@ -410,7 +402,7 @@ function buildArgsForContext (argsDefinitions) {
     return buildClosureArgs.call(this, argsDefinitions);
   }
 
-  return q({});
+  return Promise.resolve({});
 }
 
 /**
@@ -420,7 +412,6 @@ function buildArgsForContext (argsDefinitions) {
  */
 function buildClosureArgs (argsDefinitions) {
   var
-    deferred = q.defer(),
     argsFunctions = {};
 
   // Build the object that will be passed to parallel
@@ -428,16 +419,16 @@ function buildClosureArgs (argsDefinitions) {
     argsFunctions[argName] = factoryFunctionClosure.call(this, argName, argDefinition);
   });
 
-  async.parallel(argsFunctions, (error, results) => {
-    if (error) {
-      // In case we have an error we want to return an empty object because the error can come from readEngine
-      return deferred.resolve({});
-    }
+  return new Promise(resolve => {
+    async.parallel(argsFunctions, (error, results) => {
+      if (error) {
+        // In case we have an error we want to return an empty object because the error can come from readEngine
+        return resolve({});
+      }
 
-    deferred.resolve(results);
+      resolve(results);
+    });
   });
-
-  return deferred.promise;
 }
 
 /**

--- a/lib/api/core/models/security/user.js
+++ b/lib/api/core/models/security/user.js
@@ -60,7 +60,7 @@ User.prototype.isActionAllowed = function (requestObject, context, kuzzle) {
             return reject(error);
           }
 
-          resolve(result)
+          resolve(result);
         });
       })
       .catch(error => reject(error));

--- a/lib/api/core/notifier.js
+++ b/lib/api/core/notifier.js
@@ -35,9 +35,7 @@ function NotifierController (kuzzle) {
       rooms = [rooms];
     }
 
-    async.each(rooms, function (roomName) {
-      send.call(kuzzle, roomName, requestObject, content, connectionId);
-    });
+    rooms.forEach(roomName => send.call(kuzzle, roomName, requestObject, content, connectionId));
   };
 
   /**
@@ -224,8 +222,7 @@ function NotifierController (kuzzle) {
           kuzzle.notifier.notify(cachedRooms, requestObject, notification);
           return kuzzle.services.list.notificationCache.remove(id);
         })
-        .then(() => callback())
-        .catch((error) => callback(error));
+        .asCallback(callback);
     }, (error) => {
       if (error) {
         kuzzle.pluginsManager.trigger('log:error', error);

--- a/lib/api/core/notifier.js
+++ b/lib/api/core/notifier.js
@@ -23,7 +23,7 @@ function NotifierController (kuzzle) {
    * @param {string|Array} rooms - list of rooms to notify
    * @param {RequestObject} requestObject - the source request causing the notification
    * @param {Object} content - the content of the notification (see NotificationObject constructor)
-   * @param {string} connectionId
+   * @param {string} [connectionId]
    * @returns {boolean}
    */
   this.notify = function (rooms, requestObject, content, connectionId) {
@@ -48,7 +48,7 @@ function NotifierController (kuzzle) {
       .then(rooms => {
         var notificationContent = {_source: requestObject.data.body, _id: requestObject.data._id};
 
-        if (!_.isEmpty(rooms)) {
+        if (rooms.length > 0) {
           if (requestObject.controller === 'write') {
             notificationContent.state = 'pending';
 

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -1,6 +1,6 @@
 var
   _ = require('lodash'),
-  q = require('q'),
+  Promise = require('bluebird'),
   PluginImplementationError = require('kuzzle-common-objects').Errors.pluginImplementationError;
 
 function PluginContext (kuzzle) {
@@ -83,11 +83,11 @@ function createUser(userRepository, name, profile, userInfo) {
   }
 
   if (!name || typeof name !== 'string') {
-    return q.reject(new PluginImplementationError('User creation error: "name" argument invalid or missing'));
+    return Promise.reject(new PluginImplementationError('User creation error: "name" argument invalid or missing'));
   }
 
   if (typeof userInfo !== 'object' || Array.isArray(userInfo)) {
-    return q.reject(new PluginImplementationError('User creation error: invalid "info" argument (expected an object)'));
+    return Promise.reject(new PluginImplementationError('User creation error: invalid "info" argument (expected an object)'));
   }
 
   userInfo._id = name;

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -4,7 +4,7 @@ var
   PrivilegedPluginContext = require('./privilegedPluginContext'),
   async = require('async'),
   path = require('path'),
-  q = require('q'),
+  Promise = require('bluebird'),
   _ = require('lodash'),
   CircularList = require('easy-circular-list'),
   pm2 = require('pm2'),
@@ -45,7 +45,7 @@ function PluginsManager (kuzzle) {
     this.isServer = isServer;
 
     if (this.isDummy) {
-      return q();
+      return Promise.resolve();
     }
 
     return getPluginsList(kuzzle, this.isServer)
@@ -60,15 +60,11 @@ function PluginsManager (kuzzle) {
    */
   this.run = function () {
     var
-      pluginsWorker,
-      deferred = q.defer(),
-      context = new PluginContext(kuzzle),
-      privilegedContext = new PrivilegedPluginContext(kuzzle);
+      pluginsWorker;
 
     if (this.isDummy) {
-      return q({});
+      return Promise.resolve({});
     }
-
 
     if (this.isServer) {
       pluginsWorker = _.pickBy(this.plugins, plugin => plugin.config.threads !== undefined);
@@ -78,60 +74,57 @@ function PluginsManager (kuzzle) {
       }
     }
 
-    async.forEachOf(this.plugins, (plugin, pluginName, callback) => {
-      var
-        pipeWarnTime = this.config.pipeWarnTime,
-        pipeTimeout = this.config.pipeTimeout;
+    return new Promise((resolve, reject) => {
+      async.forEachOf(this.plugins, (plugin, pluginName, callback) => {
+        var
+          pipeWarnTime = this.config.pipeWarnTime,
+          pipeTimeout = this.config.pipeTimeout;
 
-      if (!plugin.activated) {
-        console.log('Plugin', pluginName, 'deactivated. Skipping...');
-        callback();
-        return true;
-      }
-
-      if (plugin.config.threads) {
-        if (this.isServer) {
-          initWorkers(plugin, pluginName)
-            .then(() => {
-              callback();
-            });
+        if (!plugin.activated) {
+          console.log('Plugin', pluginName, 'deactivated. Skipping...');
+          callback();
+          return true;
         }
 
-        return true;
-      }
+        if (plugin.config.threads) {
+          if (this.isServer) {
+            initWorkers(plugin, pluginName).then(() => callback());
+          }
 
-      plugin.object.init(
-        plugin.config,
-        plugin.config.privileged ? privilegedContext : context,
-        this.isDummy
-      );
+          return true;
+        }
 
-      if (plugin.object.hooks) {
-        initHooks(plugin, kuzzle);
-      }
+        plugin.object.init(
+          plugin.config,
+          plugin.config.privileged ? new PrivilegedPluginContext(kuzzle) : new PluginContext(kuzzle),
+          this.isDummy
+        );
 
-      if (plugin.object.pipes) {
-        initPipes.call(this, this.pipes, plugin, pipeWarnTime, pipeTimeout);
-      }
+        if (plugin.object.hooks) {
+          initHooks(plugin, kuzzle);
+        }
 
-      if (plugin.object.controllers) {
-        initControllers(this.controllers, this.routes, plugin, pluginName);
-      }
+        if (plugin.object.pipes) {
+          initPipes.call(this, this.pipes, plugin, pipeWarnTime, pipeTimeout);
+        }
 
-      if (plugin.object.scope) {
-        injectScope(plugin.object.scope, kuzzle.passport);
-      }
+        if (plugin.object.controllers) {
+          initControllers(this.controllers, this.routes, plugin, pluginName);
+        }
 
-      console.log('Plugin', pluginName, 'started');
-      callback();
-    }, (err) => {
-      if (err) {
-        return deferred.reject(err);
-      }
-      return deferred.resolve({});
+        if (plugin.object.scope) {
+          injectScope(plugin.object.scope, kuzzle.passport);
+        }
+
+        console.log('Plugin', pluginName, 'started');
+        callback();
+      }, (err) => {
+        if (err) {
+          return reject(err);
+        }
+        resolve({});
+      });
     });
-
-    return deferred.promise;
   };
 
   /**
@@ -142,43 +135,27 @@ function PluginsManager (kuzzle) {
    * @returns {Promise}
    */
   this.trigger = function (event, data) {
-    var deferred;
-
     if (this.isDummy) {
       this.kuzzle.emit(event, data);
-      return q(data);
+      return Promise.resolve(data);
     }
 
-    deferred = q.defer();
-
-    triggerPipes.call(this, event, data)
+    return triggerPipes.call(this, event, data)
       .then(modifiedData => {
-
         // Execute in parallel Hook and Worker because we don't have to wait or execute in a particular order
-        async.parallel([
-          callback => {
-            triggerWorkers.call(this, event, modifiedData)
-              .then(() => callback())
-              .catch((e) => callback(e));
-          },
-          callback => {
-            triggerHooks.call(this, event, modifiedData)
-              .then(() => callback())
-              .catch((e) => callback(e));
-          }
-        ], (err) => {
-          if (err) {
-            return deferred.reject(err);
-          }
+        return new Promise((resolve, reject) => {
+          async.parallel([
+            callback => triggerWorkers.call(this, event, modifiedData).asCallback(callback),
+            callback => triggerHooks.call(this, event, modifiedData).asCallback(callback)
+          ], err => {
+            if (err) {
+              return reject(err);
+            }
 
-          deferred.resolve(modifiedData);
+            resolve(modifiedData);
+          });
         });
-      })
-      .catch(error => {
-        deferred.reject(error);
       });
-
-    return deferred.promise;
   };
 
  /**
@@ -201,7 +178,9 @@ function PluginsManager (kuzzle) {
 function initWorkers (plugin, pluginName) {
   return pm2Promise
     .then(() => {
-      return q.ninvoke(pm2, 'start', {
+      var pm2StartPromise = Promise.promisify(pm2.start);
+
+      return pm2StartPromise({
         name: workerPrefix + pluginName,
         script: path.join(__dirname, 'pluginsWorkerWrapper.js'),
         'exec_mode': 'cluster',
@@ -213,7 +192,7 @@ function initWorkers (plugin, pluginName) {
     })
     .catch(err => {
       if (err) {
-        return q.reject(new Error('Error with plugin', pluginName, err));
+        return Promise.reject(new Error('Error with plugin', pluginName, err));
       }
     });
 }
@@ -234,24 +213,21 @@ function initWorkers (plugin, pluginName) {
  * @returns {Promise}
  */
 function pm2Init (workers, pluginsWorker, kuzzleConfig, isDummy) {
-  return q.ninvoke(pm2, 'connect')
-    .then(() => q.ninvoke(pm2, 'list'))
+  return Promise.fromNode(callback => pm2.connect(callback))
+    .then(() => Promise.fromNode(callback => pm2.list(callback)))
     .then(list => {
       var
-        deferred = q.defer(),
         names = list
           .filter(process => process.name.indexOf(workerPrefix) !== -1)
           /*jshint -W106 */
           .map(process => process.pm_id);
           /*jshint +W106 */
 
-      async.each(names, (name, callback) => {
+      return Promise.fromNode(asyncCB => async.each(names, (name, callback) => {
         pm2.delete(name, err => callback(err));
-      }, deferred.makeNodeResolver());
-
-      return deferred.promise;
+      }, err => asyncCB(err)));
     })
-    .then(() => q.ninvoke(pm2, 'launchBus'))
+    .then(() => Promise.fromNode(callback => pm2.launchBus(callback)))
     .then(bus => {
       bus.on('ready', packet => {
         var pluginName = packet.process.name.replace(workerPrefix, '');
@@ -309,11 +285,9 @@ function pm2Init (workers, pluginsWorker, kuzzleConfig, isDummy) {
         }
       });
 
-      return q();
+      return Promise.resolve();
     })
-    .catch(err => {
-      return q.reject('Error with PM2', err);
-    });
+    .catch(err => Promise.reject('Error with PM2', err));
 }
 
 function initPipes (pipes, plugin, pipeWarnTime, pipeTimeout) {
@@ -376,7 +350,7 @@ function initControllers (controllers, routes, plugin, pluginName) {
 function triggerHooks(event, data) {
   this.kuzzle.emit(event, data);
 
-  return q(data);
+  return Promise.resolve(data);
 }
 
 /**
@@ -389,7 +363,6 @@ function triggerHooks(event, data) {
  */
 function triggerPipes(event, data) {
   var
-    deferred = q.defer(),
     preparedPipes = [],
     wildcardEvent = getWildcardEvent(event);
 
@@ -402,19 +375,18 @@ function triggerPipes(event, data) {
   }
 
   if (preparedPipes.length === 0) {
-    deferred.resolve(data);
-    return deferred.promise;
+    return Promise.resolve(data);
   }
 
-  async.waterfall([function (callback) { callback(null, data); }].concat(preparedPipes), function (error, result) {
-    if (error) {
-      return deferred.reject(error);
-    }
+  return new Promise((resolve, reject) => {
+    async.waterfall([callback => callback(null, data)].concat(preparedPipes), (error, result) => {
+      if (error) {
+        return reject(error);
+      }
 
-    deferred.resolve(result);
+      resolve(result);
+    });
   });
-
-  return deferred.promise;
 }
 
 /**
@@ -443,40 +415,39 @@ function getWildcardEvent (event) {
  */
 function triggerWorkers(event, data) {
   var
-    deferred = q.defer(),
     wildcardEvent = getWildcardEvent(event);
 
   if (Object.keys(this.workers).length === 0) {
-    return q(data);
+    return Promise.resolve(data);
   }
 
-  async.forEachOf(this.workers, (worker, workerName, callback) => {
-    var pmId;
+  return new Promise((resolve, reject) => {
+    async.forEachOf(this.workers, (worker, workerName, callback) => {
+      var pmId;
 
-    if (worker.events.indexOf(event) === -1 && worker.events.indexOf(wildcardEvent) === -1) {
-      return callback();
-    }
+      if (worker.events.indexOf(event) === -1 && worker.events.indexOf(wildcardEvent) === -1) {
+        return callback();
+      }
 
-    pmId = worker.pmIds.getNext();
-    pm2.sendDataToProcessId(pmId, {
-      topic: 'trigger',
-      data: {
-        event: event,
-        message: data
-      },
-      id: pmId
-    }, (err, res) => {
-      callback(err, res);
+      pmId = worker.pmIds.getNext();
+      pm2.sendDataToProcessId(pmId, {
+        topic: 'trigger',
+        data: {
+          event: event,
+          message: data
+        },
+        id: pmId
+      }, (err, res) => {
+        callback(err, res);
+      });
+    }, (err) => {
+      if (err) {
+        return reject(err);
+      }
+
+      resolve(data);
     });
-  }, (err) => {
-    if (err) {
-      return deferred.reject(err);
-    }
-
-    deferred.resolve(data);
   });
-
-  return deferred.promise;
 }
 
 /**

--- a/lib/api/core/sandbox/index.js
+++ b/lib/api/core/sandbox/index.js
@@ -1,5 +1,5 @@
 var
-  q = require('q'),
+  Promise = require('bluebird'),
   cp = require('child_process'),
   portfinder = require('portfinder'),
   InternalError = require('kuzzle-common-objects').Errors.internalError,
@@ -29,65 +29,61 @@ function Sandbox (options) {
  */
 Sandbox.prototype.run = function (data) {
   if (this.child !== null && this.child.connected) {
-    return q.reject(new InternalError('A process is already running for this sandbox'));
+    return Promise.reject(new InternalError('A process is already running for this sandbox'));
   }
 
   return (() => {
     var
-      deferred,
       execArgv = process.execArgv.slice();
 
+
     if (process.debugPort) {
-      deferred = q.defer();
+      return new Promise(resolve => {
+        portfinder.getPort((err, debugPort) => {
+          execArgv.forEach((v, i) => {
+            var match = v.match(/^(--debug|--debug-(brk|port))(=\d+)?$/);
 
-      portfinder.getPort((err, debugPort) => {
-        execArgv.forEach((v, i) => {
-          var match = v.match(/^(--debug|--debug-(brk|port))(=\d+)?$/);
+            if (match) {
+              execArgv[i] = match[1] + '=' + debugPort;
+            }
+          });
 
-          if (match) {
-            execArgv[i] = match[1] + '=' + debugPort;
-          }
+          resolve(execArgv);
         });
-
-        deferred.resolve(execArgv);
       });
-
-      return deferred.promise;
     }
 
-    return q(execArgv);
+    return Promise.resolve(execArgv);
   })()
     .then(execArgv => {
       var
-        deferred = q.defer(),
         timer;
 
-      try {
+      return new Promise((resolve, reject) => {
+        try {
+          this.child = cp.fork(__dirname + '/_sandboxCode.js', [], {
+            execArgv: execArgv
+          });
+          this.child.send(data);
 
-        this.child = cp.fork(__dirname + '/_sandboxCode.js', [], {
-          execArgv: execArgv
-        });
-        this.child.send(data);
-
-        this.child.on('message', msg => {
-          deferred.resolve(msg);
-          this.child.kill();
-          clearTimeout(timer);
-        });
-
-        timer = setTimeout(() => {
-          if (this.child.connected) {
+          this.child.on('message', msg => {
+            resolve(msg);
             this.child.kill();
-            deferred.reject(new GatewayTimeoutError('Timeout. The sandbox did not respond within ' + this.timeout + 'ms.'));
-          }
-        }, this.timeout);
+            clearTimeout(timer);
+          });
 
-      }
-      catch (e) {
-        return q.reject(e);
-      }
+          timer = setTimeout(() => {
+            if (this.child.connected) {
+              this.child.kill();
+              reject(new GatewayTimeoutError('Timeout. The sandbox did not respond within ' + this.timeout + 'ms.'));
+            }
+          }, this.timeout);
 
-      return deferred.promise;
+        }
+        catch (e) {
+          reject(e);
+        }
+      });
     });
 
 

--- a/lib/api/core/statistics.js
+++ b/lib/api/core/statistics.js
@@ -1,6 +1,6 @@
 var
   _ = require('lodash'),
-  q = require('q'),
+  Promise = require('bluebird'),
   BadRequestError = require('kuzzle-common-objects').Errors.badRequestError;
 
 /**
@@ -128,11 +128,11 @@ function StatisticsController (kuzzle) {
    */
   this.getLastStats = function () {
     if (!this.lastFrame) {
-      return q(_.extend(this.currentStats, {timestamp: (new Date()).getTime()}));
+      return Promise.resolve(_.extend(this.currentStats, {timestamp: (new Date()).getTime()}));
     }
 
     return this.kuzzle.services.list.statsCache.get(this.lastFrame)
-      .then(value => q(_.extend(JSON.parse(value), { timestamp: (new Date(this.lastFrame)).getTime() })));
+      .then(value => Promise.resolve(_.extend(JSON.parse(value), { timestamp: (new Date(this.lastFrame)).getTime() })));
   };
 
   /**
@@ -163,12 +163,12 @@ function StatisticsController (kuzzle) {
     }
 
     if ((startTime !== undefined && isNaN(startTime)) || (stopTime !== undefined && isNaN(stopTime))) {
-      return q.reject(new BadRequestError('Invalid time value'));
+      return Promise.reject(new BadRequestError('Invalid time value'));
     }
 
     if (startTime >= currentDate) {
       response.total = response.hits.length;
-      return q(response);
+      return Promise.resolve(response);
     }
 
     if (!this.lastFrame) {
@@ -178,7 +178,7 @@ function StatisticsController (kuzzle) {
 
       response.total = response.hits.length;
 
-      return q(response);
+      return Promise.resolve(response);
     }
 
     return this.kuzzle.services.list.statsCache.getAllKeys()

--- a/lib/api/core/swagger.js
+++ b/lib/api/core/swagger.js
@@ -1,5 +1,5 @@
 var
-  q = require('q'),
+  Promise = require('bluebird'),
   _ = require('lodash');
 
 /**
@@ -118,5 +118,5 @@ module.exports = function generateSwagger (kuzzle) {
     }
   });
 
-  return q(swagger);
+  return Promise.resolve(swagger);
 };

--- a/lib/api/core/workerListener.js
+++ b/lib/api/core/workerListener.js
@@ -22,9 +22,9 @@ function WorkerListener (kuzzle, responseQueue) {
     var
       resolve,
       reject,
-      promise = new Promise(() => {
-        resolve = arguments[0];
-        reject = arguments[1];
+      promise = new Promise((rs, rj) => {
+        resolve = rs;
+        reject = rj;
       });
 
     this.waitingQueries[requestObject.requestId] = {resolve, reject, promise};
@@ -65,15 +65,4 @@ function startListener(kuzzle, responseQueue) {
   });
 }
 
-function defer () {
-  var
-    resolve,
-    reject,
-    promise = new Promise(() => {
-      resolve = arguments[0];
-      reject = arguments[1];
-    });
-
-  return {resolve, reject, promise};
-}
 module.exports = WorkerListener;

--- a/lib/api/core/workerListener.js
+++ b/lib/api/core/workerListener.js
@@ -1,5 +1,5 @@
 var
-  q = require('q');
+  Promise = require('bluebird');
 
 /**
  * @param {Kuzzle} kuzzle
@@ -19,11 +19,17 @@ function WorkerListener (kuzzle, responseQueue) {
    * @param requestObject the query object that will generate a response from Kuzzle
    */
   this.add = function (requestObject) {
-    var deferred = q.defer();
+    var
+      resolve,
+      reject,
+      promise = new Promise(() => {
+        resolve = arguments[0];
+        reject = arguments[1];
+      });
 
-    this.waitingQueries[requestObject.requestId] = deferred;
+    this.waitingQueries[requestObject.requestId] = {resolve, reject, promise};
 
-    return deferred.promise;
+    return promise;
   };
 }
 
@@ -59,4 +65,15 @@ function startListener(kuzzle, responseQueue) {
   });
 }
 
+function defer () {
+  var
+    resolve,
+    reject,
+    promise = new Promise(() => {
+      resolve = arguments[0];
+      reject = arguments[1];
+    });
+
+  return {resolve, reject, promise};
+}
 module.exports = WorkerListener;

--- a/lib/api/dsl/filters.js
+++ b/lib/api/dsl/filters.js
@@ -297,7 +297,7 @@ function Filters () {
         }
 
         // Gets all matching filter IDs
-        matchedIds.push(findMatchingFilters.call(this, filter.ids, flattenBody, cachedResults));
+        matchedIds = matchedIds.concat(findMatchingFilters.call(this, filter.ids, flattenBody, cachedResults));
       });
     });
 

--- a/lib/api/dsl/filters.js
+++ b/lib/api/dsl/filters.js
@@ -2,7 +2,7 @@
  * Filters storage and management
  */
 var
-  q = require('q'),
+  Promise = require('bluebird'),
   _ = require('lodash'),
   md5 = require('crypto-md5'),
   Methods = require('./methods'),
@@ -76,7 +76,7 @@ function Filters () {
    * @param {string} index
    * @param {string} collection
    * @param {Object} filters
-   * @returns {promise} resolves to the filter unique ID
+   * @returns {Promise} resolves to the filter unique ID
    */
   this.addSubscription = function (filterId, index, collection, filters) {
     var
@@ -84,19 +84,19 @@ function Filters () {
       privateFilterName;
 
     if (filters === undefined) {
-      return q.reject(new BadRequestError('Filters parameter can\'t be undefined'));
+      return Promise.reject(new BadRequestError('Filters parameter can\'t be undefined'));
     }
 
     filterName = Object.keys(filters)[0];
 
     if (filterName === undefined) {
-      return q.reject(new BadRequestError('Undefined filters'));
+      return Promise.reject(new BadRequestError('Undefined filters'));
     }
 
     privateFilterName = _.camelCase(filterName);
 
     if (!this.methods[privateFilterName]) {
-      return q.reject(new NotFoundError('Unknown filter with name '+ privateFilterName));
+      return Promise.reject(new NotFoundError('Unknown filter with name '+ privateFilterName));
     }
 
     return this.methods[privateFilterName](filterId, index, collection, filters[filterName])
@@ -113,7 +113,7 @@ function Filters () {
    * @param filterId
    * @param index
    * @param collection
-   * @returns {promise}
+   * @returns {Promise}
    */
   this.addCollectionSubscription = function (filterId, index, collection) {
     var 
@@ -143,7 +143,7 @@ function Filters () {
 
     this.filters[filterId] = {index, collection, encodedFilters: {}};
 
-    return q({diff: changed && [diff], filter: filterId});
+    return Promise.resolve({diff: changed && [diff], filter: filterId});
   };
 
   /**

--- a/lib/api/dsl/filters.js
+++ b/lib/api/dsl/filters.js
@@ -322,7 +322,7 @@ function Filters () {
     if (!this.filtersTree[index] ||
       !this.filtersTree[index][collection] ||
       !this.filtersTree[index][collection].globalFilterIds ||
-      _.isEmpty(this.filtersTree[index][collection].globalFilterIds)) {
+      this.filtersTree[index][collection].globalFilterIds.length === 0) {
 
       return [];
     }
@@ -387,7 +387,9 @@ function removeGlobalFilter (filterId) {
     filters = this.filters[filterId],
     treeLink;
 
-  if (!filters || _.isEmpty(this.filtersTree[filters.index][filters.collection].globalFilterIds)) {
+  if (!filters ||
+    !this.filtersTree[filters.index][filters.collection].globalFilterIds ||
+    this.filtersTree[filters.index][filters.collection].globalFilterIds.length === 0) {
     return false;
   }
 
@@ -452,7 +454,7 @@ function findMatchingFilters(filterIds, flattenBody, cachedResults) {
       return false;
     }
 
-    if (_.isEmpty(this.filters[id].encodedFilters)) {
+    if (!this.filters[id].encodedFilters || Object.keys(this.filters[id].encodedFilters).length === 0) {
       // An empty filter means that the user subscribed on the whole collection
       passAllFilters = true;
     }
@@ -591,10 +593,10 @@ function removeFilterPath(filterId, filterPath) {
   }
 
   // If we're at fields level and there are still fields stored
-  if (parent.fields && !_.isEmpty(parent.fields[subPath])) {
+  if (parent.fields && Object.keys(parent.fields[subPath]).length > 0) {
     return false;
   }
-  else if (parent[subPath] && parent[subPath].fields && !_.isEmpty(parent[subPath].fields)) {
+  else if (parent[subPath] && parent[subPath].fields && Object.keys(parent[subPath].fields).length > 0) {
     return false;
   }
 
@@ -604,7 +606,7 @@ function removeFilterPath(filterId, filterPath) {
   }
 
   // If we are at index level and there is other collections stored
-  if (subPath === pathArray[0] && !_.isEmpty(parent[subPath])) {
+  if (subPath === pathArray[0] && Object.keys(parent[subPath]).length > 0) {
     return false;
   }
 
@@ -618,7 +620,7 @@ function removeFilterPath(filterId, filterPath) {
 
   pathArray.pop();
 
-  if (_.isEmpty(pathArray)) {
+  if (pathArray.length === 0) {
     return false;
   }
 

--- a/lib/api/dsl/filters.js
+++ b/lib/api/dsl/filters.js
@@ -4,7 +4,6 @@
 var
   q = require('q'),
   _ = require('lodash'),
-  async = require('async'),
   md5 = require('crypto-md5'),
   Methods = require('./methods'),
   operators = require('./operators'),
@@ -238,11 +237,10 @@ function Filters () {
    * @param {string} collection - the collection on which the data apply
    * @param {Object} flattenBody
    * @param {Object} cachedResults
-   * @returns {Promise}
+   * @returns {Array} array of matching filter IDs
    */
   this.testFieldFilters = function (index, collection, flattenBody, cachedResults) {
     var
-      deferred = q.defer(),
       matchedIds = [],
       documentKeys = [];
 
@@ -254,10 +252,10 @@ function Filters () {
      key1.key2.key3
      ...
      */
-    Object.keys(flattenBody).forEach(function(compoundField) {
+    Object.keys(flattenBody).forEach(compoundField => {
       var key;
 
-      compoundField.split('.').forEach(function(attr) {
+      compoundField.split('.').forEach(attr => {
         if (key) {
           key += '.' + attr;
         }
@@ -269,7 +267,7 @@ function Filters () {
     });
 
     // Loop on all document attributes
-    async.each(documentKeys, (field, callbackField) => {
+    documentKeys.forEach(field => {
       var
         fieldFilters,
         hashedFieldName = md5(field);
@@ -278,48 +276,32 @@ function Filters () {
         !this.filtersTree[index][collection] ||
         !this.filtersTree[index][collection].fields ||
         !this.filtersTree[index][collection].fields[hashedFieldName]) {
-        callbackField();
         return false;
       }
 
       fieldFilters = this.filtersTree[index][collection].fields[hashedFieldName];
 
       // For each attribute, loop on all saved filters
-      async.each(Object.keys(fieldFilters), (functionName, callbackFilter) => {
+      Object.keys(fieldFilters).forEach(functionName => {
         var
         // Clean function name of potential '.' characters
-          cleanFunctionName = functionName.split('.').join(''),
           filter = fieldFilters[functionName],
-          cachePath = index + '.' + collection + '.' + hashedFieldName + '.' + cleanFunctionName;
+          cachePath = index + '.' + collection + '.' + hashedFieldName + '.' + functionName;
 
         if (cachedResults[cachePath] === undefined) {
           cachedResults[cachePath] = evalFilterArguments(filter.args, flattenBody);
         }
 
         if (!cachedResults[cachePath]) {
-          callbackFilter();
           return false;
         }
 
         // Gets all matching filter IDs
-        findMatchingFilters.call(this, filter.ids, flattenBody, cachedResults)
-          .then(foundIds => {
-            matchedIds = _.uniq(matchedIds.concat(foundIds));
-            callbackFilter();
-          })
-          .catch(error => callbackFilter(error));
-
-      }, error => callbackField(error));
-
-    }, error => {
-      if (error) {
-        return deferred.reject(error);
-      }
-
-      deferred.resolve(matchedIds);
+        matchedIds.push(findMatchingFilters.call(this, filter.ids, flattenBody, cachedResults));
+      });
     });
 
-    return deferred.promise;
+    return _.uniq(matchedIds);
   };
 
 
@@ -330,7 +312,7 @@ function Filters () {
    * @param {string} collection - the collection on which the data apply
    * @param {Object} flattenBody
    * @param {Object} cachedResults
-   * @returns {Promise}
+   * @returns {Array} array of matching IDs
    */
   this.testGlobalsFilters = function (index, collection, flattenBody, cachedResults) {
     /*
@@ -342,7 +324,7 @@ function Filters () {
       !this.filtersTree[index][collection].globalFilterIds ||
       _.isEmpty(this.filtersTree[index][collection].globalFilterIds)) {
 
-      return q([]);
+      return [];
     }
 
     return findMatchingFilters.call(this, this.filtersTree[index][collection].globalFilterIds, flattenBody, cachedResults);
@@ -353,11 +335,10 @@ function Filters () {
    * the filters tree
    *
    * @param {string} filterId
-   * @returns {Promise<T>}
    */
   this.removeFilter = function (filterId) {
     removeGlobalFilter.call(this, filterId);
-    return removeFieldFilter.call(this, filterId);
+    removeFieldFilter.call(this, filterId);
   };
 
   /**
@@ -434,24 +415,18 @@ function removeGlobalFilter (filterId) {
  *
  * @this Filters
  * @param {string} filterId of the filter to remove
- * @returns {Promise}
  */
 function removeFieldFilter (filterId) {
   var
-    deferred = q.defer(),
     filters = this.filters[filterId];
 
   if (!filters || !filters.encodedFilters) {
-    deferred.resolve();
-    return deferred.promise;
+    return false;
   }
 
-  async.each(getFiltersPathsRecursively(filters.encodedFilters), (filterPath, callback) => {
+  getFiltersPathsRecursively(filters.encodedFilters).forEach(filterPath => {
     removeFilterPath.call(this, filterId, filterPath);
-    callback();
-  }, deferred.makeNodeResolver());
-
-  return deferred.promise;
+  });
 }
 
 /**
@@ -462,20 +437,19 @@ function removeFieldFilter (filterId) {
  * @param {Array} filterIds
  * @param {Object} flattenBody
  * @param {Object} cachedResults
- * @returns {Promise}
+ * @returns {Array} array of matching ids
  */
 function findMatchingFilters(filterIds, flattenBody, cachedResults) {
   var
-    deferred = q.defer(),
     matchedIds = [];
 
-  async.each(filterIds, (id, callback) => {
+  filterIds.forEach(id => {
     var
       filter = this.filters[id],
       passAllFilters;
 
     if (!filter) {
-      return callback(`Filter "${id}" not found`);
+      return false;
     }
 
     if (_.isEmpty(this.filters[id].encodedFilters)) {
@@ -489,17 +463,9 @@ function findMatchingFilters(filterIds, flattenBody, cachedResults) {
     if (passAllFilters) {
       matchedIds.push(id);
     }
-
-    callback();
-  }, (error) => {
-    if (error) {
-      return deferred.reject(error);
-    }
-
-    return deferred.resolve(_.uniq(matchedIds));
   });
 
-  return deferred.promise;
+  return matchedIds;
 }
 
 /**

--- a/lib/api/dsl/index.js
+++ b/lib/api/dsl/index.js
@@ -2,7 +2,6 @@ var
   Filters = require('./filters'),
   NotFoundError = require('kuzzle-common-objects').Errors.notFoundError,
   BadRequestError = require('kuzzle-common-objects').Errors.badRequestError,
-  async = require('async'),
   _ = require('lodash'),
   q = require('q'),
   stringify = require('json-stable-stringify'),
@@ -62,44 +61,27 @@ function Dsl () {
    */
   this.test = function (index, collection, data, documentId) {
     var
-      deferred = q.defer(),
       cachedResults = {},
+      filters,
       flattenBody = flattenObject(data, documentId);
 
     if (!index) {
-      deferred.reject(new NotFoundError('The data doesn\'t contain an index'));
-      return deferred.promise;
+      return q.reject(new NotFoundError('The data doesn\'t contain an index'));
     }
 
     if (!collection) {
-      deferred.reject(new NotFoundError('The data doesn\'t contain a collection'));
-      return deferred.promise;
+      return q.reject(new NotFoundError('The data doesn\'t contain a collection'));
     }
 
     // No filters set for this index : we return an empty list
     if (!this.filters.filtersTree[index] || !this.filters.filtersTree[index][collection]) {
-      deferred.resolve([]);
-      return deferred.promise;
+      return q.resolve([]);
     }
 
-    async.parallel({
-      // Will try filters on field in document
-      onFields: callback => {
-        this.filters.testFieldFilters(index, collection, flattenBody, cachedResults).nodeify(callback);
-      },
-      // Will try global filters and add rooms which subscribed on the whole collection
-      onGlobals: callback => {
-        this.filters.testGlobalsFilters(index, collection, flattenBody, cachedResults).nodeify(callback);
-      }
-    }, (error, filters) => {
-      if (error) {
-        return deferred.reject(error);
-      }
+    filters = this.filters.testFieldFilters(index, collection, flattenBody, cachedResults);
+    filters.push(this.filters.testGlobalsFilters(index, collection, flattenBody, cachedResults));
 
-      deferred.resolve(_.uniq(filters.onFields.concat(filters.onGlobals)));
-    });
-
-    return deferred.promise;
+    return q(_.uniq(filters));
   };
 
   /**
@@ -113,7 +95,8 @@ function Dsl () {
       return q.reject(new BadRequestError(`Expected a filterId, got a ${typeof filterId}`));
     }
 
-    return this.filters.removeFilter(filterId);
+    this.filters.removeFilter(filterId);
+    return q();
   };
 
   /**

--- a/lib/api/dsl/index.js
+++ b/lib/api/dsl/index.js
@@ -3,7 +3,7 @@ var
   NotFoundError = require('kuzzle-common-objects').Errors.notFoundError,
   BadRequestError = require('kuzzle-common-objects').Errors.badRequestError,
   _ = require('lodash'),
-  q = require('q'),
+  Promise = require('bluebird'),
   stringify = require('json-stable-stringify'),
   crypto = require('crypto');
 
@@ -66,22 +66,22 @@ function Dsl () {
       flattenBody = flattenObject(data, documentId);
 
     if (!index) {
-      return q.reject(new NotFoundError('The data doesn\'t contain an index'));
+      return Promise.reject(new NotFoundError('The data doesn\'t contain an index'));
     }
 
     if (!collection) {
-      return q.reject(new NotFoundError('The data doesn\'t contain a collection'));
+      return Promise.reject(new NotFoundError('The data doesn\'t contain a collection'));
     }
 
     // No filters set for this index : we return an empty list
     if (!this.filters.filtersTree[index] || !this.filters.filtersTree[index][collection]) {
-      return q.resolve([]);
+      return Promise.resolve([]);
     }
 
     filters = this.filters.testFieldFilters(index, collection, flattenBody, cachedResults);
     filters.push(this.filters.testGlobalsFilters(index, collection, flattenBody, cachedResults));
 
-    return q(_.uniq(filters));
+    return Promise.resolve(_.uniq(filters));
   };
 
   /**
@@ -92,11 +92,11 @@ function Dsl () {
    */
   this.remove = function (filterId) {
     if (typeof filterId !== 'string') {
-      return q.reject(new BadRequestError(`Expected a filterId, got a ${typeof filterId}`));
+      return Promise.reject(new BadRequestError(`Expected a filterId, got a ${typeof filterId}`));
     }
 
     this.filters.removeFilter(filterId);
-    return q();
+    return Promise.resolve();
   };
 
   /**

--- a/lib/api/dsl/index.js
+++ b/lib/api/dsl/index.js
@@ -39,10 +39,10 @@ function Dsl () {
    * @param {String} index
    * @param {String} collection
    * @param {Object} filters
-   * @return {promise}
+   * @return {Promise}
    */
   this.register = function (filterId, index, collection, filters) {
-    if (!filters || _.isEmpty(filters)) {
+    if (!filters || Object.keys(filters).length === 0) {
       return this.filters.addCollectionSubscription(filterId, index, collection);
     }
 

--- a/lib/api/dsl/index.js
+++ b/lib/api/dsl/index.js
@@ -78,8 +78,9 @@ function Dsl () {
       return Promise.resolve([]);
     }
 
-    filters = this.filters.testFieldFilters(index, collection, flattenBody, cachedResults);
-    filters.push(this.filters.testGlobalsFilters(index, collection, flattenBody, cachedResults));
+    filters = 
+      this.filters.testFieldFilters(index, collection, flattenBody, cachedResults)
+        .concat(this.filters.testGlobalsFilters(index, collection, flattenBody, cachedResults));
 
     return Promise.resolve(_.uniq(filters));
   };

--- a/lib/api/dsl/methods.js
+++ b/lib/api/dsl/methods.js
@@ -7,7 +7,7 @@ var
   async = require('async'),
   BadRequestError = require('kuzzle-common-objects').Errors.badRequestError,
   KuzzleError = require('kuzzle-common-objects').Errors.kuzzleError,
-  q = require('q'),
+  Promise = require('bluebird'),
   util = require('util'),
   geohash = require('ngeohash'),
   geoUtil = require('./geoutil');
@@ -61,48 +61,44 @@ function Methods(filtersObject) {
    */
   this.range = function (roomId, index, collection, filter, not) {
     var
-      deferred,
       diff = [],
       field,
       formattedFilters;
 
     if (_.isEmpty(filter)) {
-      return q.reject(new BadRequestError('A filter can\'t be empty'));
+      return Promise.reject(new BadRequestError('A filter can\'t be empty'));
     }
-
-    deferred = q.defer();
 
     field = Object.keys(filter)[0];
     formattedFilters = {};
 
-    async.each(Object.keys(filter[field]), (rangeOperator, callback) => {
-      var
-        value = filter[field][rangeOperator],
-        encodedFunctionName,
-        result;
+    return new Promise((resolve, reject) => {
+      async.each(Object.keys(filter[field]), (rangeOperator, callback) => {
+        var
+          value = filter[field][rangeOperator],
+          encodedFunctionName,
+          result;
 
-      encodedFunctionName = `${not ? 'not' : ''}range${field}${rangeOperator}${value}`;
+        encodedFunctionName = `${not ? 'not' : ''}range${field}${rangeOperator}${value}`;
 
-      result = this.filters.add(index, collection, field, rangeOperator, value, encodedFunctionName, roomId, not);
-      if (util.isError(result)) {
-        callback(result);
-        return false;
-      }
+        result = this.filters.add(index, collection, field, rangeOperator, value, encodedFunctionName, roomId, not);
+        if (util.isError(result)) {
+          callback(result);
+          return false;
+        }
 
-      diff = diff.concat(result.diff);
-      formattedFilters[result.path] = result.filter;
+        diff = diff.concat(result.diff);
+        formattedFilters[result.path] = result.filter;
 
-      callback();
-    }, error => {
-      if (error) {
-        deferred.reject(error);
-      }
+        callback();
+      }, error => {
+        if (error) {
+          return reject(error);
+        }
 
-      deferred.resolve({diff, filter: {and: formattedFilters}});
-
+        resolve({diff, filter: {and: formattedFilters}});
+      });
     });
-
-    return deferred.promise;
   };
 
   /**
@@ -117,50 +113,44 @@ function Methods(filtersObject) {
    */
   this.bool = function (roomId, index, collection, filter, not) {
     var
-      deferred = q.defer(),
       allowedBoolFunctions = ['must', 'mustNot', 'should'],
       diff = [],
       formattedFilters = {};
 
     if (_.isEmpty(filter)) {
-      deferred.reject(new BadRequestError('A filter can\'t be empty'));
-      return deferred.promise;
+      return Promise.reject(new BadRequestError('A filter can\'t be empty'));
     }
 
-    async.each(Object.keys(filter), (method, callback) => {
-      var methodName = _.camelCase(method);
+    return new Promise((resolve, reject) => {
+      async.each(Object.keys(filter), (method, callback) => {
+        var methodName = _.camelCase(method);
 
-      if (this[methodName] === undefined || allowedBoolFunctions.indexOf(methodName) === -1) {
-        callback(new BadRequestError('Function ' + method + ' doesn\'t exist'));
-        return false;
-      }
+        if (this[methodName] === undefined || allowedBoolFunctions.indexOf(methodName) === -1) {
+          return callback(new BadRequestError('Function ' + method + ' doesn\'t exist'));
+        }
 
-      this[methodName](roomId, index, collection, filter[method], not)
-        .then(response => {
-          formattedFilters = deepExtend(formattedFilters, response.filter);
-          diff = diff.concat(response.diff);
-          callback();
-        })
-        .catch(function (error) {
-          callback(error);
-        });
+        this[methodName](roomId, index, collection, filter[method], not)
+          .then(response => {
+            formattedFilters = deepExtend(formattedFilters, response.filter);
+            diff = diff.concat(response.diff);
+            callback();
+          })
+          .catch(error => callback(error));
+      }, error => {
+        if (error) {
+          return reject(error);
+        }
 
-    }, error => {
-      if (error) {
-        return deferred.reject(error);
-      }
+        // check if there is an upper "and" that wrap the whole object
+        if ((Object.keys(formattedFilters)[0] !== 'or' && Object.keys(formattedFilters)[0] !== 'and') ||
+          Object.keys(formattedFilters).length > 1) {
 
-      // check if there is an upper "and" that wrap the whole object
-      if ((Object.keys(formattedFilters)[0] !== 'or' && Object.keys(formattedFilters)[0] !== 'and') ||
-        Object.keys(formattedFilters).length > 1) {
+          formattedFilters = {and: formattedFilters};
+        }
 
-        formattedFilters = {and: formattedFilters};
-      }
-
-      deferred.resolve({ diff, filter: formattedFilters });
+        resolve({diff, filter: formattedFilters});
+      });
     });
-
-    return deferred.promise;
   };
 
   /**
@@ -175,9 +165,7 @@ function Methods(filtersObject) {
    */
   this.must = function (roomId, index, collection, filters, not) {
     return getFormattedFilters.call(this, roomId, index, collection, filters, not)
-      .then(response => {
-        return q({diff: response.diff, filter: {and: response.filter}});
-      });
+      .then(response => ({diff: response.diff, filter: {and: response.filter}}));
   };
 
   /**
@@ -280,17 +268,17 @@ function Methods(filtersObject) {
       result;
 
     if (_.isEmpty(filter)) {
-      return q.reject(new BadRequestError('A filter can\'t be empty'));
+      return Promise.reject(new BadRequestError('A filter can\'t be empty'));
     }
 
     fieldName = filter.field;
 
     if (!fieldName) {
-      return q.reject(new BadRequestError('Filter \'exists\' must contains \'field\' attribute'));
+      return Promise.reject(new BadRequestError('Filter \'exists\' must contains \'field\' attribute'));
     }
 
     if (typeof fieldName !== 'string') {
-      return q.reject(new BadRequestError('Filter \'exists\' takes a string attribute. Found: ' + typeof fieldName));
+      return Promise.reject(new BadRequestError('Filter \'exists\' takes a string attribute. Found: ' + typeof fieldName));
     }
 
     formattedFilters = {};
@@ -298,12 +286,12 @@ function Methods(filtersObject) {
     encodedFunctionName = `${not ? 'not': ''}exists${fieldName.replace(/\./g, '')}`;
     result = this.filters.add(index, collection, fieldName, 'exists', fieldName, encodedFunctionName, roomId, not, not);
     if (util.isError(result)) {
-      return q.reject(result);
+      return Promise.reject(result);
     }
 
     formattedFilters[result.path] = result.filter;
 
-    return q({ diff: result.diff ? [ result.diff ] : [], filter: formattedFilters });
+    return Promise.resolve({ diff: result.diff ? [ result.diff ] : [], filter: formattedFilters });
   };
 
   /**
@@ -323,15 +311,15 @@ function Methods(filtersObject) {
       result;
 
     if (_.isEmpty(filter)) {
-      return q.reject(new BadRequestError('A filter can\'t be empty'));
+      return Promise.reject(new BadRequestError('A filter can\'t be empty'));
     }
 
     if (!filter.values || _.isEmpty(filter.values)) {
-      return q.reject(new BadRequestError('Filter ids must contains "values" attribute'));
+      return Promise.reject(new BadRequestError('Filter ids must contains "values" attribute'));
     }
 
     if (!Array.isArray(filter.values) || _.isEmpty(filter.values)) {
-      return q.reject(new BadRequestError('Attribute "values" in filter ids must contains a non-empty array'));
+      return Promise.reject(new BadRequestError('Attribute "values" in filter ids must contains a non-empty array'));
     }
 
     formattedFilters = {};
@@ -342,12 +330,12 @@ function Methods(filtersObject) {
     result = this.filters.add(index, collection, '_id', 'terms', filter.values, encodedFunctionName, roomId, not, false);
 
     if (util.isError(result)) {
-      return q.reject(result);
+      return Promise.reject(result);
     }
 
     formattedFilters[result.path] = result.filter;
 
-    return q({ diff: result.diff ? [ result.diff ] : [], filter: formattedFilters });
+    return Promise.resolve({ diff: result.diff ? [ result.diff ] : [], filter: formattedFilters });
   };
 
   /**
@@ -374,7 +362,7 @@ function Methods(filtersObject) {
       result;
 
     if (_.isEmpty(filter)) {
-      return q.reject(new BadRequestError('Missing filter'));
+      return Promise.reject(new BadRequestError('Missing filter'));
     }
 
     fieldName = Object.keys(filter)[0];
@@ -401,7 +389,7 @@ function Methods(filtersObject) {
       right = bBox.right;
     }
     catch (err) {
-      return q.reject(err);
+      return Promise.reject(err);
     }
 
     encodedFunctionName = `${not ? 'not': ''}${fieldName}geoBoundingBox${geohash.encode(left, top)}${geohash.encode(right, bottom)}`;
@@ -418,12 +406,12 @@ function Methods(filtersObject) {
     );
 
     if (util.isError(result)) {
-      return q.reject(result);
+      return Promise.reject(result);
     }
 
     formattedFilters[result.path] = result.filter;
 
-    return q({ diff: result.diff ? [ result.diff ] : [], filter: formattedFilters });
+    return Promise.resolve({ diff: result.diff ? [ result.diff ] : [], filter: formattedFilters });
   };
 
   /**
@@ -448,13 +436,13 @@ function Methods(filtersObject) {
       result;
 
     if (_.isEmpty(filter)) {
-      return q.reject(new BadRequestError('Missing filter'));
+      return Promise.reject(new BadRequestError('Missing filter'));
     }
 
     fieldName = Object.keys(filter).find(field => field !== 'distance');
 
     if (fieldName === undefined) {
-      return q.reject(new BadRequestError('No location field given'));
+      return Promise.reject(new BadRequestError('No location field given'));
     }
 
     geoFilter = filter[fieldName];
@@ -469,7 +457,7 @@ function Methods(filtersObject) {
     /* jshint camelcase: true */
 
     if (!filter.distance) {
-      return q.reject(new BadRequestError('No distance given'));
+      return Promise.reject(new BadRequestError('No distance given'));
     }
 
     try {
@@ -479,7 +467,7 @@ function Methods(filtersObject) {
       distance = geoUtil.getDistance(filter.distance);
     }
     catch (err) {
-      return q.reject(err);
+      return Promise.reject(err);
     }
 
     encodedFunctionName = `${not ? 'not': ''}${fieldName}geoDistance${geohash.encode(lat, lon)}${distance}`;
@@ -496,12 +484,12 @@ function Methods(filtersObject) {
     );
 
     if (util.isError(result)) {
-      return q.reject(result);
+      return Promise.reject(result);
     }
 
     formattedFilters[result.path] = result.filter;
 
-    return q({ diff: result.diff ? [ result.diff ] : [], filter: formattedFilters });
+    return Promise.resolve({ diff: result.diff ? [ result.diff ] : [], filter: formattedFilters });
   };
 
   /**
@@ -527,13 +515,13 @@ function Methods(filtersObject) {
       result;
 
     if (_.isEmpty(filter)) {
-      return q.reject(new BadRequestError('Missing filter'));
+      return Promise.reject(new BadRequestError('Missing filter'));
     }
 
     fieldName = Object.keys(filter).find(field => field !== 'from' && field !== 'to');
 
     if (fieldName === undefined) {
-      return q.reject(new BadRequestError('No location field given'));
+      return Promise.reject(new BadRequestError('No location field given'));
     }
 
     geoFilter = filter[fieldName];
@@ -547,10 +535,10 @@ function Methods(filtersObject) {
     /* jshint camelcase: true */
 
     if (!filter.from) {
-      return q.reject(new BadRequestError('No from parameter given'));
+      return Promise.reject(new BadRequestError('No from parameter given'));
     }
     if (!filter.to) {
-      return q.reject(new BadRequestError('No to parameter given'));
+      return Promise.reject(new BadRequestError('No to parameter given'));
     }
 
     try {
@@ -562,7 +550,7 @@ function Methods(filtersObject) {
       to = geoUtil.getDistance(filter.to);
     }
     catch (err) {
-      return q.reject(err);
+      return Promise.reject(err);
     }
 
     encodedFunctionName = `${not ? 'not': ''}${fieldName}geoDistanceRange${geohash.encode(lat, lon)}${from}${to}`;
@@ -579,12 +567,12 @@ function Methods(filtersObject) {
     );
 
     if (util.isError(result)) {
-      return q.reject(result);
+      return Promise.reject(result);
     }
 
     formattedFilters[result.path] = result.filter;
 
-    return q({ diff: result.diff ? [ result.diff ] : [], filter: formattedFilters });
+    return Promise.resolve({ diff: result.diff ? [ result.diff ] : [], filter: formattedFilters });
   };
 
   /**
@@ -607,7 +595,7 @@ function Methods(filtersObject) {
       result;
 
     if (_.isEmpty(filter)) {
-      return q.reject(new BadRequestError('Missing filter'));
+      return Promise.reject(new BadRequestError('Missing filter'));
     }
 
     fieldName = Object.keys(filter)[0];
@@ -617,7 +605,7 @@ function Methods(filtersObject) {
       polygon = geoUtil.constructPolygon(geoFilter);
     }
     catch (err) {
-      return q.reject(err);
+      return Promise.reject(err);
     }
 
     polygon.forEach(point => geoHashPolygon.push(geohash.encode(point.lat, point.lon)));
@@ -636,19 +624,19 @@ function Methods(filtersObject) {
     );
 
     if (util.isError(result)) {
-      return q.reject(result);
+      return Promise.reject(result);
     }
 
     formattedFilters[result.path] = result.filter;
 
-    return q({ diff: result.diff ? [ result.diff ] : [], filter: formattedFilters });
+    return Promise.resolve({ diff: result.diff ? [ result.diff ] : [], filter: formattedFilters });
   };
 
   /**
    * Return true only if the point in field is in the square
    */
   this.geoShape = function () {
-    return q.reject(new KuzzleError('geoShape is not implemented yet.'));
+    return Promise.reject(new KuzzleError('geoShape is not implemented yet.'));
   };
 
   /**
@@ -664,11 +652,11 @@ function Methods(filtersObject) {
       flags;
 
     if (typeof filter !== 'object') {
-      return q.reject(new BadRequestError('Regexp argument must be an object'));
+      return Promise.reject(new BadRequestError('Regexp argument must be an object'));
     }
     
     if (Object.keys(filter).length !== 1) {
-      return q.reject(new BadRequestError('Regexp can take only one field entry'));
+      return Promise.reject(new BadRequestError('Regexp can take only one field entry'));
     }
     
     field = Object.keys(filter)[0];
@@ -682,7 +670,7 @@ function Methods(filtersObject) {
         value = value.value;
       }
       else {
-        return q.reject(new BadRequestError('Missing regexp value'));
+        return Promise.reject(new BadRequestError('Missing regexp value'));
       }
     }
 
@@ -690,17 +678,17 @@ function Methods(filtersObject) {
       regexp = new RegExp(value, flags);
     }
     catch (err) {
-      return q.reject(err);
+      return Promise.reject(err);
     }
 
     encodedFunctionName = `${not ? 'not': ''}regexp${field}${regexp.toString()}`;
 
     result = this.filters.add(index, collection, field, 'regexp', regexp.toString(), encodedFunctionName, roomId, not, false);
     if (util.isError(result)) {
-      return q.reject(result);
+      return Promise.reject(result);
     }
 
-    return q({ diff: result.diff ? [ result.diff ] : [], filter: {[result.path]: result.filter}});
+    return Promise.resolve({ diff: result.diff ? [ result.diff ] : [], filter: {[result.path]: result.filter}});
   };
 
   /**
@@ -721,13 +709,13 @@ function Methods(filtersObject) {
       result;
 
     if (_.isEmpty(filter)) {
-      return q.reject(new BadRequestError('A filter can\'t be empty'));
+      return Promise.reject(new BadRequestError('A filter can\'t be empty'));
     }
 
     fieldName = filter.field;
 
     if (!fieldName) {
-      return q.reject(new BadRequestError('Filter \'missing\' must contains \'field\' attribute'));
+      return Promise.reject(new BadRequestError('Filter \'missing\' must contains \'field\' attribute'));
     }
 
     formattedFilters = {};
@@ -736,12 +724,12 @@ function Methods(filtersObject) {
 
     result = this.filters.add(index, collection, fieldName, 'missing', fieldName, encodedFunctionName, roomId, not, not);
     if (util.isError(result)) {
-      return q.reject(result);
+      return Promise.reject(result);
     }
 
     formattedFilters[result.path] = result.filter;
 
-    return q({ diff: result.diff ? [ result.diff ] : [], filter: formattedFilters});
+    return Promise.resolve({ diff: result.diff ? [ result.diff ] : [], filter: formattedFilters});
   };
 }
 
@@ -759,12 +747,10 @@ function Methods(filtersObject) {
 function getFormattedFilters(roomId, index, collection, filters, not) {
   var
     diff = [],
-    deferred = q.defer(),
     formattedFilters;
 
   if (_.isEmpty(filters)) {
-    deferred.reject(new BadRequestError('Filters can\'t be empty'));
-    return deferred.promise;
+    return Promise.reject(new BadRequestError('Filters can\'t be empty'));
   }
 
   formattedFilters = {};
@@ -773,44 +759,44 @@ function getFormattedFilters(roomId, index, collection, filters, not) {
     filters = [filters];
   }
 
-  async.each(filters, (filter, callback) => {
-    var
-      method,
-      methodName;
+  return new Promise((resolve, reject) => {
+    async.each(filters, (filter, callback) => {
+      var
+        method,
+        methodName;
 
-    if (_.isEmpty(filter)) {
-      // just ignore if one of filters is empty, we don't have to rise an error
-      callback();
-      return false;
-    }
-
-    method = Object.keys(filter)[0];
-    methodName = _.camelCase(method);
-
-    if (this[methodName] === undefined) {
-      callback(new BadRequestError('Function ' + method + ' doesn\'t exist'));
-      return false;
-    }
-
-    this[methodName](roomId, index, collection, filter[method], not)
-      .then(response => {
-        diff = diff.concat(response.diff);
-        formattedFilters = deepExtend(formattedFilters, response.filter);
+      if (_.isEmpty(filter)) {
+        // just ignore if one of filters is empty, we don't have to rise an error
         callback();
-      })
-      .catch(error => {
-        callback(error);
-      });
+        return false;
+      }
 
-  }, (error) => {
-    if (error) {
-      deferred.reject(error);
-    }
+      method = Object.keys(filter)[0];
+      methodName = _.camelCase(method);
 
-    deferred.resolve({ diff: diff, filter: formattedFilters});
+      if (this[methodName] === undefined) {
+        callback(new BadRequestError('Function ' + method + ' doesn\'t exist'));
+        return false;
+      }
+
+      this[methodName](roomId, index, collection, filter[method], not)
+        .then(response => {
+          diff = diff.concat(response.diff);
+          formattedFilters = deepExtend(formattedFilters, response.filter);
+          callback();
+        })
+        .catch(error => {
+          callback(error);
+        });
+
+    }, (error) => {
+      if (error) {
+        return reject(error);
+      }
+
+      resolve({diff: diff, filter: formattedFilters});
+    });
   });
-
-  return deferred.promise;
 }
 
 /**
@@ -825,35 +811,32 @@ function getFormattedFilters(roomId, index, collection, filters, not) {
  */
 function getFormattedFiltersAsList (roomId, index, collection, filters, not) {
   var
-    deferred = q.defer(),
     diff = [],
     formattedFilters = [];
 
   if (!Array.isArray(filters) || filters.length === 0) {
-    deferred.reject(new BadRequestError('This filter must contains a filters array'));
-    return deferred.promise;
+    return Promise.reject(new BadRequestError('This filter must contains a filters array'));
   }
 
+  return new Promise((resolve, reject) => {
+    async.each(filters, (filter, callback) => {
+      getFormattedFilters.call(this, roomId, index, collection, filter, not)
+        .then(response => {
+          diff = diff.concat(response.diff);
+          formattedFilters.push(response.filter);
+          callback();
+        })
+        .catch(error => {
+          callback(error);
+        });
+    }, error => {
+      if (error) {
+        return reject(error);
+      }
 
-  async.each(filters, (filter, callback) => {
-    getFormattedFilters.call(this, roomId, index, collection, filter, not)
-      .then(response => {
-        diff = diff.concat(response.diff);
-        formattedFilters.push(response.filter);
-        callback();
-      })
-      .catch(error => {
-        callback(error);
-      });
-  }, error => {
-    if (error) {
-      return deferred.reject(error);
-    }
-
-    return deferred.resolve({ diff, filters: formattedFilters });
+      resolve({diff, filters: formattedFilters});
+    });
   });
-
-  return deferred.promise;
 }
 
 /**
@@ -910,7 +893,7 @@ function termFunction(termType, roomId, index, collection, filter, not) {
     result;
 
   if (_.isEmpty(filter)) {
-    return q.reject(new BadRequestError('A filter can\'t be empty'));
+    return Promise.reject(new BadRequestError('A filter can\'t be empty'));
   }
 
   field = Object.keys(filter)[0];
@@ -918,19 +901,19 @@ function termFunction(termType, roomId, index, collection, filter, not) {
   formattedFilters = {};
 
   if (termType === 'terms' && !Array.isArray(value)) {
-    return q.reject(new BadRequestError('Filter terms must contains an array'));
+    return Promise.reject(new BadRequestError('Filter terms must contains an array'));
   }
 
   encodedFunctionName = `${not ? 'not': ''}${termType}${field.replace(/\./g, '')}${value}`;
 
   result = this.filters.add(index, collection, field, termType, value, encodedFunctionName, roomId, not);
   if (util.isError(result)) {
-    return q.reject(result);
+    return Promise.reject(result);
   }
 
   formattedFilters[result.path] = result.filter;
 
-  return q({ diff: result.diff ? [ result.diff ] : [], filter: formattedFilters });
+  return Promise.resolve({ diff: result.diff ? [ result.diff ] : [], filter: formattedFilters });
 }
 
 module.exports = Methods;

--- a/lib/api/dsl/methods.js
+++ b/lib/api/dsl/methods.js
@@ -65,7 +65,7 @@ function Methods(filtersObject) {
       field,
       formattedFilters;
 
-    if (_.isEmpty(filter)) {
+    if (!filter || Object.keys(filter).length === 0) {
       return Promise.reject(new BadRequestError('A filter can\'t be empty'));
     }
 
@@ -117,7 +117,7 @@ function Methods(filtersObject) {
       diff = [],
       formattedFilters = {};
 
-    if (_.isEmpty(filter)) {
+    if (!filter || Object.keys(filter).length === 0) {
       return Promise.reject(new BadRequestError('A filter can\'t be empty'));
     }
 
@@ -267,7 +267,7 @@ function Methods(filtersObject) {
       encodedFunctionName,
       result;
 
-    if (_.isEmpty(filter)) {
+    if (!filter || Object.keys(filter).length === 0) {
       return Promise.reject(new BadRequestError('A filter can\'t be empty'));
     }
 
@@ -310,15 +310,15 @@ function Methods(filtersObject) {
       encodedFunctionName,
       result;
 
-    if (_.isEmpty(filter)) {
+    if (!filter || Object.keys(filter).length === 0) {
       return Promise.reject(new BadRequestError('A filter can\'t be empty'));
     }
 
-    if (!filter.values || _.isEmpty(filter.values)) {
+    if (!filter.values || Object.keys(filter.values).length === 0) {
       return Promise.reject(new BadRequestError('Filter ids must contains "values" attribute'));
     }
 
-    if (!Array.isArray(filter.values) || _.isEmpty(filter.values)) {
+    if (!Array.isArray(filter.values) || filter.values.length === 0) {
       return Promise.reject(new BadRequestError('Attribute "values" in filter ids must contains a non-empty array'));
     }
 
@@ -361,7 +361,7 @@ function Methods(filtersObject) {
       right,
       result;
 
-    if (_.isEmpty(filter)) {
+    if (!filter || Object.keys(filter).length === 0) {
       return Promise.reject(new BadRequestError('Missing filter'));
     }
 
@@ -435,7 +435,7 @@ function Methods(filtersObject) {
       distance,
       result;
 
-    if (_.isEmpty(filter)) {
+    if (!filter || Object.keys(filter).length === 0) {
       return Promise.reject(new BadRequestError('Missing filter'));
     }
 
@@ -514,7 +514,7 @@ function Methods(filtersObject) {
       to,
       result;
 
-    if (_.isEmpty(filter)) {
+    if (!filter || Object.keys(filter).length === 0) {
       return Promise.reject(new BadRequestError('Missing filter'));
     }
 
@@ -594,7 +594,7 @@ function Methods(filtersObject) {
       geoHashPolygon = [],
       result;
 
-    if (_.isEmpty(filter)) {
+    if (!filter || Object.keys(filter).length === 0) {
       return Promise.reject(new BadRequestError('Missing filter'));
     }
 
@@ -708,7 +708,7 @@ function Methods(filtersObject) {
       encodedFunctionName,
       result;
 
-    if (_.isEmpty(filter)) {
+    if (!filter || Object.keys(filter).length === 0) {
       return Promise.reject(new BadRequestError('A filter can\'t be empty'));
     }
 
@@ -749,7 +749,7 @@ function getFormattedFilters(roomId, index, collection, filters, not) {
     diff = [],
     formattedFilters;
 
-  if (_.isEmpty(filters)) {
+  if (!filters || Object.keys(filters).length === 0) {
     return Promise.reject(new BadRequestError('Filters can\'t be empty'));
   }
 
@@ -765,7 +765,7 @@ function getFormattedFilters(roomId, index, collection, filters, not) {
         method,
         methodName;
 
-      if (_.isEmpty(filter)) {
+      if (Object.keys(filter).length === 0) {
         // just ignore if one of filters is empty, we don't have to rise an error
         callback();
         return false;
@@ -850,10 +850,10 @@ function deepExtend(filters1, filters2) {
     attr,
     resultFilters;
 
-  if (_.isEmpty(filters1)) {
+  if (!filters1 || Object.keys(filters1).length === 0) {
     return filters2;
   }
-  if (_.isEmpty(filters2)) {
+  if (!filters2 || Object.keys(filters2).length === 0) {
     return filters1;
   }
 
@@ -892,7 +892,7 @@ function termFunction(termType, roomId, index, collection, filter, not) {
     encodedFunctionName,
     result;
 
-  if (_.isEmpty(filter)) {
+  if (!filter || Object.keys(filter).length === 0) {
     return Promise.reject(new BadRequestError('A filter can\'t be empty'));
   }
 

--- a/lib/api/dsl/operators.js
+++ b/lib/api/dsl/operators.js
@@ -160,7 +160,7 @@ module.exports = operators = {
     if (documentValues === null) {
       return false;
     }
-    if (_.isObject(documentValues) && _.isEmpty(documentValues)) {
+    if (_.isObject(documentValues) && Object.keys(documentValues).length === 0) {
       return false;
     }
 
@@ -328,7 +328,7 @@ module.exports = operators = {
     if (documentValues === null) {
       return true;
     }
-    if (_.isObject(documentValues) && _.isEmpty(documentValues)) {
+    if (_.isObject(documentValues) && Object.keys(documentValues).length === 0) {
       return true;
     }
 

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -1,16 +1,6 @@
 var
   Kuzzle = require('./Kuzzle');
-/*
-require('pmx').init({
-  http          : true, // HTTP routes logging (default: true)
-  ignore_routes : [/notFound/], // Ignore http routes with this pattern (Default: [])
-  errors        : true, // Exceptions loggin (default: true)
-  custom_probes : true, // Auto expose JS Loop Latency and HTTP req/s as custom metrics
-  network       : true, // Network monitoring at the application level
-  ports         : true,  // Shows which ports your app is listening on (default: false)
-  profiling : true
-});
-*/
+
 module.exports = function KuzzleFactory () {
   return new Kuzzle();
 };

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -1,15 +1,15 @@
 var
-  pmx = require('pmx').init({
-    http          : true, // HTTP routes logging (default: true)
-    ignore_routes : [/notFound/], // Ignore http routes with this pattern (Default: [])
-    errors        : true, // Exceptions loggin (default: true)
-    custom_probes : true, // Auto expose JS Loop Latency and HTTP req/s as custom metrics
-    network       : true, // Network monitoring at the application level
-    ports         : true,  // Shows which ports your app is listening on (default: false)
-    profiling : true
-  }),
   Kuzzle = require('./Kuzzle');
 
+require('pmx').init({
+  http          : true, // HTTP routes logging (default: true)
+  ignore_routes : [/notFound/], // Ignore http routes with this pattern (Default: [])
+  errors        : true, // Exceptions loggin (default: true)
+  custom_probes : true, // Auto expose JS Loop Latency and HTTP req/s as custom metrics
+  network       : true, // Network monitoring at the application level
+  ports         : true,  // Shows which ports your app is listening on (default: false)
+  profiling : true
+});
 
 module.exports = function KuzzleFactory () {
   return new Kuzzle();

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -1,4 +1,15 @@
-var Kuzzle = require('./Kuzzle');
+var
+  pmx = require('pmx').init({
+    http          : true, // HTTP routes logging (default: true)
+    ignore_routes : [/notFound/], // Ignore http routes with this pattern (Default: [])
+    errors        : true, // Exceptions loggin (default: true)
+    custom_probes : true, // Auto expose JS Loop Latency and HTTP req/s as custom metrics
+    network       : true, // Network monitoring at the application level
+    ports         : true,  // Shows which ports your app is listening on (default: false)
+    profiling : true
+  }),
+  Kuzzle = require('./Kuzzle');
+
 
 module.exports = function KuzzleFactory () {
   return new Kuzzle();

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -1,6 +1,6 @@
 var
   Kuzzle = require('./Kuzzle');
-
+/*
 require('pmx').init({
   http          : true, // HTTP routes logging (default: true)
   ignore_routes : [/notFound/], // Ignore http routes with this pattern (Default: [])
@@ -10,7 +10,7 @@ require('pmx').init({
   ports         : true,  // Shows which ports your app is listening on (default: false)
   profiling : true
 });
-
+*/
 module.exports = function KuzzleFactory () {
   return new Kuzzle();
 };

--- a/lib/api/start.js
+++ b/lib/api/start.js
@@ -4,7 +4,7 @@
  * You may change the default behavior by passing parameters to the kuzzle start command.
  */
 var
-  q = require('q'),
+  Promise = require('bluebird'),
   packageInfo = require('../../package.json'),
   EntryPoints = require('./core/entryPoints'),
   HotelClerk = require('./core/hotelClerk'),
@@ -40,9 +40,6 @@ var
  * @param {Object} feature allow to programatically tune what part of Kuzzle you want to run
  */
 module.exports = function start (params, feature) {
-  var
-    kuzzleStarted = q.defer();
-
   if (feature === undefined) {
     feature = {};
   }
@@ -68,14 +65,15 @@ module.exports = function start (params, feature) {
   this.passport = new PassportWrapper();
 
   this.pluginsManager = new PluginsManager(this);
-  this.pluginsManager.init(this.isServer, feature.dummy)
+
+  return this.pluginsManager.init(this.isServer, feature.dummy)
     .then(() => this.pluginsManager.run())
     .then(() => {
       this.tokenManager = new TokenManager(this);
       this.indexCache = new IndexCache(this);
 
       if (this.isWorker) {
-        return q();
+        return Promise.resolve();
       }
 
       if (feature.dummy) {
@@ -127,7 +125,7 @@ module.exports = function start (params, feature) {
         this.entryPoints.init();
       }
 
-      return q();
+      return Promise.resolve();
     })
     .then(() => {
       this.pluginsManager.trigger('log:info', 'Core components ready');
@@ -140,13 +138,9 @@ module.exports = function start (params, feature) {
       this.remoteActionsController.init();
 
       this.pluginsManager.trigger('core:kuzzleStart', 'Kuzzle is started');
-
-      kuzzleStarted.resolve({});
     })
     .catch(error => {
       this.pluginsManager.trigger('log:error', error);
-      kuzzleStarted.reject(error);
+      return Promise.reject(error);
     });
-
-  return kuzzleStarted.promise;
 };

--- a/lib/hooks/index.js
+++ b/lib/hooks/index.js
@@ -1,7 +1,5 @@
 var
-// library for execute asynchronous methods
-  async = require('async'),
-  q = require('q');
+  Promise = require('bluebird');
 
 /**
  * Hooks will build all hooks defined in config/hooks file
@@ -15,47 +13,42 @@ function Hooks (kuzzle) {
   this.kuzzle = kuzzle;
 
   this.init = function () {
-    var
-      deferred = q.defer(),
-      // hooks = this in order to avoid too many bind in callback functions bellow
-      hooks = this;
+    return new Promise((resolve, reject) => {
+      var result;
 
-    async.each(Object.keys(this.kuzzle.config.hooks), function parseEvents (event, callbackEvent) {
-      async.each(hooks.kuzzle.config.hooks[event], function parseDefinitions (definition, callbackDefinition) {
-        var
-          hookName,
-          functionName;
+      result = Object.keys(this.kuzzle.config.hooks).every(event => {
+        return this.kuzzle.config.hooks[event].every(definition => {
+          var
+            hookName,
+            functionName;
 
-        definition = definition.split(':');
-        hookName = definition[0];
-        functionName = definition[1];
+          definition = definition.split(':');
+          hookName = definition[0];
+          functionName = definition[1];
 
-        if (!hooks.kuzzle.hooks[hookName]) {
-          try {
-            hooks.list[hookName] = require('./' + hookName);
-            hooks.list[hookName].init(hooks.kuzzle);
+          if (!this.kuzzle.hooks[hookName]) {
+            try {
+              this.list[hookName] = require('./' + hookName);
+              this.list[hookName].init(this.kuzzle);
+            }
+            catch (e) {
+              reject(e);
+              return false;
+            }
           }
-          catch (e) {
-            callbackDefinition(e);
-            return false;
-          }
-        }
 
-        hooks.kuzzle.on(event, function (object) {
-          hooks.list[hookName][functionName](object, event);
+          this.kuzzle.on(event, object => {
+            this.list[hookName][functionName](object, event);
+          });
+
+          return true;
         });
-
-        callbackDefinition();
-      }, function (error) {
-        callbackEvent(error);
       });
-    }, function (error) {
-      if (error) {
-        return deferred.reject(error);
+
+      if (result) {
+        resolve();
       }
-      deferred.resolve();
     });
-    return deferred.promise;
   };
 }
 

--- a/lib/services/broker/index.js
+++ b/lib/services/broker/index.js
@@ -3,7 +3,6 @@ var
   WSServer = require('./wsBrokerServer');
 
 module.exports = function (brokerType, onlyClient, notifyOnListen) {
-  
   return function (kuzzle, opts) {
     if (!kuzzle.config[brokerType]) {
       throw new Error(`No configuration found for broker ${brokerType}. Are you sure this broker exists?`);

--- a/lib/services/broker/wsBrokerClient.js
+++ b/lib/services/broker/wsBrokerClient.js
@@ -19,6 +19,7 @@ function WSBrokerClient (brokerType, options, pluginsManager, notifyOnListen) {
 
   this.client = {
     socket: null,
+    connected: null,
     state: 'disconnected',
     retryInterval: options.retryInterval || 1000
   };
@@ -45,8 +46,25 @@ function WSBrokerClient (brokerType, options, pluginsManager, notifyOnListen) {
  * @type {WSBrokerClient.client}
  */
 WSBrokerClient.prototype.init = function () {
+  var
+    resolve,
+    reject,
+    promise;
+
+  if (this.client.connected) {
+    return this.client.connected.promise;
+  }
+
+  promise = new Promise((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+
   this.client.state = 'pending';
-  return this._connect();
+  this.client.connected = {resolve, reject, promise};
+  this._connect();
+
+  return this.client.connected.promise;
 };
 
 /**
@@ -64,6 +82,7 @@ WSBrokerClient.prototype.listen = function (room, cb) {
   if (this.handlers[room] === undefined) {
     this.handlers[room] = [];
   }
+
   this.handlers[room].push(cb);
 
   if (this.notifyOnListen !== false) {
@@ -119,85 +138,88 @@ WSBrokerClient.prototype.close = function () {
 WSBrokerClient.prototype._connect = function () {
   this.client.socket = this.ws();
 
-  return new Promise(resolve => {
-    this.client.socket.on('message', msg => {
-      msg = JSON.parse(msg);
+  this.client.socket.on('message', msg => {
+    msg = JSON.parse(msg);
 
-      if (msg.room && this.handlers[msg.room]) {
-        this.handlers[msg.room].forEach(cb => cb(msg.data));
+    if (msg.room && this.handlers[msg.room]) {
+      this.handlers[msg.room].forEach(cb => cb(msg.data));
+    }
+  });
+
+  this.client.socket.on('open', () => {
+    this.pluginsManager.trigger(this.eventName + ':connected', 'Connected to Kuzzle server');
+
+    // if we were already listening to some rooms, subscribe again to the server
+    Object.keys(this.handlers).forEach(room => {
+      this.pluginsManager.trigger(this.eventName + ':reregistering', 'Re-registering room: ' + room);
+
+      if (this.notifyOnListen !== false) {
+        this.client.socket.send(JSON.stringify({
+          action: 'listen',
+          room: room
+        }));
       }
     });
 
-    this.client.socket.on('open', () => {
-      this.pluginsManager.trigger(this.eventName + ':connected', 'Connected to Kuzzle server');
+    this.onConnectHandlers.forEach(f => f());
+    this.client.state = 'connected';
 
-      // if we were already listening to some rooms, subscribe again to the server
-      Object.keys(this.handlers).forEach(room => {
-        this.pluginsManager.trigger(this.eventName + ':reregistering', 'Re-registering room: ' + room);
+    if (!this.client.connected.promise.isFulfilled()) {
+      return this.client.connected.resolve(this.client.socket);
+    }
 
-        if (this.notifyOnListen !== false) {
-          this.client.socket.send(JSON.stringify({
-            action: 'listen',
-            room: room
-          }));
-        }
-      });
+    this.pluginsManager.trigger('log:warn', `[${this.eventName}] Node is connected while it was previously already.`);
+  });
 
-      this.onConnectHandlers.forEach(f => f());
-      this.client.state = 'connected';
+  this.client.socket.on('close', code => {
+    // Automatically reconnect except if this.close() was called
+    if (this.client.state === 'disconnected') {
+      return false;
+    }
+    this.close();
 
-      resolve(this.client.socket);
+    this.onCloseHandlers.forEach(f => f());
+
+    this.pluginsManager.trigger(this.eventName + ':socketClosed',
+      `Socket closed with code ${code}
+    ==> RECONNECTING IN ${this.client.retryInterval}ms`
+    );
+
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
+
+    if (this.reconnect) {
+      this.retryTimer = setTimeout(() => this._connect(), this.client.retryInterval);
+    }
+  });
+
+  this.client.socket.on('error', err => {
+    this.close();
+
+    this.onErrorHandlers.forEach(f => f());
+
+    this.pluginsManager.trigger('log:error',
+      `[${this.eventName}] Error while trying to connect to ws://${this.server.host}:${this.server.port} [${err.message}]
+    ==> RECONNECTING IN ${this.client.retryInterval}ms`
+    );
+    this.pluginsManager.trigger(this.eventName + ':error', {
+      host: this.server.host,
+      port: this.server.port,
+      message: err.message,
+      retry: this.client.retryInterval
     });
 
-    this.client.socket.on('close', code => {
-      // Automatically reconnect except if this.close() was called
-      if (this.client.state === 'disconnected') {
-        return false;
-      }
-      this.close();
+    this.client.state = 'retrying';
 
-      this.onCloseHandlers.forEach(f => f());
-
-      this.pluginsManager.trigger(this.eventName + ':socketClosed',
-        `Socket closed with code ${code}
-      ==> RECONNECTING IN ${this.client.retryInterval}ms`
-      );
-
-      if (this.retryTimer) {
-        clearTimeout(this.retryTimer);
-        this.retryTimer = null;
-      }
-      if (this.reconnect) {
-        this.retryTimer = setTimeout(() => this._connect(), this.client.retryInterval);
-      }
-    });
-
-    this.client.socket.on('error', err => {
-      this.close();
-
-      this.onErrorHandlers.forEach(f => f());
-
-      this.pluginsManager.trigger('log:error',
-        `[${this.eventName}] Error while trying to connect to ws://${this.server.host}:${this.server.port} [${err.message}]
-      ==> RECONNECTING IN ${this.client.retryInterval}ms`
-      );
-      this.pluginsManager.trigger(this.eventName + ':error', {
-        host: this.server.host,
-        port: this.server.port,
-        message: err.message,
-        retry: this.client.retryInterval
-      });
-
-      this.client.state = 'retrying';
-
-      if (this.retryTimer) {
-        clearTimeout(this.retryTimer);
-        this.retryTimer = null;
-      }
-      if (this.reconnect) {
-        this.retryTimer = setTimeout(() => this._connect(), this.client.retryInterval);
-      }
-    });
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
+    if (this.reconnect) {
+      this.retryTimer = setTimeout(() => this._connect(), this.client.retryInterval);
+    }
   });
 };
 

--- a/lib/services/broker/wsBrokerClient.js
+++ b/lib/services/broker/wsBrokerClient.js
@@ -56,9 +56,9 @@ WSBrokerClient.prototype.init = function () {
   }
 
   promise = new Promise((res, rej) => {
-      resolve = res;
-      reject = rej;
-    });
+    resolve = res;
+    reject = rej;
+  });
 
   this.client.state = 'pending';
   this.client.connected = {resolve, reject, promise};

--- a/lib/services/broker/wsBrokerClient.js
+++ b/lib/services/broker/wsBrokerClient.js
@@ -1,5 +1,5 @@
 var
-  q = require('q'),
+  Promise = require('bluebird'),
   WS = require('ws'),
   InternalError = require('kuzzle-common-objects').Errors.internalError;
 
@@ -19,7 +19,6 @@ function WSBrokerClient (brokerType, options, pluginsManager, notifyOnListen) {
 
   this.client = {
     socket: null,
-    connected: null,
     state: 'disconnected',
     retryInterval: options.retryInterval || 1000
   };
@@ -46,15 +45,8 @@ function WSBrokerClient (brokerType, options, pluginsManager, notifyOnListen) {
  * @type {WSBrokerClient.client}
  */
 WSBrokerClient.prototype.init = function () {
-  if (this.client.connected) {
-    return this.client.connected.promise;
-  }
-  this.client.connected = q.defer();
   this.client.state = 'pending';
-
-  this._connect();
-
-  return this.client.connected.promise;
+  return this._connect();
 };
 
 /**
@@ -127,85 +119,86 @@ WSBrokerClient.prototype.close = function () {
 WSBrokerClient.prototype._connect = function () {
   this.client.socket = this.ws();
 
-  this.client.socket.on('message', msg => {
-    msg = JSON.parse(msg);
+  return new Promise(resolve => {
+    this.client.socket.on('message', msg => {
+      msg = JSON.parse(msg);
 
-    if (msg.room && this.handlers[msg.room]) {
-      this.handlers[msg.room].forEach(cb => cb(msg.data));
-    }
-  });
-
-  this.client.socket.on('open', () => {
-    this.pluginsManager.trigger(this.eventName+':connected', 'Connected to Kuzzle server');
-
-    // if we were already listening to some rooms, subscribe again to the server
-    Object.keys(this.handlers).forEach(room => {
-      this.pluginsManager.trigger(this.eventName+':reregistering', 'Re-registering room: ' + room);
-
-      if (this.notifyOnListen !== false) {
-        this.client.socket.send(JSON.stringify({
-          action: 'listen',
-          room: room
-        }));
+      if (msg.room && this.handlers[msg.room]) {
+        this.handlers[msg.room].forEach(cb => cb(msg.data));
       }
     });
-    
-    this.onConnectHandlers.forEach(f => f());
 
-    this.client.state = 'connected';
-    
-    if (!this.client.connected.promise.isFulfilled()) {
-      return this.client.connected.resolve(this.client.socket);
-    }
-    
-    this.pluginsManager.trigger('log:warn', `[${this.eventName}] Node is connected while it was previously already.`);
-  });
+    this.client.socket.on('open', () => {
+      this.pluginsManager.trigger(this.eventName + ':connected', 'Connected to Kuzzle server');
 
-  this.client.socket.on('close', code => {
-    // Automatically reconnect except if this.close() was called
-    if (this.client.state === 'disconnected') {
-      return false;
-    }
-    this.close();
-    
-    this.onCloseHandlers.forEach(f => f());
+      // if we were already listening to some rooms, subscribe again to the server
+      Object.keys(this.handlers).forEach(room => {
+        this.pluginsManager.trigger(this.eventName + ':reregistering', 'Re-registering room: ' + room);
 
-    this.pluginsManager.trigger(this.eventName+':socketClosed',
-      `Socket closed with code ${code}
+        if (this.notifyOnListen !== false) {
+          this.client.socket.send(JSON.stringify({
+            action: 'listen',
+            room: room
+          }));
+        }
+      });
+
+      this.onConnectHandlers.forEach(f => f());
+      this.client.state = 'connected';
+
+      resolve(this.client.socket);
+    });
+
+    this.client.socket.on('close', code => {
+      // Automatically reconnect except if this.close() was called
+      if (this.client.state === 'disconnected') {
+        return false;
+      }
+      this.close();
+
+      this.onCloseHandlers.forEach(f => f());
+
+      this.pluginsManager.trigger(this.eventName + ':socketClosed',
+        `Socket closed with code ${code}
       ==> RECONNECTING IN ${this.client.retryInterval}ms`
-    );
+      );
 
-    if (this.retryTimer) {
-      clearTimeout(this.retryTimer);
-      this.retryTimer = null;
-    }
-    if (this.reconnect) {
-      this.retryTimer = setTimeout(() => this._connect(), this.client.retryInterval);
-    }
-  });
+      if (this.retryTimer) {
+        clearTimeout(this.retryTimer);
+        this.retryTimer = null;
+      }
+      if (this.reconnect) {
+        this.retryTimer = setTimeout(() => this._connect(), this.client.retryInterval);
+      }
+    });
 
-  this.client.socket.on('error', err => {
-    this.close();
-    
-    this.onErrorHandlers.forEach(f => f());
+    this.client.socket.on('error', err => {
+      this.close();
 
-    this.pluginsManager.trigger('log:error',
-      `[${this.eventName}] Error while trying to connect to ws://${this.server.host}:${this.server.port} [${err.message}]
+      this.onErrorHandlers.forEach(f => f());
+
+      this.pluginsManager.trigger('log:error',
+        `[${this.eventName}] Error while trying to connect to ws://${this.server.host}:${this.server.port} [${err.message}]
       ==> RECONNECTING IN ${this.client.retryInterval}ms`
-    );
-    this.pluginsManager.trigger(this.eventName+':error', {host: this.server.host, port: this.server.port, message: err.message, retry: this.client.retryInterval});
+      );
+      this.pluginsManager.trigger(this.eventName + ':error', {
+        host: this.server.host,
+        port: this.server.port,
+        message: err.message,
+        retry: this.client.retryInterval
+      });
 
-    this.client.state = 'retrying';
-    
-    if (this.retryTimer) {
-      clearTimeout(this.retryTimer);
-      this.retryTimer = null;
-    }
-    if (this.reconnect) {
-      this.retryTimer = setTimeout(() => this._connect(), this.client.retryInterval);
-    }
+      this.client.state = 'retrying';
+
+      if (this.retryTimer) {
+        clearTimeout(this.retryTimer);
+        this.retryTimer = null;
+      }
+      if (this.reconnect) {
+        this.retryTimer = setTimeout(() => this._connect(), this.client.retryInterval);
+      }
+    });
   });
-  
 };
 
 /**
@@ -229,7 +222,7 @@ WSBrokerClient.prototype.send = function (room, data) {
 };
 
 WSBrokerClient.prototype.waitForClients = function () {
-  return q.reject(new InternalError('Not implemented for broker client'));
+  return Promise.reject(new InternalError('Not implemented for broker client'));
 };
 
 module.exports = WSBrokerClient;

--- a/lib/services/broker/wsBrokerServer.js
+++ b/lib/services/broker/wsBrokerServer.js
@@ -1,5 +1,5 @@
 var
-  q = require('q'),
+  Promise = require('bluebird'),
   CircularList = require('easy-circular-list'),
   InternalError = require('kuzzle-common-objects').Errors.internalError,
   WS = require('ws').Server;
@@ -37,75 +37,70 @@ function WSBrokerServer (brokerType, options, pluginsManager) {
  * @returns {Promise}
  */
 WSBrokerServer.prototype.init = function () {
-  var
-    deferred = q.defer();
-
   if (this.server) {
-    deferred.reject(new InternalError('Websocket server already started'));
-    return deferred.promise;
+    return Promise.reject(new InternalError('Websocket server already started'));
   }
 
-  this.server = this.ws(this.options.server, () => {
-    deferred.resolve();
-  });
+  return new Promise(resolve => {
+    this.server = this.ws(this.options.server, () => {
+      resolve();
+    });
 
-  this.server.on('connection', clientSocket => {
-    clientSocket.on('message', msg => {
-      msg = JSON.parse(msg);
+    this.server.on('connection', clientSocket => {
+      clientSocket.on('message', msg => {
+        msg = JSON.parse(msg);
 
-      switch (msg.action) {
-        // the listen action is called by the client to inform the server it
-        // wants to be notified on the room activity
-        case 'listen':
-          if (this.rooms[msg.room] === undefined) {
-            this.rooms[msg.room] = new CircularList([]);
-          }
-          if (this.rooms[msg.room].getArray().indexOf(clientSocket) === -1) {
-            this.rooms[msg.room].add(clientSocket);
-          }
-          break;
-        case 'unsubscribe':
-          if (this.rooms[msg.room]) {
-            this.rooms[msg.room].remove(clientSocket);
-            if (this.rooms[msg.room].getSize() === 0) {
-              delete this.rooms[msg.room];
+        switch (msg.action) {
+          // the listen action is called by the client to inform the server it
+          // wants to be notified on the room activity
+          case 'listen':
+            if (this.rooms[msg.room] === undefined) {
+              this.rooms[msg.room] = new CircularList([]);
             }
-          }
-          break;
+            if (this.rooms[msg.room].getArray().indexOf(clientSocket) === -1) {
+              this.rooms[msg.room].add(clientSocket);
+            }
+            break;
+          case 'unsubscribe':
+            if (this.rooms[msg.room]) {
+              this.rooms[msg.room].remove(clientSocket);
+              if (this.rooms[msg.room].getSize() === 0) {
+                delete this.rooms[msg.room];
+              }
+            }
+            break;
 
-        // broadcast & send can be used in 2 ways:
-        //   1 - (most common): pass a message to the server to a room on which
-        //                      a callback was set to trigger a remote action
-        //   2 - If some other clients have subscribed to the room, they will
-        //       be also notified
-        case 'send':
-          this.dispatch(msg.room, msg.data);
-          this.send(msg.room, msg.data, clientSocket);
-          break;
-        case 'broadcast':
-          this.dispatch(msg.room, msg.data);
-          this.broadcast(msg.room, msg.data, clientSocket);
-          break;
-      }
+          // broadcast & send can be used in 2 ways:
+          //   1 - (most common): pass a message to the server to a room on which
+          //                      a callback was set to trigger a remote action
+          //   2 - If some other clients have subscribed to the room, they will
+          //       be also notified
+          case 'send':
+            this.dispatch(msg.room, msg.data);
+            this.send(msg.room, msg.data, clientSocket);
+            break;
+          case 'broadcast':
+            this.dispatch(msg.room, msg.data);
+            this.broadcast(msg.room, msg.data, clientSocket);
+            break;
+        }
+      });
+
+      clientSocket.on('close', (code, message) => {
+        this.pluginsManager.trigger('log:info', `client disconnected [${code}] ${message}`);
+        removeClient.call(this, clientSocket);
+      });
+
+      clientSocket.on('error', err => {
+        this.pluginsManager.trigger('log:error', err);
+      });
     });
 
-    clientSocket.on('close', (code, message) => {
-      this.pluginsManager.trigger('log:info', `client disconnected [${code}] ${message}`);
-      removeClient.call(this, clientSocket);
-    });
-
-    clientSocket.on('error', err => {
-      this.pluginsManager.trigger('log:error', err);
+    this.server.on('error', error => {
+      this.pluginsManager.trigger('log:error', `Connection error: [${error.code}] ${error.message}`);
+      this.onErrorHandlers.forEach(f => f());
     });
   });
-
-  this.server.on('error', error => {
-    this.pluginsManager.trigger('log:error', `Connection error: [${error.code}] ${error.message}`);
-    
-    this.onErrorHandlers.forEach(f => f());
-  });
-  
-  return deferred.promise;
 };
 
 /**
@@ -218,23 +213,20 @@ WSBrokerServer.prototype.listen = function (room, cb) {
  */
 WSBrokerServer.prototype.waitForClients = function (room) {
   var
-    deferred,
     interval;
 
   if (this.rooms[room]) {
-    return q();
+    return Promise.resolve();
   }
 
-  deferred = q.defer();
-
-  interval = setInterval(() => {
-    if (this.rooms[room]) {
-      deferred.resolve();
-      clearInterval(interval);
-    }
-  }, 100);
-
-  return deferred.promise;
+  return new Promise(resolve => {
+    interval = setInterval(() => {
+      if (this.rooms[room]) {
+        clearInterval(interval);
+        resolve();
+      }
+    }, 100);
+  });
 };
 
 /**
@@ -259,7 +251,7 @@ WSBrokerServer.prototype.close = function () {
 /**
  * Returns the underlying Websocket.
  *
- * @returns {Websocket.Server}
+ * @returns {WS}
  */
 WSBrokerServer.prototype.socket = function () {
   return this.server;

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -170,8 +170,8 @@ function ElasticSearch (kuzzle, options) {
       So, in order to suppress this discrepancy, if a count action is called without a body but with a query,
       we embed the query object in a body one.
     */
-    if (_.isEmpty(data.body)) {
-      if (!_.isEmpty(data.query)) {
+    if (!data.body || Object.keys(data.body).length === 0) {
+      if (data.query && Object.keys(data.query).length > 0) {
         data.body = { query: data.query };
         delete data.query;
       } else {

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -356,56 +356,55 @@ function ElasticSearch (kuzzle, options) {
       data = cleanData.call(this, requestObject),
       error = null;
 
-    if (data.body) {
-      // set missing index & type if possible
-      async.eachLimit(data.body, 20, item => {
-        var action = Object.keys(item)[0];
-        if (nameActions.indexOf(action) !== -1) {
-          if (!item[action]._type && data.type !== undefined) {
-            item[action]._type = data.type;
-          }
-          if (!item[action]._type) {
-            error = new BadRequestError('Missing data collection argument');
-          }
-
-          if (!item[action]._index && data.index !== undefined) {
-            item[action]._index = data.index;
-          }
-          if (!item[action]._index) {
-            error = new BadRequestError('Missing data collection argument');
-            return false;
-          }
-        }
-      });
-
-      if (!error) {
-        return this.client.bulk(data)
-          .then(response => refreshIndexIfNeeded.call(this, data, response))
-          .then(result => {
-            // If some errors occured during the Bulk, we send a "Partial Error" response :
-            if (result.errors) {
-              result.partialErrors = [];
-
-              result.items.forEach(resultItem => {
-                Object.keys(resultItem).forEach(action => {
-                  var item = resultItem[action];
-                  if (item.error) {
-                    item.action = action;
-                    result.partialErrors.push(item);
-                  }
-                });
-              });
-            }
-
-            return result;
-          });
-      }
-      else {
-        return Promise.reject(error);
-      }
+    if (!data.body) {
+      return Promise.reject(new BadRequestError('Bulk import: Parse error: document <body> is missing'));
     }
 
-    return Promise.reject(new BadRequestError('Bulk import: Parse error: document <body> is missing'));
+    // set missing index & type if possible
+    data.body.forEach(item => {
+      var action = Object.keys(item)[0];
+      if (nameActions.indexOf(action) !== -1) {
+        if (!item[action]._type && data.type !== undefined) {
+          item[action]._type = data.type;
+        }
+        if (!item[action]._type) {
+          error = new BadRequestError('Missing data collection argument');
+        }
+
+        if (!item[action]._index && data.index !== undefined) {
+          item[action]._index = data.index;
+        }
+        if (!item[action]._index) {
+          error = new BadRequestError('Missing data collection argument');
+          return false;
+        }
+      }
+    });
+
+    if (error) {
+      return Promise.reject(error);
+    }
+
+    return this.client.bulk(data)
+      .then(response => refreshIndexIfNeeded.call(this, data, response))
+      .then(result => {
+        // If some errors occured during the Bulk, we send a "Partial Error" response :
+        if (result.errors) {
+          result.partialErrors = [];
+
+          Object.keys(result.items).forEach(resultItem => {
+            Object.keys(result.items[resultItem]).forEach(action => {
+              var item = result.items[resultItem][action];
+              if (item.error) {
+                item.action = action;
+                result.partialErrors.push(item);
+              }
+            });
+          });
+        }
+
+        return result;
+      });
   };
 
   /**
@@ -668,6 +667,7 @@ function getAllIdsFromQuery(data) {
 function refreshIndexIfNeeded(data, response) {
   if (data && data.index && this.settings.autoRefresh[data.index]) {
     return this.refreshIndex(new RequestObject({ index: data.index }))
+      .then(() => response)
       .catch(error => {
         // index refresh failures are non-blocking
         this.kuzzle.pluginsManager.trigger('log:error', new InternalError('Error refreshing index ' + data.index + ':\n' + error.message));

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -1,6 +1,6 @@
 var
   _ = require('lodash'),
-  q = require('q'),
+  Promise = require('bluebird'),
   async = require('async'),
   util = require('util'),
   Service = require('./service'),
@@ -40,11 +40,11 @@ function ElasticSearch (kuzzle, options) {
   /**
    * Initialize the elasticsearch client
    *
-   * @returns {Object} client
+   * @returns {Promise}
    */
   this.init = function () {
     if (this.client) {
-      return this;
+      return Promise.resolve(this);
     }
 
     this.client = new es.Client({
@@ -52,7 +52,7 @@ function ElasticSearch (kuzzle, options) {
       apiVersion: kuzzle.config[this.settings.service].apiVersion
     });
 
-    return q(this);
+    return Promise.resolve(this);
   };
 
   /**
@@ -125,7 +125,7 @@ function ElasticSearch (kuzzle, options) {
     // Just in case the user make a GET on url /mainindex/test/_search
     // Without this test we return something weird: a result.hits.hits with all document without filter because the body is empty in REST by default
     if (data.id === '_search') {
-      return q.reject(new BadRequestError('The action _search can\'t be done with a GET'));
+      return Promise.reject(new BadRequestError('The action _search can\'t be done with a GET'));
     }
 
     return this.client.get(data);
@@ -255,7 +255,7 @@ function ElasticSearch (kuzzle, options) {
           return this.client.index(data);
         }
 
-        return q.reject(new NotFoundError('Document with id ' + data.id + ' not found.'));
+        return Promise.reject(new NotFoundError('Document with id ' + data.id + ' not found.'));
       })
       .then(result => refreshIndexIfNeeded.call(this, data, _.extend(result, {_source: requestObject.data.body})));
   };
@@ -282,36 +282,33 @@ function ElasticSearch (kuzzle, options) {
    */
   this.deleteByQuery = function (requestObject) {
     var
-      deferred = q.defer(),
       data = cleanData.call(this, requestObject),
       bodyBulk = [];
 
     if (requestObject.data.body === null) {
-      return q.reject(new BadRequestError('null is not a valid document ID'));
+      return Promise.reject(new BadRequestError('null is not a valid document ID'));
     }
 
     data.scroll = '30s';
 
-    getAllIdsFromQuery.call(this, data)
+    return getAllIdsFromQuery.call(this, data)
       .then(ids => {
-        async.each(ids, (id, callback) => {
-          bodyBulk.push({delete: {_index: data.index, _type: data.type, _id: id}});
-          callback();
-        }, () => {
-          if (bodyBulk.length === 0) {
-            deferred.resolve({ids : []});
-            return false;
-          }
+        return new Promise((resolve, reject) => {
+          async.each(ids, (id, callback) => {
+            bodyBulk.push({delete: {_index: data.index, _type: data.type, _id: id}});
+            callback();
+          }, () => {
+            if (bodyBulk.length === 0) {
+              return resolve({ids: []});
+            }
 
-          this.client.bulk({body: bodyBulk})
-            .then(() => refreshIndexIfNeeded.call(this, data, {ids: ids}))
-            .then(result => deferred.resolve(result))
-            .catch(error => deferred.reject(error));
+            this.client.bulk({body: bodyBulk})
+              .then(() => refreshIndexIfNeeded.call(this, data, {ids: ids}))
+              .then(result => resolve(result))
+              .catch(error => reject(error));
+          });
         });
-      })
-      .catch(error => deferred.reject(error));
-
-    return deferred.promise;
+      });
   };
 
   /**
@@ -355,9 +352,9 @@ function ElasticSearch (kuzzle, options) {
    */
   this.import = function (requestObject) {
     var
-      deferred = q.defer(),
       nameActions = ['index', 'create', 'update', 'delete'],
-      data = cleanData.call(this, requestObject);
+      data = cleanData.call(this, requestObject),
+      error = null;
 
     if (data.body) {
       // set missing index & type if possible
@@ -368,63 +365,47 @@ function ElasticSearch (kuzzle, options) {
             item[action]._type = data.type;
           }
           if (!item[action]._type) {
-            deferred.reject(new BadRequestError('Missing data collection argument'));
-            return false;
+            error = new BadRequestError('Missing data collection argument');
           }
 
           if (!item[action]._index && data.index !== undefined) {
             item[action]._index = data.index;
           }
           if (!item[action]._index) {
-            deferred.reject(new BadRequestError('Missing data collection argument'));
+            error = new BadRequestError('Missing data collection argument');
             return false;
           }
         }
       });
 
-      if (!deferred.promise.isRejected()) {
-        this.client.bulk(data)
+      if (!error) {
+        return this.client.bulk(data)
           .then(response => refreshIndexIfNeeded.call(this, data, response))
-          .then(function (result) {
-            var
-              stack;
-
+          .then(result => {
             // If some errors occured during the Bulk, we send a "Partial Error" response :
             if (result.errors) {
-              stack = [];
-              async.each(result.items, function(resultItem, resultCallback) {
-                async.each(Object.keys(resultItem), function(action, callback) {
+              result.partialErrors = [];
+
+              result.items.forEach(resultItem => {
+                Object.keys(resultItem).forEach(action => {
                   var item = resultItem[action];
                   if (item.error) {
                     item.action = action;
-                    stack.push(item);
+                    result.partialErrors.push(item);
                   }
-                  callback();
                 });
-                resultCallback();
               });
-
-              result.partialErrors = stack;
             }
 
-            async.each(result.items, function(resultItem, resultCallback) {
-              async.each(Object.keys(resultItem), function(action, callback) {
-                callback();
-              });
-              resultCallback();
-            });
-
-            deferred.resolve(result);
-          })
-          .catch(function (error) {
-            deferred.reject(error);
+            return result;
           });
       }
-
-      return deferred.promise;
+      else {
+        return Promise.reject(error);
+      }
     }
 
-    return q.reject(new BadRequestError('Bulk import: Parse error: document <body> is missing'));
+    return Promise.reject(new BadRequestError('Bulk import: Parse error: document <body> is missing'));
   };
 
   /**
@@ -458,7 +439,7 @@ function ElasticSearch (kuzzle, options) {
           return result;
         }
 
-        return q.reject(new NotFoundError('No mapping for index "' + requestObject.index + '"'));
+        return Promise.reject(new NotFoundError('No mapping for index "' + requestObject.index + '"'));
       });
   };
 
@@ -497,7 +478,7 @@ function ElasticSearch (kuzzle, options) {
     delete requestObject.data.body;
 
     if (deletedIndexes === undefined || deletedIndexes.length === 0) {
-      return q({deleted: []});
+      return Promise.resolve({deleted: []});
     }
 
     return this.client.indices.delete({index: deletedIndexes})
@@ -576,7 +557,7 @@ function ElasticSearch (kuzzle, options) {
    * @returns {Promise}
    */
   this.getAutoRefresh = function (requestObject) {
-    return q(this.settings.autoRefresh[requestObject.index] === true);
+    return Promise.resolve(this.settings.autoRefresh[requestObject.index] === true);
   };
 
   /**
@@ -648,33 +629,31 @@ function cleanData(requestObject) {
  */
 function getAllIdsFromQuery(data) {
   var
-    deferred = q.defer(),
     ids = [];
 
-  this.client.search(data, function getMoreUntilDone (error, response) {
-    if (error) {
-      deferred.reject(error);
-      return false;
-    }
+  return new Promise((resolve, reject) => {
+    this.client.search(data, function getMoreUntilDone(error, response) {
+      if (error) {
+        return reject(error);
+      }
 
-    response.hits.hits.forEach(function (hit) {
-      ids.push(hit._id);
-    });
+      response.hits.hits.forEach(function (hit) {
+        ids.push(hit._id);
+      });
 
-    /* jshint camelcase: false */
-    if (response.hits.total !== ids.length) {
-      this.client.scroll({
-        scrollId: response._scroll_id,
-        scroll: data.scroll
-      }, getMoreUntilDone.bind(this));
-    }
-    else {
-      deferred.resolve(ids);
-    }
-    /* jshint camelcase: true */
-  }.bind(this));
-
-  return deferred.promise;
+      /* jshint camelcase: false */
+      if (response.hits.total !== ids.length) {
+        this.client.scroll({
+          scrollId: response._scroll_id,
+          scroll: data.scroll
+        }, getMoreUntilDone.bind(this));
+      }
+      else {
+        resolve(ids);
+      }
+      /* jshint camelcase: true */
+    }.bind(this));
+  });
 }
 
 /**
@@ -687,24 +666,15 @@ function getAllIdsFromQuery(data) {
  * @returns {Promise}
  */
 function refreshIndexIfNeeded(data, response) {
-  var deferred;
-
   if (data && data.index && this.settings.autoRefresh[data.index]) {
-    deferred = q.defer();
-
-    this.refreshIndex(new RequestObject({ index: data.index }))
-      .then(() => {
-        deferred.resolve(response);
-      })
+    return this.refreshIndex(new RequestObject({ index: data.index }))
       .catch(error => {
         // index refresh failures are non-blocking
         this.kuzzle.pluginsManager.trigger('log:error', new InternalError('Error refreshing index ' + data.index + ':\n' + error.message));
 
-        deferred.resolve(response);
+        return Promise.resolve(response);
       });
-
-    return deferred.promise;
   }
 
-  return q(response);
+  return Promise.resolve(response);
 }

--- a/lib/services/index.js
+++ b/lib/services/index.js
@@ -1,5 +1,5 @@
 var
-  q = require('q'),
+  Promise = require('bluebird'),
   _ = require('lodash'),
   InternalError = require('kuzzle-common-objects').Errors.internalError;
 
@@ -44,7 +44,6 @@ module.exports = function (kuzzle) {
     promises = Object.keys(kuzzle.config.services).map(service => {
       // We need to use a deferred promise here as the internalEngine (es) promises do not implement `finally`.
       var
-        deferred = q.defer(),
         init,
         opt = {service, isServer: server};
 
@@ -52,29 +51,23 @@ module.exports = function (kuzzle) {
         ? whitelist.indexOf(service) > -1
         : blacklist.indexOf(service) === -1;
 
-      kuzzle.internalEngine
+      return kuzzle.internalEngine
         .get(kuzzle.config.serviceSettingsCollection, service)
         .then(response => {
           opt = _.merge(opt, response._source);
 
-          return registerService.call(this, service, opt, init)
-            .then(deferred.resolve)
-            .catch(deferred.reject);
+          return registerService.call(this, service, opt, init);
         })
         .catch(err => {
           if (err.status === 404) {
-            return registerService.call(this, service, opt, init)
-              .then(deferred.resolve)
-              .catch(deferred.reject);
+            return registerService.call(this, service, opt, init);
           }
 
-          return deferred.reject(err);
+          return Promise.reject(err);
         });
-
-      return deferred.promise;
     });
     
-    return q.all(promises);
+    return Promise.all(promises);
   };
 };
 
@@ -95,7 +88,7 @@ function registerService (serviceName, opts, init) {
   }
 
   if (!init) {
-    return q();
+    return Promise.resolve();
   }
 
   return this.list[serviceName].init()

--- a/lib/services/internalEngine.js
+++ b/lib/services/internalEngine.js
@@ -22,7 +22,7 @@
 
 var
   _ = require('lodash'),
-  q = require('q'),
+  Promise = require('bluebird'),
   NotFoundError = require('kuzzle-common-objects').Errors.notFoundError,
   Elasticsearch = require('elasticsearch');
 
@@ -41,16 +41,14 @@ function InternalEngine (kuzzle) {
    * @returns {Object} client
    */
   this.init = function () {
-    if (this.client) {
-      return this;
+    if (!this.client) {
+      this.client = new Elasticsearch.Client({
+        host: kuzzle.config[this.engineType].hosts,
+        apiVersion: kuzzle.config[this.engineType].apiVersion
+      });
     }
 
-    this.client = new Elasticsearch.Client({
-      host: kuzzle.config[this.engineType].hosts,
-      apiVersion: kuzzle.config[this.engineType].apiVersion
-    });
-
-    return this;
+    return Promise.resolve(this);
   };
 
   /**
@@ -227,7 +225,7 @@ function InternalEngine (kuzzle) {
           return this.client.index(request);
         }
 
-        return q.reject(new NotFoundError('Document with id ' + id + ' not found.'));
+        return Promise.reject(new NotFoundError('Document with id ' + id + ' not found.'));
       })
       .then(result => _.extend(result, {_source: content}));
   };

--- a/lib/services/rabbit.js
+++ b/lib/services/rabbit.js
@@ -5,7 +5,7 @@ var
   amqp = require('amqplib'),
   util = require('util'),
   Service = require('./service'),
-  q = require('q'),
+  Promise = require('bluebird'),
   // AMQP management variables
   amqpConnection,
   amqpMainChannel,
@@ -34,6 +34,8 @@ function RabbitMQ (kuzzle, options) {
 
   /**
    * Initialize the connection with the amqp broker
+   *
+   * @returns {Promise}
    */
   this.init = function () {
     if (process.env.MQ_BROKER_ENABLED) {
@@ -45,7 +47,7 @@ function RabbitMQ (kuzzle, options) {
 
     amqpDomain.on('error', this.onErrorRestart.bind(this));
 
-    return q(this);
+    return Promise.resolve(this);
   };
 
   /**
@@ -56,52 +58,45 @@ function RabbitMQ (kuzzle, options) {
    * @return {Promise}
    */
   this.toggle = function (toggle) {
-    var
-      deferred,
-      self = this;
-
-    if (toggle === self.enabled) {
-      return q.reject(new InternalError('RabbitMQ service is already ' + (toggle ? 'enabled' : 'disabled')));
+    if (toggle === this.enabled) {
+      return Promise.reject(new InternalError('RabbitMQ service is already ' + (toggle ? 'enabled' : 'disabled')));
     }
 
-    deferred = q.defer();
-    self.enabled = toggle;
+    this.enabled = toggle;
 
     if (toggle) {
-      amqpConnection = amqp.connect('amqp://' + self.kuzzleConfig.mqBroker.host + ':' + self.kuzzleConfig.mqBroker.port);
+      amqpConnection = amqp.connect(`amqp://${this.kuzzleConfig.mqBroker.host}:${this.kuzzleConfig.mqBroker.port}`);
 
-      amqpConnection
-        .then(function (connection) {
+      return amqpConnection
+        .then(connection => {
           amqpDomain.add(connection);
           amqpMainChannel = connection.createChannel();
 
           // Register bufferized listeners
-          Object.keys(self.listeners).forEach(function (room) {
-            var listener = self.listeners[room];
-            self[listener.type](room, listener.callback);
+          Object.keys(this.listeners).forEach(room => {
+            var listener = this.listeners[room];
+            this[listener.type](room, listener.callback);
           });
 
           kuzzle.pluginsManager.trigger('rabbit:started', 'RabbitMQ Service started');
-          deferred.resolve('RabbitMQ Service started');
+          return 'RabbitMQ Service started';
         })
-        .catch(function (error) {
+        .catch(error => {
           kuzzle.pluginsManager.trigger('log:error',
             'Unable to contact the RabbitMQ server: ' + error.message + ' ' +
             'Check that it is running and the connection URL'
           );
-          kuzzle.pluginsManager.trigger('rabbit:error',error);
+          kuzzle.pluginsManager.trigger('rabbit:error', error);
 
-          deferred.reject(new ServiceUnavailableError('Unable to contact the RabbitMQ server: ' + error.message));
+          return Promise.reject(new ServiceUnavailableError('Unable to contact the RabbitMQ server: ' + error.message));
         });
     }
     else {
-      self.close();
+      this.close();
 
       kuzzle.pluginsManager.trigger('rabbit:stopped', 'RabbitMQ Service stopped');
-      deferred.resolve('RabbitMQ Service stopped');
+      return Promise.resolve('RabbitMQ Service stopped');
     }
-
-    return deferred.promise;
   };
 
   /**
@@ -369,20 +364,19 @@ module.exports = RabbitMQ;
 
 function waitForMainChannel () {
   var
-    deferred = q.defer(),
     checking;
 
   if (amqpMainChannel) {
-    deferred.resolve(amqpMainChannel);
+    return Promise.resolve(amqpMainChannel);
   }
   else {
-    checking = setTimeout(function() {
-      if (amqpMainChannel) {
-        clearTimeout(checking);
-        deferred.resolve(amqpMainChannel);
-      }
-    }, 50);
+    return new Promise(resolve => {
+      checking = setTimeout(() => {
+        if (amqpMainChannel) {
+          clearTimeout(checking);
+          resolve(amqpMainChannel);
+        }
+      }, 50);
+    });
   }
-
-  return deferred.promise;
 }

--- a/lib/services/rabbit.js
+++ b/lib/services/rabbit.js
@@ -91,12 +91,11 @@ function RabbitMQ (kuzzle, options) {
           return Promise.reject(new ServiceUnavailableError('Unable to contact the RabbitMQ server: ' + error.message));
         });
     }
-    else {
-      this.close();
 
-      kuzzle.pluginsManager.trigger('rabbit:stopped', 'RabbitMQ Service stopped');
-      return Promise.resolve('RabbitMQ Service stopped');
-    }
+    this.close();
+
+    kuzzle.pluginsManager.trigger('rabbit:stopped', 'RabbitMQ Service stopped');
+    return Promise.resolve('RabbitMQ Service stopped');
   };
 
   /**
@@ -369,14 +368,13 @@ function waitForMainChannel () {
   if (amqpMainChannel) {
     return Promise.resolve(amqpMainChannel);
   }
-  else {
-    return new Promise(resolve => {
-      checking = setTimeout(() => {
-        if (amqpMainChannel) {
-          clearTimeout(checking);
-          resolve(amqpMainChannel);
-        }
-      }, 50);
-    });
-  }
+
+  return new Promise(resolve => {
+    checking = setTimeout(() => {
+      if (amqpMainChannel) {
+        clearTimeout(checking);
+        resolve(amqpMainChannel);
+      }
+    }, 50);
+  });
 }

--- a/lib/services/rabbit.js
+++ b/lib/services/rabbit.js
@@ -38,16 +38,13 @@ function RabbitMQ (kuzzle, options) {
    * @returns {Promise}
    */
   this.init = function () {
-    if (process.env.MQ_BROKER_ENABLED) {
-      this.toggle(process.env.MQ_BROKER_ENABLED === '1');
-    }
-    else {
-      this.toggle(this.kuzzleConfig.mqBroker.enabled);
-    }
-
     amqpDomain.on('error', this.onErrorRestart.bind(this));
 
-    return Promise.resolve(this);
+    if (process.env.MQ_BROKER_ENABLED) {
+      return this.toggle(process.env.MQ_BROKER_ENABLED === '1');
+    }
+
+    return this.toggle(this.kuzzleConfig.mqBroker.enabled);
   };
 
   /**
@@ -110,7 +107,7 @@ function RabbitMQ (kuzzle, options) {
     }
 
     waitForMainChannel()
-      .then(function (channel) {
+      .then(channel => {
         channel.assertQueue(room, {durable: true})
           .then(function () {
             channel.sendToQueue(room, new Buffer(stringify(data)), {deliveryMode: true});

--- a/lib/services/redis.js
+++ b/lib/services/redis.js
@@ -1,6 +1,6 @@
 var
   _ = require('lodash'),
-  q = require('q'),
+  Promise = require('bluebird'),
   util = require('util'),
   IORedis = require('ioredis'),
   InternalError = require('kuzzle-common-objects').Errors.internalError,
@@ -31,63 +31,56 @@ function Redis (kuzzle, options) {
    * Initialize the redis client, select the service associated database and flush it to make sure we start
    * from a clean slate
    *
-   * @returns {Object} client
+   * @returns {Promise} client
    */
   this.init = function () {
-    if (this.initialized) {
-      return this.initialized.promise;
-    }
-
-    this.initialized = q.defer();
-
     if (this.kuzzleConfig.cache.databases.indexOf(this.settings.service) === -1) {
-      this.initialized.reject(new InternalError('Unknown database: ', this.settings.service));
-      return this.initialized.promise;
+      return Promise.reject(new InternalError('Unknown database: ', this.settings.service));
     }
 
-    this.client = buildClient(this.kuzzleConfig.cache);
+    return new Promise((resolve, reject) => {
+      this.client = buildClient(this.kuzzleConfig.cache);
 
-    this.client.on('ready', () => {
-      this.client.select(this.kuzzleConfig.cache.databases.indexOf(this.settings.service), error => {
-        if (error) {
-          return this.initialized.reject(error);
-        }
-
-        // do not flush publicCache
-        if (this.settings.service === 'memoryStorage') {
-          return this.initialized.resolve(this);
-        }
-
-        this.client.flushdb(err => {
-          if (err) {
-            return this.initialized.reject(err);
+      this.client.on('ready', () => {
+        this.client.select(this.kuzzleConfig.cache.databases.indexOf(this.settings.service), error => {
+          if (error) {
+            return reject(error);
           }
-          this.initialized.resolve(this);
+
+          // do not flush publicCache
+          if (this.settings.service === 'memoryStorage') {
+            return resolve(this);
+          }
+
+          this.client.flushdb(err => {
+            if (err) {
+              return reject(err);
+            }
+
+            resolve(this);
+          });
         });
       });
+
+      this.client.on('error', error => {
+        reject(error);
+        kuzzle.pluginsManager.trigger('log:error', error);
+      });
+
+      this.commands = this.client.getBuiltinCommands();
+
+      // Canonical implementations. Just wrapping redis client library into promises
+      this.commands.forEach(command => {
+        if (this[command]) {
+          // do not override existing method
+          return;
+        }
+
+        this[command] = function () {
+          return this.client[command].apply(this.client, arguments);
+        }.bind(this);
+      });
     });
-
-    this.client.on('error', error => {
-      this.initialized.reject(error);
-
-      kuzzle.pluginsManager.trigger('log:error', error);
-    });
-
-    this.commands = this.client.getBuiltinCommands();
-
-    // Canonical implementations. Just wrapping redis client library into promises
-    this.commands.forEach(command => {
-      if (this[command]) {
-        // do not override existing method
-        return;
-      }
-
-      this[command] = function () {
-        return this.client[command].apply(this.client, arguments);
-      }.bind(this);
-    });
-
-    return this.initialized.promise;
   };
 
   /**
@@ -136,14 +129,14 @@ function Redis (kuzzle, options) {
       addSet = [key];
 
     if (!values) {
-      return q(0);
+      return Promise.resolve(0);
     }
 
     if (typeof values === 'string') {
       addSet.push(values);
     } else {
       if (values.length === 0) {
-        return q(0);
+        return Promise.resolve(0);
       }
       addSet = addSet.concat(values);
     }
@@ -212,21 +205,21 @@ function Redis (kuzzle, options) {
    * @returns {Promise} promise resolving to an array of keys
    */
   this.searchKeys = function (pattern) {
-    var
-      deferred = q.defer(),
-      keys = [],
-      stream = this.client.scanStream({
-        match: pattern
+    return new Promise(resolve => {
+      var
+        keys = [],
+        stream = this.client.scanStream({
+          match: pattern
+        });
+
+      stream.on('data', resultKeys => {
+        keys = keys.concat(resultKeys);
       });
 
-    stream.on('data', resultKeys => {
-      keys = keys.concat(resultKeys);
+      stream.on('end', () => {
+        resolve(_.uniq(keys));
+      });
     });
-    stream.on('end', () => {
-      deferred.resolve(_.uniq(keys));
-    });
-
-    return deferred.promise;
   };
 
   /**
@@ -252,7 +245,7 @@ function Redis (kuzzle, options) {
     }
 
     if (args.length === 0) {
-      return q([]);
+      return Promise.resolve([]);
     }
 
     return this.client.mget(args);

--- a/lib/services/service.js
+++ b/lib/services/service.js
@@ -1,5 +1,5 @@
 var
-  q = require('q');
+  Promise = require('bluebird');
 
 /**
  * Services squeleton
@@ -14,7 +14,7 @@ function Service() {
 
 Service.prototype.saveSettings = function () {
   if (!this.settings) {
-    return q();
+    return Promise.resolve();
   }
 
   return this.kuzzle.internalEngine

--- a/lib/workers/index.js
+++ b/lib/workers/index.js
@@ -1,6 +1,6 @@
 var
   async = require('async'),
-  q = require('q');
+  Promise = require('bluebird');
 
 /**
  * @property {Object} list
@@ -13,33 +13,35 @@ function Workers (kuzzle) {
   this.kuzzle = kuzzle;
 
   this.init = function (options) {
-    var deferred = q.defer();
+    var promises;
 
-    Object.keys(kuzzle.config.workers).forEach(groupWorkers => {
-      kuzzle.pluginsManager.trigger('workerGroup:loaded', groupWorkers);
+    promises = Object.keys(kuzzle.config.workers).map(groupWorkers => {
+      return new Promise((resolve, reject) => {
+        kuzzle.pluginsManager.trigger('workerGroup:loaded', groupWorkers);
 
-      /*
-       Loads each worker in a worker group sequentially and in the same order as listed in
-       the configuration file.
-       This is done to allow some workers to depend on the presence of other workers.
-       */
-      async.each(kuzzle.config.workers[groupWorkers], (worker, callback) => {
-        loadWorker.call(this, worker, options)
-          .then(() => callback())
-          .catch(error => {
-            error.message = `Worker "${worker}" failed to init: ${error}`;
-            callback(error);
-          });
-      }, error => {
-        if (error) {
-          return deferred.reject(error);
-        }
+        /*
+         Loads each worker in a worker group sequentially and in the same order as listed in
+         the configuration file.
+         This is done to allow some workers to depend on the presence of other workers.
+         */
+        async.each(kuzzle.config.workers[groupWorkers], (worker, callback) => {
+          loadWorker.call(this, worker, options)
+            .then(() => callback())
+            .catch(error => {
+              error.message = `Worker "${worker}" failed to init: ${error}`;
+              callback(error);
+            });
+        }, error => {
+          if (error) {
+            return reject(error);
+          }
 
-        return deferred.resolve();
+          resolve();
+        });
       });
     });
 
-    return deferred.promise;
+    return Promise.all(promises);
   };
 }
 
@@ -55,9 +57,9 @@ function loadWorker(worker, options) {
     return this.list[worker].init(options);
   }
   catch (error) {
-    this.kuzzle.pluginsManager.trigger('log:error', 'Worker Loader: unable to load worker', worker, ': ', error.message);
+    this.kuzzle.pluginsManager.trigger('log:error', `Worker Loader: unable to load worker ${worker}: ${error.message}`);
     this.kuzzle.pluginsManager.trigger('log:info', 'Resuming loading workers...');
-    return q.reject(error);
+    return Promise.reject(error);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -76,15 +76,13 @@
     "mock-require": "^1.3.0",
     "mqtt": "1.12.0",
     "parser-yaml": "^0.1.1",
-    "pmx": "^0.6.2",
     "rewire": "2.5.2",
     "should": "9.0.2",
     "should-sinon": "0.0.5",
     "sinon": "1.17.4",
     "sinon-as-promised": "^4.0.0",
     "socket.io-client": "1.4.8",
-    "stomp-client": "0.8.1",
-    "v8-profiler": "^5.6.5"
+    "stomp-client": "0.8.1"
   },
   "engines": {
     "node": ">= 4.4.5",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "amqplib": "0.4.2",
     "async": "1.5.2",
     "big.js": "3.1.3",
+    "bluebird": "^3.4.1",
     "body-parser": "1.15.2",
     "bufferutil": "^1.2.1",
     "bunyan": "^1.5.1",
@@ -53,7 +54,6 @@
     "pm2": "1.1.3",
     "portfinder": "^1.0.3",
     "proper-lockfile": "^1.1.2",
-    "q": "2.0.3",
     "rc": "1.1.6",
     "readline-sync": "^1.3.0",
     "request-promise": "^3.0.0",
@@ -76,13 +76,15 @@
     "mock-require": "^1.3.0",
     "mqtt": "1.12.0",
     "parser-yaml": "^0.1.1",
+    "pmx": "^0.6.2",
     "rewire": "2.5.2",
     "should": "9.0.2",
     "should-sinon": "0.0.5",
     "sinon": "1.17.4",
     "sinon-as-promised": "^4.0.0",
     "socket.io-client": "1.4.8",
-    "stomp-client": "0.8.1"
+    "stomp-client": "0.8.1",
+    "v8-profiler": "^5.6.5"
   },
   "engines": {
     "node": ">= 4.4.5",

--- a/test/api/controllers/adminController.test.js
+++ b/test/api/controllers/adminController.test.js
@@ -1,7 +1,7 @@
 var
   should = require('should'),
   _ = require('lodash'),
-  q = require('q'),
+  Promise = require('bluebird'),
   sinon = require('sinon'),
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
@@ -13,7 +13,7 @@ var
   BadRequestError = require.main.require('kuzzle-common-objects').Errors.badRequestError,
   PartialError = require.main.require('kuzzle-common-objects').Errors.partialError;
 
-require('sinon-as-promised')(q.Promise);
+require('sinon-as-promised')(Promise);
 
 describe('Test: admin controller', function () {
   var
@@ -87,7 +87,7 @@ describe('Test: admin controller', function () {
           should(kuzzle.indexCache.add.called).be.false();
           should(kuzzle.indexCache.remove.called).be.false();
           should(kuzzle.indexCache.reset.called).be.false();
-          return q.reject();
+          return Promise.reject();
         })
       ).be.rejected();
     });
@@ -312,7 +312,7 @@ describe('Test: admin controller', function () {
           body: {indexes: ['%text1', '%text2', '%text3']}
         }),
         isActionAllowedStub = sandbox.stub(user, 'isActionAllowed'),
-        workerListenerStub = request => q({deleted: request.data.body.indexes});
+        workerListenerStub = request => Promise.resolve({deleted: request.data.body.indexes});
 
       this.timeout(50);
 

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -1,7 +1,7 @@
 var
   should = require('should'),
   jwt = require('jsonwebtoken'),
-  q = require('q'),
+  Promise = require('bluebird'),
   /** @type {Params} */
   params = require('rc')('kuzzle'),
   passport = require('passport'),
@@ -17,7 +17,7 @@ var
   MockupWrapper,
   MockupStrategy;
 
-require('sinon-as-promised')(q.Promise);
+require('sinon-as-promised')(Promise);
 
 /**
  * @param name
@@ -57,12 +57,12 @@ MockupStrategy.prototype.authenticate = function(req) {
 MockupWrapper = function(MockupReturn) {
   this.authenticate = function(request) {
     if (MockupReturn === 'resolve') {
-      return q({_id: request.query.username});
+      return Promise.resolve({_id: request.query.username});
     } else if (MockupReturn === 'oauth') {
-      return q({headers: {Location: 'http://github.com'}});
+      return Promise.resolve({headers: {Location: 'http://github.com'}});
     }
 
-    return q.reject(new Error('Mockup Wrapper Error'));
+    return Promise.reject(new Error('Mockup Wrapper Error'));
   };
 };
 
@@ -85,9 +85,9 @@ describe('Test the auth controller', function () {
 
         kuzzle.repositories.user.load = function(t) {
           if (t === 'unknown_user') {
-            return q(null);
+            return Promise.resolve(null);
           }
-          return q({
+          return Promise.resolve({
             _id: t,
             profileId: t
           });
@@ -102,14 +102,7 @@ describe('Test the auth controller', function () {
   describe('#login', function () {
     beforeEach(() => {
       return passport.use(new MockupStrategy('mockup', function(username, callback) {
-        var
-          deferred = q.defer(),
-          user = {
-            _id: username
-          };
-        deferred.resolve(user);
-        deferred.promise.nodeify(callback);
-        return deferred.promise;
+        callback(null, {_id: username});
       }));
     });
 
@@ -139,13 +132,14 @@ describe('Test the auth controller', function () {
         authenticate: function(data, strategy) {
           should(strategy).be.exactly('local');
           done();
-          return q.reject();
+          return Promise.reject('foo');
         }
       };
 
       delete requestObject.data.body.strategy;
 
-      kuzzle.funnel.controllers.auth.login(requestObject, {});
+      kuzzle.funnel.controllers.auth.login(requestObject, {})
+        .catch(err => should(err).be.eql('foo'));
     });
 
     it('should be able to set authentication expiration', function (done) {
@@ -236,7 +230,7 @@ describe('Test the auth controller', function () {
 
     it('should emit a auth:afterLogout event', () => {
       var
-        spy = sandbox.stub(kuzzle.pluginsManager, 'trigger', (event, data) => q(data));
+        spy = sandbox.stub(kuzzle.pluginsManager, 'trigger', (event, data) => Promise.resolve(data));
 
       sandbox.stub(kuzzle.repositories.token.cacheEngine, 'expire').resolves({});
 
@@ -254,7 +248,7 @@ describe('Test the auth controller', function () {
 
       kuzzle.pluginsManager.trigger = function (event) {
         if (event === 'auth:afterLogout' || event === 'auth:beforeLogout') {
-          return q.reject();
+          return Promise.reject();
         }
       };
 
@@ -266,7 +260,7 @@ describe('Test the auth controller', function () {
 
       kuzzle.repositories.token.expire = function(token) {
         should(token).be.exactly(context.token);
-        return q();
+        return Promise.resolve();
       };
 
       kuzzle.funnel.controllers.auth.logout(requestObject, context)
@@ -281,7 +275,7 @@ describe('Test the auth controller', function () {
       this.timeout(50);
 
       kuzzle.repositories.token.expire = function() {
-        return q.reject();
+        return Promise.reject();
       };
 
       return should(kuzzle.funnel.controllers.auth.logout(requestObject, context)).be.rejected();
@@ -293,7 +287,7 @@ describe('Test the auth controller', function () {
 
       kuzzle.hotelClerk.removeCustomerFromAllRooms = function() {
         removeCustomerFromAllRooms = true;
-        return q.reject();
+        return Promise.reject();
       };
 
       delete context.connection.id;
@@ -354,7 +348,7 @@ describe('Test the auth controller', function () {
     it('should return a valid response if the token is valid', function (done) {
       kuzzle.repositories.token.verifyToken = arg => {
         should(arg).be.eql(requestObject.data.body.token);
-        return q(stubToken);
+        return Promise.resolve(stubToken);
       };
 
       kuzzle.funnel.controllers.auth.checkToken(requestObject)
@@ -371,7 +365,7 @@ describe('Test the auth controller', function () {
     it('should return a valid response if the token is not valid', function (done) {
       kuzzle.repositories.token.verifyToken = arg => {
         should(arg).be.eql(requestObject.data.body.token);
-        return q.reject({status: 401, message: 'foobar'});
+        return Promise.reject({status: 401, message: 'foobar'});
       };
 
       kuzzle.funnel.controllers.auth.checkToken(requestObject)
@@ -388,7 +382,7 @@ describe('Test the auth controller', function () {
     it('should return a rejected promise if an error occurs', function () {
       kuzzle.repositories.token.verifyToken = arg => {
         should(arg).be.eql(requestObject.data.body.token);
-        return q.reject({status: 500});
+        return Promise.reject({status: 500});
       };
 
       return should(kuzzle.funnel.controllers.auth.checkToken(requestObject)).be.rejected();
@@ -412,12 +406,12 @@ describe('Test the auth controller', function () {
               return {_id: 'admin', _source: { profileID: 'admin' }};
             }
 
-            return q(null);
+            return Promise.resolve(null);
           };
 
           anotherKuzzle.repositories.user.persist = (user, opts) => {
             persistOptions = opts;
-            return q(user);
+            return Promise.resolve(user);
           };
 
           done();

--- a/test/api/controllers/bulkController.test.js
+++ b/test/api/controllers/bulkController.test.js
@@ -2,7 +2,7 @@ var
   should = require('should'),
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
-  q = require('q'),
+  Promise = require('bluebird'),
   RequestObject = require.main.require('kuzzle-common-objects').Models.requestObject,
   ResponseObject = require.main.require('kuzzle-common-objects').Models.responseObject,
   PartialError = require.main.require('kuzzle-common-objects').Errors.partialError;
@@ -37,7 +37,7 @@ describe('Test the bulk controller', function () {
   });
 
   it('should return a response object', () => {
-    kuzzle.workerListener.add = () => q({});
+    kuzzle.workerListener.add = () => Promise.resolve({});
     return should(
       kuzzle.funnel.controllers.bulk.import(requestObject)
         .then(response => {
@@ -50,7 +50,7 @@ describe('Test the bulk controller', function () {
 
   it('should handle partial errors', () => {
     kuzzle.workerListener.add = () => {
-      return q({partialErrors: ['foo', 'bar']});
+      return Promise.resolve({partialErrors: ['foo', 'bar']});
     };
 
     return should(
@@ -64,7 +64,7 @@ describe('Test the bulk controller', function () {
   });
 
   it('should return a ResponseObject in a rejected promise in case of error', () => {
-    kuzzle.workerListener.add = () => q.reject(new Error('foobar'));
+    kuzzle.workerListener.add = () => Promise.reject(new Error('foobar'));
 
     return should(
       kuzzle.funnel.controllers.bulk.import(requestObject)
@@ -72,7 +72,7 @@ describe('Test the bulk controller', function () {
           should(response).be.instanceOf(ResponseObject);
           should(response.error).not.be.null();
           should(response.error.message).be.eql('foobar');
-          return q.reject();
+          return Promise.reject();
         })
     ).be.rejected();
   });

--- a/test/api/controllers/funnelController/execute.test.js
+++ b/test/api/controllers/funnelController/execute.test.js
@@ -1,6 +1,6 @@
 var
   should = require('should'),
-  q = require('q'),
+  Promise = require('bluebird'),
   RequestObject = require.main.require('kuzzle-common-objects').Models.requestObject,
   ResponseObject = require.main.require('kuzzle-common-objects').Models.responseObject,
   ServiceUnavailableError = require.main.require('kuzzle-common-objects').Errors.serviceUnavailableError,
@@ -18,30 +18,29 @@ describe('funnelController.execute', () => {
     context,
     requestReplayed;
 
-  before(function (callback) {
+  before(() => {
     context = {
       connection: {id: 'connectionid'},
       token: null
     };
 
     kuzzle = new Kuzzle();
-    kuzzle.start(params, {dummy: true})
+    
+    return kuzzle.start(params, {dummy: true})
       .then(() => {
         FunnelController.__set__('processRequest', (funnelKuzzle, controllers, funnelRequestObject) => {
           processRequestCalled = true;
 
           if (funnelRequestObject.errorMe) {
-            return q.reject(new Error('errored on purpose'));
+            return Promise.reject(new Error('errored on purpose'));
           }
 
-          return q(new ResponseObject(funnelRequestObject));
+          return Promise.resolve(new ResponseObject(funnelRequestObject));
         });
 
         FunnelController.__set__('playCachedRequests', function () {
           requestReplayed = true;
         });
-
-        callback();
       });
   });
 

--- a/test/api/controllers/funnelController/processRequest.test.js
+++ b/test/api/controllers/funnelController/processRequest.test.js
@@ -1,6 +1,6 @@
 var
   should = require('should'),
-  q = require('q'),
+  Promise = require('bluebird'),
   sinon = require('sinon'),
   RequestObject = require.main.require('kuzzle-common-objects').Models.requestObject,
   BadRequestError = require.main.require('kuzzle-common-objects').Errors.badRequestError,
@@ -11,7 +11,7 @@ var
   rewire = require('rewire'),
   FunnelController = rewire('../../../../lib/api/controllers/funnelController');
 
-require('sinon-as-promised')(q.Promise);
+require('sinon-as-promised')(Promise);
 
 describe('funnelController.processRequest', function () {
   var
@@ -32,7 +32,7 @@ describe('funnelController.processRequest', function () {
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     sandbox.stub(kuzzle.repositories.token, 'verifyToken', () => {
-      return q({
+      return Promise.resolve({
         userId: 'user'
       });
     });

--- a/test/api/controllers/readController.test.js
+++ b/test/api/controllers/readController.test.js
@@ -1,6 +1,6 @@
 var
   should = require('should'),
-  q = require('q'),
+  Promise = require('bluebird'),
   /** @type {Params} */
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
@@ -18,10 +18,10 @@ describe('Test: read controller', function () {
   before(() => {
     mockFunction = () => {
       if (error) {
-        return q.reject(new Error('foobar'));
+        return Promise.reject(new Error('foobar'));
       }
 
-      return q(mockResponse);
+      return Promise.resolve(mockResponse);
     };
 
     kuzzle = new Kuzzle();
@@ -130,11 +130,11 @@ describe('Test: read controller', function () {
     before(function () {
       kuzzle.services.list.readEngine.listCollections = function() {
         if (error) {
-          return q.reject(new Error('foobar'));
+          return Promise.reject(new Error('foobar'));
         }
 
         stored = true;
-        return q({collections: {stored: ['foo']}});
+        return Promise.resolve({collections: {stored: ['foo']}});
       };
 
       kuzzle.hotelClerk.getRealtimeCollections = function () {
@@ -254,10 +254,10 @@ describe('Test: read controller', function () {
         if (kuzzle.services.list[service].getInfos) {
           kuzzle.services.list[service].getInfos = () => {
             if (error) {
-              return q.reject(new Error('foobar'));
+              return Promise.reject(new Error('foobar'));
             }
 
-            return q({});
+            return Promise.resolve({});
           };
         }
       });

--- a/test/api/controllers/remoteActionsController/cleanAndPrepare.test.js
+++ b/test/api/controllers/remoteActionsController/cleanAndPrepare.test.js
@@ -1,14 +1,14 @@
 var
   rc = require('rc'),
   params = rc('kuzzle'),
-  q = require('q'),
+  Promise = require('bluebird'),
   should = require('should'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
   RequestObject = require.main.require('kuzzle-common-objects').Models.requestObject;
 
 describe('Test: clean and prepare database remote action', function () {
 
-  it('should call cleanDb and prepareDb', function (done) {
+  it('should call cleanDb and prepareDb', () => {
     var 
       cleanDbCalled = false,
       prepareDbCalled = false,
@@ -16,20 +16,22 @@ describe('Test: clean and prepare database remote action', function () {
       kuzzle;
 
     kuzzle = new Kuzzle();
-    kuzzle.start(params, {dummy: true})
+    return kuzzle.start(params, {dummy: true})
       .then(() => {
-        kuzzle.remoteActionsController.actions.cleanDb = function () { cleanDbCalled = true; return q(); };
-        kuzzle.remoteActionsController.actions.prepareDb = function () { prepareDbCalled = true; return q(); };
+        kuzzle.remoteActionsController.actions.cleanDb = function () {
+          cleanDbCalled = true;
+          return Promise.resolve();
+        };
+        kuzzle.remoteActionsController.actions.prepareDb = function () {
+          prepareDbCalled = true;
+          return Promise.resolve();
+        };
 
-        kuzzle.remoteActionsController.actions.cleanAndPrepare(kuzzle, request)
-          .then(function () {
-            should(cleanDbCalled).be.true();
-            should(prepareDbCalled).be.true();
-            done();
-          })
-          .catch((err) => {
-            done(err);
-          });
+        return kuzzle.remoteActionsController.actions.cleanAndPrepare(kuzzle, request);
+      })
+      .then(() => {
+        should(cleanDbCalled).be.true();
+        should(prepareDbCalled).be.true();
       });
   });
 });

--- a/test/api/controllers/remoteActionsController/cleanDb.test.js
+++ b/test/api/controllers/remoteActionsController/cleanDb.test.js
@@ -1,7 +1,7 @@
 var
   rc = require('rc'),
   params = rc('kuzzle'),
-  q = require('q'),
+  Promise = require('bluebird'),
   should = require('should'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
   RequestObject = require.main.require('kuzzle-common-objects').Models.requestObject,
@@ -22,7 +22,7 @@ describe('Test: clean database', function () {
           writeEngine: {},
           readEngine: {
             listIndexes: function () {
-              return q({
+              return Promise.resolve({
                 data: {
                   body: {
                     indexes: ['foo', 'bar']
@@ -67,7 +67,7 @@ describe('Test: clean database', function () {
           should(data).be.exactly('Reset done: Kuzzle is now like a virgin, touched for the very first time !');
         }
 
-        return q(data);
+        return Promise.resolve(data);
       }
     };
 
@@ -76,7 +76,7 @@ describe('Test: clean database', function () {
         should(requestObject.controller).be.eql('admin');
         should(requestObject.action).be.eql('deleteIndexes');
         workerCalled = true;
-        return q();
+        return Promise.resolve();
       }
     };
 
@@ -100,7 +100,7 @@ describe('Test: clean database', function () {
       writeEngine: {},
       readEngine: {
         listIndexes: function () {
-          return q({
+          return Promise.resolve({
             data: {
               body: {
                 indexes: ['foo', 'bar']
@@ -120,7 +120,7 @@ describe('Test: clean database', function () {
         workerCalled = true;
         should(requestObject.controller).be.eql('admin');
         should(requestObject.action).be.eql('deleteIndexes');
-        return q.reject('error');
+        return Promise.reject('error');
       }
     };
 
@@ -131,7 +131,7 @@ describe('Test: clean database', function () {
           hasFiredCleanDbError = true;
         }
 
-        return q(data);
+        return Promise.resolve(data);
       }
     };
 

--- a/test/api/controllers/remoteActionsController/enableServices.test.js
+++ b/test/api/controllers/remoteActionsController/enableServices.test.js
@@ -1,7 +1,7 @@
 var
   rc = require('rc'),
   params = rc('kuzzle'),
-  q = require('q'),
+  Promise = require('bluebird'),
   should = require('should'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
   RequestObject = require.main.require('kuzzle-common-objects').Models.requestObject;
@@ -19,7 +19,7 @@ describe('Test: enable services controller', function () {
           foo: {
             toggle: function (enable) {
               serviceEnable = enable;
-              return q();
+              return Promise.resolve();
             }
           },
           bar: {}

--- a/test/api/controllers/remoteActionsController/managePlugins.test.js
+++ b/test/api/controllers/remoteActionsController/managePlugins.test.js
@@ -1,5 +1,5 @@
 var
-  q = require('q'),
+  Promise = require('bluebird'),
   should = require('should'),
   rewire = require('rewire'),
   sinon = require('sinon'),
@@ -12,7 +12,7 @@ var
   clcNotice = managePlugins.__get__('clcNotice'),
   sandbox;
 
-require('sinon-as-promised')(q.Promise);
+require('sinon-as-promised')(Promise);
 
 describe('Test: managePlugins remote action caller', function () {
   var

--- a/test/api/controllers/remoteActionsController/swagger.test.js
+++ b/test/api/controllers/remoteActionsController/swagger.test.js
@@ -2,14 +2,14 @@ var
   rc = require('rc'),
   fs = require('fs'),
   params = rc('kuzzle'),
-  q = require('q'),
+  Promise = require('bluebird'),
   should = require('should'),
   sinon = require('sinon'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
   InternalError = require.main.require('kuzzle-common-objects').Errors.internalError,
   swagger = require.main.require('lib/api/controllers/remoteActions/swagger');
 
-require('sinon-as-promised')(q.Promise);
+require('sinon-as-promised')(Promise);
 
 describe('Test: Swagger files generation', () => {
   var

--- a/test/api/controllers/routerController/initRouterHttp.test.js
+++ b/test/api/controllers/routerController/initRouterHttp.test.js
@@ -6,7 +6,7 @@
 var
   should = require('should'),
   http = require('http'),
-  q = require('q'),
+  Promise = require('bluebird'),
   kuzzleParams = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
   rewire = require('rewire'),
@@ -19,38 +19,37 @@ var
  */
 function parseHttpResponse (response, yaml) {
   var
-    deferred = q.defer(),
     data = '';
 
   response.on('data', chunk => {
     data += chunk;
   });
 
-  response.on('end', () => {
-    var result;
+  return new Promise((resolve, reject) => {
+    response.on('end', () => {
+      var result;
 
-    if (yaml === true) {
-      yamlToJson(data, (err, res) => {
-        if (err) {
-          return deferred.reject(err);
+      if (yaml === true) {
+        yamlToJson(data, (err, res) => {
+          if (err) {
+            return reject(err);
+          }
+
+          result = res;
+        });
+      }
+      else {
+        try {
+          result = JSON.parse(data);
         }
-
-        result = res;
-      });
-    } 
-    else {
-      try {
-        result = JSON.parse(data);
+        catch (e) {
+          return reject(e);
+        }
       }
-      catch (e) {
-        return deferred.reject(e);
-      }
-    }
 
-    deferred.resolve(result);
+      resolve(result);
+    });
   });
-
-  return deferred.promise;
 }
 
 describe('Test: routerController.initRouterHttp', () => {

--- a/test/api/controllers/routerController/routerController.test.js
+++ b/test/api/controllers/routerController/routerController.test.js
@@ -3,13 +3,13 @@ var
   sinon = require('sinon'),
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
-  q = require('q'),
+  Promise = require('bluebird'),
   RequestObject = require.main.require('kuzzle-common-objects').Models.requestObject,
   Token = require.main.require('lib/api/core/models/security/token'),
   Role = require.main.require('lib/api/core/models/security/role'),
   PluginImplementationError = require.main.require('kuzzle-common-objects').Errors.pluginImplementationError;
 
-require('sinon-as-promised')(q.Promise);
+require('sinon-as-promised')(Promise);
 
 describe('Test: routerController', () => {
   var sandbox;
@@ -104,7 +104,7 @@ describe('Test: routerController', () => {
               profileId: 'profile',
               isActionAllowed: sinon.stub().resolves(true),
               getProfile: () => {
-                return q({
+                return Promise.resolve({
                   _id: 'profile',
                   policies: ['role'],
                   getRoles: sinon.stub().resolves([role]),
@@ -116,7 +116,7 @@ describe('Test: routerController', () => {
             token._id = 'fake-token';
             token.userId = user._id;
 
-            return q(token);
+            return Promise.resolve(token);
           };
 
           return kuzzle.router.newConnection('foo', 'bar');

--- a/test/api/controllers/securityController.test.js
+++ b/test/api/controllers/securityController.test.js
@@ -1,5 +1,5 @@
 var
-  q = require('q'),
+  Promise = require('bluebird'),
   should = require('should'),
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
@@ -15,7 +15,7 @@ describe('Test: security controller', function () {
     kuzzle.start(params, {dummy: true})
       .then(function () {
         kuzzle.repositories.role.validateAndSaveRole = role => {
-          return q(role);
+          return Promise.resolve(role);
         };
 
         done();

--- a/test/api/controllers/securityController/profiles.test.js
+++ b/test/api/controllers/securityController/profiles.test.js
@@ -1,6 +1,6 @@
 var
   should = require('should'),
-  q = require('q'),
+  Promise = require('bluebird'),
   sinon = require('sinon'),
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
@@ -8,7 +8,7 @@ var
   NotFoundError = require.main.require('kuzzle-common-objects').Errors.notFoundError,
   ResponseObject = require.main.require('kuzzle-common-objects').Models.responseObject;
 
-require('sinon-as-promised')(q.Promise);
+require('sinon-as-promised')(Promise);
 
 describe('Test: security controller - profiles', function () {
   var

--- a/test/api/controllers/securityController/roles.test.js
+++ b/test/api/controllers/securityController/roles.test.js
@@ -1,6 +1,6 @@
 var
   should = require('should'),
-  q = require('q'),
+  Promise = require('bluebird'),
   sinon = require('sinon'),
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
@@ -26,18 +26,18 @@ describe('Test: security controller - roles', function () {
 
     sandbox.stub(kuzzle.repositories.role, 'validateAndSaveRole', role => {
       if (role._id === 'alreadyExists') {
-        return q.reject();
+        return Promise.reject();
       }
 
-      return q(role);
+      return Promise.resolve(role);
     });
 
     sandbox.stub(kuzzle.repositories.role, 'loadOneFromDatabase', id => {
       if (id === 'badId') {
-        return q(null);
+        return Promise.resolve(null);
       }
 
-      return q({
+      return Promise.resolve({
         _index: kuzzle.config.internalIndex,
         _type: 'roles',
         _id: id,
@@ -47,10 +47,10 @@ describe('Test: security controller - roles', function () {
 
     sandbox.stub(kuzzle.repositories.role, 'loadMultiFromDatabase', ids => {
       if (error) {
-        return q.reject(new Error('foobar'));
+        return Promise.reject(new Error('foobar'));
       }
 
-      return q(ids.map(id => {
+      return Promise.resolve(ids.map(id => {
         return {
           _id: id,
           _source: null
@@ -60,10 +60,10 @@ describe('Test: security controller - roles', function () {
 
     sandbox.stub(kuzzle.repositories.role, 'search', () => {
       if (error) {
-        return q.reject(new Error(''));
+        return Promise.reject(new Error(''));
       }
 
-      return q({
+      return Promise.resolve({
         hits: [{_id: 'test'}],
         total: 1
       });
@@ -71,10 +71,10 @@ describe('Test: security controller - roles', function () {
 
     sandbox.stub(kuzzle.repositories.role, 'deleteFromDatabase', () => {
       if (error) {
-        return q.reject(new Error(''));
+        return Promise.reject(new Error(''));
       }
 
-      return q({_id: 'test'});
+      return Promise.resolve({_id: 'test'});
     });
     sandbox.mock(kuzzle.repositories.profile, 'profiles', {});
     sandbox.mock(kuzzle.repositories.role, 'roles', {});
@@ -198,10 +198,10 @@ describe('Test: security controller - roles', function () {
 
       kuzzle.repositories.role.validateAndSaveRole = role => {
         if (role._id === 'alreadyExists') {
-          return q.reject();
+          return Promise.reject();
         }
 
-        return q(role);
+        return Promise.resolve(role);
       };
 
       kuzzle.funnel.controllers.security.updateRole(new RequestObject({

--- a/test/api/controllers/securityController/users.test.js
+++ b/test/api/controllers/securityController/users.test.js
@@ -1,5 +1,5 @@
 var
-  q = require('q'),
+  Promise = require('bluebird'),
   should = require('should'),
   sinon = require('sinon'),
   params = require('rc')('kuzzle'),
@@ -8,7 +8,7 @@ var
   NotFoundError = require.main.require('kuzzle-common-objects').Errors.notFoundError,
   ResponseObject = require.main.require('kuzzle-common-objects').Models.responseObject;
 
-require('sinon-as-promised')(q.Promise);
+require('sinon-as-promised')(Promise);
 
 describe('Test: security controller - users', function () {
   var
@@ -21,7 +21,7 @@ describe('Test: security controller - users', function () {
       .then(function () {
         // Mock
         kuzzle.services.list.readEngine.search = () => {
-          return q({
+          return Promise.resolve({
             hits: [{_id: 'admin', _source: { profileId: 'admin' }}],
             total: 1
           });
@@ -35,15 +35,15 @@ describe('Test: security controller - users', function () {
             return kuzzle.repositories.user.admin();
           }
 
-          return q(null);
+          return Promise.resolve(null);
         };
 
         kuzzle.repositories.user.persist = (user) => {
-          return q(user);
+          return Promise.resolve(user);
         };
 
         kuzzle.repositories.user.deleteFromDatabase = () => {
-          return q({_id: 'test'});
+          return Promise.resolve({_id: 'test'});
         };
       });
   });

--- a/test/api/controllers/subscribeController.test.js
+++ b/test/api/controllers/subscribeController.test.js
@@ -1,13 +1,13 @@
 var
   should = require('should'),
   params = require('rc')('kuzzle'),
-  q = require('q'),
+  Promise = require('bluebird'),
   sinon = require('sinon'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
   RequestObject = require.main.require('kuzzle-common-objects').Models.requestObject,
   ResponseObject = require.main.require('kuzzle-common-objects').Models.responseObject;
 
-require('sinon-as-promised')(q.Promise);
+require('sinon-as-promised')(Promise);
 
 describe('Test: subscribe controller', function () {
   var

--- a/test/api/controllers/writeController.test.js
+++ b/test/api/controllers/writeController.test.js
@@ -1,6 +1,6 @@
 var
   should = require('should'),
-  q = require('q'),
+  Promise = require('bluebird'),
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
   RequestObject = require.main.require('kuzzle-common-objects').Models.requestObject,
@@ -40,10 +40,10 @@ describe('Test: write controller', function () {
             messagePublished = true;
 
             if (error) {
-              return q.reject(new Error(''));
+              return Promise.reject(new Error(''));
             }
 
-            return q({});
+            return Promise.resolve({});
           }
         };
 
@@ -54,10 +54,10 @@ describe('Test: write controller', function () {
   beforeEach(function () {
     kuzzle.workerListener.add = rq => {
       if (error) {
-        return q.reject(new Error(''));
+        return Promise.reject(new Error(''));
       }
 
-      return q(rq);
+      return Promise.resolve(rq);
     };
 
     requestObject = new RequestObject({body: {foo: 'bar'}}, {}, 'unit-test');
@@ -219,7 +219,7 @@ describe('Test: write controller', function () {
     it('should notify on document creation', () => {
       var request = new RequestObject({body: {foo: 'bar'}}, {}, 'unit-test');
 
-      kuzzle.workerListener.add = () => q({ created: true });
+      kuzzle.workerListener.add = () => Promise.resolve({ created: true });
 
       return kuzzle.funnel.controllers.write.createOrReplace(request)
         .then(response => {
@@ -232,7 +232,7 @@ describe('Test: write controller', function () {
     it('should notify on document replace', () => {
       var request = new RequestObject({body: {foo: 'bar'}}, {}, 'unit-test');
 
-      kuzzle.workerListener.add = () => q({ created: false });
+      kuzzle.workerListener.add = () => Promise.resolve({ created: false });
 
       return kuzzle.funnel.controllers.write.createOrReplace(request)
         .then(response => {

--- a/test/api/core/auth/passportWrapper.test.js
+++ b/test/api/core/auth/passportWrapper.test.js
@@ -1,6 +1,5 @@
 var
   should = require('should'),
-  q = require('q'),
   passport = require('passport'),
   util = require('util'),
   params = require('rc')('kuzzle'),
@@ -56,15 +55,10 @@ describe('Test the passport Wrapper', function () {
         passportWrapper = new PassportWrapper(kuzzle);
 
         passport.use(new MockupStrategy('mockup', function(username, callback) {
-          var
-            deferred = q.defer(),
-            user = {
-              _id: username,
-              name: 'Johnny Cash'
-            };
-          deferred.resolve(user);
-          deferred.promise.nodeify(callback);
-          return deferred.promise;
+          callback(null, {
+            _id: username,
+            name: 'Johnny Cash'
+          });
         }));
 
         passport.use(new MockupStrategy('null', function(username, callback) {
@@ -72,11 +66,7 @@ describe('Test the passport Wrapper', function () {
         }));
 
         passport.use(new MockupStrategy('error', function(username, callback) {
-          var
-            deferred = q.defer();
-          deferred.reject(new ForbiddenError('Bad Credentials'));
-          deferred.promise.nodeify(callback);
-          return deferred.promise;
+          callback(new ForbiddenError('Bad Credentials'));
         }));
 
         done();

--- a/test/api/core/auth/tokenManager.test.js
+++ b/test/api/core/auth/tokenManager.test.js
@@ -105,7 +105,7 @@ describe('Test: token manager core component', function () {
         connectionId = id;
       };
 
-      kuzzle.hotelClerk.removeCustomerFromAllRooms = () => {subscriptionsCleaned = true;};
+      kuzzle.hotelClerk.removeCustomerFromAllRooms = () => {subscriptionsCleaned = true; return Promise.resolve();};
     });
 
     beforeEach(function () {

--- a/test/api/core/hotelClerk/addSubscription.test.js
+++ b/test/api/core/hotelClerk/addSubscription.test.js
@@ -1,6 +1,6 @@
 var
   should = require('should'),
-  q = require('q'),
+  Promise = require('bluebird'),
   RequestObject = require.main.require('kuzzle-common-objects').Models.requestObject,
   InternalError = require.main.require('kuzzle-common-objects').Errors.internalError,
   BadRequestError = require.main.require('kuzzle-common-objects').Errors.badRequestError,
@@ -275,7 +275,7 @@ describe('Test: hotelClerk.addSubscription', function () {
         should(result).have.property('channel');
         should(result).have.property('roomId');
 
-        return q(result.roomId);
+        return Promise.resolve(result.roomId);
       })
       .then(id => {
         var requestObject2 = new RequestObject({

--- a/test/api/core/hotelClerk/listSubscriptions.test.js
+++ b/test/api/core/hotelClerk/listSubscriptions.test.js
@@ -1,11 +1,11 @@
 var
   should = require('should'),
-  q = require('q'),
+  Promise = require('bluebird'),
   sinon = require('sinon'),
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle');
 
-require('sinon-as-promised')(q.Promise);
+require('sinon-as-promised')(Promise);
 
 describe('Test: hotelClerk.listSubscription', function () {
   var
@@ -72,10 +72,7 @@ describe('Test: hotelClerk.listSubscription', function () {
       }
     };
     sandbox.stub(kuzzle.repositories.user, 'load').resolves({_id: 'user', isActionAllowed: r => {
-      if (r.collection === 'foo') {
-        return q(true);
-      }
-      return q(false);
+      return Promise.resolve(r.collection === 'foo');
     }});
 
     return kuzzle.hotelClerk.listSubscriptions(context)

--- a/test/api/core/hotelClerk/removeCustomerFromAllRooms.test.js
+++ b/test/api/core/hotelClerk/removeCustomerFromAllRooms.test.js
@@ -51,7 +51,7 @@ describe('Test: hotelClerk.removeCustomerFromAllRooms', function () {
   });
 
   it('should do nothing when a bad connectionId is given', function () {
-    return should(kuzzle.hotelClerk.removeCustomerFromAllRooms({id: 'unknown'})).be.rejected();
+    return should(kuzzle.hotelClerk.removeCustomerFromAllRooms({id: 'unknown'})).be.fulfilledWith(undefined);
   });
 
   it('should clean up customers, rooms and filtersTree object', function () {

--- a/test/api/core/hotelClerk/removeCustomerFromAllRooms.test.js
+++ b/test/api/core/hotelClerk/removeCustomerFromAllRooms.test.js
@@ -1,12 +1,12 @@
 var
   should = require('should'),
-  q = require('q'),
+  Promise = require('bluebird'),
   sinon = require('sinon'),
   RequestObject = require.main.require('kuzzle-common-objects').Models.requestObject,
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle');
 
-require('sinon-as-promised')(q.Promise);
+require('sinon-as-promised')(Promise);
 
 describe('Test: hotelClerk.removeCustomerFromAllRooms', function () {
   var
@@ -98,12 +98,10 @@ describe('Test: hotelClerk.removeCustomerFromAllRooms', function () {
       });
   });
 
-  it('should log an error if a problem occurs while unsubscribing', function (done) {
+  it('should log an error if a problem occurs while unsubscribing', () => {
     this.timeout(500);
     sandbox.stub(kuzzle.dsl, 'remove').rejects();
 
-    kuzzle.once('log:error', () => done());
-
-    kuzzle.hotelClerk.removeCustomerFromAllRooms(connection);
+    return should(kuzzle.hotelClerk.removeCustomerFromAllRooms(connection)).be.rejected();
   });
 });

--- a/test/api/core/hotelClerk/removeRooms.test.js
+++ b/test/api/core/hotelClerk/removeRooms.test.js
@@ -310,13 +310,12 @@ describe('Test: hotelClerk.removeRooms', function () {
       });
   });
 
-  it('should return a response with partial error if a roomId doesn\'t correspond to the collection', function () {
+  it('should return a response with partial error if a roomId doesn\'t correspond to the index', function () {
     var
-      badRoomName = '0ca6c2f9b4cc6450a63e3fe848ec7138',
+      index2RoomName = 'e6255f81a2934ad02636a8ebf533dd46',
       requestObjectSubscribe1 = new RequestObject({
         controller: 'subscribe',
         action: 'on',
-        requestId: roomName,
         index: index,
         collection: collection1,
         body: {}
@@ -324,7 +323,42 @@ describe('Test: hotelClerk.removeRooms', function () {
       requestObjectSubscribe2 = new RequestObject({
         controller: 'subscribe',
         action: 'on',
+        index: 'index2',
+        collection: collection1,
+        body: {}
+      }),
+      requestObjectRemove = new RequestObject({
+        controller: 'admin',
+        action: 'removeRooms',
         requestId: roomName,
+        index: index,
+        collection: collection1,
+        body: {rooms: [index2RoomName]}
+      });
+
+    return kuzzle.hotelClerk.addSubscription(requestObjectSubscribe1, context)
+      .then(() => kuzzle.hotelClerk.addSubscription(requestObjectSubscribe2, context))
+      .then(() => kuzzle.hotelClerk.removeRooms(requestObjectRemove))
+      .then((response) => {
+        should(response.acknowledge).be.true();
+        should(response.partialErrors.length).be.exactly(1);
+        should(response.partialErrors).be.an.Array().and.match([`The room ${index2RoomName} does not match index ${index}`]);
+      });
+  });
+
+  it('should return a response with partial error if a roomId doesn\'t correspond to the collection', function () {
+    var
+      collection2RoomName = '36a737bfc8da2f3c1673137a3b159d4a',
+      requestObjectSubscribe1 = new RequestObject({
+        controller: 'subscribe',
+        action: 'on',
+        index: index,
+        collection: collection1,
+        body: {}
+      }),
+      requestObjectSubscribe2 = new RequestObject({
+        controller: 'subscribe',
+        action: 'on',
         index: index,
         collection: collection2,
         body: {}
@@ -335,7 +369,7 @@ describe('Test: hotelClerk.removeRooms', function () {
         requestId: roomName,
         index: index,
         collection: collection1,
-        body: {rooms: [badRoomName]}
+        body: {rooms: [collection2RoomName]}
       });
 
     return kuzzle.hotelClerk.addSubscription(requestObjectSubscribe1, context)
@@ -344,7 +378,7 @@ describe('Test: hotelClerk.removeRooms', function () {
       .then((response) => {
         should(response.acknowledge).be.true();
         should(response.partialErrors.length).be.exactly(1);
-        should(response.partialErrors).be.an.Array().and.match([`No room with id ${badRoomName}`]);
+        should(response.partialErrors).be.an.Array().and.match([`The room ${collection2RoomName} does not match collection ${collection1}`]);
       });
   });
 

--- a/test/api/core/hotelClerk/removeRooms.test.js
+++ b/test/api/core/hotelClerk/removeRooms.test.js
@@ -79,8 +79,7 @@ describe('Test: hotelClerk.removeRooms', function () {
     return should(kuzzle.hotelClerk.removeRooms(requestObject)).rejectedWith(NotFoundError);
   });
 
-  it('should reject an error if there is no subscription on this collection', function () {
-
+  it('should reject an error if there is no subscription on this collection', () => {
     var
       requestObjectSubscribe = new RequestObject({
         controller: 'subscribe',
@@ -101,7 +100,7 @@ describe('Test: hotelClerk.removeRooms', function () {
 
     return kuzzle.hotelClerk.addSubscription(requestObjectSubscribe, context)
       .then(() => {
-        should(kuzzle.hotelClerk.removeRooms(requestObject)).rejectedWith(BadRequestError);
+        return should(kuzzle.hotelClerk.removeRooms(requestObject)).rejectedWith(NotFoundError);
       });
   });
 

--- a/test/api/core/hotelClerk/removeSubscription.test.js
+++ b/test/api/core/hotelClerk/removeSubscription.test.js
@@ -1,6 +1,6 @@
 var
   should = require('should'),
-  q = require('q'),
+  Promise = require('bluebird'),
   sinon = require('sinon'),
   RequestObject = require.main.require('kuzzle-common-objects').Models.requestObject,
   BadRequestError = require.main.require('kuzzle-common-objects').Errors.badRequestError,
@@ -8,7 +8,7 @@ var
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle');
 
-require('sinon-as-promised')(q.Promise);
+require('sinon-as-promised')(Promise);
 
 describe('Test: hotelClerk.removeSubscription', function () {
   var

--- a/test/api/core/indexCache.test.js
+++ b/test/api/core/indexCache.test.js
@@ -1,10 +1,9 @@
 var
   should = require('should'),
-  q = require('q'),
+  Promise = require('bluebird'),
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
   IndexCache = require.main.require('lib/api/core/indexCache');
-
 
 describe('Test: core/indexCache', function () {
   var
@@ -17,7 +16,7 @@ describe('Test: core/indexCache', function () {
       .then(function () {
         kuzzle.services.list.readEngine = {
           listIndexes: () => {
-            return q({ indexes: ['foo'] });
+            return Promise.resolve({ indexes: ['foo'] });
           },
 
           listCollections: () => {
@@ -27,7 +26,7 @@ describe('Test: core/indexCache', function () {
               }
             };
 
-            return q(stubResponse);
+            return Promise.resolve(stubResponse);
           }
         };
 

--- a/test/api/core/models/repositories/profileRepository.test.js
+++ b/test/api/core/models/repositories/profileRepository.test.js
@@ -108,7 +108,7 @@ describe('Test: repositories/profileRepository', () => {
       var profileObject = new Profile();
       profileObject._id = 'testprofile';
 
-      should(kuzzle.repositories.profile.loadProfile(profileObject)).be.rejectedWith('A profileId must be provided');
+      return should(kuzzle.repositories.profile.loadProfile(profileObject)).be.rejectedWith('A profileId must be provided');
     });
   });
 
@@ -131,11 +131,11 @@ describe('Test: repositories/profileRepository', () => {
     });
 
     it('should rejects when no profileIds is given', () => {
-      should(kuzzle.repositories.profile.loadProfiles()).be.rejectedWith('Missing profilesIds');
+      return should(kuzzle.repositories.profile.loadProfiles()).be.rejectedWith('Missing profilesIds');
     });
 
     it('should rejects when no profileIds is not an Array', () => {
-      should(kuzzle.repositories.profile.loadProfiles(42)).be.rejectedWith('An array of strings must be provided as profilesIds');
+      return should(kuzzle.repositories.profile.loadProfiles(42)).be.rejectedWith('An array of strings must be provided as profilesIds');
     });
 
     it('should respond with an emty array when profileIds is an empty array', () => {
@@ -147,7 +147,7 @@ describe('Test: repositories/profileRepository', () => {
     });
 
     it('should rejects when profileIds contains some non string entry', () => {
-      should(kuzzle.repositories.profile.loadProfiles([12])).be.rejectedWith('An array of strings must be provided as profilesIds');
+      return should(kuzzle.repositories.profile.loadProfiles([12])).be.rejectedWith('An array of strings must be provided as profilesIds');
     });
   });
 

--- a/test/api/core/models/repositories/profileRepository.test.js
+++ b/test/api/core/models/repositories/profileRepository.test.js
@@ -1,5 +1,5 @@
 var
-  q = require('q'),
+  Promise = require('bluebird'),
   sinon = require('sinon'),
   params = require('rc')('kuzzle'),
   should = require('should'),
@@ -12,7 +12,7 @@ var
   RequestObject = require.main.require('kuzzle-common-objects').Models.requestObject,
   Kuzzle = require.main.require('lib/api/Kuzzle');
 
-require('sinon-as-promised')(q.Promise);
+require('sinon-as-promised')(Promise);
 
 describe('Test: repositories/profileRepository', () => {
   var
@@ -29,14 +29,14 @@ describe('Test: repositories/profileRepository', () => {
       profileRepository:{
         loadFromCache: (id) => {
           if (id !== 'testprofile-cached') {
-            return q(null);
+            return Promise.resolve(null);
           }
-          return q(testProfile);
+          return Promise.resolve(testProfile);
         }
       },
       roleRepository:{
         loadRoles: (keys) => {
-          return q(keys
+          return Promise.resolve(keys
             .map((key) => {
               var role = new Role();
               role._id = key;
@@ -259,7 +259,7 @@ describe('Test: repositories/profileRepository', () => {
 
     it('should properly format the roles filter', () => {
       sandbox.stub(kuzzle.repositories.profile, 'search', (filter) => {
-        return q({
+        return Promise.resolve({
           hits: [{_id: 'test'}],
           total: 1,
           filter: filter
@@ -288,7 +288,7 @@ describe('Test: repositories/profileRepository', () => {
     });
 
     it('should properly persist the profile', () => {
-      sandbox.stub(kuzzle.repositories.profile, 'persistToDatabase', profile => q({_id: profile._id}));
+      sandbox.stub(kuzzle.repositories.profile, 'persistToDatabase', profile => Promise.resolve({_id: profile._id}));
       sandbox.stub(kuzzle.repositories.role, 'loadRoles', stubs.roleRepository.loadRoles);
 
       return kuzzle.repositories.profile.validateAndSaveProfile(testProfile)
@@ -300,7 +300,7 @@ describe('Test: repositories/profileRepository', () => {
     });
 
     it('should properly persist the profile with a non object role', () => {
-      sandbox.stub(kuzzle.repositories.profile, 'persistToDatabase', profile => q({_id: profile._id}));
+      sandbox.stub(kuzzle.repositories.profile, 'persistToDatabase', profile => Promise.resolve({_id: profile._id}));
       sandbox.stub(kuzzle.repositories.role, 'loadRoles', stubs.roleRepository.loadRoles);
 
       testProfile.policies = [{_id: 'anonymous'}];

--- a/test/api/core/models/repositories/repository.test.js
+++ b/test/api/core/models/repositories/repository.test.js
@@ -2,7 +2,6 @@ var
   Promise = require('bluebird'),
   should = require('should'),
   InternalError = require.main.require('kuzzle-common-objects').Errors.internalError,
-  NotFoundError = require.main.require('kuzzle-common-objects').Errors.notFoundError,
   Repository = require.main.require('lib/api/core/models/repositories/repository'),
   RequestObject = require.main.require('kuzzle-common-objects').Models.requestObject;
 
@@ -62,7 +61,6 @@ describe('Test: repositories/repository', () => {
 
   mockReadEngine = {
     get: (requestObject, forward) => {
-      var err;
       if (forward !== false) {
         forwardedObject = requestObject;
       }
@@ -88,11 +86,6 @@ describe('Test: repositories/repository', () => {
       }
 
       return Promise.resolve({found: false});
-/*
-      err = new NotFoundError('Not found');
-      err.found = false;
-      err._id = requestObject.data._id;
-      return Promise.reject(err);*/
     },
     mget: requestObject => {
       var
@@ -117,7 +110,6 @@ describe('Test: repositories/repository', () => {
 
       return Promise.all(promises)
         .then(results => {
-          console.dir(results, {depth: null})
           var
             result = results
               .map(r => {

--- a/test/api/core/models/repositories/roleRepository.test.js
+++ b/test/api/core/models/repositories/roleRepository.test.js
@@ -1,5 +1,5 @@
 var
-  q = require('q'),
+  Promise = require('bluebird'),
   sinon = require('sinon'),
   params = require('rc')('kuzzle'),
   should = require('should'),
@@ -9,7 +9,7 @@ var
   Role = require.main.require('lib/api/core/models/security/role'),
   Kuzzle = require.main.require('lib/api/Kuzzle');
 
-require('sinon-as-promised')(q.Promise);
+require('sinon-as-promised')(Promise);
 
 describe('Test: repositories/roleRepository', function () {
   var
@@ -143,7 +143,7 @@ describe('Test: repositories/roleRepository', function () {
         savedSize = size;
         savedHydrate = hydrate;
 
-        return q();
+        return Promise.resolve();
       });
 
       return kuzzle.repositories.role.searchRole(new RequestObject({body: {from: 1, size: 3, hydrate: false}}))
@@ -162,7 +162,7 @@ describe('Test: repositories/roleRepository', function () {
       sandbox.stub(kuzzle.repositories.role, 'search', (filter) => {
         savedFilter = filter;
 
-        return q();
+        return Promise.resolve();
       });
 
       return kuzzle.repositories.role.searchRole(new RequestObject({body: {controllers: ['test']}}))
@@ -259,7 +259,7 @@ describe('Test: repositories/roleRepository', function () {
 
       sandbox.stub(kuzzle.repositories.role.writeLayer, 'execute', requestObject => {
         forwardedObject = requestObject;
-        return q({});
+        return Promise.resolve({});
       });
 
       return kuzzle.repositories.role.validateAndSaveRole(role)

--- a/test/api/core/models/repositories/tokenRepository.test.js
+++ b/test/api/core/models/repositories/tokenRepository.test.js
@@ -1,6 +1,6 @@
 var
   jwt = require('jsonwebtoken'),
-  q = require('q'),
+  Promise = require('bluebird'),
   should = require('should'),
   /** @type {Params} */
   params = require('rc')('kuzzle'),
@@ -34,21 +34,21 @@ beforeEach(function (done) {
   mockCacheEngine = {
     get: function (key) {
       if (key === tokenRepository.index + '/' + tokenRepository.collection + '/tokenInCache') {
-        return q(JSON.stringify(tokenInCache));
+        return Promise.resolve(JSON.stringify(tokenInCache));
       }
-      return q(null);
+      return Promise.resolve(null);
     },
     volatileSet: function () {
-      return q('OK');
+      return Promise.resolve('OK');
     },
-    expire: function (key, ttl) { return q({key: key, ttl: ttl}); }
+    expire: function (key, ttl) { return Promise.resolve({key: key, ttl: ttl}); }
   };
 
   mockProfileRepository = {
     loadProfile: function (profileKey) {
       var profile = new Profile();
       profile._id = profileKey;
-      return q(profile);
+      return Promise.resolve(profile);
     }
   };
 
@@ -58,7 +58,7 @@ beforeEach(function (done) {
       user._id = username;
       user.profileId = 'anonymous';
 
-      return q(user);
+      return Promise.resolve(user);
     },
     anonymous: function () {
       var
@@ -79,7 +79,7 @@ beforeEach(function (done) {
       user.profileId = 'anonymous';
       profile.policies = [{_id: role._id}];
 
-      return q(user);
+      return Promise.resolve(user);
     },
     admin: function () {
       var
@@ -100,7 +100,7 @@ beforeEach(function (done) {
       user.profileId = 'admin';
       profile.policies = [{_id: role._id}];
 
-      return q(user);
+      return Promise.resolve(user);
     }
   };
 
@@ -153,21 +153,16 @@ describe('Test: repositories/tokenRepository', function () {
   });
 
   describe('#hydrate', function () {
-    it('should return the given token if the given data is not a valid object', function (done) {
+    it('should return the given token if the given data is not a valid object', function () {
       var
         t = new Token();
 
-      q.all([
+      return Promise.all([
         tokenRepository.hydrate(t, null),
         tokenRepository.hydrate(t),
         tokenRepository.hydrate(t, 'a scalar')
       ])
-        .then(function (results) {
-          results.forEach(function (token) {
-            should(token).be.exactly(t);
-          });
-          done();
-        });
+        .then(results => results.forEach(token => should(token).be.exactly(t)));
     });
 
     it('should return the anonymous token if no _id is set', done => {
@@ -184,7 +179,6 @@ describe('Test: repositories/tokenRepository', function () {
 
   describe('#verifyToken', function () {
     it('should reject the promise if the jwt is invalid', function () {
-
       return should(tokenRepository.verifyToken('invalidToken')).be.rejectedWith(UnauthorizedError, {
         details: {
           subCode: UnauthorizedError.prototype.subCodes.JsonWebTokenError,
@@ -199,65 +193,32 @@ describe('Test: repositories/tokenRepository', function () {
 
       token = jwt.sign({_id: -99999}, params.jsonWebToken.secret, {algorithm: params.jsonWebToken.algorithm});
 
-      should(tokenRepository.verifyToken(token)).be.rejectedWith(UnauthorizedError, {
-        message: 'Token invalid'
+      return should(tokenRepository.verifyToken(token)).be.rejectedWith(UnauthorizedError, {
+        message: 'Invalid token'
       });
     });
 
-    it('shoud reject the promise if the jwt is expired', function (done) {
-      var token = jwt.sign({_id: -1}, params.jsonWebToken.secret, {algorithm: params.jsonWebToken.algorithm, expiresIn: 1});
+    it('shoud reject the promise if the jwt is expired', function () {
+      var token = jwt.sign({_id: -1}, params.jsonWebToken.secret, {algorithm: params.jsonWebToken.algorithm, expiresIn: 0});
 
-      setTimeout(function () {
-        should(tokenRepository.verifyToken(token)).be.rejectedWith(UnauthorizedError, {
-          details: {
-            subCode: UnauthorizedError.prototype.subCodes.TokenExpired
-          }
+      return should(tokenRepository.verifyToken(token)).be.rejectedWith(UnauthorizedError, {
+        details: {
+          subCode: UnauthorizedError.prototype.subCodes.TokenExpired
+        }
         });
-        done();
-      }, 101);
     });
 
     it('should reject the promise if an error occurred while fetching the user from the cache', () => {
       var token = jwt.sign({_id: 'auser'}, params.jsonWebToken.secret, {algorithm: params.jsonWebToken.algorithm});
 
-      tokenRepository.loadFromCache = () => {
-        return q.reject(new InternalError('Error'));
-      };
+      sandbox.stub(tokenRepository, 'loadFromCache').rejects(new InternalError('Error'));
 
-      return should(tokenRepository.verifyToken(token)
-        .catch(err => {
-          delete tokenRepository.loadFromCache;
-
-          return q.reject(err);
-        })).be.rejectedWith(InternalError);
+      return should(tokenRepository.verifyToken(token)).be.rejectedWith(InternalError);
     });
 
-
-    it('should reject the promise if an untrapped error is raised', () => {
-      var token = jwt.sign({_id: null}, params.jsonWebToken.secret, {algorithm: params.jsonWebToken.algorithm});
-
-      tokenRepository.anonymous = () => {
-        throw new InternalError('Uncaught error');
-      };
-      should(tokenRepository.verifyToken(token)
-        .catch(err => {
-          delete tokenRepository.anonymous;
-
-          return q.reject(err);
-        })).be.rejectedWith(InternalError, {details: {message: 'Uncaught error'}});
-    });
-
-    it('should load the anonymous user if the token is null', function (done) {
-
-      tokenRepository.verifyToken(null)
-        .then(function (userToken) {
-          assertIsAnonymous(userToken);
-
-          done();
-        })
-        .catch(function (error) {
-          done(error);
-        });
+    it('should load the anonymous user if the token is null', () => {
+      return tokenRepository.verifyToken(null)
+        .then(userToken => assertIsAnonymous(userToken));
     });
   });
 
@@ -278,7 +239,7 @@ describe('Test: repositories/tokenRepository', function () {
         .catch(err => {
           kuzzle.config.jsonWebToken.algorithm = params.jsonWebToken.algorithm;
 
-          return q.reject(err);
+          return Promise.reject(err);
         })).be.rejectedWith(InternalError);
     });
 
@@ -386,7 +347,7 @@ describe('Test: repositories/tokenRepository', function () {
         user = new User();
 
       Repository.prototype.expireFromCache = function () {
-        return q.reject();
+        return Promise.reject();
       };
 
       user._id = 'userInCache';

--- a/test/api/core/models/repositories/tokenRepository.test.js
+++ b/test/api/core/models/repositories/tokenRepository.test.js
@@ -205,7 +205,7 @@ describe('Test: repositories/tokenRepository', function () {
         details: {
           subCode: UnauthorizedError.prototype.subCodes.TokenExpired
         }
-        });
+      });
     });
 
     it('should reject the promise if an error occurred while fetching the user from the cache', () => {

--- a/test/api/core/models/security/profile.test.js
+++ b/test/api/core/models/security/profile.test.js
@@ -1,13 +1,13 @@
 var
   should = require('should'),
-  q = require('q'),
+  Promise = require('bluebird'),
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
   sinon = require('sinon'),
   Profile = require.main.require('lib/api/core/models/security/profile'),
   Role = require.main.require('lib/api/core/models/security/role');
 
-require('sinon-as-promised')(q.Promise);
+require('sinon-as-promised')(Promise);
 
 describe('Test: security/profileTest', function () {
   var
@@ -70,7 +70,7 @@ describe('Test: security/profileTest', function () {
 
     profile.policies = [{_id: 'disallowAllRole'}];
 
-    sandbox.stub(kuzzle.repositories.role, 'loadRole', roleId => q(roles[roleId]));
+    sandbox.stub(kuzzle.repositories.role, 'loadRole', roleId => Promise.resolve(roles[roleId]));
 
     return profile.isActionAllowed(requestObject, context, kuzzle)
       .then(isAllowed => {
@@ -140,7 +140,7 @@ describe('Test: security/profileTest', function () {
     };
     profile.policies.push({_id: role3._id});
 
-    sandbox.stub(kuzzle.repositories.role, 'loadRole', roleId => q(roles[roleId]));
+    sandbox.stub(kuzzle.repositories.role, 'loadRole', roleId => Promise.resolve(roles[roleId]));
 
     return profile.getRights(kuzzle)
       .then(rights => {

--- a/test/api/core/models/security/role.test.js
+++ b/test/api/core/models/security/role.test.js
@@ -1,6 +1,6 @@
 var
   should = require('should'),
-  q = require('q'),
+  Promise = require('bluebird'),
   rewire = require('rewire'),
   BadRequestError = require.main.require('kuzzle-common-objects').Errors.badRequestError,
   RequestObject = require.main.require('kuzzle-common-objects').Models.requestObject,
@@ -33,26 +33,26 @@ describe('Test: security/roleTest', () => {
           readEngine: {
             search: requestObject => {
               if (requestObject.data.body.filter.ids.values[0] !== 'foobar') {
-                return q({hits: [documentAda]});
+                return Promise.resolve({hits: [documentAda]});
               }
 
-              return q({hits: [documentFalseAda]});
+              return Promise.resolve({hits: [documentFalseAda]});
             },
             get: requestObject => {
               if (requestObject.data.id === 'reject') {
-                return q.reject(new InternalError('Our Error'));
+                return Promise.reject(new InternalError('Our Error'));
               } else if (requestObject.data.id !== 'foobar') {
-                return q(documentAda);
+                return Promise.resolve(documentAda);
               }
 
-              return q(documentFalseAda);
+              return Promise.resolve(documentFalseAda);
             },
             mget: requestObject => {
               if (requestObject.data.body.ids[0] !== 'foobar') {
-                return q({hits: [documentAda]});
+                return Promise.resolve({hits: [documentAda]});
               }
 
-              return q({hits: [documentFalseAda]});
+              return Promise.resolve({hits: [documentFalseAda]});
             }
           }
         }
@@ -937,7 +937,7 @@ describe('Test: security/roleTest', () => {
       var foo =
         Role.__with__({
           Sandbox: function () {
-            this.run = () => q.reject(new Error('our unit test error'));
+            this.run = () => Promise.reject(new Error('our unit test error'));
           }
         })(() => {
           var role = new Role();
@@ -963,7 +963,7 @@ describe('Test: security/roleTest', () => {
       var foo =
         Role.__with__({
           Sandbox: function () {
-            this.run = () => q({result: 'I am not a boolean'});
+            this.run = () => Promise.resolve({result: 'I am not a boolean'});
           }
         })(() => {
           var role = new Role();
@@ -987,7 +987,7 @@ describe('Test: security/roleTest', () => {
     it('should resolve the promise if the sandbox returned a boolean', () => {
       return Role.__with__({
         Sandbox: function () {
-          this.run = () => q({ result: true });
+          this.run = () => Promise.resolve({ result: true });
         }
       })(() => {
         var role = new Role();

--- a/test/api/core/models/security/user.test.js
+++ b/test/api/core/models/security/user.test.js
@@ -1,12 +1,12 @@
 var
-  q = require('q'),
+  Promise = require('bluebird'),
   should = require('should'),
   sinon = require('sinon'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
   Profile = require.main.require('lib/api/core/models/security/profile'),
   User = require.main.require('lib/api/core/models/security/user');
 
-require('sinon-as-promised')(q.Promise);
+require('sinon-as-promised')(Promise);
 
 describe('Test: security/userTest', () => {
   var

--- a/test/api/core/models/security/user.test.js
+++ b/test/api/core/models/security/user.test.js
@@ -12,17 +12,21 @@ describe('Test: security/userTest', () => {
   var
     kuzzle,
     sandbox,
-    profile = new Profile(),
-    user = new User();
-
-  profile._id = 'profile';
-  profile.isActionAllowed = sinon.stub().resolves(true);
-  profile._id = 'profile';
-  user.profilesIds = ['profile'];
+    profile,
+    user;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     kuzzle = new Kuzzle();
+
+    profile = new Profile();
+    profile._id = 'profile';
+    profile.isActionAllowed = sinon.stub().resolves(true);
+    profile._id = 'profile';
+
+    user = new User();
+    user.profilesIds = ['profile'];
+
     kuzzle.repositories = {
       profile: {
         loadProfile: sinon.stub().resolves(profile),
@@ -82,12 +86,12 @@ describe('Test: security/userTest', () => {
       .then(isActionAllowed => {
         should(isActionAllowed).be.a.Boolean();
         should(isActionAllowed).be.false();
-        should(profile.isActionAllowed.called).be.true();
+        should(profile.isActionAllowed.called).be.false();
       });
   });
 
   it('should rejects if the loadProfiles throws an error', () => {
     sandbox.stub(user, 'getProfiles').rejects('error');
-    should(user.isActionAllowed({}, {}, kuzzle)).be.rejectedWith('error');
+    return should(user.isActionAllowed({}, {}, kuzzle)).be.rejectedWith('error');
   });
 });

--- a/test/api/core/notifier/notifyDocumentCreate.test.js
+++ b/test/api/core/notifier/notifyDocumentCreate.test.js
@@ -7,7 +7,7 @@
  */
 var
   should = require('should'),
-  q = require('q'),
+  Promise = require('bluebird'),
   RequestObject = require.main.require('kuzzle-common-objects').Models.requestObject,
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle');
@@ -16,12 +16,12 @@ var mockupCacheService = {
   id: undefined,
   room: undefined,
 
-  search: function () { return q(['foobar']); },
-  remove: function () { return q({}); },
+  search: function () { return Promise.resolve(['foobar']); },
+  remove: function () { return Promise.resolve({}); },
   add: function (id, room) {
     this.id = id;
     this.room = room;
-    return q({});
+    return Promise.resolve({});
   }
 };
 

--- a/test/api/core/notifier/notifyDocumentDelete.test.js
+++ b/test/api/core/notifier/notifyDocumentDelete.test.js
@@ -7,7 +7,7 @@
  */
 var
   should = require('should'),
-  q = require('q'),
+  Promise = require('bluebird'),
   RequestObject = require.main.require('kuzzle-common-objects').Models.requestObject,
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle');
@@ -17,15 +17,15 @@ var mockupCacheService = {
 
   remove: function (id) {
     this.id = id;
-    return q({});
+    return Promise.resolve({});
   },
 
   search: function (id) {
     if (id === 'errorme') {
-      return q.reject(new Error());
+      return Promise.reject(new Error());
     }
 
-    return q(['']);
+    return Promise.resolve(['']);
   }
 };
 

--- a/test/api/core/notifier/notifyDocumentReplace.test.js
+++ b/test/api/core/notifier/notifyDocumentReplace.test.js
@@ -7,7 +7,7 @@
  */
 var
   should = require('should'),
-  q = require('q'),
+  Promise = require('bluebird'),
   RequestObject = require.main.require('kuzzle-common-objects').Models.requestObject,
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle');
@@ -26,25 +26,25 @@ var mockupCacheService = {
       this.addId = id;
       this.room = room;
     }
-    return q({});
+    return Promise.resolve({});
   },
 
   remove: function (id, room) {
     if (room.length > 0) {
       this.removeId = id;
     }
-    return q({});
+    return Promise.resolve({});
   },
 
   search: function (id) {
     if (['removeme', 'addme'].indexOf(id) !== -1) {
-      return q(['foobar']);
+      return Promise.resolve(['foobar']);
     }
     else if (id === 'errorme') {
-      return q.reject(new Error('rejected'));
+      return Promise.reject(new Error('rejected'));
     }
 
-    return q([]);
+    return Promise.resolve([]);
   }
 };
 

--- a/test/api/core/notifier/notifyDocumentUpdate.test.js
+++ b/test/api/core/notifier/notifyDocumentUpdate.test.js
@@ -7,7 +7,7 @@
  */
 var
   should = require('should'),
-  q = require('q'),
+  Promise = require('bluebird'),
   RequestObject = require.main.require('kuzzle-common-objects').Models.requestObject,
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle');
@@ -26,34 +26,34 @@ var mockupCacheService = {
       this.addId = id;
       this.room = room;
     }
-    return q({});
+    return Promise.resolve({});
   },
 
   remove: function (id, room) {
     if (room.length > 0) {
       this.removeId = id;
     }
-    return q({});
+    return Promise.resolve({});
   },
 
   search: function (id) {
     if (id === 'removeme') {
-      return q(['foobar']);
+      return Promise.resolve(['foobar']);
     }
 
-    return q([]);
+    return Promise.resolve([]);
   }
 };
 
 var mockupTestFilters = (index, collection, data, id) => {
   if (id === 'errorme') {
-    return q.reject(new Error('rejected'));
+    return Promise.reject(new Error('rejected'));
   }
   else if (id === 'removeme') {
-    return q([]);
+    return Promise.resolve([]);
   }
   
-  return q(['foobar']);
+  return Promise.resolve(['foobar']);
 };
 
 describe('Test: notifier.notifyDocumentUpdate', function () {
@@ -70,7 +70,7 @@ describe('Test: notifier.notifyDocumentUpdate', function () {
       .then(function () {
         kuzzle.services.list.notificationCache = mockupCacheService;
         kuzzle.services.list.readEngine = {
-          get: r => q({_id: r.data._id, _source: requestObject.data.body})
+          get: r => Promise.resolve({_id: r.data._id, _source: requestObject.data.body})
         };
         kuzzle.dsl.test = mockupTestFilters;
         kuzzle.notifier.notify = function (rooms, r, n) {

--- a/test/api/core/notifier/publish.test.js
+++ b/test/api/core/notifier/publish.test.js
@@ -5,7 +5,7 @@
  */
 var
   should = require('should'),
-  q = require('q'),
+  Promise = require('bluebird'),
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
   RequestObject = require.main.require('kuzzle-common-objects').Models.requestObject;
@@ -25,7 +25,7 @@ describe('Test: notifier.publish', function () {
     return kuzzle.start(params, {dummy: true})
       .then(() => {
         kuzzle.services.list.notificationCache = {
-          add: function () { cached = true; return q({}); },
+          add: function () { cached = true; return Promise.resolve({}); },
           expire: function () { expired = true; }
         };
       });
@@ -46,7 +46,7 @@ describe('Test: notifier.publish', function () {
       notification = n;
     };
 
-    kuzzle.dsl.test = () => q(rooms);
+    kuzzle.dsl.test = () => Promise.resolve(rooms);
 
     notification = null;
     cached = false;
@@ -131,7 +131,7 @@ describe('Test: notifier.publish', function () {
   });
 
   it('should return a rejected promise if dsl.test fails', () => {
-    kuzzle.dsl.test = () => q.reject(new Error(''));
+    kuzzle.dsl.test = () => Promise.reject(new Error(''));
     return should(kuzzle.notifier.publish(new RequestObject(request))).be.rejected();
   });
 });

--- a/test/api/core/pluginsManager/getPluginsList.test.js
+++ b/test/api/core/pluginsManager/getPluginsList.test.js
@@ -1,13 +1,13 @@
 var
   should = require('should'),
   rewire = require('rewire'),
-  q = require('q'),
+  Promise = require('bluebird'),
   sinon = require('sinon'),
   params = require('rc')('kuzzle'),
   Kuzzle = require.main.require('lib/api/Kuzzle'),
   PluginsManager = rewire('../../../../lib/api/core/plugins/pluginsManager');
 
-require('sinon-as-promised')(q.Promise);
+require('sinon-as-promised')(Promise);
 
 describe('Plugins manager: getPluginsList', function () {
   var 

--- a/test/api/core/pluginsManager/init.test.js
+++ b/test/api/core/pluginsManager/init.test.js
@@ -1,10 +1,10 @@
 var
-  q = require('q'),
+  Promise = require('bluebird'),
   sinon = require('sinon'),
   rewire = require('rewire'),
   PluginsManager = rewire('../../../../lib/api/core/plugins/pluginsManager');
 
-require('sinon-as-promised')(q.Promise);
+require('sinon-as-promised')(Promise);
 
 describe('PluginsManager: init()', () => {
   var

--- a/test/api/core/statistics.test.js
+++ b/test/api/core/statistics.test.js
@@ -4,7 +4,7 @@
 var
   _ = require('lodash'),
   should = require('should'),
-  q = require('q'),
+  Promise = require('bluebird'),
   rewire = require('rewire'),
   params = require('rc')('kuzzle'),
   sinon = require('sinon'),
@@ -297,7 +297,7 @@ describe('Test: statistics core component', function () {
     var statsCache = kuzzle.services.list.statsCache;
 
     kuzzle.services.list.statsCache = {
-      get: () => { return q.reject(new Error()); }
+      get: () => { return Promise.reject(new Error()); }
     };
 
     stats.lastFrame = Date.now();
@@ -306,7 +306,7 @@ describe('Test: statistics core component', function () {
       stats.getLastStats(requestObject)
         .catch(error => {
           kuzzle.services.list.statsCache = statsCache;
-          return q.reject(error);
+          return Promise.reject(error);
         })
     ).be.rejected();
   });

--- a/test/api/dsl/filters/findMatchingFilters.test.js
+++ b/test/api/dsl/filters/findMatchingFilters.test.js
@@ -13,16 +13,16 @@ describe('Test: dsl.filters.findMatchingFilters', function () {
   });
 
   it('should return a rejected promise when the room to test does\'t exist', function () {
-    return should(findMatchingFilters.call(filters, ['foo'], {}, {})).be.rejected();
+    should(findMatchingFilters.call(filters, ['foo'], {}, {})).be.empty();
   });
 
   it('should mark the filter as notifiable if no filter are provided', function () {
     filters.filters.foo = {};
 
-    return should(findMatchingFilters.call(filters, ['foo'], {}, {})).be.fulfilledWith(['foo']);
+    should(findMatchingFilters.call(filters, ['foo'], {}, {})).match(['foo']);
   });
 
-  it('should return the correct list of rooms whose filters are matching', function (done) {
+  it('should return the correct list of rooms whose filters are matching', function () {
     filters.filters = {
       foo: {
         encodedFilters: { returnValue: true }
@@ -40,20 +40,13 @@ describe('Test: dsl.filters.findMatchingFilters', function () {
         return filter.returnValue;
       }
     })(function () {
-      findMatchingFilters.call(filters, ['foo', 'bar', 'baz'])
-        .then(function (ids) {
-          should(ids).be.an.Array().and.match(['foo', 'baz']);
-          done();
-        })
-        .catch(function (e) {
-          done(e);
-        });
+      should(findMatchingFilters.call(filters, ['foo', 'bar', 'baz'])).match(['foo', 'baz']);
     });
   });
 
   it('should not return duplicate room ids', function () {
     filters.filters.foo = {};
 
-    return should(findMatchingFilters.call(filters, ['foo', 'foo'], {}, {})).be.fulfilledWith(['foo']);
+    should(findMatchingFilters.call(filters, ['foo', 'foo'], {}, {})).match(['foo']);
   });
 });

--- a/test/api/dsl/filters/removeFieldFilter.test.js
+++ b/test/api/dsl/filters/removeFieldFilter.test.js
@@ -12,6 +12,6 @@ describe('Test: dsl.removeFieldFilter', function () {
   });
 
   it('should do nothing if no filters are provided', function () {
-    return should(DslFilters.__get__('removeFieldFilter').call(filters, null)).be.fulfilled();
+    should(DslFilters.__get__('removeFieldFilter').call(filters, null)).be.false();
   });
 });

--- a/test/api/dsl/filters/testFieldFilters.test.js
+++ b/test/api/dsl/filters/testFieldFilters.test.js
@@ -1,6 +1,5 @@
 var
   should = require('should'),
-  Promise = require('bluebird'),
   rewire = require('rewire'),
   md5 = require('crypto-md5'),
   DslFilters = rewire('../../../../lib/api/dsl/filters'),

--- a/test/api/dsl/filters/testGlobalsFilter.test.js
+++ b/test/api/dsl/filters/testGlobalsFilter.test.js
@@ -1,6 +1,5 @@
 var
   should = require('should'),
-  q = require('q'),
   rewire = require('rewire'),
   DslFilters = rewire('../../../../lib/api/dsl/filters'),
   Dsl = rewire('../../../../lib/api/dsl/index');
@@ -19,7 +18,7 @@ describe('Test: dsl.filters.testGlobalsFilters', function () {
       should(ids).be.an.Array();
       should(body).be.exactly(flattenBody);
       should(cache).match(cachedResult);
-      return q(ids);
+      return ids;
     });
 
     filters = new DslFilters();
@@ -28,19 +27,19 @@ describe('Test: dsl.filters.testGlobalsFilters', function () {
     flattenBody = Dsl.__get__('flattenObject')(data);
   });
 
-  it('should resolve to an empty array if there if the collection doesn\'t contain a room array', function () {
-    return should(filters.testGlobalsFilters(index, collection, flattenBody, cachedResult)).be.fulfilledWith([]);
+  it('should return an empty array if there if the collection doesn\'t contain a room array', function () {
+    should(filters.testGlobalsFilters(index, collection, flattenBody, cachedResult)).be.empty();
   });
 
-  it('should resolve to an empty array if there is no rooms registered on that collection', function () {
+  it('should an empty array if there is no rooms registered on that collection', function () {
     filters.filtersTree[index][collection].rooms = [];
-    return should(filters.testGlobalsFilters(index, collection, flattenBody, cachedResult)).be.fulfilledWith([]);
+    should(filters.testGlobalsFilters(index, collection, flattenBody, cachedResult)).be.empty();
   });
 
   it('should call the testRooms with the appropriate set of arguments', function () {
     var ids = ['Excuse', 'me', 'while', 'I', 'kiss', 'the', 'sky'];
 
     filters.filtersTree[index][collection].globalFilterIds = ids;
-    return should(filters.testGlobalsFilters(index, collection, flattenBody, cachedResult)).be.fulfilledWith(ids);
+    should(filters.testGlobalsFilters(index, collection, flattenBody, cachedResult)).match(ids);
   });
 });

--- a/test/api/dsl/index/remove.test.js
+++ b/test/api/dsl/index/remove.test.js
@@ -1,6 +1,6 @@
 var
   should = require('should'),
-  q = require('q'),
+  Promise = require('bluebird'),
   rewire = require('rewire'),
   Dsl = rewire('../../../../lib/api/dsl/index');
 
@@ -40,16 +40,6 @@ describe('Test: dsl.remove', function () {
         return dsl.remove(filterId);
       })
       .then(() => should(dsl.filters.filtersTree).be.empty().Object());
-  });
-
-  it('should return a rejected promise on fail', function () {
-    dsl.filters.removeFilter = () => q.reject(new Error('rejected'));
-
-    return dsl.register(filterId, index, collection, {})
-      .then(() => {
-        should(dsl.filters.filtersTree).not.be.empty().Object();
-        return should(dsl.remove(filterId)).be.rejected();
-      });
   });
 
   it('should fail if the provided filter ID is not a string', function () {

--- a/test/api/dsl/index/remove.test.js
+++ b/test/api/dsl/index/remove.test.js
@@ -1,6 +1,5 @@
 var
   should = require('should'),
-  Promise = require('bluebird'),
   rewire = require('rewire'),
   Dsl = rewire('../../../../lib/api/dsl/index');
 

--- a/test/api/dsl/index/test.test.js
+++ b/test/api/dsl/index/test.test.js
@@ -1,6 +1,5 @@
 var
   should = require('should'),
-  Promise = require('bluebird'),
   rewire = require('rewire'),
   NotFoundError = require.main.require('kuzzle-common-objects').Errors.notFoundError,
   Dsl = rewire('../../../../lib/api/dsl/index');

--- a/test/api/dsl/index/test.test.js
+++ b/test/api/dsl/index/test.test.js
@@ -1,6 +1,6 @@
 var
   should = require('should'),
-  q = require('q'),
+  Promise = require('bluebird'),
   rewire = require('rewire'),
   NotFoundError = require.main.require('kuzzle-common-objects').Errors.notFoundError,
   Dsl = rewire('../../../../lib/api/dsl/index');
@@ -93,16 +93,5 @@ describe('Test: dsl.test', function () {
 
   it('should return an error if no collection is provided', function () {
     return should(dsl.test(index, null, dataGrace)).be.rejectedWith(NotFoundError);
-  });
-
-  it('should reject the promise if testFieldFilter fails', () => {
-    dsl.filters.testFieldFilters = () => q.reject(new Error('rejected'));
-
-    return should(dsl.test(index, collection, dataGrace)).be.rejectedWith('rejected');
-  });
-
-  it('should reject the promise if testGlobalsFilter fails', () => {
-    dsl.filters.testGlobalsFilters = () => q.reject(new Error('rejected'));
-    return should(dsl.test(index, collection, dataGrace)).be.rejectedWith('rejected');
   });
 });

--- a/test/api/dsl/methods/and.test.js
+++ b/test/api/dsl/methods/and.test.js
@@ -1,6 +1,6 @@
 var
   should = require('should'),
-  q = require('q'),
+  Promise = require('bluebird'),
   rewire = require('rewire'),
   md5 = require('crypto-md5'),
   Filters = require.main.require('lib/api/dsl/filters'),
@@ -82,7 +82,7 @@ describe('Test "and" method', function () {
 
   it('should return a rejected promise if getFormattedFilters fails', function () {
     return Methods.__with__({
-      getFormattedFilters: function () { return q.reject(new Error('rejected')); }
+      getFormattedFilters: function () { return Promise.reject(new Error('rejected')); }
     })(function () {
       return should(methods.and(filterId, index, collection, filter)).be.rejectedWith('rejected');
     });

--- a/test/api/dsl/methods/bool.test.js
+++ b/test/api/dsl/methods/bool.test.js
@@ -1,6 +1,6 @@
 var
   should = require('should'),
-  q = require('q'),
+  Promise = require('bluebird'),
   rewire = require('rewire'),
   md5 = require('crypto-md5'),
   Filters = require.main.require('lib/api/dsl/filters'),
@@ -183,7 +183,7 @@ describe('Test bool method', function () {
   it('should return a rejected promise if one of the bool sub-methods fails', function () {
     var f = { must: [ { foo: 'bar' } ] };
 
-    methods.must = function () { return q.reject(new Error('rejected')); };
+    methods.must = function () { return Promise.reject(new Error('rejected')); };
     return should(methods.bool(filterId, index, collection, f)).be.rejectedWith('rejected');
   });
 });

--- a/test/api/dsl/methods/getFormattedFilters.test.js
+++ b/test/api/dsl/methods/getFormattedFilters.test.js
@@ -2,7 +2,7 @@ var
   should = require('should'),
   rewire = require('rewire'),
   md5 = require('crypto-md5'),
-  q = require('q'),
+  Promise = require('bluebird'),
   Filters = require.main.require('lib/api/dsl/filters'),
   Methods = rewire('../../../../lib/api/dsl/methods'),
   BadRequestError = require.main.require('kuzzle-common-objects').Errors.badRequestError;
@@ -130,7 +130,7 @@ describe('Test: dsl.getFormattedFilters method', function () {
         }
       };
 
-    methods.exists = function () { return q.reject(new Error('rejected')); };
+    methods.exists = function () { return Promise.reject(new Error('rejected')); };
 
     return should(getFormattedFilters.call(methods, 'roomId', 'index', 'collection', filter)).be.rejectedWith('rejected');
   });

--- a/test/api/dsl/methods/must.test.js
+++ b/test/api/dsl/methods/must.test.js
@@ -1,7 +1,7 @@
 var
   should = require('should'),
   rewire = require('rewire'),
-  q = require('q'),
+  Promise = require('bluebird'),
   Methods = rewire('../../../../lib/api/dsl/methods');
 
 describe('Test: dsl.must method', function () {
@@ -10,10 +10,10 @@ describe('Test: dsl.must method', function () {
   before(function () {
     Methods.__set__('getFormattedFilters', function (roomId) {
       if (roomId === 'resolve') {
-        return q({filter: 'resolved'});
+        return Promise.resolve({filter: 'resolved'});
       }
 
-      return q.reject(new Error('rejected'));
+      return Promise.reject(new Error('rejected'));
     });
 
     methods = new Methods({filtersTree: {}});

--- a/test/api/dsl/methods/or.test.js
+++ b/test/api/dsl/methods/or.test.js
@@ -2,7 +2,7 @@ var
   should = require('should'),
   rewire = require('rewire'),
   md5 = require('crypto-md5'),
-  q = require('q'),
+  Promise = require('bluebird'),
   Filters = require.main.require('lib/api/dsl/filters'),
   Methods = rewire('../../../../lib/api/dsl/methods'),
   BadRequestError = require.main.require('kuzzle-common-objects').Errors.badRequestError;
@@ -100,7 +100,7 @@ describe('Test or method', function () {
 
   it('should return a rejected promise if getFormattedFilters fails', function () {
     return Methods.__with__({
-      getFormattedFilters: function () { return q.reject(new Error('rejected')); }
+      getFormattedFilters: function () { return Promise.reject(new Error('rejected')); }
     })(function () {
       return should(methods.or(filterId, index, collection, filter)).be.rejectedWith('rejected');
     });

--- a/test/api/dsl/methods/should.test.js
+++ b/test/api/dsl/methods/should.test.js
@@ -1,7 +1,7 @@
 var
   should = require('should'),
   rewire = require('rewire'),
-  q = require('q'),
+  Promise = require('bluebird'),
   Methods = rewire('../../../../lib/api/dsl/methods');
 
 describe('Test: dsl.should method', function () {
@@ -12,10 +12,10 @@ describe('Test: dsl.should method', function () {
 
     Methods.__set__('getFormattedFilters', function (roomId) {
       if (roomId === 'resolve') {
-        return q('resolved');
+        return Promise.resolve('resolved');
       }
 
-      return q.reject(new Error('rejected'));
+      return Promise.reject(new Error('rejected'));
     });
 
     methods = new Methods({filtersTree: {}});

--- a/test/mocks/services/redisClient.mock.js
+++ b/test/mocks/services/redisClient.mock.js
@@ -1,12 +1,12 @@
 var
   EventEmitter = require('eventemitter2').EventEmitter2,
   redisCommands = (require('ioredis')({lazyConnect: true})).getBuiltinCommands(),
-  q = require('q'),
+  Promise = require('bluebird'),
   mock = {};
 
 redisCommands.forEach(command => {
   mock[command] = mock[command.toUpperCase()] = function () {
-    return q({
+    return Promise.resolve({
       name: command,
       args: Array.prototype.slice.call(arguments)
     });

--- a/test/services/implementations/broker.test.js
+++ b/test/services/implementations/broker.test.js
@@ -1,5 +1,5 @@
 var
-  q = require('q'),
+  Promise = require('bluebird'),
   rewire = require('rewire'),
   sinon = require('sinon'),
   sandbox = sinon.sandbox.create(),
@@ -76,7 +76,7 @@ describe('Test: Internal broker', function () {
       client = new InternalBroker(kuzzle, {isServer: false});
       client.ws = () => new WSClientMock(server.server);
 
-      return q.all([
+      return Promise.all([
         server.init(),
         client.init()
       ]);
@@ -141,7 +141,7 @@ describe('Test: Internal broker', function () {
         var
           beforeInitOnCalls;
 
-        return q.all([server.init(),client.init()])
+        return Promise.all([server.init(),client.init()])
           .then(() => {
             beforeInitOnCalls = client.client.socket.on.callCount;
             return client.init();
@@ -176,7 +176,7 @@ describe('Test: Internal broker', function () {
     });
 
     describe('#listen & #unsubscribe', () => {
-      beforeEach(() => q.all([server.init(),client.init()]));
+      beforeEach(() => Promise.all([server.init(),client.init()]));
 
       it ('should store the cb and send the request to the server', () => {
         var cb = sinon.stub();
@@ -213,7 +213,7 @@ describe('Test: Internal broker', function () {
     });
 
     describe('#close', () => {
-      beforeEach(() => q.all([server.init(),client.init()]));
+      beforeEach(() => Promise.all([server.init(),client.init()]));
 
       it('should close the socket', () => {
         var socket = client.client.socket;
@@ -234,7 +234,7 @@ describe('Test: Internal broker', function () {
     });
 
     describe('#send & broadcast', () => {
-      beforeEach(() => q.all([server.init(),client.init()]));
+      beforeEach(() => Promise.all([server.init(),client.init()]));
 
       it('`send` should send properly envelopped data', () => {
         var
@@ -274,7 +274,7 @@ describe('Test: Internal broker', function () {
         client.onCloseHandlers = [];
         client.onErrorHandlers = [];
         
-        return q.all([server.init(),client.init()]);
+        return Promise.all([server.init(),client.init()]);
       });
 
       it('on open, should re-register if some callbacks were attached', () => {
@@ -411,7 +411,7 @@ describe('Test: Internal broker', function () {
       client3 = new WSBrokerClient('internalBroker', {}, kuzzle.pluginsManager);
       client1.ws = client2.ws = client3.ws = () => new WSClientMock(server.server);
 
-      return q.all([
+      return Promise.all([
         server.init(),
         client1.init(),
         client2.init(),
@@ -602,13 +602,13 @@ describe('Test: Internal broker', function () {
 
         // wait 1h
         clock.tick(1000 * 3600);
-        should(response.inspect().state).be.exactly('pending');
+        should(response.isPending()).be.true();
       });
 
       it('should resolve the promise once a client connects to the room', () => {
         var response = server.waitForClients('test');
 
-        should(response.inspect().state).be.exactly('pending');
+        should(response.isPending()).be.true();
 
         server.rooms = { test: true };
         clock.tick(200);

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -565,7 +565,6 @@ describe('Test: ElasticSearch service', function () {
 
           should(result.errors).be.true();
           should(result.partialErrors).be.an.Array().and.match([{status: 404}]).and.match([{error: /^DocumentMissingException/}]);
-          console.dir(result, {depth:null})
         })).be.fulfilled();
     });
 

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -1,6 +1,6 @@
 var
   should = require('should'),
-  q = require('q'),
+  Promise = require('bluebird'),
   sinon = require('sinon'),
   rewire = require('rewire'),
   params = require('rc')('kuzzle'),
@@ -79,9 +79,8 @@ describe('Test: ElasticSearch service', function () {
   });
 
   describe('#init', function () {
-    it('should initialize properly', function (done) {
-      should(elasticsearch.init()).be.exactly(elasticsearch);
-      done();
+    it('should initialize properly', function () {
+      return should(elasticsearch.init()).be.fulfilledWith(elasticsearch);
     });
   });
 
@@ -498,7 +497,7 @@ describe('Test: ElasticSearch service', function () {
       requestObject.data.body = {};
 
       return ES.__with__({
-        getAllIdsFromQuery: () => q(['foo', 'bar'])
+        getAllIdsFromQuery: () => Promise.resolve(['foo', 'bar'])
       })(function () {
         return should(elasticsearch.deleteByQuery(requestObject)).be.rejected();
       });
@@ -566,6 +565,7 @@ describe('Test: ElasticSearch service', function () {
 
           should(result.errors).be.true();
           should(result.partialErrors).be.an.Array().and.match([{status: 404}]).and.match([{error: /^DocumentMissingException/}]);
+          console.dir(result, {depth:null})
         })).be.fulfilled();
     });
 
@@ -890,7 +890,7 @@ describe('Test: ElasticSearch service', function () {
 
     it('should reject the deleteIndex promise if elasticsearch throws an error', () => {
       elasticsearch.client.indices.delete = function () {
-        return q.reject(new Error());
+        return Promise.reject(new Error());
       };
 
       return should(elasticsearch.deleteIndex(requestObject)).be.rejected();

--- a/test/services/init.test.js
+++ b/test/services/init.test.js
@@ -1,5 +1,5 @@
 var
-  q = require('q'),
+  Promise = require('bluebird'),
   should = require('should'),
   params = require('rc')('kuzzle'),
   rewire = require('rewire'),
@@ -170,7 +170,7 @@ describe('Test service initialization function', function () {
       // we need to mock require in the function's scope module.
       return Services.__with__({
         require: () => function () {
-          this.init = () => q.defer().promise;
+          this.init = () => new Promise(() => {});
         }
       })(() => {
         var r = registerService.call(scope, 'myService', { timeout: 1000 }, true);
@@ -189,7 +189,7 @@ describe('Test service initialization function', function () {
       // we need to mock require in the function's scope module.
       return Services.__with__({
         require: () => function () {
-          this.init = () => q.reject(myError);
+          this.init = () => Promise.reject(myError);
         }
       })(() => {
         return should(registerService.call(scope, 'myService', {}, true))

--- a/test/services/internalEngine.test.js
+++ b/test/services/internalEngine.test.js
@@ -27,7 +27,7 @@ describe('InternalEngine', () => {
 
   describe('#init', () => {
     it('should act as a singleton', () => {
-      should(kuzzle.internalEngine.init()).be.exactly(kuzzle.internalEngine);
+      return should(kuzzle.internalEngine.init()).be.fulfilledWith(kuzzle.internalEngine);
     });
   });
 

--- a/test/workers/index.test.js
+++ b/test/workers/index.test.js
@@ -75,9 +75,6 @@ describe('Testing: workers loader', function () {
   });
 
   it('should raise an error if a worker cannot be loaded', function () {
-    var
-      saved = kuzzle.config.workers;
-
     kuzzle.config.workers = {
       foo: ['foo', 'write', 'bar']
     };

--- a/test/workers/write.test.js
+++ b/test/workers/write.test.js
@@ -1,7 +1,7 @@
 var
   should = require('should'),
   rewire = require('rewire'),
-  q = require('q'),
+  Promise = require('bluebird'),
   params = require('rc')('kuzzle'),
   sinon = require('sinon'),
   sandbox = sinon.sandbox.create(),
@@ -19,13 +19,13 @@ describe('Testing: write worker', function () {
 
     return kuzzle.start(params, {dummy: true})
       .then(function () {
-        kuzzle.services.init = function () {return q();};
+        kuzzle.services.init = function () {return Promise.resolve();};
 
         // we test successful write commands using a mockup 'create' action...
-        kuzzle.services.list.writeEngine.create = function (request) { return q(request); };
+        kuzzle.services.list.writeEngine.create = function (request) { return Promise.resolve(request); };
 
         // ...and failed write command with a mockup 'update' action
-        kuzzle.services.list.writeEngine.update = function () { return q.reject(new Error('rejected')); };
+        kuzzle.services.list.writeEngine.update = function () { return Promise.reject(new Error('rejected')); };
       });
   });
 


### PR DESCRIPTION
:warning: :warning: :warning:
* MERGE ONLY AFTER #344 and #345
* Once these 2 PRs are merged, please freeze Kuzzle code until this PR is merged
* Applying this PR (or using this PR's branch) requires a `npm install` execution

:warning: :warning: :warning:

Following the first batch of benchmark results and analysis, this PR solves performances and memory issues.

# CHANGELOG

## Performances improvement

* Replace Q with Bluebird. Increases performances by roughly 30% and reduces memory consumption drastically
* Async is now used only when strictly necessary, reducing call queue usage and preventing the overflow occuring in Kuzzle DSL `test` functions
* Remove all usages of `lodash.isEmpty` as benchmarks result show slow response from this function

## Unrelated bugfixes

* Remove promise parameter and resolution from Passport responses, as the provided promise is already resolved by the Passport wrapper object
* Move `require` declarations outside of `ProfileRepository`, `TokenRepository`, `UserRepository` and `RoleRepository` exported objects
* Removed unnecessary promise use from parts of the DSL, namely room removal and filter testing
* RabbitMQ service now resolves its initialization promise once it has connected to RabbitMQ
* ElasticSearch and InternalEngine initialization functions now always return a promise
* Worker group initialization now resolves its promise once ALL groups are loaded (or once one group fails to load)
* Fix several unit tests that were silently failing
* Fix `HotelClerk.removeRooms` unit tests, who incorrectly succeeded

## Functional tests fixes

* AMQP disconnection now binds the connection context to connection.close (prevents unhandled errors)
* `BeforeFeatures` hook now use the `createIndex` API route instead of bulk imports
* `After` hook now wait for `refreshIndex` to finish before disconnecting a client
* Now use UUID V4 instead of V1
