### PR TITLE
Fix #381: Startup message about administrator status is wrong

### DIFF
--- a/bin/commands/start.js
+++ b/bin/commands/start.js
@@ -88,7 +88,7 @@ module.exports = function (options) {
  ████████████████████████████████████`);
       return kuzzle.remoteActionsController.actions.adminExists()
         .then((res) => {
-          if (res) {
+          if (res.data.body.exists) {
             console.log(ok('[✔] It seems that you already have an admin account.'));
           }
           else {

--- a/lib/api/controllers/adminController.js
+++ b/lib/api/controllers/adminController.js
@@ -317,7 +317,7 @@ function AdminController(kuzzle) {
         return this.adminExists();
       })
       .then((adminExists) => {
-        if (adminExists.data.body) {
+        if (adminExists.data.body.exists) {
           return Promise.reject(new Error('admin user is already set'));
         }
 
@@ -338,7 +338,7 @@ function AdminController(kuzzle) {
   this.adminExists = requestObject => {
     return kuzzle.pluginsManager.trigger('admin:beforeAdminExists', requestObject)
       .then(() => kuzzle.internalEngine.search('users', {query: {terms: {profileIds: ['admin']}}}))
-      .then((response) => kuzzle.pluginsManager.trigger('admin:afterAdminExists', new ResponseObject(requestObject, response.hits.length > 0)));
+      .then((response) => kuzzle.pluginsManager.trigger('admin:afterAdminExists', new ResponseObject(requestObject, {exists: response.hits.length > 0})));
   };
 }
 

--- a/test/api/controllers/adminController.test.js
+++ b/test/api/controllers/adminController.test.js
@@ -495,7 +495,7 @@ describe('Test: admin controller', () => {
 
       return adminController.adminExists()
         .then((response) => {
-          should(response).match({data: {body: false}});
+          should(response).match({data: {body: {exists: false}}});
         });
     });
 
@@ -504,7 +504,7 @@ describe('Test: admin controller', () => {
 
       return adminController.adminExists()
         .then((response) => {
-          should(response).match({data: {body: true}});
+          should(response).match({data: {body: {exists: true}}});
         });
     });
   });
@@ -540,7 +540,7 @@ describe('Test: admin controller', () => {
         }
       });
 
-      adminController.adminExists = sandbox.stub().resolves({data: {body: true}});
+      adminController.adminExists = sandbox.stub().resolves({data: {body: {exists: true}}});
 
       return should(adminController.createFirstAdmin(request)).be.rejected();
     });
@@ -553,7 +553,7 @@ describe('Test: admin controller', () => {
         }
       });
 
-      adminController.adminExists = sandbox.stub().resolves({data: {body: false}});
+      adminController.adminExists = sandbox.stub().resolves({data: {body: {exists: false}}});
 
       return adminController.createFirstAdmin(request)
         .then(() => {
@@ -573,7 +573,7 @@ describe('Test: admin controller', () => {
         }
       });
 
-      adminController.adminExists = sandbox.stub().resolves({data: {body: false}});
+      adminController.adminExists = sandbox.stub().resolves({data: {body: {exists: false}}});
       sandbox.stub(adminController, 'refreshIndex').resolves({});
 
       return adminController.createFirstAdmin(request)


### PR DESCRIPTION
The startup script uses the `adminExists` method of the admin controller, but it interprets the result as a boolean instead of a response object.

This PR fixes this problem, and also changes the response of the `adminExists` method.

Instead of returning this:

```json
{
  "data": {
    "body": true
  }
}
```

It now returns this:

```json
{
  "data": {
    "body": {
      "exists": true
    }
  }
}
```
