### PR TITLE
Kuz 631 internalengine for security repositories

### DIFF
--- a/lib/api/core/models/repositories/README.md
+++ b/lib/api/core/models/repositories/README.md
@@ -25,15 +25,9 @@ The ttl to use for the CacheEngine. If set to false, the objects get an unlimite
 
 The constructor function for the business objects. The load* methods will return some new instances of this function.
 
-* *function* readEngine (optional)
+* *function* storageEngine (optional)
 
-The read engine to use to retrieve the business objects from the database. Defaults to Kuzzle's readEngine (elasticsearch).
-
-* *function* writeLayer (optional)
-
-The write layer to use to persist business objects to the database.  
-This layer exposes only a `execute` function, taking a `RequestObject` object as an argument, and returning a promise.  
-Defaults to Kuzzle's write workers.
+The read engine to use to retrieve the business objects to/from the database. Defaults to Kuzzle's internalEngine (elasticsearch).
 
 * *function* cacheEngine (optional)
 
@@ -77,13 +71,13 @@ If no matching document could be found, an empty array is returned.
 Repository.prototype.search = function (filter, from, size, hydrate) {...}
 ```
 
-This method tries to load document from readEngine or the business objects (according to hydrate parameter) from the database matching the given ids.
+This method tries to load document from storageEngine or the business objects (according to hydrate parameter) from the database matching the given ids.
 
 ### parameters
 
 * *object* filter
 
-The filter sent to the readEngine in order to retrieve documents.
+The filter sent to the storageEngine in order to retrieve documents.
 
 * *Integer* from
 
@@ -95,11 +89,11 @@ Number of hits to return (default: 20).
 
 * *Boolean* hydrate
 
-If hydrate is true, the function resolve a ResponseObject with a list of business objects. If hydrate is false, resolve a ResponseObject with documents directly from readEngine. (default: false).
+If hydrate is true, the function resolve a ResponseObject with a list of business objects. If hydrate is false, resolve a ResponseObject with documents directly from storageEngine. (default: false).
 
 ### returns
 
-Returns a promise that resolves a ResponseObject that contains either a list of business objects or a list of document from readEngine according to the parameter hydrate.
+Returns a promise that resolves a ResponseObject that contains either a list of business objects or a list of document from storageEngine according to the parameter hydrate.
 
 
 ## loadFromCache

--- a/lib/api/core/models/repositories/README.md
+++ b/lib/api/core/models/repositories/README.md
@@ -25,7 +25,7 @@ The ttl to use for the CacheEngine. If set to false, the objects get an unlimite
 
 The constructor function for the business objects. The load* methods will return some new instances of this function.
 
-* *function* storageEngine (optional)
+* *function* databaseEngine (optional)
 
 The read engine to use to retrieve the business objects to/from the database. Defaults to Kuzzle's internalEngine (elasticsearch).
 
@@ -71,13 +71,13 @@ If no matching document could be found, an empty array is returned.
 Repository.prototype.search = function (filter, from, size, hydrate) {...}
 ```
 
-This method tries to load document from storageEngine or the business objects (according to hydrate parameter) from the database matching the given ids.
+This method tries to load document from databaseEngine or the business objects (according to hydrate parameter) from the database matching the given ids.
 
 ### parameters
 
 * *object* filter
 
-The filter sent to the storageEngine in order to retrieve documents.
+The filter sent to the databaseEngine in order to retrieve documents.
 
 * *Integer* from
 
@@ -89,11 +89,11 @@ Number of hits to return (default: 20).
 
 * *Boolean* hydrate
 
-If hydrate is true, the function resolve a ResponseObject with a list of business objects. If hydrate is false, resolve a ResponseObject with documents directly from storageEngine. (default: false).
+If hydrate is true, the function resolve a ResponseObject with a list of business objects. If hydrate is false, resolve a ResponseObject with documents directly from databaseEngine. (default: false).
 
 ### returns
 
-Returns a promise that resolves a ResponseObject that contains either a list of business objects or a list of document from storageEngine according to the parameter hydrate.
+Returns a promise that resolves a ResponseObject that contains either a list of business objects or a list of document from databaseEngine according to the parameter hydrate.
 
 
 ## loadFromCache

--- a/lib/api/core/models/repositories/README.md
+++ b/lib/api/core/models/repositories/README.md
@@ -68,10 +68,10 @@ If no matching document could be found, an empty array is returned.
 ## search
 
 ```javascript
-Repository.prototype.search = function (filter, from, size, hydrate) {...}
+Repository.prototype.search = function (filter, from, size) {...}
 ```
 
