### PR TITLE
profilesIds as a string

### DIFF
--- a/lib/api/core/models/repositories/userRepository.js
+++ b/lib/api/core/models/repositories/userRepository.js
@@ -87,6 +87,10 @@ UserRepository.prototype.hydrate = function (user, data) {
   }
 
   if (data.profilesIds) {
+    if (!Array.isArray(data.profilesIds)) {
+      data.profilesIds = [data.profilesIds]
+    }
+
     dataProfilesIds = data.profilesIds;
     delete data.profilesIds;
   }

--- a/test/api/core/models/repositories/userRepository.test.js
+++ b/test/api/core/models/repositories/userRepository.test.js
@@ -147,7 +147,7 @@ describe('Test: repositories/userRepository', () => {
         .then((result) => {
           should(result.profilesIds).be.an.instanceOf(Array);
           should(result.profilesIds[0]).be.exactly('admin');
-        })
+        });
     });
 
     it('should reject the promise if the profile cannot be found', () => {

--- a/test/api/core/models/repositories/userRepository.test.js
+++ b/test/api/core/models/repositories/userRepository.test.js
@@ -139,6 +139,17 @@ describe('Test: repositories/userRepository', () => {
         .then(result => assertIsAnonymous(result));
     });
 
+    it('should convert a profilesIds string into array', () => {
+      var user = new User();
+      user._id = 'admin';
+
+      return userRepository.hydrate(user, {profilesIds: 'admin'})
+        .then((result) => {
+          should(result.profilesIds).be.an.instanceOf(Array);
+          should(result.profilesIds[0]).be.exactly('admin');
+        })
+    });
+
     it('should reject the promise if the profile cannot be found', () => {
       var user = new User();
 


### PR DESCRIPTION
In Elasticsearch mapping there is no type `array`. A type `string` can contains an array and profilesIds field has mapping like
```
"profilesIds": {
  "type": "string"
}
```

In BO we can't know if this is a `string` or an `array`. So, currently we have a different behaviour: Elasticsearch accept `string` and convert to an `array` but not Kuzzle.