### PR TITLE
Fix roles format : missing _source entries in results

### DIFF
--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -52,7 +52,13 @@ function SecurityController (kuzzle) {
 
         return kuzzle.repositories.role.loadMultiFromDatabase(modifiedRequestObject.data.body.ids);
       })
-      .then(roles => kuzzle.pluginsManager.trigger('security:afterMGetRoles', new ResponseObject(modifiedRequestObject, {hits: roles, total: roles.length})));
+      .then(roles => {
+        roles = roles.map((role => {
+          return formatProcessing.formatRoleForSerialization(role);
+        }));
+
+        return kuzzle.pluginsManager.trigger('security:afterMGetRoles', new ResponseObject(modifiedRequestObject, {hits: roles, total: roles.length}));
+      });
   };
 
   /**
@@ -67,6 +73,13 @@ function SecurityController (kuzzle) {
       .then(newRequestObject => {
         modifiedRequestObject = newRequestObject;
         return kuzzle.repositories.role.searchRole(modifiedRequestObject);
+      })
+      .then(response => {
+        response.hits = response.hits.map((role => {
+          return formatProcessing.formatRoleForSerialization(role);
+        }));
+
+        return response;
       })
       .then(response => kuzzle.pluginsManager.trigger('security:afterSearchRole', new ResponseObject(modifiedRequestObject, response)));
   };

--- a/lib/api/core/auth/formatProcessing.js
+++ b/lib/api/core/auth/formatProcessing.js
@@ -14,6 +14,8 @@ module.exports = {
 
     delete response._source._id;
     delete response._source.closures;
+    delete response._source.allowInternalIndex;
+    delete response._source.restrictedTo;
 
     return response;
   },

--- a/lib/api/core/models/repositories/index.js
+++ b/lib/api/core/models/repositories/index.js
@@ -1,4 +1,4 @@
-module.exports = function (kuzzle) {
+module.exports = function Repositories (kuzzle) {
   var
     RoleRepository = require('./roleRepository')(kuzzle),
     ProfileRepository = require('./profileRepository')(kuzzle),

--- a/lib/api/core/models/repositories/profileRepository.js
+++ b/lib/api/core/models/repositories/profileRepository.js
@@ -7,6 +7,10 @@ var
   NotFoundError = require('kuzzle-common-objects').Errors.notFoundError,
   Repository = require('./repository');
 
+/**
+ * @param {Kuzzle} kuzzle
+ * @returns {ProfileRepository}
+ */
 module.exports = function (kuzzle) {
   var extractRoleIds = policiesOrRoles => {
     return policiesOrRoles.map(element => {
@@ -17,6 +21,11 @@ module.exports = function (kuzzle) {
     });
   };
 
+  /**
+   * @class ProfileRepository
+   * @extends Repository
+   * @constructor
+   */
   function ProfileRepository () {
     this.profiles = {};
   }
@@ -25,7 +34,7 @@ module.exports = function (kuzzle) {
     index: kuzzle.config.internalIndex,
     collection: 'profiles',
     ObjectConstructor: Profile,
-    cacheEngine: kuzzle.services.list.userCache
+    cacheEngine: kuzzle.services.list.securityCache
   });
 
   /**
@@ -43,9 +52,14 @@ module.exports = function (kuzzle) {
       return Promise.reject(new BadRequestError('A profileId must be provided'));
     }
 
+    if (this.profiles[profileId]) {
+      return Promise.resolve(this.profiles[profileId]);
+    }
+
     return this.load(profileId)
       .then(result => {
         if (result) {
+          this.profiles[profileId] = result;
           return result;
         }
 
@@ -57,7 +71,7 @@ module.exports = function (kuzzle) {
   /**
    * Loads a Profile object given its id.
    *
-   * @param {array} Array of profiles ids
+   * @param {Array} profilesIds Array of profiles ids
    * @returns {Promise} Resolves to the matching Profile object if found, null if not.
    */
   ProfileRepository.prototype.loadProfiles = function (profilesIds) {
@@ -75,14 +89,13 @@ module.exports = function (kuzzle) {
       return Promise.resolve([]);
     }
 
-    promises = profilesIds.map(profileId => this.load(profileId));
+    promises = profilesIds.map(profileId => this.loadProfile(profileId));
 
     return Promise.all(promises)
       .then(results => {
         var profiles = [];
         results.forEach(profile => {
           if (profile !== null) {
-            this.profiles[profile._id] = profile;
             profiles.push(profile);
           }
         });
@@ -120,6 +133,7 @@ module.exports = function (kuzzle) {
     var filter = {};
 
     if (roles && Array.isArray(roles) && roles.length) {
+      // todo: refactor filter, 'or' is deprecated since es 2.x
       filter.or = [];
       roles.forEach(roleId => {
         filter.or.push({terms: { 'policies.roleId': [ roleId ] }});
@@ -190,14 +204,21 @@ module.exports = function (kuzzle) {
 
     filter = {terms: { 'profiles': [ profile._id ] }};
 
-    return kuzzle.repositories.user.search(filter, 0, 1, false)
+    return kuzzle.repositories.user.search(filter, 0, 1)
       .then(response => {
         if (response.total > 0) {
           return Promise.reject(new ForbiddenError('The profile "' + profile._id + '" cannot be deleted since it is used by some users.'));
         }
 
         return this.deleteFromCache(profile._id)
-          .then(() => this.deleteFromDatabase(profile._id));
+          .then(() => this.deleteFromDatabase(profile._id))
+          .then((deleteResponse) => {
+            if (this.profiles[profile._id] !== undefined) {
+              delete this.profiles[profile._id];
+            }
+
+            return deleteResponse;
+          });
 
       });
   };
@@ -231,10 +252,10 @@ module.exports = function (kuzzle) {
 
     return profile.validateDefinition()
       .then(() => {
-        this.profiles[profile._id] = this.serializeToDatabase(profile);
+        this.profiles[profile._id] = profile;
         return this.persistToDatabase(profile, opts);
       })
-      .then(() => this.hydrate(profile, this.profiles[profile._id]));
+      .then(() => profile);
   };
 
   return ProfileRepository;

--- a/lib/api/core/models/repositories/repository.js
+++ b/lib/api/core/models/repositories/repository.js
@@ -139,7 +139,7 @@ Repository.prototype.loadMultiFromDatabase = function (_ids) {
  * @param {Number} from manage pagination
  * @param {Number} size manage pagination
  *
- * @returns {promise}
+ * @returns {Promise}
  */
 Repository.prototype.search = function (filter, from, size) {
   var
@@ -346,7 +346,7 @@ Repository.prototype.persistToCache = function (object, opts) {
  *   key: if provided, removes the given key instead of the default one (<collection>/<id>)
  *
  * @param {String} id
- * @param {Object} opts optional options for the current operation
+ * @param {Object} [opts={}] optional options for the current operation
  * @returns {Promise}
  */
 Repository.prototype.deleteFromCache = function (id, opts) {

--- a/lib/api/core/models/repositories/roleRepository.js
+++ b/lib/api/core/models/repositories/roleRepository.js
@@ -5,7 +5,17 @@ var
   Repository = require('./repository'),
   Role = require('../security/role');
 
+/**
+ * @param {Kuzzle} kuzzle
+ * @returns {RoleRepository}
+ */
 module.exports = function (kuzzle) {
+
+  /**
+   * @class RoleRepository
+   * @extends Repository
+   * @constructor
+   */
   function RoleRepository() {
     this.roles = {};
   }
@@ -14,7 +24,7 @@ module.exports = function (kuzzle) {
     index: kuzzle.config.internalIndex,
     collection: 'roles',
     ObjectConstructor: Role,
-    cacheEngine: kuzzle.services.list.userCache
+    cacheEngine: kuzzle.services.list.securityCache
   });
 
   /**

--- a/lib/api/core/models/repositories/roleRepository.js
+++ b/lib/api/core/models/repositories/roleRepository.js
@@ -150,6 +150,7 @@ module.exports = function (kuzzle) {
     requestObject.data.body = requestObject.data.body || {};
 
     if (requestObject.data.body.controllers && Array.isArray(requestObject.data.body.controllers)) {
+      // todo: refactor filter, 'or' is deprecated since es 2.x
       filter = {or: []};
 
       requestObject.data.body.controllers.forEach(controller => {
@@ -163,7 +164,7 @@ module.exports = function (kuzzle) {
     }
 
     // todo: get list from ES and do a .map on it for filter on collection/controller/action in addition to index
-    return this.search(filter, requestObject.data.body.from, requestObject.data.body.size, false);
+    return this.search(filter, requestObject.data.body.from, requestObject.data.body.size);
   };
 
   /**

--- a/lib/api/core/models/repositories/tokenRepository.js
+++ b/lib/api/core/models/repositories/tokenRepository.js
@@ -8,6 +8,10 @@ var
   InternalError = require('kuzzle-common-objects').Errors.internalError,
   UnauthorizedError = require('kuzzle-common-objects').Errors.unauthorizedError;
 
+/**
+ * @param {Kuzzle} kuzzle
+ * @returns {TokenRepository}
+ */
 module.exports = function (kuzzle) {
   function parseTimespan(time) {
     var milliseconds;
@@ -28,6 +32,12 @@ module.exports = function (kuzzle) {
     return -1;
   }
 
+  /**
+   * @class TokenRepository
+   * @extends Repository
+   * @param opts
+   * @constructor
+   */
   function TokenRepository (opts) {
     var options = opts || {};
 

--- a/lib/api/core/models/repositories/userRepository.js
+++ b/lib/api/core/models/repositories/userRepository.js
@@ -6,7 +6,17 @@ var
   Repository = require('./repository'),
   NotFoundError = require('kuzzle-common-objects').Errors.notFoundError;
 
+/**
+ * @param {Kuzzle} kuzzle
+ * @returns {UserRepository}
+ */
 module.exports = function (kuzzle) {
+  /**
+   * @class UserRepository
+   * @extends Repository
+   * @param opts
+   * @constructor
+   */
   function UserRepository (opts) {
     var options = opts || {};
 
@@ -19,7 +29,7 @@ module.exports = function (kuzzle) {
     index: kuzzle.config.internalIndex,
     collection: 'users',
     ObjectConstructor: User,
-    cacheEngine: kuzzle.services.list.userCache
+    cacheEngine: kuzzle.services.list.securityCache
   });
 
   UserRepository.prototype.load = function (id) {

--- a/lib/api/core/models/security/role.js
+++ b/lib/api/core/models/security/role.js
@@ -15,6 +15,8 @@ var
  */
 function Role () {
   this.controllers = {};
+
+  // closures, allowInternalIndex and restrictedTo are computed for internal use only.
   this.closures = {};
   this.allowInternalIndex = false;
 

--- a/lib/api/start.js
+++ b/lib/api/start.js
@@ -37,7 +37,7 @@ var
  * @this {Kuzzle}
  * @param {Object} params command line and/or configuration file arguments
  *                        overrides the 'feature' argument
- * @param {Object} feature allow to programatically tune what part of Kuzzle you want to run
+ * @param {Object} [feature={}] allow to programatically tune what part of Kuzzle you want to run
  */
 module.exports = function start (params, feature) {
   if (feature === undefined) {

--- a/lib/config/models/cache.js
+++ b/lib/config/models/cache.js
@@ -20,7 +20,7 @@ module.exports = function (params) {
     }
   }
 
-  cache.databases = ['notificationCache', 'statsCache', 'userCache', 'internalCache', 'tokenCache', 'memoryStorage'];
+  cache.databases = ['notificationCache', 'statsCache', 'securityCache', 'internalCache', 'tokenCache', 'memoryStorage'];
 
   return cache;
 };

--- a/lib/config/services.js
+++ b/lib/config/services.js
@@ -5,7 +5,7 @@ module.exports = function () {
     writeEngine: 'elasticsearch',
     readEngine: 'elasticsearch',
     notificationCache: 'redis',
-    userCache: 'redis',
+    securityCache: 'redis',
     internalCache: 'redis',
     // redis index exposed to the end user by the memory storage controller
     memoryStorage: 'redis',

--- a/test/api/controllers/securityController/profiles.test.js
+++ b/test/api/controllers/securityController/profiles.test.js
@@ -112,22 +112,11 @@ describe('Test: security controller - profiles', function () {
           should(result.data.body.hits).be.an.Array();
           should(result.data.body.hits).not.be.empty();
           should(result.data.body.hits[0]).be.an.Object();
+          should(result.data.body.hits[0]._id).be.an.String();
+          should(result.data.body.hits[0]._source).be.an.Object();
           should(result.data.body.hits[0]._source.policies).be.an.Array();
           should(result.data.body.hits[0]._source.policies[0]).be.an.Object();
           should(result.data.body.hits[0]._source.policies[0].roleId).be.an.String();
-        });
-    });
-
-    it('should resolve to a responseObject with roles on a mGetProfiles call with hydrate', () => {
-      sandbox.stub(kuzzle.repositories.profile, 'loadMultiFromDatabase').resolves([{_id: 'test', _source: {}}]);
-      return kuzzle.funnel.controllers.security.mGetProfiles(new RequestObject({
-        body: {ids: ['test'], hydrate: true}
-      }))
-        .then(result => {
-          should(result).be.an.instanceOf(ResponseObject);
-          should(result.data.body.hits).be.an.Array();
-          should(result.data.body.hits).not.be.empty();
-          should(result.data.body.hits[0]).be.an.Object();
         });
     });
   });

--- a/test/api/controllers/securityController/users.test.js
+++ b/test/api/controllers/securityController/users.test.js
@@ -97,7 +97,7 @@ describe('Test: security controller - users', function () {
     it('should reject with a response object in case of error', () => {
       sandbox.stub(kuzzle.repositories.user, 'search').rejects();
       return should(kuzzle.funnel.controllers.security.searchUsers(new RequestObject({
-        body: {hydrate: false}
+        body: {}
       }))).be.rejected();
     });
   });

--- a/test/api/core/models/repositories/roleRepository.test.js
+++ b/test/api/core/models/repositories/roleRepository.test.js
@@ -134,24 +134,21 @@ describe('Test: repositories/roleRepository', function () {
       var
         savedFilter,
         savedFrom,
-        savedSize,
-        savedHydrate;
+        savedSize;
 
-      sandbox.stub(kuzzle.repositories.role, 'search', (filter, from, size, hydrate) => {
+      sandbox.stub(kuzzle.repositories.role, 'search', (filter, from, size) => {
         savedFilter = filter;
         savedFrom = from;
         savedSize = size;
-        savedHydrate = hydrate;
 
         return Promise.resolve();
       });
 
-      return kuzzle.repositories.role.searchRole(new RequestObject({body: {from: 1, size: 3, hydrate: false}}))
+      return kuzzle.repositories.role.searchRole(new RequestObject({body: {from: 1, size: 3}}))
         .then(() => {
           should(savedFilter).be.eql({});
           should(savedFrom).be.eql(1);
           should(savedSize).be.eql(3);
-          should(savedHydrate).be.false();
         });
     });
 


### PR DESCRIPTION
* Added `formatProcessing.formatRoleForSerialization` call on roles that are fetched though `security.mGetRoles` & `security.searchRoles`
* Removed role's `allowInternalIndex` & `restrictedTo` data from responses 
* Fixed a bug in `ProfileRepository`: internal cache wasn't updated when a profile was updated
* Renamed `kuzzle.services.list.userCache` to `kuzzle.services.list.securityCache` because it was also used by profiles & roles repositories 
* Removed references to old hydrate options