-This method tries to load document from databaseEngine or the business objects (according to hydrate parameter) from the database matching the given ids.
+This method tries to load documents matching the given ids from the databaseEngine.
 
 ### parameters
 
@@ -87,13 +87,9 @@ Starting offset (default: 0).
 
 Number of hits to return (default: 20).
 
-* *Boolean* hydrate
-
-If hydrate is true, the function resolve a ResponseObject with a list of business objects. If hydrate is false, resolve a ResponseObject with documents directly from databaseEngine. (default: false).
-
 ### returns
 
-Returns a promise that resolves a ResponseObject that contains either a list of business objects or a list of document from databaseEngine according to the parameter hydrate.
+Returns a promise that resolves a ResponseObject that contains a list of documents from databaseEngine.
 
 
 ## loadFromCache

--- a/lib/api/core/models/repositories/repository.js
+++ b/lib/api/core/models/repositories/repository.js
@@ -1,8 +1,7 @@
 var
   _ = require('lodash'),
   Promise = require('bluebird'),
-  InternalError = require('kuzzle-common-objects').Errors.internalError,
-  RequestObject = require('kuzzle-common-objects').Models.requestObject;
+  InternalError = require('kuzzle-common-objects').Errors.internalError;
 
 /**
  * @param {Kuzzle} kuzzle
@@ -14,8 +13,7 @@ function Repository (kuzzle) {
   this.ttl = kuzzle.config.repositories.cacheTTL;
   this.collection = null;
   this.ObjectConstructor = null;
-  this.writeLayer = null;
-  this.readEngine = null;
+  this.storageEngine = null;
   this.cacheEngine = null;
 }
 
@@ -25,31 +23,19 @@ function Repository (kuzzle) {
  * @param options
  */
 Repository.prototype.init = function(options) {
-  // if set to null, it means that we explicitely dont want a readEngine for this repository
-  // as null is falsy, without this check, the readEngine is always set...
-  if (options.readEngine === null) {
-    this.readEngine = options.readEngine;
+  // if set to null, it means that we explicitely dont want a storageEngine for this repository
+  // as null is falsy, without this check, the storageEngine is always set...
+  if (options.storageEngine === null) {
+    this.storageEngine = options.storageEngine;
   }
   else {
-    this.readEngine = options.readEngine || this.kuzzle.services.list.readEngine;
+    this.storageEngine = options.storageEngine || this.kuzzle.internalEngine;
   }
   if (options.cacheEngine === null) {
     this.cacheEngine = options.cacheEngine;
   }
   else {
     this.cacheEngine = options.cacheEngine || this.kuzzle.services.list.internalCache;
-  }
-
-  /*
-    If no custom write engine layer is provided, fallback to the standard Kuzzle write engine
-   */
-  if (!this.writeLayer) {
-    this.writeLayer = {
-      execute: requestObject => {
-        this.kuzzle.pluginsManager.trigger('data:before' + requestObject.action.charAt(0).toUpperCase() + requestObject.action.slice(1), requestObject);
-        return this.kuzzle.services.list.writeEngine[requestObject.action](requestObject);
-      }
-    };
   }
 };
 
@@ -60,20 +46,9 @@ Repository.prototype.init = function(options) {
  */
 Repository.prototype.loadOneFromDatabase = function (id) {
   var
-    requestObject,
     result;
 
-  requestObject = new RequestObject({
-    controller: 'read',
-    action: 'get',
-    collection: this.collection,
-    index: this.index,
-    body: {
-      _id: id
-    }
-  });
-
-  return this.readEngine.get(requestObject)
+  return this.storageEngine.get(this.collection, id)
     .then(response => {
       if (response._id) {
         result = new this.ObjectConstructor();
@@ -101,7 +76,6 @@ Repository.prototype.loadOneFromDatabase = function (id) {
  */
 Repository.prototype.loadMultiFromDatabase = function (_ids) {
   var
-    requestObject,
     ids = [];
 
   if (!_.isArray(_ids)) {
@@ -116,17 +90,7 @@ Repository.prototype.loadMultiFromDatabase = function (_ids) {
     }
   });
 
-  requestObject = new RequestObject({
-    controller: 'read',
-    action: 'mget',
-    collection: this.collection,
-    index: this.index,
-    body: {
-      ids: ids
-    }
-  });
-
-  return this.readEngine.mget(requestObject)
+  return this.storageEngine.mget(this.collection, ids)
     .then(response => {
       if (!response.hits || response.hits.length === 0) {
         return Promise.resolve([]);
@@ -152,22 +116,7 @@ Repository.prototype.loadMultiFromDatabase = function (_ids) {
  * @returns {Promise}
  */
 Repository.prototype.search = function (filter, from, size) {
-  var
-    requestObject;
-
-  requestObject = new RequestObject({
-    controller: 'read',
-    action: 'search',
-    collection: this.collection,
-    index: this.index,
-    body: {
-      filter: filter,
-      from: from || 0,
-      size: size || 20
-    }
-  });
-
-  return this.readEngine.search(requestObject)
+  return this.storageEngine.search(this.collection, filter, from, size)
     .then(response => {
       if (!response.hits || response.hits.length === 0) {
         return {total: 0, hits: []};
@@ -238,7 +187,7 @@ Repository.prototype.load = function (id, opts) {
   return this.loadFromCache(id, opts)
     .then(object => {
       if (object === null) {
-        if (this.readEngine === null) {
+        if (this.storageEngine === null) {
           return null;
         }
 
@@ -265,17 +214,9 @@ Repository.prototype.load = function (id, opts) {
 Repository.prototype.persistToDatabase = function (object, opts) {
   var
     options = opts || {},
-    method = options.method || 'createOrReplace',
-    requestObject = new RequestObject({
-      controller: 'write',
-      action: method,
-      collection: this.collection,
-      index: this.index,
-      _id: object._id,
-      body: this.serializeToDatabase(object)
-    });
+    method = options.method || 'createOrReplace';
 
-  return this.writeLayer.execute(requestObject);
+  return this.storageEngine[method](this.collection, object._id, this.serializeToDatabase(object));
 };
 
 /**
@@ -293,7 +234,7 @@ Repository.prototype.delete = function (id, opts) {
   if (this.cacheEngine) {
     promises.push(this.deleteFromCache(id, opts));
   }
-  if (this.writeLayer) {
+  if (this.storageEngine) {
     promises.push(this.deleteFromDatabase(id));
   }
 
@@ -306,20 +247,7 @@ Repository.prototype.delete = function (id, opts) {
  * @param id
  */
 Repository.prototype.deleteFromDatabase = function (id) {
-  var
-    requestObject;
-
-  requestObject = new RequestObject({
-    controller: 'write',
-    action: 'delete',
-    collection: this.collection,
-    index: this.index,
-    body: {
-      _id: id
-    }
-  });
-
-  return this.writeLayer.execute(requestObject);
+  return this.storageEngine.delete(this.collection, id);
 };
 
 /**

--- a/lib/api/core/models/repositories/repository.js
+++ b/lib/api/core/models/repositories/repository.js
@@ -13,7 +13,7 @@ function Repository (kuzzle) {
   this.ttl = kuzzle.config.repositories.cacheTTL;
   this.collection = null;
   this.ObjectConstructor = null;
-  this.storageEngine = null;
+  this.databaseEngine = null;
   this.cacheEngine = null;
 }
 
@@ -23,13 +23,13 @@ function Repository (kuzzle) {
  * @param options
  */
 Repository.prototype.init = function(options) {
-  // if set to null, it means that we explicitely dont want a storageEngine for this repository
-  // as null is falsy, without this check, the storageEngine is always set...
-  if (options.storageEngine === null) {
-    this.storageEngine = options.storageEngine;
+  // if set to null, it means that we explicitely dont want a databaseEngine for this repository
+  // as null is falsy, without this check, the databaseEngine is always set...
+  if (options.databaseEngine === null) {
+    this.databaseEngine = options.databaseEngine;
   }
   else {
-    this.storageEngine = options.storageEngine || this.kuzzle.internalEngine;
+    this.databaseEngine = options.databaseEngine || this.kuzzle.internalEngine;
   }
   if (options.cacheEngine === null) {
     this.cacheEngine = options.cacheEngine;
@@ -48,7 +48,7 @@ Repository.prototype.loadOneFromDatabase = function (id) {
   var
     result;
 
-  return this.storageEngine.get(this.collection, id)
+  return this.databaseEngine.get(this.collection, id)
     .then(response => {
       if (response._id) {
         result = new this.ObjectConstructor();
@@ -90,7 +90,7 @@ Repository.prototype.loadMultiFromDatabase = function (_ids) {
     }
   });
 
-  return this.storageEngine.mget(this.collection, ids)
+  return this.databaseEngine.mget(this.collection, ids)
     .then(response => {
       if (!response.hits || response.hits.length === 0) {
         return Promise.resolve([]);
@@ -116,7 +116,7 @@ Repository.prototype.loadMultiFromDatabase = function (_ids) {
  * @returns {Promise}
  */
 Repository.prototype.search = function (filter, from, size) {
-  return this.storageEngine.search(this.collection, filter, from, size)
+  return this.databaseEngine.search(this.collection, filter, from, size)
     .then(response => {
       if (!response.hits || response.hits.length === 0) {
         return {total: 0, hits: []};
@@ -187,7 +187,7 @@ Repository.prototype.load = function (id, opts) {
   return this.loadFromCache(id, opts)
     .then(object => {
       if (object === null) {
-        if (this.storageEngine === null) {
+        if (this.databaseEngine === null) {
           return null;
         }
 
@@ -216,7 +216,7 @@ Repository.prototype.persistToDatabase = function (object, opts) {
     options = opts || {},
     method = options.method || 'createOrReplace';
 
-  return this.storageEngine[method](this.collection, object._id, this.serializeToDatabase(object));
+  return this.databaseEngine[method](this.collection, object._id, this.serializeToDatabase(object));
 };
 
 /**
@@ -234,7 +234,7 @@ Repository.prototype.delete = function (id, opts) {
   if (this.cacheEngine) {
     promises.push(this.deleteFromCache(id, opts));
   }
-  if (this.storageEngine) {
+  if (this.databaseEngine) {
     promises.push(this.deleteFromDatabase(id));
   }
 
@@ -247,7 +247,7 @@ Repository.prototype.delete = function (id, opts) {
  * @param id
  */
 Repository.prototype.deleteFromDatabase = function (id) {
-  return this.storageEngine.delete(this.collection, id);
+  return this.databaseEngine.delete(this.collection, id);
 };
 
 /**

--- a/lib/api/core/models/repositories/tokenRepository.js
+++ b/lib/api/core/models/repositories/tokenRepository.js
@@ -49,7 +49,7 @@ TokenRepository.prototype.constructor = TokenRepository;
 TokenRepository.prototype.init = function() {
   Repository.prototype.init.call(this, {
     cacheEngine: this.kuzzle.services.list.tokenCache,
-    readEngine: null
+    storageEngine: null
   });
 };
 

--- a/lib/api/core/models/repositories/tokenRepository.js
+++ b/lib/api/core/models/repositories/tokenRepository.js
@@ -49,7 +49,7 @@ TokenRepository.prototype.constructor = TokenRepository;
 TokenRepository.prototype.init = function() {
   Repository.prototype.init.call(this, {
     cacheEngine: this.kuzzle.services.list.tokenCache,
-    storageEngine: null
+    databaseEngine: null
   });
 };
 

--- a/lib/services/internalEngine.js
+++ b/lib/services/internalEngine.js
@@ -54,15 +54,21 @@ function InternalEngine (kuzzle) {
   /**
    * Search documents from elasticsearch with a query
    * @param {string} type - data collection
-   * @param {object} [filters] - optional
+   * @param {object} [filter] - optional
+   * @param {Number} from manage pagination
+   * @param {Number} size manage pagination
    * @returns {Promise} resolve documents matching the filter
    */
-  this.search = function (type, filters) {
+  this.search = function (type, filter, from, size) {
     var
       request = {
         index: this.index,
         type,
-        body: filters || {}
+        body: {
+          filter: filter || {},
+          from: from || 0,
+          size: size || 20
+        }
       };
 
     return this.client.search(request)

--- a/test/api/core/models/repositories/profileRepository.test.js
+++ b/test/api/core/models/repositories/profileRepository.test.js
@@ -93,7 +93,8 @@ describe('Test: repositories/profileRepository', () => {
     });
 
     it('should load a profile from the db', () => {
-      sandbox.stub(kuzzle.services.list.readEngine, 'get').resolves(testProfilePlain);
+      kuzzle.internalEngine.get.restore();
+      sandbox.stub(kuzzle.internalEngine, 'get').resolves(testProfilePlain);
       sandbox.stub(kuzzle.repositories.role, 'loadRoles', stubs.roleRepository.loadRoles);
       return kuzzle.repositories.profile.loadProfile('testprofile')
         .then(result => {
@@ -114,7 +115,10 @@ describe('Test: repositories/profileRepository', () => {
     it('should not load a not existing profile', () => {
       var
         existingProfile = new Profile(),
-        stub = sandbox.stub(kuzzle.services.list.readEngine, 'get');
+        stub;
+
+      kuzzle.internalEngine.get.restore();
+      stub = sandbox.stub(kuzzle.internalEngine, 'get');
 
       existingProfile._id = 'existingProfile';
       stub.onCall(0).rejects(new NotFoundError('Not found'));
@@ -173,7 +177,7 @@ describe('Test: repositories/profileRepository', () => {
 
   describe('#hydrate', () => {
     it('should reject the promise in case of error', () => {
-      sandbox.stub(kuzzle.services.list.readEngine, 'get').rejects(new InternalError('Error'));
+      sandbox.stub(kuzzle.repositories.profile, 'load').rejects(new InternalError('Error'));
       return should(kuzzle.repositories.profile.loadProfile('errorprofile')).be.rejectedWith(InternalError);
     });
 
@@ -204,7 +208,7 @@ describe('Test: repositories/profileRepository', () => {
         }
       });
 
-      sandbox.stub(kuzzle.repositories.user.readEngine, 'search').resolves({total: 1, hits: ['test']});
+      sandbox.stub(kuzzle.internalEngine, 'search').resolves({total: 1, hits: ['test']});
 
       return should(kuzzle.repositories.profile.deleteProfile({_id: 'test'})).rejectedWith(ForbiddenError);
     });
@@ -252,7 +256,7 @@ describe('Test: repositories/profileRepository', () => {
 
   describe('#serializeToDatabase', () => {
     it('should return a plain flat object', () => {
-      sandbox.stub(kuzzle.services.list.readEngine, 'get').resolves(testProfilePlain);
+      sandbox.stub(kuzzle.repositories.profile, 'load').resolves(testProfilePlain);
       sandbox.stub(kuzzle.repositories.role, 'loadRoles', stubs.roleRepository.loadRoles);
       return kuzzle.repositories.profile.loadProfile('testprofile')
         .then(profile => {

--- a/test/api/core/models/repositories/repository.test.js
+++ b/test/api/core/models/repositories/repository.test.js
@@ -13,7 +13,7 @@ describe('Test: repositories/repository', () => {
     repository,
     ObjectConstructor,
     mockCacheEngine,
-    mockStorageEngine,
+    mockDatabaseEngine,
     cachedObject,
     uncachedObject;
 
@@ -59,7 +59,7 @@ describe('Test: repositories/repository', () => {
     persist: key => { forwardedObject = {op: 'persist', key: key}; return Promise.resolve('OK'); }
   };
 
-  mockStorageEngine = {
+  mockDatabaseEngine = {
     get: (type, id) => {
       if (id === 'persisted') {
         return Promise.resolve(persistedObject);
@@ -88,7 +88,7 @@ describe('Test: repositories/repository', () => {
         promises = [];
 
       ids.forEach(id => {
-        promises.push(mockStorageEngine.get(repository.collection, id));
+        promises.push(mockDatabaseEngine.get(repository.collection, id));
       });
 
       return Promise.all(promises)
@@ -136,7 +136,7 @@ describe('Test: repositories/repository', () => {
   beforeEach(() => {
     forwardedObject = null;
     repository.ObjectConstructor = ObjectConstructor;
-    repository.storageEngine = mockStorageEngine;
+    repository.databaseEngine = mockDatabaseEngine;
     repository.cacheEngine = mockCacheEngine;
   });
 
@@ -274,7 +274,7 @@ describe('Test: repositories/repository', () => {
         });
     });
 
-    it('should return a valid ObjectConstructor instance if found only in storageEngine', () => {
+    it('should return a valid ObjectConstructor instance if found only in databaseEngine', () => {
       return repository.load('uncached')
         .then(result => {
           should(result).be.an.instanceOf(ObjectConstructor);
@@ -284,7 +284,7 @@ describe('Test: repositories/repository', () => {
         });
     });
 
-    it('should get content only from storageEngine if cacheEngine is null', () => {
+    it('should get content only from databaseEngine if cacheEngine is null', () => {
       repository.cacheEngine = null;
 
       return repository.load('cached')
@@ -296,8 +296,8 @@ describe('Test: repositories/repository', () => {
         });
     });
 
-    it('should get content only from cacheEngine if storageEngine is null', () => {
-      repository.storageEngine = null;
+    it('should get content only from cacheEngine if databaseEngine is null', () => {
+      repository.databaseEngine = null;
 
       return repository.load('uncached')
         .then(result => should(result).be.null());

--- a/test/api/core/models/repositories/repository.test.js
+++ b/test/api/core/models/repositories/repository.test.js
@@ -3,8 +3,7 @@ var
   should = require('should'),
   Kuzzle = require.main.require('lib/api/kuzzle'),
   InternalError = require.main.require('kuzzle-common-objects').Errors.internalError,
-  Repository = require.main.require('lib/api/core/models/repositories/repository'),
-  RequestObject = require.main.require('kuzzle-common-objects').Models.requestObject;
+  Repository = require.main.require('lib/api/core/models/repositories/repository');
 
 describe('Test: repositories/repository', () => {
   var
@@ -14,8 +13,7 @@ describe('Test: repositories/repository', () => {
     repository,
     ObjectConstructor,
     mockCacheEngine,
-    mockReadEngine,
-    mockWriteLayer,
+    mockStorageEngine,
     cachedObject,
     uncachedObject;
 
@@ -61,53 +59,36 @@ describe('Test: repositories/repository', () => {
     persist: key => { forwardedObject = {op: 'persist', key: key}; return Promise.resolve('OK'); }
   };
 
-  mockReadEngine = {
-    get: (requestObject, forward) => {
-      if (forward !== false) {
-        forwardedObject = requestObject;
-      }
-
-      if (requestObject.data._id === 'persisted') {
+  mockStorageEngine = {
+    get: (type, id) => {
+      if (id === 'persisted') {
         return Promise.resolve(persistedObject);
       }
 
-      if (requestObject.data._id === 'uncached') {
+      if (id === 'uncached') {
         return Promise.resolve(uncachedObject);
       }
 
-      if (requestObject.data._id === 'cached') {
+      if (id === 'cached') {
         return Promise.resolve(uncachedObject);
       }
 
-      if (requestObject.data._id === 'source') {
+      if (id === 'source') {
         return Promise.resolve({_id:'theId', _source: {foo: 'bar'}});
       }
 
-      if (requestObject.data._id === 'error') {
+      if (id === 'error') {
         return Promise.reject(new InternalError('Error'));
       }
 
       return Promise.resolve({found: false});
     },
-    mget: requestObject => {
+    mget: (type, ids) => {
       var
         promises = [];
 
-      forwardedObject = requestObject;
-
-      requestObject.data.body.ids.forEach(id => {
-        var req = new RequestObject({
-          controller: 'read',
-          action: 'get',
-          requestId: 'foo',
-          collection: repository.collection,
-          index: repository.index,
-          body: {
-            _id: id
-          }
-        });
-
-        promises.push(mockReadEngine.get(req, false));
+      ids.forEach(id => {
+        promises.push(mockStorageEngine.get(repository.collection, id));
       });
 
       return Promise.all(promises)
@@ -125,22 +106,23 @@ describe('Test: repositories/repository', () => {
           return {hits: result};
         });
     },
-    search: (requestObject) => {
-      if (requestObject.data.body.filter.empty) {
+    search: (type, filter) => {
+      if (filter.empty) {
         return Promise.resolve({});
       }
-      if (requestObject.data.body.filter.error) {
+      if (filter.error) {
         return Promise.reject({});
       }
       return Promise.resolve({hits: [{_id: 'role', _source: {controllers: {}}}], total: 1});
-    }
-  };
-
-  mockWriteLayer = {
-    execute: o => {
-      forwardedObject = o;
     },
-    delete: requestObject => Promise.resolve(requestObject)
+    createOrReplace: (type, id, content) => {
+      forwardedObject = {type, id, content};
+      return Promise.resolve(content);
+    },
+    delete: (type, id) => {
+      forwardedObject = {type, id};
+      return Promise.resolve(id);
+    }
   };
 
   before(() => {
@@ -149,17 +131,12 @@ describe('Test: repositories/repository', () => {
     repository = new Repository(kuzzle);
     repository.index = '%test';
     repository.collection = 'repository';
-    repository.ObjectConstructor = ObjectConstructor;
-    repository.readEngine = mockReadEngine;
-    repository.writeLayer = mockWriteLayer;
-    repository.cacheEngine = mockCacheEngine;
   });
 
   beforeEach(() => {
     forwardedObject = null;
     repository.ObjectConstructor = ObjectConstructor;
-    repository.readEngine = mockReadEngine;
-    repository.writeLayer = mockWriteLayer;
+    repository.storageEngine = mockStorageEngine;
     repository.cacheEngine = mockCacheEngine;
   });
 
@@ -171,17 +148,6 @@ describe('Test: repositories/repository', () => {
 
     it('should reject the promise in case of error', () => {
       return should(repository.loadOneFromDatabase('error')).be.rejectedWith(InternalError);
-    });
-
-    it('should create a valid requestObject request for the readEngine', () => {
-      return repository.loadOneFromDatabase(-9999)
-        .then(() => {
-          should(forwardedObject).be.instanceOf(RequestObject);
-          should(forwardedObject.controller).be.exactly('read');
-          should(forwardedObject.action).be.exactly('get');
-          should(forwardedObject.data._id).be.exactly(-9999);
-          should(forwardedObject.collection).be.exactly(repository.collection);
-        });
     });
 
     it('should return a valid ObjectConstructor instance if found', () => {
@@ -210,17 +176,6 @@ describe('Test: repositories/repository', () => {
 
     it('should reject the promise in case of error', () => {
       return should(repository.loadMultiFromDatabase('error')).be.rejectedWith(InternalError);
-    });
-
-    it('should create a valid requestObject request for the readEngine', () => {
-      return repository.loadMultiFromDatabase([-999, 'persisted', -998])
-        .then(() => {
-          should(forwardedObject).be.instanceOf(RequestObject);
-          should(forwardedObject.controller).be.exactly('read');
-          should(forwardedObject.action).be.exactly('mget');
-          should(forwardedObject.collection).be.exactly(repository.collection);
-          should(forwardedObject.data.body.ids).be.eql([-999, 'persisted', -998]);
-        });
     });
 
     it('should return a list of plain object', () => {
@@ -319,7 +274,7 @@ describe('Test: repositories/repository', () => {
         });
     });
 
-    it('should return a valid ObjectConstructor instance if found only in readEngine', () => {
+    it('should return a valid ObjectConstructor instance if found only in storageEngine', () => {
       return repository.load('uncached')
         .then(result => {
           should(result).be.an.instanceOf(ObjectConstructor);
@@ -329,7 +284,7 @@ describe('Test: repositories/repository', () => {
         });
     });
 
-    it('should get content only from readEngine if cacheEngine is null', () => {
+    it('should get content only from storageEngine if cacheEngine is null', () => {
       repository.cacheEngine = null;
 
       return repository.load('cached')
@@ -341,8 +296,8 @@ describe('Test: repositories/repository', () => {
         });
     });
 
-    it('should get content only from cacheEngine if readEngine is null', () => {
-      repository.readEngine = null;
+    it('should get content only from cacheEngine if storageEngine is null', () => {
+      repository.storageEngine = null;
 
       return repository.load('uncached')
         .then(result => should(result).be.null());
@@ -350,24 +305,25 @@ describe('Test: repositories/repository', () => {
   });
 
   describe('#persistToDatabase', () => {
-    it('should construct a valid requestObject', () => {
-      repository.persistToDatabase(persistedObject);
-
-      should(forwardedObject).be.an.instanceOf(RequestObject);
-      should(forwardedObject.data.body).be.eql(persistedObject);
+    it('should call the createOrReplace method of internal Engine', () => {
+      return repository.persistToDatabase(persistedObject)
+        .then(() => {
+          should(forwardedObject.content).be.eql(persistedObject);
+          should(forwardedObject.type).be.eql(repository.collection);
+          should(forwardedObject.id).be.eql(persistedObject._id);
+        });
     });
   });
 
   describe('#deleteFromDatabase', () => {
     it('should construct a valid requestObject', () => {
-      repository.deleteFromDatabase('test');
-
-      should(forwardedObject).be.an.instanceOf(RequestObject);
-      should(forwardedObject).match({
-        data: { _id: 'test' },
-        controller: 'write',
-        action: 'delete'
-      });
+      return repository.deleteFromDatabase('test')
+        .then(() => {
+          should(forwardedObject).match({
+            id: 'test',
+            type: repository.collection
+          });
+        });
     });
   });
 

--- a/test/api/core/models/repositories/roleRepository.test.js
+++ b/test/api/core/models/repositories/roleRepository.test.js
@@ -252,7 +252,7 @@ describe('Test: repositories/roleRepository', () => {
       role._id = 'test';
       role.controllers = controllers;
 
-      sandbox.stub(kuzzle.repositories.role.storageEngine, 'createOrReplace', (type, id, content) => {
+      sandbox.stub(kuzzle.repositories.role.databaseEngine, 'createOrReplace', (type, id, content) => {
         forwardedObject = {type, id, content};
         return Promise.resolve({});
       });

--- a/test/api/core/models/repositories/userRepository.test.js
+++ b/test/api/core/models/repositories/userRepository.test.js
@@ -19,7 +19,7 @@ describe('Test: repositories/userRepository', () => {
     var
       encryptedPassword = '5c4ec74fd64bb57c05b4948f3a7e9c7d450f069a',
       mockCacheEngine,
-      mockStorageEngine,
+      mockDatabaseEngine,
       mockProfileRepository,
       userInCache,
       userInDB;
@@ -36,7 +36,7 @@ describe('Test: repositories/userRepository', () => {
       expire: () => {return Promise.resolve('OK'); }
     };
 
-    mockStorageEngine = {
+    mockDatabaseEngine = {
       get: (type, id) => {
         if (id === 'userInDB') {
           return Promise.resolve(userInDB);
@@ -91,7 +91,7 @@ describe('Test: repositories/userRepository', () => {
 
     userRepository = new UserRepository(kuzzle);
     userRepository.cacheEngine = mockCacheEngine;
-    userRepository.storageEngine = mockStorageEngine;
+    userRepository.databaseEngine = mockDatabaseEngine;
 
   });
 

--- a/test/api/core/models/repositories/userRepository.test.js
+++ b/test/api/core/models/repositories/userRepository.test.js
@@ -5,7 +5,6 @@ var
   Kuzzle = require.main.require('lib/api/kuzzle'),
   InternalError = require.main.require('kuzzle-common-objects').Errors.internalError,
   NotFoundError = require.main.require('kuzzle-common-objects').Errors.notFoundError,
-  ResponseObject = require.main.require('kuzzle-common-objects').Models.responseObject,
   Profile = require.main.require('lib/api/core/models/security/profile'),
   User = require.main.require('lib/api/core/models/security/user'),
   UserRepository = require.main.require('lib/api/core/models/repositories/userRepository');
@@ -20,8 +19,7 @@ describe('Test: repositories/userRepository', () => {
     var
       encryptedPassword = '5c4ec74fd64bb57c05b4948f3a7e9c7d450f069a',
       mockCacheEngine,
-      mockReadEngine,
-      mockWriteLayer,
+      mockStorageEngine,
       mockProfileRepository,
       userInCache,
       userInDB;
@@ -38,18 +36,15 @@ describe('Test: repositories/userRepository', () => {
       expire: () => {return Promise.resolve('OK'); }
     };
 
-    mockReadEngine = {
-      get: requestObject => {
-        if (requestObject.data._id === 'userInDB') {
-          return Promise.resolve(new ResponseObject(requestObject, userInDB));
+    mockStorageEngine = {
+      get: (type, id) => {
+        if (id === 'userInDB') {
+          return Promise.resolve(userInDB);
         }
 
         return Promise.resolve(new NotFoundError('User not found in db'));
-      }
-    };
-
-    mockWriteLayer = {
-      execute: () => Promise.resolve({})
+      },
+      createOrReplace: () => Promise.resolve({})
     };
 
     mockProfileRepository = {
@@ -96,8 +91,7 @@ describe('Test: repositories/userRepository', () => {
 
     userRepository = new UserRepository(kuzzle);
     userRepository.cacheEngine = mockCacheEngine;
-    userRepository.readEngine = mockReadEngine;
-    userRepository.writeLayer = mockWriteLayer;
+    userRepository.storageEngine = mockStorageEngine;
 
   });
 

--- a/test/services/internalEngine.test.js
+++ b/test/services/internalEngine.test.js
@@ -13,6 +13,10 @@ describe('InternalEngine', () => {
     kuzzle = new Kuzzle();
   });
 
+  beforeEach(() => {
+    kuzzle.internalEngine.init();
+  });
+
   afterEach(() => {
     sandbox.restore();
   });
@@ -42,7 +46,7 @@ describe('InternalEngine', () => {
           should(mock.args[0][0]).match({
             index: kuzzle.config.internalIndex,
             type: collection,
-            body: filters
+            body: {filter: filters}
           });
 
           should(result).be.an.Object().and.not.be.empty();


### PR DESCRIPTION
Force the repositories to use the internalEngine instead of readEngine/writeWorker to persist users/roles/profiles into the database.


Also add parameters "from" and "size" to internalEngine.search() method
