### PR TITLE
[BREAKING] Replace profilesIds to profileIds

### DIFF
--- a/features/REST.feature
+++ b/features/REST.feature
@@ -210,26 +210,26 @@ Feature: Test REST API
     And I create a new user "useradmin" with id "useradmin-id"
     And I create a user "user2" with id "user2-id"
     And I can't create a new user "user2" with id "useradmin-id"
-    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
-    Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profilesIds":["#prefix#profile2"]}}
+    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profileIds":["admin"]}}
+    Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profileIds":["#prefix#profile2"]}}
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 2 users
     Then I delete the user "user2-id"
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 1 users matching {"_id":"#prefix#useradmin-id","_source":{"name":{"first":"David","last":"Bowie"}}}
     When I log in as useradmin-id:testpwd expiring in 1h
-    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
+    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profileIds":["admin"]}}
     Then I log out
-    Then I am getting the current user, which matches {"_id":-1,"_source":{"profilesIds":["anonymous"]}}
+    Then I am getting the current user, which matches {"_id":-1,"_source":{"profileIds":["anonymous"]}}
 
   @usingREST @cleanSecurity
   Scenario: user updateSelf
     When I create a new user "useradmin" with id "useradmin-id"
-    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
+    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profileIds":["admin"]}}
     When I log in as useradmin-id:testpwd expiring in 1h
-    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
+    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profileIds":["admin"]}}
     Then I update current user with data {"foo":"bar"}
-    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"],"foo":"bar"}}
+    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profileIds":["admin"],"foo":"bar"}}
     Then I log out
-    Then I am getting the current user, which matches {"_id":-1,"_source":{"profilesIds":["anonymous"]}}
+    Then I am getting the current user, which matches {"_id":-1,"_source":{"profileIds":["anonymous"]}}
 
   @usingREST @cleanSecurity
   Scenario: user permissions

--- a/features/Websocket.feature
+++ b/features/Websocket.feature
@@ -323,26 +323,26 @@ Feature: Test websocket API
     And I create a new user "useradmin" with id "useradmin-id"
     And I create a user "user2" with id "user2-id"
     And I can't create a new user "user2" with id "useradmin-id"
-    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
-    Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profilesIds":["#prefix#profile2"]}}
+    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profileIds":["admin"]}}
+    Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profileIds":["#prefix#profile2"]}}
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 2 users
     Then I delete the user "user2-id"
     Then I search for {"regexp":{"_uid":"users.#prefix#.*"}} and find 1 users matching {"_id":"#prefix#useradmin-id","_source":{"name":{"first":"David","last":"Bowie"}}}
     When I log in as useradmin-id:testpwd expiring in 1h
-    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
+    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profileIds":["admin"]}}
     Then I log out
-    Then I am getting the current user, which matches {"_id":-1,"_source":{"profilesIds":["anonymous"]}}
+    Then I am getting the current user, which matches {"_id":-1,"_source":{"profileIds":["anonymous"]}}
 
   @usingWebsocket @cleanSecurity
   Scenario: user updateSelf
     When I create a new user "useradmin" with id "useradmin-id"
-    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
+    Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profileIds":["admin"]}}
     When I log in as useradmin-id:testpwd expiring in 1h
-    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"]}}
+    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profileIds":["admin"]}}
     Then I update current user with data {"foo":"bar"}
-    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profilesIds":["admin"],"foo":"bar"}}
+    Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profileIds":["admin"],"foo":"bar"}}
     Then I log out
-    Then I am getting the current user, which matches {"_id":-1,"_source":{"profilesIds":["anonymous"]}}
+    Then I am getting the current user, which matches {"_id":-1,"_source":{"profileIds":["anonymous"]}}
 
   @usingWebsocket @cleanSecurity @unsubscribe
   Scenario: token expiration

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -165,11 +165,11 @@ module.exports = function () {
           last: 'Bowie',
           real: 'David Robert Jones'
         },
