### PR TITLE
jshint pragmas cleanup

### DIFF
--- a/features/support/world.js
+++ b/features/support/world.js
@@ -59,7 +59,6 @@ module.exports = function () {
     ];
 
 
-    /* jshint camelcase: false */
     this.schema = {
       properties: {
         firstName: {
@@ -73,7 +72,6 @@ module.exports = function () {
         }
       }
     };
-    /* jshint camelcase: true */
 
     this.metadata = {
       iwant: 'to break free',

--- a/lib/api/core/models/security/role.js
+++ b/lib/api/core/models/security/role.js
@@ -312,7 +312,6 @@ function executeClosure (kuzzle, path, actionRights, requestObject, context) {
 
   if (actionRights.args && Object.keys(actionRights.args).length > 0 && !this.closures[path].getArgsDefinitions) {
     try {
-      /* jshint evil: true */
       /* eslint-disable no-eval */
       this.closures[path].getArgsDefinitions = global.eval('(function (requestObject) {return ' +
         JSON
@@ -320,7 +319,6 @@ function executeClosure (kuzzle, path, actionRights, requestObject, context) {
           .replace(/"\$(requestObject\.[a-zA-Z0-9_\-.]*[a-zA-Z0-9])"/g, '$1')
           .replace('"$currentId"', 'requestObject.data._id') +
         ';})');
-      /* jshint evil: false */
       /* eslint-enable no-eval */
     }
     catch (err) {

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -193,9 +193,7 @@ function pm2Init (workers, pluginsWorker, kuzzleConfig) {
       var
         names = list
           .filter(process => process.name.indexOf(workerPrefix) !== -1)
-          /*jshint -W106 */
           .map(process => process.pm_id);
-          /*jshint +W106 */
 
       return Promise.fromNode(asyncCB => async.each(names, (name, callback) => {
         pm2.delete(name, err => callback(err));
@@ -210,9 +208,7 @@ function pm2Init (workers, pluginsWorker, kuzzleConfig) {
           return false;
         }
 
-        /*jshint -W106 */
         pm2.sendDataToProcessId(packet.process.pm_id, {
-        /*jshint +W106 */
           topic: 'initialize',
           data: {
             config: pluginsWorker[pluginName].config,
@@ -236,18 +232,14 @@ function pm2Init (workers, pluginsWorker, kuzzleConfig) {
           workers[packet.process.name].events = packet.data.events;
         }
 
-        /*jshint -W106 */
         workers[packet.process.name].pmIds.add(packet.process.pm_id);
-        /*jshint +W106 */
       });
 
       bus.on('process:event', packet => {
         if (packet.event) {
           if (packet.event === 'exit') {
             if (workers[packet.process.name]) {
-              /*jshint -W106 */
               workers[packet.process.name].pmIds.remove(packet.process.pm_id);
-              /*jshint +W106 */
 
               // /!\ We remove it only once from workers, exit event is received twice
               if (workers[packet.process.name].pmIds && workers[packet.process.name].pmIds.getSize() === 0) {

--- a/lib/api/dsl/methods.js
+++ b/lib/api/dsl/methods.js
@@ -368,9 +368,6 @@ function Methods(filtersObject) {
     fieldName = Object.keys(filter)[0];
 
     geoFilter = filter[fieldName];
-    // elastic search DSL allows the undescore notation
-    // we need an exception for the linter
-    /* jshint camelcase: false */
     if (geoFilter.top_left) {
       geoFilter.topLeft = geoFilter.top_left;
       delete geoFilter.top_left;
@@ -379,7 +376,6 @@ function Methods(filtersObject) {
       geoFilter.bottomRight = geoFilter.bottom_right;
       delete geoFilter.bottom_right;
     }
-    /* jshint camelcase: true */
 
     try {
       bBox = geoUtil.constructBBox(geoFilter);
@@ -449,12 +445,10 @@ function Methods(filtersObject) {
 
     // elastic search DSL allows the undescore notation
     // we need an exception for the linter
-    /* jshint camelcase: false */
     if (geoFilter.lat_lon) {
       geoFilter.latLon = geoFilter.lat_lon;
       delete geoFilter.lat_lon;
     }
-    /* jshint camelcase: true */
 
     if (!filter.distance) {
       return Promise.reject(new BadRequestError('No distance given'));
@@ -525,14 +519,10 @@ function Methods(filtersObject) {
     }
 
     geoFilter = filter[fieldName];
-    // elastic search DSL allows the undescore notation
-    // we need an exception for the linter
-    /* jshint camelcase: false */
     if (geoFilter.lat_lon) {
       geoFilter.latLon = geoFilter.lat_lon;
       delete geoFilter.lat_lon;
     }
-    /* jshint camelcase: true */
 
     if (!filter.from) {
       return Promise.reject(new BadRequestError('No from parameter given'));

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -73,18 +73,14 @@ function ElasticSearch (kuzzle, options, config) {
       .then(res => {
         /** @type {{version: {number: Number, lucene_version: String}}} res */
         response.version = res.version.number;
-        /* jshint camelcase: false */
         response.lucene = res.version.lucene_version;
-        /* jshint camelcase: true */
 
         return this.client.cluster.health();
       })
       .then(res => {
         /** @type {{status: String, number_of_nodes: Number}} res */
         response.status = res.status;
-        /* jshint camelcase: false */
         response.nodes = res.number_of_nodes;
-        /* jshint camelcase: true */
         return this.client.cluster.stats({human: true});
       })
       .then(res => {
@@ -678,7 +674,6 @@ function getAllIdsFromQuery(data) {
         ids.push(hit._id);
       });
 
-      /* jshint camelcase: false */
       if (response.hits.total !== ids.length) {
         this.client.scroll({
           scrollId: response._scroll_id,
@@ -688,7 +683,6 @@ function getAllIdsFromQuery(data) {
       else {
         resolve(ids);
       }
-      /* jshint camelcase: true */
     }.bind(this));
   });
 }

--- a/test/api/core/pluginsManager/run.test.js
+++ b/test/api/core/pluginsManager/run.test.js
@@ -20,12 +20,11 @@ describe('Test plugins manager run', () => {
 
   before(() => {
     pm2Mock = function () {
-      /* jshint -W106 */
       var universalProcess = {
         name: workerPrefix + 'testPlugin',
         pm_id: 42
       };
-      /* jshint +W106 */
+
       var busData = {
         'initialized': {
           process: universalProcess,
@@ -58,23 +57,19 @@ describe('Test plugins manager run', () => {
         },
         delete: function (pmId, callback) {
           processList = processList.filter(item => {
-            /* jshint -W106 */
             return item.process.pm_id !== pmId;
-            /* jshint +W106 */
           });
           callback(null);
         },
         start: function (processSpec, callback) {
           var i;
           for(i = 0; i < processSpec.instances; i++) {
-            /* jshint -W106 */
             processList.push({
               process: {
                 name: processSpec.name,
                 pm_id: uniqueness++
               }
             });
-            /* jshint +W106 */
           }
           callback();
         },
@@ -459,9 +454,7 @@ describe('Test plugins manager run', () => {
     pluginsManager.run()
       .then(() => {
         should(pm2Mock.getProcessList()).length(1);
-        /* jshint -W106 */
         should(pm2Mock.getProcessList()[0].process.pm_id).not.equal(42);
-        /* jshint +W106 */
         done();
       });
   });

--- a/test/api/dsl/methods/geoDistance.test.js
+++ b/test/api/dsl/methods/geoDistance.test.js
@@ -161,7 +161,6 @@ describe('Test geoDistance method', () => {
   });
 
   it('should handle correctly the case when the location is noted with the underscore notation', () => {
-    /* jshint camelcase: false */
     var
       underscoreFilter = {
         distance: 111318,
@@ -172,7 +171,6 @@ describe('Test geoDistance method', () => {
           }
         }
       };
-    /* jshint camelcase: true */
 
     return methods.geoDistance(filterId, index, collection, underscoreFilter);
   });

--- a/test/api/dsl/methods/geoDistanceRange.test.js
+++ b/test/api/dsl/methods/geoDistanceRange.test.js
@@ -146,7 +146,6 @@ describe('Test geoDistanceRange method', () => {
   });
 
   it('should handle correctly the case when from and to comes first, before the location', () => {
-    /* jshint camelcase: false */
     var
       underscoreFilter = {
         from: 123,
@@ -158,7 +157,6 @@ describe('Test geoDistanceRange method', () => {
           }
         }
       };
-    /* jshint camelcase: true */
 
     return methods.geoDistanceRange(filterId, index, collection, underscoreFilter);
   });

--- a/test/api/dsl/methods/ids.test.js
+++ b/test/api/dsl/methods/ids.test.js
@@ -37,13 +37,11 @@ describe('Test ids method', () => {
   });
 
   it('should construct the filterTree with correct curried function name', () => {
-    /* jshint camelcase:false */
     should(methods.filters.filtersTree[index][collection].fields[fieldId][idsIdidGrace]).not.be.empty();
     should(methods.filters.filtersTree[index][collection].fields[fieldId][notidsIdidGrace]).not.be.empty();
   });
 
   it('should construct the filterTree with correct room list', () => {
-    /* jshint camelcase:false */
     var
       ids = methods.filters.filtersTree[index][collection].fields[fieldId][idsIdidGrace].ids,
       idsNot = methods.filters.filtersTree[index][collection].fields[fieldId][notidsIdidGrace].ids;
@@ -59,7 +57,6 @@ describe('Test ids method', () => {
   });
 
   it('should construct the filterTree with correct functions ids', () => {
-    /* jshint camelcase:false */
     should(methods.filters.filtersTree[index][collection].fields[fieldId][idsIdidGrace].args).match({
       operator: 'terms',
       not: false,


### PR DESCRIPTION
JSHint has been removed from our dependencies, but lots of jshint pragmas are still in the code.

This PR removes all these now superfluous pragmas.