### PR TITLE
Real-time DSL: should_not support

### DIFF
--- a/lib/api/dsl/methods.js
+++ b/lib/api/dsl/methods.js
@@ -169,7 +169,8 @@ function Methods(filtersObject) {
   };
 
   /**
-   * Build rooms and filtersTree according to a given filter for 'must_not' filter (and not in nested filters)
+   * Build rooms and filtersTree according to a given filter for 'must_not' filter
+   * (and not in nested filters)
    *
    * @param {String} roomId
    * @param {String} index
@@ -199,6 +200,25 @@ function Methods(filtersObject) {
    */
   this.should = function (roomId, index, collection, filters, not) {
     return this.or(roomId, index, collection, filters, not);
+  };
+
+  /**
+   * Build rooms and filtersTree according to a given filter for 'should_not' filter
+   * (or in nested filters with a minimum should match option)
+   *
+   * @param {String} roomId
+   * @param {String} index
+   * @param {String} collection
+   * @param {Object} filters given by user on subscribe
+   * @param {Boolean} [not] if not is true, invert the boolean result
+   * @return {Promise} the formatted filter that need to be added to the room
+   */
+  this.shouldNot = function (roomId, index, collection, filters, not) {
+    if (not === undefined) {
+      not = false;
+    }
+
+    return this.should(roomId, index, collection, filters, !not);
   };
 
   /**

--- a/lib/api/dsl/methods.js
+++ b/lib/api/dsl/methods.js
@@ -113,7 +113,7 @@ function Methods(filtersObject) {
    */
   this.bool = function (roomId, index, collection, filter, not) {
     var
-      allowedBoolFunctions = ['must', 'mustNot', 'should'],
+      allowedBoolFunctions = ['must', 'mustNot', 'should', 'shouldNot'],
       diff = [],
       formattedFilters = {};
 
@@ -198,10 +198,6 @@ function Methods(filtersObject) {
    * @return {Promise} the formatted filter that need to be added to the room
    */
   this.should = function (roomId, index, collection, filters, not) {
-    if (not) {
-      return this.and(roomId, index, collection, filters, not);
-    }
-
     return this.or(roomId, index, collection, filters, not);
   };
 

--- a/test/api/dsl/methods/should.test.js
+++ b/test/api/dsl/methods/should.test.js
@@ -21,14 +21,14 @@ describe('Test: dsl.should method', () => {
     methods = new Methods({filtersTree: {}});
   });
 
-  it('should call the function "AND" in case of a should-not filter', () => {
-    var andIsCalled = false;
-    methods.and = () => {
-      andIsCalled = true;
+  it('should call the function "OR" in case of a should-not filter', () => {
+    var orIsCalled = false;
+    methods.or = () => {
+      orIsCalled = true;
     };
 
     methods.should('roomId', 'index', {}, {}, true);
-    should(andIsCalled).be.exactly(true);
+    should(orIsCalled).be.exactly(true);
   });
 
   it('should call the function "OR" in case of a should filter', () => {

--- a/test/api/dsl/methods/shouldNot.test.js
+++ b/test/api/dsl/methods/shouldNot.test.js
@@ -5,7 +5,7 @@ var
   Promise = require('bluebird'),
   Methods = rewire('../../../../lib/api/dsl/methods');
 
-describe('Test: dsl.should method', () => {
+describe('Test: dsl.shouldNot method', () => {
   var
     methods,
     sandbox;
@@ -22,8 +22,15 @@ describe('Test: dsl.should method', () => {
 
   it('should call the function "OR" in case of a should filter', () => {
     sandbox.stub(methods, 'or');
-    methods.should('roomId', 'index', {}, {}, false);
+    methods.shouldNot('roomId', 'index', {}, {}, false);
     should(methods.or.called).be.true();
-    should(methods.or.calledWith('roomId', 'index', {}, {}, false)).be.true();
+    should(methods.or.calledWith('roomId', 'index', {}, {}, true)).be.true();
+  });
+
+  it('should force the "not" argument to "true" if undefined', () => {
+    sandbox.stub(methods, 'or');
+    methods.shouldNot('roomId', 'index', {}, {});
+    should(methods.or.called).be.true();
+    should(methods.or.calledWith('roomId', 'index', {}, {}, true)).be.true();
   });
 });


### PR DESCRIPTION
The `bool` keyword is supposed to accept a `should_not` attribute, returning true if one of its listed conditions is falsey.

This PR add support for this keyword: everything necessary was already implemented, there simply was no entry for this attribute.  And the code there was wrong anyway: in case of a `should_not` attribute, instead of a AND operand applied to all listed conditions, we have to apply a OR one, but with a `not` argument set to `true`