### PR TITLE
Fix #380: extend router body limit

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -14,7 +14,7 @@
   /*
   "plugins": {
     // [Common]
-    //   * pipeWarnTime: time in ms after wich a warning will be emitted to
+    //   * pipeWarnTime: time in ms after which a warning will be emitted to
     //     the logger if the pipe action has not completed
     //   * pipeTimeout: time in ms after which a pipe action will be killed
     //     if it has not completed
@@ -172,6 +172,9 @@
   /*
   "server": {
     // * http port: port on which Kuzzle will expose its REST api
+    // * http maxRequestSize: the size limit of a request. If it's a string, the
+         value is passed to the "bytes" library (https://www.npmjs.com/package/bytes).
+         If this is a number, then the value specifies the number of bytes.
     // * maxConcurrentRequests: Number of requests Kuzzle treats simultaneously.
     //   Requests received above this limit are bufferized.
     // * maxRetainedRequests: Maximum number of requests that can be bufferized.
@@ -179,7 +182,8 @@
     // * warningRetainedRequestsLimit: Number of bufferized requests after
     //   which Kuzzle will throw warnings to the logger
     "http": {
-      "port": 7511
+      "port": 7511,
+      "maxRequestSize": "1MB"
     },
     "maxConcurrentRequests": 50,
     "maxRetainedRequests": 50000,

--- a/default.config.js
+++ b/default.config.js
@@ -111,7 +111,8 @@ module.exports = {
 
   server: {
     http: {
-      port: 7511
+      port: 7511,
+      maxRequestSize: '1MB'
     },
     maxConcurrentRequests: 50,
     maxRetainedRequests: 50000,

--- a/features/support/apiREST.js
+++ b/features/support/apiREST.js
@@ -30,10 +30,7 @@ function initRoutes() {
       pluginsManager: {
         routes: []
       },
-      config: {
-        apiVersion: '1.0',
-        httpRoutes: require('../../lib/config/httpRoutes')
-      }
+      config: require('../../default.config')
     });
 
   Router.prototype.use = Router.prototype.get = Router.prototype.post = Router.prototype.delete = Router.prototype.put = function () {};

--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -177,7 +177,7 @@ function RouterController (kuzzle) {
     });
 
     // add a body parsing middleware to our API
-    api.use(bodyParser.json());
+    api.use(bodyParser.json({limit: kuzzle.config.server.http.maxRequestSize}));
 
     apiBase.get('/swagger.json', (request, response) => {
       generateSwagger(kuzzle)


### PR DESCRIPTION
* Added a new `maxRequestSize` to the default configuration file, set to 1MB
* Updated the `.kuzzlerc` sample file
