### PR TITLE
Let IP be an IP

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -18,6 +18,10 @@ function unstringify (cfg) {
     }
     
     if (typeof cfg[k] === 'string') {
+      // If it's an IP we don't want to use it as float
+      if (/^([0-9]{1,3}\.){3}([0-9]{1,3})$/.test(cfg[k])) {
+        return;
+      }
       if (cfg[k] === 'true') {
         cfg[k] = true;
       }


### PR DESCRIPTION
If the host is an IP the file `lib/config/index` will transform it into a float. This can produce something like

```
export kuzzle_services__proxyBroker__host=10.0.2.251
export kuzzle_services__proxyBroker__port=7331
pm2 restart all
```

```
[proxyBroker] Error while trying to connect to ws://10:7331
```