-        profilesIds: ['admin'],
+        profileIds: ['admin'],
         password: 'testpwd'
       },
       user1: {
-        profilesIds: [this.idPrefix + 'profile1'],
+        profileIds: [this.idPrefix + 'profile1'],
         password: 'testpwd1'
       },
       user2: {
@@ -178,32 +178,32 @@ module.exports = function () {
           last: 'Wozniak'
         },
         hobby: 'Segway Polo',
-        profilesIds: [this.idPrefix + 'profile2'],
+        profileIds: [this.idPrefix + 'profile2'],
         password: 'testpwd2'
       },
       user3: {
-        profilesIds: [this.idPrefix + 'profile3'],
+        profileIds: [this.idPrefix + 'profile3'],
         password: 'testpwd3'
       },
       user4: {
-        profilesIds: [this.idPrefix + 'profile4'],
+        profileIds: [this.idPrefix + 'profile4'],
         password: 'testpwd4'
       },
       user5: {
-        profilesIds: [this.idPrefix + 'profile5'],
+        profileIds: [this.idPrefix + 'profile5'],
         password: 'testpwd5'
       },
       user6: {
-        profilesIds: [this.idPrefix + 'profile6'],
+        profileIds: [this.idPrefix + 'profile6'],
         password: 'testpwd6'
       },
       unexistingprofile: {
         name: 'John Doe',
-        profilesIds: [this.idPrefix + 'i-dont-exist']
+        profileIds: [this.idPrefix + 'i-dont-exist']
       },
       invalidprofileType: {
         name: 'John Doe',
-        profilesIds: [null]
+        profileIds: [null]
       }
     };
 

