### PR TITLE
KUZ-693 remove dsl create filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking changes
 
 * Rename a couple of DSL keywords to avoid confusion with Elasticsearch's DSL #392
+* Remove `createFilterId` from the real-time engine exposed methods. The filter's unique ID is now returned by the `register` method #401 
 
 # 1.0.0-RC6
 

--- a/features/step_definitions/subscription.js
+++ b/features/step_definitions/subscription.js
@@ -109,13 +109,15 @@ var apiSteps = function () {
     this.api.countSubscription()
       .then(function (response) {
         if (response.error) {
-          callback(new Error(response.error.message));
-          return false;
+          return callback(new Error(response.error.message));
         }
 
-        if (!response.result.count || response.result.count !== parseInt(number)) {
-          callback(new Error('No correct value for count. Expected ' + number + ', got ' + response.result));
-          return false;
+        if (!response.result.count) {
+          return callback(new Error('Expected a "count" value in response'));
+        }
+
+        if (response.result.count !== parseInt(number)) {
+          return callback(new Error('No correct value for count. Expected ' + number + ', got ' + response.result.count));
         }
 
         callback();

--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -381,62 +381,50 @@ function removeListRoomsInCollection (index, collection, rooms) {
 function createRoom (index, collection, filters) {
   var
     diff,
+    formattedFilter,
     roomId;
 
   if (!index || !collection) {
     return Promise.reject(new BadRequestError('Cannot subscribe without an index and a collection'));
   }
 
-  roomId = this.kuzzle.dsl.createFilterId(index, collection, filters);
+  return this.kuzzle.dsl.register(index, collection, filters)
+    .then(response => {
+      roomId = response.id;
+      diff = response.diff;
+      formattedFilter = response.filter;
 
-  return Promise.fromNode(asyncCB => async.retry(callback => {
-    // if the room is about to be destroyed, we have to delay its re-creation until its destruction has completed
-    if (this.rooms[roomId] && this.rooms[roomId].destroyed) {
-      return callback(new InternalError('Cannot create the room ' + roomId + ' because it has been marked for destruction'));
-    }
+      if (!diff && this.rooms[roomId] && !this.rooms[roomId].destroyed) {
+        return {diff, roomId};
+      }
 
-    if (!this.rooms[roomId]) {
-      // If it's a new room, we have to calculate filters to apply on the future documents
-      this.kuzzle.dsl.register(roomId, index, collection, filters)
-        .then(response => {
-          var formattedFilters;
-
-          if (response && response.filter !== undefined) {
-            formattedFilters = response.filter;
-          }
-
-          if (response) {
-            diff = response.diff;
-          }
-
-          if (this.rooms[roomId]) {
-            return callback(null, roomId);
-          }
-
-          this.kuzzle.pluginsManager.trigger('room:new', {
+      return Promise.fromNode(asyncCB => async.retry(callback => {
+        // if the room is about to be destroyed, we have to delay its re-registration until its destruction has completed
+        if (this.rooms[roomId] && this.rooms[roomId].destroyed) {
+          return callback(new InternalError(`Cannot create the room ${roomId} because it has been marked for destruction`));
+        }
+        callback(null, {roomId});
+      }, asyncCB))
+        .then(() => {
+          return this.kuzzle.pluginsManager.trigger('room:new', {
             roomId: roomId,
             index: index,
             collection: collection,
-            formattedFilters: formattedFilters
-          })
-            .then(modifiedData => {
-              this.rooms[modifiedData.roomId] = {
-                id: modifiedData.roomId,
-                customers: [],
-                index: modifiedData.index,
-                channels: {},
-                collection: modifiedData.collection
-              };
-
-              callback(null, {diff, roomId});
-            });
+            formattedFilters: formattedFilter
+          });
         })
-        .catch(error => callback(error));
-    }
-    else {
-      callback(null, {roomId});
-    }
-  }, asyncCB));
+        .then(modifiedData => {
+          this.rooms[modifiedData.roomId] = {
+            id: modifiedData.roomId,
+            customers: [],
+            index: modifiedData.index,
+            channels: {},
+            collection: modifiedData.collection
+          };
+
+          return {diff, roomId};
+        });
+    });
 }
 
 /**
@@ -633,7 +621,7 @@ function removeRoomForAllCustomers (roomId) {
  * @param {String} roomId
  * @param {RequestObject} requestObject
  * @param {Object} context
- * @returns {NotificationObject}
+ * @returns {Promise}
  */
 function subscribeToRoom (roomId, requestObject, context) {
   var

--- a/lib/api/dsl/filters.js
+++ b/lib/api/dsl/filters.js
@@ -102,7 +102,8 @@ function Filters () {
     return this.methods[privateFilterName](filterId, index, collection, filters[filterName])
       .then(response => {
         this.filters[filterId] = {index, collection, encodedFilters: response.filter};
-        return { diff: response.diff, filter: filterId };
+
+        return { diff: response.diff.length > 0 && response.diff, id: filterId, filter: response.filter };
       });
   };
 
@@ -143,7 +144,7 @@ function Filters () {
 
     this.filters[filterId] = {index, collection, encodedFilters: {}};
 
-    return Promise.resolve({diff: changed && [diff], filter: filterId});
+    return Promise.resolve({diff: changed && [diff], id: filterId, filter: {}});
   };
 
   /**

--- a/lib/api/dsl/index.js
+++ b/lib/api/dsl/index.js
@@ -14,34 +14,20 @@ function Dsl () {
   this.filters = new Filters();
 
   /**
-   * Create an unique filter ID from an user filter.
-   * The calculation is predictable, meaning the resulting
-   * filter ID will always be the same with identical filters,
-   * independently of the terms order.
-   *
-   * @param index
-   * @param collection
-   * @param filters
-   * @results {string} filter unique ID
-   */
-  this.createFilterId = function (index, collection, filters) {
-    var idObject = {index, collection};
-
-    idObject.filters = filters || {};
-
-    return crypto.createHash('md5').update(stringify(idObject)).digest('hex');
-  };
-
-  /**
    * Subscribe a filter to the DSL
+   * Resolves to an object containing the diff resulting from this
+   * action, the unique filter ID and the reworked filters
    *
-   * @param {String} filterId
    * @param {String} index
    * @param {String} collection
    * @param {Object} filters
    * @return {Promise}
    */
-  this.register = function (filterId, index, collection, filters) {
+  this.register = function (index, collection, filters) {
+    var
+      idObject = {index, collection, filters: filters || {}},
+      filterId = crypto.createHash('md5').update(stringify(idObject)).digest('hex');
+
     if (!filters || Object.keys(filters).length === 0) {
       return this.filters.addCollectionSubscription(filterId, index, collection);
     }

--- a/test/api/core/hotelClerk/removeRooms.test.js
+++ b/test/api/core/hotelClerk/removeRooms.test.js
@@ -12,7 +12,6 @@ describe('Test: hotelClerk.removeRooms', () => {
     kuzzle,
     connection = {id: 'connectionid'},
     context,
-    roomName,
     index = 'test',
     collection1 = 'user',
     collection2 = 'foo',
@@ -50,7 +49,6 @@ describe('Test: hotelClerk.removeRooms', () => {
     var requestObject = new RequestObject({
       controller: 'admin',
       action: 'removeRooms',
-      requestId: roomName,
       index: undefined,
       collection: collection1,
       body: {}
@@ -63,7 +61,6 @@ describe('Test: hotelClerk.removeRooms', () => {
     var requestObject = new RequestObject({
       controller: 'admin',
       action: 'removeRooms',
-      requestId: roomName,
       index: index,
       collection: undefined,
       body: {}
@@ -76,7 +73,6 @@ describe('Test: hotelClerk.removeRooms', () => {
     var requestObject = new RequestObject({
       controller: 'admin',
       action: 'removeRooms',
-      requestId: roomName,
       index: index,
       collection: collection1,
       body: {}
@@ -90,7 +86,6 @@ describe('Test: hotelClerk.removeRooms', () => {
       requestObjectSubscribe = new RequestObject({
         controller: 'subscribe',
         action: 'on',
-        requestId: roomName,
         index: index,
         collection: collection1,
         body: {}
@@ -98,7 +93,6 @@ describe('Test: hotelClerk.removeRooms', () => {
       requestObject = new RequestObject({
         controller: 'admin',
         action: 'removeRooms',
-        requestId: roomName,
         index: index,
         collection: collection2,
         body: {}
@@ -115,7 +109,6 @@ describe('Test: hotelClerk.removeRooms', () => {
       requestObjectSubscribe = new RequestObject({
         controller: 'subscribe',
         action: 'on',
-        requestId: roomName,
         index: index,
         collection: collection1,
         body: {}
@@ -123,7 +116,6 @@ describe('Test: hotelClerk.removeRooms', () => {
       requestObjectRemove = new RequestObject({
         controller: 'admin',
         action: 'removeRooms',
-        requestId: roomName,
         index: index,
         collection: collection1,
         body: {}
@@ -145,7 +137,6 @@ describe('Test: hotelClerk.removeRooms', () => {
       requestObjectSubscribe = new RequestObject({
         controller: 'subscribe',
         action: 'on',
-        requestId: roomName,
         index: index,
         collection: collection1,
         body: filter1
@@ -153,7 +144,6 @@ describe('Test: hotelClerk.removeRooms', () => {
       requestObjectRemove = new RequestObject({
         controller: 'admin',
         action: 'removeRooms',
-        requestId: roomName,
         index: index,
         collection: collection1,
         body: {}
@@ -175,7 +165,6 @@ describe('Test: hotelClerk.removeRooms', () => {
       requestObjectSubscribeGlobal = new RequestObject({
         controller: 'subscribe',
         action: 'on',
-        requestId: roomName,
         index: index,
         collection: collection1,
         body: {}
@@ -183,7 +172,6 @@ describe('Test: hotelClerk.removeRooms', () => {
       requestObjectSubscribeFilter = new RequestObject({
         controller: 'subscribe',
         action: 'on',
-        requestId: roomName,
         index: index,
         collection: collection1,
         body: filter1
@@ -191,7 +179,6 @@ describe('Test: hotelClerk.removeRooms', () => {
       requestObjectRemove = new RequestObject({
         controller: 'admin',
         action: 'removeRooms',
-        requestId: roomName,
         index: index,
         collection: collection1,
         body: {}
@@ -214,7 +201,6 @@ describe('Test: hotelClerk.removeRooms', () => {
       requestObjectSubscribeCollection1 = new RequestObject({
         controller: 'subscribe',
         action: 'on',
-        requestId: roomName,
         index: index,
         collection: collection1,
         body: {}
@@ -222,7 +208,6 @@ describe('Test: hotelClerk.removeRooms', () => {
       requestObjectSubscribeCollection2 = new RequestObject({
         controller: 'subscribe',
         action: 'on',
-        requestId: roomName,
         index: index,
         collection: collection2,
         body: {}
@@ -230,7 +215,6 @@ describe('Test: hotelClerk.removeRooms', () => {
       requestObjectRemove = new RequestObject({
         controller: 'admin',
         action: 'removeRooms',
-        requestId: roomName,
         index: index,
         collection: collection1,
         body: {}
@@ -259,7 +243,6 @@ describe('Test: hotelClerk.removeRooms', () => {
       requestObjectSubscribeCollection1 = new RequestObject({
         controller: 'subscribe',
         action: 'on',
-        requestId: roomName,
         index: index,
         collection: collection1,
         body: {}
@@ -267,7 +250,6 @@ describe('Test: hotelClerk.removeRooms', () => {
       requestObjectRemove = new RequestObject({
         controller: 'admin',
         action: 'removeRooms',
-        requestId: roomName,
         index: index,
         collection: collection1,
         body: {rooms: {}}
@@ -312,7 +294,7 @@ describe('Test: hotelClerk.removeRooms', () => {
       .then(() => kuzzle.hotelClerk.removeRooms(requestObjectRemove))
       .then(() => {
         should(Object.keys(kuzzle.hotelClerk.rooms).length).be.exactly(1);
-        should(kuzzle.hotelClerk.rooms[roomName]).be.undefined();
+        should(kuzzle.hotelClerk.rooms[roomId]).be.undefined();
       });
   });
 
@@ -336,7 +318,6 @@ describe('Test: hotelClerk.removeRooms', () => {
       requestObjectRemove = new RequestObject({
         controller: 'admin',
         action: 'removeRooms',
-        requestId: roomName,
         index: index,
         collection: collection1,
         body: {rooms: [index2RoomName]}
@@ -372,7 +353,6 @@ describe('Test: hotelClerk.removeRooms', () => {
       requestObjectRemove = new RequestObject({
         controller: 'admin',
         action: 'removeRooms',
-        requestId: roomName,
         index: index,
         collection: collection1,
         body: {rooms: [collection2RoomName]}
@@ -394,7 +374,6 @@ describe('Test: hotelClerk.removeRooms', () => {
       requestObjectSubscribe = new RequestObject({
         controller: 'subscribe',
         action: 'on',
-        requestId: roomName,
         index: index,
         collection: collection1,
         body: {}
@@ -402,7 +381,6 @@ describe('Test: hotelClerk.removeRooms', () => {
       requestObjectRemove = new RequestObject({
         controller: 'admin',
         action: 'removeRooms',
-        requestId: roomName,
         index: index,
         collection: collection1,
         body: {rooms: [badRoomName]}

--- a/test/api/dsl/filters/addCollectionSubscription.test.js
+++ b/test/api/dsl/filters/addCollectionSubscription.test.js
@@ -25,7 +25,7 @@ describe('Test: dsl.filters.addCollectionSubscription', () => {
             fi: 'foo'
           }} 
         ]);
-        should(response.filter).be.exactly('foo');
+        should(response.id).be.exactly('foo');
 
         should(filters.filtersTree[index]).be.an.Object();
         should(filters.filtersTree[index].bar).be.an.Object();

--- a/test/api/dsl/index/remove.test.js
+++ b/test/api/dsl/index/remove.test.js
@@ -8,7 +8,6 @@ describe('Test: dsl.remove', () => {
     dsl,
     index = 'test',
     collection = 'user',
-    filterId = 'foo',
     filter = {
       in: {
         city: ['NYC', 'London']
@@ -24,19 +23,19 @@ describe('Test: dsl.remove', () => {
   });
 
   it('should remove a filter containing field filters', () => {
-    return dsl.register(filterId, index, collection, filter)
-      .then(() => {
+    return dsl.register(index, collection, filter)
+      .then(response => {
         should(dsl.filters.filtersTree).not.be.empty().Object();
-        return dsl.remove(filterId);
+        return dsl.remove(response.id);
       })
       .then(() => should(dsl.filters.filtersTree).be.empty().Object());
   });
 
   it('should remove a room containing global filters', () => {
-    return dsl.register(filterId, index, collection, {})
-      .then(() => {
+    return dsl.register(index, collection, {})
+      .then(response => {
         should(dsl.filters.filtersTree).not.be.empty().Object();
-        return dsl.remove(filterId);
+        return dsl.remove(response.id);
       })
       .then(() => should(dsl.filters.filtersTree).be.empty().Object());
   });

--- a/test/api/dsl/index/test.test.js
+++ b/test/api/dsl/index/test.test.js
@@ -7,7 +7,7 @@ var
 describe('Test: dsl.test', () => {
   var
     dsl,
-    filterId = 'foobar',
+    filterId,
     index = 'index',
     collection = 'user',
     dataGrace = {
@@ -66,7 +66,10 @@ describe('Test: dsl.test', () => {
   beforeEach(() => {
     /** @type Dsl */
     dsl = new Dsl();
-    return dsl.register(filterId, index, collection, filterGrace);
+    return dsl.register(index, collection, filterGrace)
+      .then(response => {
+        filterId = response.id;
+      });
   });
 
   it('should return an array with my filter id when document matches', () => {


### PR DESCRIPTION
From building the new real-time engine, I came across a problem with the currently exposed ``DSL.createFilterId`` method.

Its purpose is to examine the provided filters, and to return an unique identifier. More importantly, filters can be written using different forms, and they all should return the same ID.

As the current real-time engine does not normalize filters, we can have different IDs and it doesn't matter much. But the new real-time engine functions differently and it needs to rewrite and normalize filters.
However this operation has a cost: a few milliseconds are required to process complex filters.

We cannot afford to normalize filters to calculate an unique ID, and re-normalize them afterward to register them in the engine, using the ``DSL.register`` method.

So this task involves:
* removing the ``DSL.createFilterId`` method altogether
* removing the 1st argument of ``DSL.register`` ("filterId")
* making ``DSL.register`` return the calculated filter unique ID along with the usual response object


This is a breaking change, because it impacts the real-time engine signature exposed to plugins.
