### PR TITLE
add default config into kuzzle image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM kuzzleio/base:alpine
 MAINTAINER Kuzzle <support@kuzzle.io>
 
 ADD ./ /var/app/
+ADD ./docker-compose/scripts/run.sh /run.sh
+ADD ./docker-compose/config/pm2.json /config/pm2.json
 
 RUN set -ex && \
     apk add \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,11 +11,6 @@ kuzzle:
     - elasticsearch
     - redis
     - proxy:api
-  volumes:
-    - "./docker-compose/scripts/run.sh:/run.sh"
-    - "./docker-compose/config:/config"
-  environment:
-    - FEATURE_COVERAGE
 
 redis:
   image: redis:3.0-alpine


### PR DESCRIPTION
Simplify the default files needed to run a kuzzle stack

- Added default pm2 config file into kuzzle image
- Added default run file into kuzzle image
- Removed default volume from base docker-compose file
- Remove environment entry from base docker-compose file