--- a/lib/api/controllers/adminController.js
+++ b/lib/api/controllers/adminController.js
@@ -308,7 +308,7 @@ function AdminController(kuzzle) {
       reset = requestObject.data.body.reset || false;
 
     delete requestObject.data.body.reset;
-    requestObject.data.body.profilesIds = ['admin'];
+    requestObject.data.body.profileIds = ['admin'];
 
     return kuzzle.pluginsManager.trigger('admin:beforeCreateFirstAdmin', requestObject)
       .then(newRequestObject => {
@@ -337,7 +337,7 @@ function AdminController(kuzzle) {
 
   this.adminExists = requestObject => {
     return kuzzle.pluginsManager.trigger('admin:beforeAdminExists', requestObject)
-      .then(() => kuzzle.internalEngine.search('users', {query: {terms: {profilesIds: ['admin']}}}))
+      .then(() => kuzzle.internalEngine.search('users', {query: {terms: {profileIds: ['admin']}}}))
       .then((response) => kuzzle.pluginsManager.trigger('admin:afterAdminExists', new ResponseObject(requestObject, response.hits.length > 0)));
   };
 }

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -141,7 +141,7 @@ function AuthController (kuzzle) {
           return Promise.reject(new UnauthorizedError('User must be connected in order to call updateSelf'));
         }
 
-        if (modifiedRequestObject.data.body.profilesIds) {
+        if (modifiedRequestObject.data.body.profileIds) {
           return Promise.reject(new BadRequestError('profile can not be provided in updateSelf'));
         }
 

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -462,8 +462,8 @@ function SecurityController (kuzzle) {
 
         modifiedRequestObject = newRequestObject;
 
-        if (!modifiedRequestObject.data.body || !modifiedRequestObject.data.body.profilesIds) {
-          return Promise.reject(new BadRequestError('Invalid user object. No profilesIds property found.'));
+        if (!modifiedRequestObject.data.body || !modifiedRequestObject.data.body.profileIds) {
+          return Promise.reject(new BadRequestError('Invalid user object. No profileIds property found.'));
         }
 
         pojoUser = modifiedRequestObject.data.body;
@@ -596,7 +596,7 @@ function SecurityController (kuzzle) {
       .then(newRequestObject => {
         modifiedRequestObject = newRequestObject;
 
-        if (!modifiedRequestObject.data.body || !modifiedRequestObject.data.body.profilesIds) {
+        if (!modifiedRequestObject.data.body || !modifiedRequestObject.data.body.profileIds) {
           return Promise.reject(new BadRequestError('Invalid user object. No profile property found.'));
         }
 

--- a/lib/api/core/models/repositories/profileRepository.js
+++ b/lib/api/core/models/repositories/profileRepository.js
@@ -72,25 +72,25 @@ ProfileRepository.prototype.loadProfile = function (profileId) {
 /**
  * Loads a Profile object given its id.
  *
- * @param {Array} profilesIds Array of profiles ids
+ * @param {Array} profileIds Array of profiles ids
  * @returns {Promise} Resolves to the matching Profile object if found, null if not.
  */
-ProfileRepository.prototype.loadProfiles = function (profilesIds) {
+ProfileRepository.prototype.loadProfiles = function (profileIds) {
   var promises;
 
-  if (!profilesIds) {
-    return Promise.reject(new BadRequestError('Missing profilesIds'));
+  if (!profileIds) {
+    return Promise.reject(new BadRequestError('Missing profileIds'));
   }
 
-  if (!_.isArray(profilesIds) || profilesIds.reduce((prev, profile) => (prev || typeof profile !== 'string'), false)) {
-    return Promise.reject(new BadRequestError('An array of strings must be provided as profilesIds'));
+  if (!_.isArray(profileIds) || profileIds.reduce((prev, profile) => (prev || typeof profile !== 'string'), false)) {
+    return Promise.reject(new BadRequestError('An array of strings must be provided as profileIds'));
   }
 
-  if (profilesIds.length === 0) {
+  if (profileIds.length === 0) {
     return Promise.resolve([]);
   }
 
-  promises = profilesIds.map(profileId => this.loadProfile(profileId));
+  promises = profileIds.map(profileId => this.loadProfile(profileId));
 
   return Promise.all(promises)
     .then(results => {

--- a/lib/api/core/models/repositories/userRepository.js
+++ b/lib/api/core/models/repositories/userRepository.js
@@ -69,12 +69,12 @@ UserRepository.prototype.anonymous = function () {
   return Promise.resolve(_.assignIn(user, {
     _id: -1,
     name: 'Anonymous',
-    profilesIds: ['anonymous']
+    profileIds: ['anonymous']
   }));
 };
 
 UserRepository.prototype.hydrate = function (user, data) {
-  var source, dataProfilesIds;
+  var source, dataprofileIds;
 
   if (!_.isObject(data)) {
     return Promise.resolve(user);
@@ -86,17 +86,17 @@ UserRepository.prototype.hydrate = function (user, data) {
     Object.assign(data, source);
   }
 
-  if (data.profilesIds) {
-    if (!Array.isArray(data.profilesIds)) {
-      data.profilesIds = [data.profilesIds];
+  if (data.profileIds) {
+    if (!Array.isArray(data.profileIds)) {
+      data.profileIds = [data.profileIds];
     }
 
-    dataProfilesIds = data.profilesIds;
-    delete data.profilesIds;
+    dataprofileIds = data.profileIds;
+    delete data.profileIds;
   }
 
   _.assignIn(user, data);
-  _.assign(user.profilesIds, dataProfilesIds);
+  _.assign(user.profileIds, dataprofileIds);
 
   if (user._id === undefined || user._id === null) {
     return this.anonymous();
@@ -104,15 +104,15 @@ UserRepository.prototype.hydrate = function (user, data) {
 
   // if the user exists (have an _id) but no profile
   // set it to default
-  if (user.profilesIds.length === 0) {
-    user.profilesIds = ['default'];
+  if (user.profileIds.length === 0) {
+    user.profileIds = ['default'];
   }
 
-  return this.kuzzle.repositories.profile.loadProfiles(user.profilesIds)
+  return this.kuzzle.repositories.profile.loadProfiles(user.profileIds)
     .then(profiles => {
       var
-        profilesIds = profiles.map(profile => profile._id),
-        profilesNotFound = _.difference(user.profilesIds, profilesIds);
+        profileIds = profiles.map(profile => profile._id),
+        profilesNotFound = _.difference(user.profileIds, profileIds);
 
       // Fail if not all roles are found
       if (profilesNotFound.length) {

--- a/lib/api/core/models/security/user.js
+++ b/lib/api/core/models/security/user.js
@@ -9,7 +9,7 @@ var
  */
 function User () {
   this._id = null;
-  this.profilesIds = [];
+  this.profileIds = [];
 }
 
 /**
@@ -18,7 +18,7 @@ function User () {
  * @return {Promise}
  */
 User.prototype.getProfiles = function (kuzzle) {
-  return kuzzle.repositories.profile.loadProfiles(this.profilesIds);
+  return kuzzle.repositories.profile.loadProfiles(this.profileIds);
 };
 
 /**
@@ -41,7 +41,7 @@ User.prototype.getRights = function (kuzzle) {
 };
 
 User.prototype.isActionAllowed = function (requestObject, context, kuzzle) {
-  if (this.profilesIds === undefined || this.profilesIds.length === 0) {
+  if (this.profileIds === undefined || this.profileIds.length === 0) {
     return Promise.resolve(false);
   }
 

--- a/test/api/controllers/adminController.test.js
+++ b/test/api/controllers/adminController.test.js
@@ -486,7 +486,7 @@ describe('Test: admin controller', () => {
 
       return adminController.adminExists()
         .then(() => {
-          should(kuzzle.internalEngine.search).be.calledWithMatch('users', {query: {terms: {profilesIds: ['admin']}}});
+          should(kuzzle.internalEngine.search).be.calledWithMatch('users', {query: {terms: {profileIds: ['admin']}}});
         });
     });
 
@@ -558,7 +558,7 @@ describe('Test: admin controller', () => {
       return adminController.createFirstAdmin(request)
         .then(() => {
           should(createOrReplaceUser).be.calledOnce();
-          should(createOrReplaceUser).be.calledWithMatch({data: {_id: 'toto', body: {password: 'pwd', profilesIds: ['admin']}}});
+          should(createOrReplaceUser).be.calledWithMatch({data: {_id: 'toto', body: {password: 'pwd', profileIds: ['admin']}}});
           should(resetRolesStub).have.callCount(0);
           should(resetProfilesStub).have.callCount(0);
         });
@@ -579,7 +579,7 @@ describe('Test: admin controller', () => {
       return adminController.createFirstAdmin(request)
         .then(() => {
           should(createOrReplaceUser).be.calledOnce();
-          should(createOrReplaceUser).be.calledWithMatch({data: {_id: 'toto', body: {password: 'pwd', profilesIds: ['admin']}}});
+          should(createOrReplaceUser).be.calledWithMatch({data: {_id: 'toto', body: {password: 'pwd', profileIds: ['admin']}}});
           should(resetRolesStub).have.callCount(1);
           should(resetProfilesStub).have.callCount(1);
         });

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -89,7 +89,7 @@ describe('Test the auth controller', () => {
           }
           return Promise.resolve({
             _id: t,
-            profilesIds: [t]
+            profileIds: [t]
           });
         });
       });
@@ -285,7 +285,7 @@ describe('Test the auth controller', () => {
       return kuzzle.funnel.controllers.auth.getCurrentUser(rq, token)
         .then(response => {
           should(response.data.body._id).be.exactly('admin');
-          should(response.data.body._source.profilesIds).be.eql(['admin']);
+          should(response.data.body._source.profileIds).be.eql(['admin']);
         });
     });
 
@@ -390,7 +390,7 @@ describe('Test the auth controller', () => {
 
     it('should reject if profile is specified', () => {
       should(kuzzle.funnel.controllers.auth.updateSelf(new RequestObject({
-        body: { foo: 'bar', profilesIds: ['test'] }
+        body: { foo: 'bar', profileIds: ['test'] }
       }), { token: { userId: 'admin', _id: 'admin' }}))
         .be.rejected();
     });

--- a/test/api/controllers/routerController/routerController.test.js
+++ b/test/api/controllers/routerController/routerController.test.js
@@ -97,7 +97,7 @@ describe('Test: routerController', () => {
 
         user = {
           _id: 'user',
-          profilesIds: ['profile'],
+          profileIds: ['profile'],
           isActionAllowed: sinon.stub().resolves(true),
           getProfile: () => {
             return Promise.resolve({

--- a/test/api/controllers/securityController/users.test.js
+++ b/test/api/controllers/securityController/users.test.js
@@ -22,7 +22,7 @@ describe('Test: security controller - users', () => {
       .then(() => kuzzle.funnel.init())
       .then(() => {
         sandbox.stub(kuzzle.services.list.readEngine, 'search').resolves({
-          hits: [{_id: 'admin', _source: { profilesIds: ['admin'] }}],
+          hits: [{_id: 'admin', _source: { profileIds: ['admin'] }}],
           total: 1
         });
 
@@ -64,7 +64,7 @@ describe('Test: security controller - users', () => {
   describe('#searchUsers', () => {
     it('should return a valid responseObject', () => {
       sandbox.stub(kuzzle.repositories.user, 'search').resolves({
-        hits: [{_id: 'admin', _source: {profilesIds: ['admin']}}],
+        hits: [{_id: 'admin', _source: {profileIds: ['admin']}}],
         total: 2
       });
 
@@ -120,7 +120,7 @@ describe('Test: security controller - users', () => {
       sandbox.stub(kuzzle.repositories.user, 'hydrate').resolves();
 
       return kuzzle.funnel.controllers.security.createUser(new RequestObject({
-        body: { _id: 'test', name: 'John Doe', profilesIds: ['anonymous'] }
+        body: { _id: 'test', name: 'John Doe', profileIds: ['anonymous'] }
       }))
         .then(response => {
           mock.verify();
@@ -135,7 +135,7 @@ describe('Test: security controller - users', () => {
         mockHydrate = sandbox.mock(kuzzle.repositories.user).expects('hydrate').once().resolves();
 
       return kuzzle.funnel.controllers.security.createUser(new RequestObject({
-        body: { name: 'John Doe', profilesIds: ['anonymous'] }
+        body: { name: 'John Doe', profileIds: ['anonymous'] }
       }))
         .then(response => {
           mockHydrate.verify();
@@ -187,7 +187,7 @@ describe('Test: security controller - users', () => {
 
       return kuzzle.funnel.controllers.security.updateUser(new RequestObject({
         _id: 'test',
-        body: {profilesIds: ['anonymous'], foo: 'bar'}
+        body: {profileIds: ['anonymous'], foo: 'bar'}
       }))
         .then(response => {
           should(response).be.an.instanceOf(ResponseObject);
@@ -206,7 +206,7 @@ describe('Test: security controller - users', () => {
       return kuzzle.funnel.controllers.security.createOrReplaceUser(new RequestObject({
         body: {
           _id: 'test',
-          profilesIds: ['admin']
+          profileIds: ['admin']
         }
       }))
         .then(response => {

--- a/test/api/core/models/repositories/profileRepository.test.js
+++ b/test/api/core/models/repositories/profileRepository.test.js
@@ -133,11 +133,11 @@ describe('Test: repositories/profileRepository', () => {
     });
 
     it('should rejects when no profileIds is given', () => {
-      return should(kuzzle.repositories.profile.loadProfiles()).be.rejectedWith('Missing profilesIds');
+      return should(kuzzle.repositories.profile.loadProfiles()).be.rejectedWith('Missing profileIds');
     });
 
     it('should rejects when no profileIds is not an Array', () => {
-      return should(kuzzle.repositories.profile.loadProfiles(42)).be.rejectedWith('An array of strings must be provided as profilesIds');
+      return should(kuzzle.repositories.profile.loadProfiles(42)).be.rejectedWith('An array of strings must be provided as profileIds');
     });
 
     it('should respond with an emty array when profileIds is an empty array', () => {
@@ -149,7 +149,7 @@ describe('Test: repositories/profileRepository', () => {
     });
 
     it('should rejects when profileIds contains some non string entry', () => {
-      return should(kuzzle.repositories.profile.loadProfiles([12])).be.rejectedWith('An array of strings must be provided as profilesIds');
+      return should(kuzzle.repositories.profile.loadProfiles([12])).be.rejectedWith('An array of strings must be provided as profileIds');
     });
   });
 

--- a/test/api/core/models/repositories/tokenRepository.test.js
+++ b/test/api/core/models/repositories/tokenRepository.test.js
@@ -56,7 +56,7 @@ describe('Test: repositories/tokenRepository', () => {
       load: username => {
         var user = new User();
         user._id = username;
-        user.profilesIds = ['anonymous'];
+        user.profileIds = ['anonymous'];
 
         return Promise.resolve(user);
       },
@@ -76,7 +76,7 @@ describe('Test: repositories/tokenRepository', () => {
         };
 
         user._id = -1;
-        user.profilesIds = ['anonymous'];
+        user.profileIds = ['anonymous'];
         profile.policies = [{roleId: role._id}];
 
         return Promise.resolve(user);
@@ -97,7 +97,7 @@ describe('Test: repositories/tokenRepository', () => {
         };
 
         user._id = 'admin';
-        user.profilesIds = ['admin'];
+        user.profileIds = ['admin'];
         profile.policies = [{roleId: role._id}];
 
         return Promise.resolve(user);

--- a/test/api/core/models/repositories/userRepository.test.js
+++ b/test/api/core/models/repositories/userRepository.test.js
@@ -74,17 +74,17 @@ describe('Test: repositories/userRepository', () => {
     userInCache = {
       _id: 'userInCache',
       name: 'Johnny Cash',
-      profilesIds: ['userincacheprofile'],
+      profileIds: ['userincacheprofile'],
       password: encryptedPassword
     };
     userInDB = {
       _id: 'userInDB',
       name: 'Debbie Jones',
-      profilesIds: ['userindbprofile']
+      profileIds: ['userindbprofile']
     };
     userInvalidProfile = {
       _id: 'userInvalidProfile',
-      profilesIds: ['notfound']
+      profileIds: ['notfound']
     };
 
     kuzzle.repositories.profile = mockProfileRepository;
@@ -127,20 +127,20 @@ describe('Test: repositories/userRepository', () => {
 
     it('should return the anonymous user if no _id is set', () => {
       var user = new User();
-      user.profilesIds = 'a profile';
+      user.profileIds = 'a profile';
 
       return userRepository.hydrate(user, {})
         .then(result => assertIsAnonymous(result));
     });
 
-    it('should convert a profilesIds string into array', () => {
+    it('should convert a profileIds string into array', () => {
       var user = new User();
       user._id = 'admin';
 
-      return userRepository.hydrate(user, {profilesIds: 'admin'})
+      return userRepository.hydrate(user, {profileIds: 'admin'})
         .then((result) => {
-          should(result.profilesIds).be.an.instanceOf(Array);
-          should(result.profilesIds[0]).be.exactly('admin');
+          should(result.profileIds).be.an.instanceOf(Array);
+          should(result.profileIds[0]).be.exactly('admin');
         });
     });
 
@@ -168,8 +168,8 @@ describe('Test: repositories/userRepository', () => {
         .then(user => {
           should(user._id).be.exactly('userInCache');
           should(user.name).be.exactly('Johnny Cash');
-          should(user.profilesIds).be.an.Array();
-          should(user.profilesIds[0]).be.exactly('userincacheprofile');
+          should(user.profileIds).be.an.Array();
+          should(user.profileIds[0]).be.exactly('userincacheprofile');
         });
     });
 
@@ -199,8 +199,8 @@ describe('Test: repositories/userRepository', () => {
           should(result).not.be.an.instanceOf(User);
           should(result).be.an.Object();
           should(result._id).be.exactly(-1);
-          should(result.profilesIds).be.an.Array();
-          should(result.profilesIds[0]).be.exactly('anonymous');
+          should(result.profileIds).be.an.Array();
+          should(result.profileIds[0]).be.exactly('anonymous');
         });
     });
   });
@@ -209,7 +209,7 @@ describe('Test: repositories/userRepository', () => {
     it('should compute a user id if not set', () => {
       var user = new User();
       user.name = 'John Doe';
-      user.profilesIds = ['a profile'];
+      user.profileIds = ['a profile'];
 
       userRepository.persist(user);
 
@@ -230,7 +230,7 @@ describe('Test: repositories/userRepository', () => {
 
       return userRepository.hydrate(user, {})
         .then(result => {
-          return should(result.profilesIds[0]).be.eql('default');
+          return should(result.profileIds[0]).be.eql('default');
         });
     });
   });
@@ -239,6 +239,6 @@ describe('Test: repositories/userRepository', () => {
 function assertIsAnonymous (user) {
   should(user._id).be.exactly(-1);
   should(user.name).be.exactly('Anonymous');
-  should(user.profilesIds).be.an.instanceOf(Array);
-  should(user.profilesIds[0]).be.exactly('anonymous');
+  should(user.profileIds).be.an.instanceOf(Array);
+  should(user.profileIds[0]).be.exactly('anonymous');
 }

--- a/test/api/core/models/security/user.test.js
+++ b/test/api/core/models/security/user.test.js
@@ -27,7 +27,7 @@ describe('Test: security/userTest', () => {
     profile2.isActionAllowed = sinon.stub().resolves(false);
 
     user = new User();
-    user.profilesIds = ['profile', 'profile2'];
+    user.profileIds = ['profile', 'profile2'];
 
     kuzzle.repositories = {
       profile: {
@@ -130,7 +130,7 @@ describe('Test: security/userTest', () => {
   });
 
   it('should respond false if the user have no profileIds', () => {
-    user.profilesIds = [];
+    user.profileIds = [];
     return user.isActionAllowed({}, {}, kuzzle)
       .then(isActionAllowed => {
         should(isActionAllowed).be.a.Boolean();


### PR DESCRIPTION
Replaced `profilesIds` to `profileIds` because some of the code is using `profilesIds` and some other `profileIds` so we decided to change them all to `profileIds`