### PR TITLE
Fix 396: remove redis flushdb from init script

### DIFF
--- a/bin/commands/clearCache.js
+++ b/bin/commands/clearCache.js
@@ -36,9 +36,9 @@ module.exports = function (database, options) {
     console.log(warn('[ℹ] This operation cannot be undone.\n'));
     userIsSure = params.noint || readlineSync.question('[❓] Are you sure? If so, please type "I am sure" (if not just press [Enter]): ') === 'I am sure';
   } else if (database) {
-    userIsSure = readlineSync.keyInYN(question('[❓] Do you want t clear Kuzzle internal cache for "'.concat(database, '".')));
+    userIsSure = readlineSync.keyInYN(question('[❓] Do you want to clear Kuzzle internal cache for "'.concat(database, '".')));
   } else {
-    userIsSure = readlineSync.keyInYN(question('[❓] Do you want t clear all Kuzzle internal cache'));
+    userIsSure = readlineSync.keyInYN(question('[❓] Do you want to clear all Kuzzle internal cache'));
   }
 
   if (userIsSure) {

--- a/bin/commands/clearCache.js
+++ b/bin/commands/clearCache.js
@@ -1,0 +1,58 @@
+/* eslint-disable no-console */
+
+var
+  rc = require('rc'),
+  params = rc('kuzzle'),
+  Kuzzle = require('../../lib/api/kuzzle'),
+  readlineSync = require('readline-sync'),
+  clc = require('cli-color');
+
+module.exports = function (database, options) {
+  var
+    error,
+    warn,
+    notice,
+    ok,
+    question,
+    userIsSure = false,
+    data = {},
+    kuzzle = new Kuzzle();
+
+  if (options === undefined) {
+    options = database;
+    database = null;
+  }
+
+  data.database = database;
+
+  error = string => options.parent.noColors ? string : clc.red(string);
+  warn = string => options.parent.noColors ? string : clc.yellow(string);
+  notice = string => options.parent.noColors ? string : clc.cyanBright(string);
+  ok = string => options.parent.noColors ? string: clc.green.bold(string);
+  question = string => options.parent.noColors ? string : clc.whiteBright(string);
+
+  if (database === 'memoryStorage') {
+    console.log(warn('[ℹ] You are about to clear Kuzzle memoryStorage database.'));
+    console.log(warn('[ℹ] This operation cannot be undone.\n'));
+    userIsSure = params.noint || readlineSync.question('[❓] Are you sure? If so, please type "I am sure" (if not just press [Enter]): ') === 'I am sure';
+  } else if (database) {
+    userIsSure = readlineSync.keyInYN(question('[❓] Do you want t clear Kuzzle internal cache for "'.concat(database, '".')));
+  } else {
+    userIsSure = readlineSync.keyInYN(question('[❓] Do you want t clear all Kuzzle internal cache'));
+  }
+
+  if (userIsSure) {
+    console.log(notice('[ℹ] Processing...\n'));
+    return kuzzle.remoteActions.do('clearCache', data)
+      .then(() => {
+        console.log(ok('[✔] Done!'));
+        process.exit(0);
+      })
+      .catch(err => {
+        console.log(error('[✖]', err));
+        process.exit(1);
+      });
+  }
+
+  console.log(notice('[ℹ] Nothing have been done... you do not look that sure...'));
+};

--- a/bin/kuzzle
+++ b/bin/kuzzle
@@ -37,6 +37,12 @@ program
   .description('install all plugins configured in .kuzzlerc')
   .action(require('./commands/install'));
 
+// $ kuzzle clearCache
+program
+  .command('clearCache')
+  .description('clear internal caches in Redis')
+  .action(require('./commands/clearCache'));
+
 // $ kuzzle likeAvirgin
 program
   .command('likeAvirgin')

--- a/lib/api/controllers/remoteActions/cleanDb.js
+++ b/lib/api/controllers/remoteActions/cleanDb.js
@@ -11,9 +11,11 @@ var
 function cleanDb () {
   return _kuzzle.internalEngine.deleteIndex(_kuzzle.internalEngine.index)
     .then(response => {
-      return new Promise((resolve, reject) => {
-        _kuzzle.services.list.memoryStorage.flushdb(err => err ? reject(err) : resolve());
-      }).then(() => {
+      return Promise.all(_kuzzle.config.services.cache.aliases.map(id => {
+        return new Promise((resolve, reject) => {
+          _kuzzle.services.list[id].flushdb(err => err ? reject(err) : resolve());
+        });
+      })).then(() => {
         return response;
       });
     })

--- a/lib/api/controllers/remoteActions/cleanDb.js
+++ b/lib/api/controllers/remoteActions/cleanDb.js
@@ -1,4 +1,5 @@
 var
+  Promise = require('bluebird'),
   _kuzzle;
 
 /**
@@ -10,8 +11,15 @@ var
 function cleanDb () {
   return _kuzzle.internalEngine.deleteIndex(_kuzzle.internalEngine.index)
     .then(response => {
+      return new Promise((resolve, reject) => {
+        _kuzzle.services.list.memoryStorage.flushdb(err => err ? reject(err) : resolve());
+      }).then(() => {
+        return response;
+      });
+    })
+    .then(response => {
       _kuzzle.indexCache.remove(_kuzzle.internalEngine.index);
-      
+
       return response;
     });
 }

--- a/lib/api/controllers/remoteActions/clearCache.js
+++ b/lib/api/controllers/remoteActions/clearCache.js
@@ -1,0 +1,40 @@
+var
+  Promise = require('bluebird'),
+  _kuzzle;
+
+/**
+ * Clear Redis Caches
+ *
+ * @param {Kuzzle} kuzzle
+ * @param {Request} request
+ * @returns {Promise}
+ */
+function clearCache (request) {
+  var
+    cacheEngine,
+    database = request.data.body.database;
+
+  if (database) {
+    cacheEngine = _kuzzle.services.list[database];
+    if (cacheEngine === undefined) {
+      return Promise.reject('Database '.concat(database, ' not found!'));
+    }
+    return new Promise((resolve, reject) => {
+      cacheEngine.flushdb(err => err ? reject(err) : resolve());
+    });
+  }
+
+  return Promise.all(_kuzzle.config.services.cache.aliases.map(id => {
+    if (id === 'memoryStorage') {
+      return Promise.resolve();
+    }
+    return new Promise((resolve, reject) => {
+      _kuzzle.services.list[id].flushdb(err => err ? reject(err) : resolve());
+    });
+  }));
+}
+
+module.exports = function (kuzzle) {
+  _kuzzle = kuzzle;
+  return clearCache;
+};

--- a/lib/api/controllers/remoteActionsController.js
+++ b/lib/api/controllers/remoteActionsController.js
@@ -18,6 +18,7 @@ function RemoteActionsController (kuzzle) {
     createFirstAdmin: adminController.createFirstAdmin,
     cleanAndPrepare: require('./remoteActions/cleanAndPrepare')(kuzzle),
     cleanDb: require('./remoteActions/cleanDb')(kuzzle),
+    clearCache: require('./remoteActions/clearCache')(kuzzle),
     enableServices: require('./remoteActions/enableServices')(kuzzle),
     managePlugins: require('./remoteActions/managePlugins')(kuzzle),
     prepareDb:require('./remoteActions/prepareDb')(kuzzle)
@@ -30,7 +31,7 @@ function RemoteActionsController (kuzzle) {
 
   this.onListenCB = (request) => {
     var err;
-    
+
     if (!request.action) {
       err = new BadRequestError('No action given.');
 

--- a/lib/api/remoteActions/index.js
+++ b/lib/api/remoteActions/index.js
@@ -71,6 +71,7 @@ module.exports = function RemoteActions (kuzzle) {
 function initActions () {
   this.actions.adminExists = new Action();
   this.actions.cleanAndPrepare = new Action();
+  this.actions.clearCache = new Action();
   this.actions.cleanDb = new Action();
   this.actions.createFirstAdmin = new Action();
   this.actions.enableServices = new Action();

--- a/lib/services/redis.js
+++ b/lib/services/redis.js
@@ -47,18 +47,7 @@ function Redis (kuzzle, options, config) {
             return reject(error);
           }
 
-          // do not flush publicCache
-          if (this.settings.service === 'memoryStorage') {
-            return resolve(this);
-          }
-
-          this.client.flushdb(err => {
-            if (err) {
-              return reject(err);
-            }
-
-            resolve(this);
-          });
+          return resolve(this);
         });
       });
 

--- a/lib/services/redis.js
+++ b/lib/services/redis.js
@@ -42,6 +42,7 @@ function Redis (kuzzle, options, config) {
       this.client = buildClient(config);
 
       this.client.on('ready', () => {
+        kuzzle.pluginsManager.trigger('log:info', 'Redis service: Connected to ' + this.settings.service);
         this.client.select(config.databases.indexOf(this.settings.service), error => {
           if (error) {
             return reject(error);

--- a/test/api/controllers/remoteActionsController/cleanDb.test.js
+++ b/test/api/controllers/remoteActionsController/cleanDb.test.js
@@ -17,7 +17,15 @@ describe('Test: clean database', () => {
         index: 'testIndex',
         deleteIndex: sinon.stub().resolves('deleteIndex')
       },
-      isServer: true
+      services: {
+        list: {
+          memoryStorage: {
+            flushdb: callback => {
+              callback(null);
+            }
+          }
+        }
+      }
     };
 
     cleanDb = require('../../../../lib/api/controllers/remoteActions/cleanDb')(kuzzle);
@@ -32,6 +40,14 @@ describe('Test: clean database', () => {
         should(kuzzle.internalEngine.deleteIndex).be.calledWithExactly('testIndex');
         should(kuzzle.indexCache.remove).be.calledOnce();
         should(kuzzle.indexCache.remove).be.calledWith('testIndex');
+      });
+  });
+
+  it('should clean the memoryStorage', () => {
+    var spy = sinon.spy(kuzzle.services.list.memoryStorage, 'flushdb');
+    return cleanDb()
+      .then(() => {
+        should(spy).be.calledOnce();
       });
   });
 

--- a/test/api/controllers/remoteActionsController/cleanDb.test.js
+++ b/test/api/controllers/remoteActionsController/cleanDb.test.js
@@ -10,6 +10,13 @@ describe('Test: clean database', () => {
 
   beforeEach(() => {
     kuzzle = {
+      config: {
+        services: {
+          cache: {
+            aliases: ['memoryStorage', 'foo', 'bar']
+          }
+        }
+      },
       indexCache: {
         remove: sinon.spy()
       },
@@ -20,9 +27,13 @@ describe('Test: clean database', () => {
       services: {
         list: {
           memoryStorage: {
-            flushdb: callback => {
-              callback(null);
-            }
+            flushdb: callback => callback(null)
+          },
+          foo: {
+            flushdb: callback => callback(null)
+          },
+          bar: {
+            flushdb: callback => callback(null)
           }
         }
       }
@@ -43,11 +54,18 @@ describe('Test: clean database', () => {
       });
   });
 
-  it('should clean the memoryStorage', () => {
-    var spy = sinon.spy(kuzzle.services.list.memoryStorage, 'flushdb');
+  it('should clean the memoryStorage and the internal caches', () => {
+    var spies = {
+      memoryStorage: sinon.spy(kuzzle.services.list.memoryStorage, 'flushdb'),
+      foo: sinon.spy(kuzzle.services.list.foo, 'flushdb'),
+      bar: sinon.spy(kuzzle.services.list.bar, 'flushdb')
+    };
+
     return cleanDb()
       .then(() => {
-        should(spy).be.calledOnce();
+        should(spies.memoryStorage).be.calledOnce();
+        should(spies.foo).be.calledOnce();
+        should(spies.bar).be.calledOnce();
       });
   });
 

--- a/test/api/controllers/remoteActionsController/clearCache.test.js
+++ b/test/api/controllers/remoteActionsController/clearCache.test.js
@@ -1,0 +1,91 @@
+var
+  should = require('should'),
+  sinon = require('sinon');
+
+
+describe('Test: clear cache', () => {
+  var
+    clearCache,
+    spies,
+    kuzzle;
+
+  beforeEach(() => {
+    kuzzle = {
+      config: {
+        services: {
+          cache: {
+            aliases: ['memoryStorage', 'foo', 'bar']
+          }
+        }
+      },
+      services: {
+        list: {
+          memoryStorage: {
+            flushdb: callback => {
+              callback(null);
+            }
+          },
+          foo: {
+            flushdb: callback => {
+              callback(null);
+            }
+          },
+          bar: {
+            flushdb: callback => {
+              callback(null);
+            }
+          },
+        }
+      }
+    };
+
+    spies = {
+      memoryStorage: sinon.spy(kuzzle.services.list.memoryStorage, 'flushdb'),
+      foo: sinon.spy(kuzzle.services.list.foo, 'flushdb'),
+      bar: sinon.spy(kuzzle.services.list.bar, 'flushdb')
+    };
+
+    clearCache = require('../../../../lib/api/controllers/remoteActions/clearCache')(kuzzle);
+  });
+
+
+  it('should clean explicitely any volatile database', () => {
+    var request = {data: {body: {database: 'foo'}}};
+
+    return clearCache(request)
+      .then(() => {
+        should(spies.foo).be.calledOnce();
+        should(spies.bar).not.be.called();
+        should(spies.memoryStorage).not.be.called();
+      });
+  });
+
+  it('should clean explicitely the memoryStorage', () => {
+    var request = {data: {body: {database: 'memoryStorage'}}};
+
+    return clearCache(request)
+      .then(() => {
+        should(spies.foo).not.be.called();
+        should(spies.bar).not.be.called();
+        should(spies.memoryStorage).be.calledOnce();
+      });
+  });
+
+  it('should return a rejected Promise if an unknown database name is provided', () => {
+    var request = {data: {body: {database: 'fake'}}};
+
+    should(clearCache(request)).be.rejected();
+  });
+
+  it('should clean all volatile redis dbs if no database name is provided', () => {
+    var request = {data: {body: {}}};
+
+    return clearCache(request)
+      .then(() => {
+        should(spies.foo).be.calledOnce();
+        should(spies.bar).be.calledOnce();
+        should(spies.memoryStorage).not.be.called();
+      });
+  });
+
+});

--- a/test/api/remoteActions/index.test.js
+++ b/test/api/remoteActions/index.test.js
@@ -56,12 +56,13 @@ describe('Tests: api/remoteActions/index.js', () => {
           adminExists: action,
           cleanAndPrepare: action,
           cleanDb: action,
+          clearCache: action,
           createFirstAdmin: action,
           enableServices: action,
           managePlugins: action,
           prepareDb: action
         });
-        should(spy).have.callCount(7);
+        should(spy).have.callCount(8);
       });
     });
 

--- a/test/services/redis.test.js
+++ b/test/services/redis.test.js
@@ -45,7 +45,7 @@ describe('Test redis service', () => {
     });
   });
 
-  it('should flush publicCache for common services', () => {
+  it('should not flush publicCache', () => {
     var
       myRedis = new Redis(kuzzle, {service: dbname}, kuzzle.config.services.cache),
       myRedisClient = new RedisClientMock(),
@@ -56,39 +56,7 @@ describe('Test redis service', () => {
         .then(() => {
           should(myRedis).have.property('client');
           should(myRedis.client).be.an.Object();
-          should(spy.calledOnce).be.true();
-        });
-    });
-  });
-
-  it('should not flush publicCache for memoryStorage service', () => {
-    var
-      myRedis = new Redis(kuzzle, {service: 'memoryStorage'}, kuzzle.config.services.cache),
-      myRedisClient = new RedisClientMock(),
-      spy = sandbox.spy(myRedisClient, 'flushdb');
-
-    return Redis.__with__('buildClient', () => myRedisClient)(() => {
-      return myRedis.init()
-        .then(() => {
-          should(myRedis).have.property('client');
-          should(myRedis.client).be.an.Object();
-          should(spy.called).be.false();
-        });
-    });
-  });
-
-  it('should reject if an error occurs during flushdb', () => {
-    var
-      myRedis = new Redis(kuzzle, {service: dbname}, kuzzle.config.services.cache),
-      myRedisClient = new RedisClientMock();
-
-    sandbox.stub(myRedisClient, 'flushdb', callback => callback(new Error('flushdb error')));
-
-    return Redis.__with__('buildClient', () => myRedisClient)(() => {
-      return myRedis.init()
-        .then(() => should.fail('An error should be raised'))
-        .catch((err) => {
-          should(err.message).be.equal('flushdb error');
+          should(spy.calledOnce).be.false();
         });
     });
   });


### PR DESCRIPTION
fix #396 :
* remove redis flushdb from init script
* add CLI commands to flush DB by hands, with following behaviour:
  * if no database name is provided, all volatile databases are flushed (that means: all except "memoryStorage")
  * if a database name is provided, only this database is flushed (with a strong confirmation needed for "memoryStorage")
* flush also "memoryStorage" within "cleanDB" command


