### PR TITLE
[MASTER] Hotfix #408 kuzzle create first admin fails

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,7 +39,7 @@
     "no-undef": 2,
     "no-undef-init": 1,
     "no-unreachable": 2,
-    "no-unused-expressions": 2,
+    "no-unused-expressions": [2, {"allowShortCircuit": true}],
     "no-useless-call": 2,
     "no-with": 2,
     "quotes": [2, "single"],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # 1.0.0-RC6
 
+* Hotfix "createFirstAdmin" CLI command #409
+
+# 1.0.0-RC6
+
 * https://github.com/kuzzleio/kuzzle/releases/tag/1.0.0-RC6
 
 # 1.0.0-RC5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 *__note:__ the # at the end of lines are the pull request numbers on GitHub*
 
-# 1.0.0-RC6
+# 1.0.0-RC6.1
 
 * Hotfix "createFirstAdmin" CLI command #409
 

--- a/bin/commands/createFirstAdmin.js
+++ b/bin/commands/createFirstAdmin.js
@@ -73,8 +73,7 @@ module.exports = function (options) {
 
   return kuzzle.remoteActions.do('adminExists', params)
     .then(adminExists => {
-      if (adminExists.data.body) {
-
+      if (adminExists.data.body.exists) {
         console.log('An administrator account already exists.');
         process.exit(0);
       }

--- a/bin/commands/createFirstAdmin.js
+++ b/bin/commands/createFirstAdmin.js
@@ -114,6 +114,8 @@ module.exports = function (options) {
         console.log(clcOk('   - default'));
         console.log(clcOk('   - anonymous'));
       }
+
+      process.exit(0);
     })
     .catch(err => {
       console.error(clcError(err));

--- a/bin/commands/createFirstAdmin.js
+++ b/bin/commands/createFirstAdmin.js
@@ -15,7 +15,7 @@ var
 function getUserName () {
   var username;
 
-  username = readlineSync.question(clcQuestion('\n[❓] Please enter a username for the first admin\n'));
+  username = readlineSync.question(clcQuestion('\n[❓] First administrator account name\n'));
 
   if (username.length === 0) {
     return getUserName();
@@ -29,7 +29,7 @@ function getPassword () {
     password,
     confirmation;
 
-  password = readlineSync.question(clcQuestion('\n[❓] Please enter a password for the account\n'),
+  password = readlineSync.question(clcQuestion('\n[❓] First administrator account password\n'),
     {hideEchoBack: true}
   );
   confirmation = readlineSync.question(clcQuestion('Please confirm your password\n'),
@@ -45,15 +45,16 @@ function getPassword () {
 }
 
 function shouldWeResetRoles () {
-  return Promise.resolve(readlineSync.keyInYN(clcQuestion('[❓] Reset roles?')));
+  return Promise.resolve(readlineSync.keyInYN(clcQuestion('[❓] Restrict rights of the default and anonymous roles?')));
 }
 
 function confirm (username, resetRoles) {
-  var msg = `\n[❓] About to create admin user "${username}"`;
+  var msg = `\n[❓] About to create the administrator account "${username}"`;
 
   if (resetRoles) {
-    msg += ' and reset default roles';
+    msg += ' and restrict rights of the default and anonymous roles';
   }
+
   msg += '.\nConfirm? ';
   return Promise.resolve(readlineSync.keyInYN(clcQuestion(msg)));
 }
@@ -73,7 +74,8 @@ module.exports = function (options) {
   return kuzzle.remoteActions.do('adminExists', params)
     .then(adminExists => {
       if (adminExists.data.body) {
-        console.log('admin user is already set');
+
+        console.log('An administrator account already exists.');
         process.exit(0);
       }
 
@@ -104,25 +106,20 @@ module.exports = function (options) {
           {pid: params.pid, debug: options.parent.debug});
         })
         .then(() => {
-          console.log(clcOk(`[✔] "${username}" user created with admin rights`));
+          console.log(clcOk(`[✔] "${username}" administrator account created`));
 
           if (resetRoles) {
-            console.log(clcOk('[✔] "default" profile reset'));
-            console.log(clcOk('[✔] "admin" profile reset'));
-            console.log(clcOk('[✔] "anonymous" profile reset'));
-            console.log(clcOk('[✔] "default" role reset'));
-            console.log(clcOk('[✔] "admin" role reset'));
-            console.log(clcOk('[✔] "anonymous" role reset'));
+            console.log(clcOk('[✔] Rights restriction applied to the following roles: '));
+            console.log(clcOk('   - default'));
+            console.log(clcOk('   - anonymous'));
           }
+
           process.exit(0);
         })
         .catch(err => {
           console.error(err);
           process.exit(1);
         });
-    })
-    .then(() => {
-
     })
     .catch(err => console.log(err));
 

--- a/bin/commands/createFirstAdmin.js
+++ b/bin/commands/createFirstAdmin.js
@@ -79,48 +79,43 @@ module.exports = function (options) {
         process.exit(0);
       }
 
-      getUserName()
-        .then(response => {
-          username = response;
-          return getPassword();
-        })
-        .then(pwd => {
-          password = pwd;
-          return shouldWeResetRoles();
-        })
-        .then(response => {
-          resetRoles = response;
-
-          return confirm(username, resetRoles);
-        })
-        .then(response => {
-          if (!response) {
-            process.exit(0);
-          }
-
-          return kuzzle.remoteActions.do('createFirstAdmin', {
-            _id: username,
-            password,
-            reset: resetRoles
-          },
-          {pid: params.pid, debug: options.parent.debug});
-        })
-        .then(() => {
-          console.log(clcOk(`[✔] "${username}" administrator account created`));
-
-          if (resetRoles) {
-            console.log(clcOk('[✔] Rights restriction applied to the following roles: '));
-            console.log(clcOk('   - default'));
-            console.log(clcOk('   - anonymous'));
-          }
-
-          process.exit(0);
-        })
-        .catch(err => {
-          console.error(err);
-          process.exit(1);
-        });
+      return getUserName();
     })
-    .catch(err => console.log(err));
+    .then(response => {
+      username = response;
+      return getPassword();
+    })
+    .then(pwd => {
+      password = pwd;
+      return shouldWeResetRoles();
+    })
+    .then(response => {
+      resetRoles = response;
 
+      return confirm(username, resetRoles);
+    })
+    .then(response => {
+      if (!response) {
+        process.exit(0);
+      }
+
+      return kuzzle.remoteActions.do('createFirstAdmin', {
+        _id: username,
+        password,
+        reset: resetRoles
+      }, {pid: params.pid, debug: options.parent.debug});
+    })
+    .then(() => {
+      console.log(clcOk(`[✔] "${username}" administrator account created`));
+
+      if (resetRoles) {
+        console.log(clcOk('[✔] Rights restriction applied to the following roles: '));
+        console.log(clcOk('   - default'));
+        console.log(clcOk('   - anonymous'));
+      }
+    })
+    .catch(err => {
+      console.error(clcError(err));
+      process.exit(1);
+    });
 };

--- a/bin/commands/createFirstAdmin.js
+++ b/bin/commands/createFirstAdmin.js
@@ -10,7 +10,8 @@ var
   params = rc('kuzzle'),
   clcQuestion = clc.whiteBright,
   clcOk = clc.green.bold,
-  clcError = clc.red;
+  clcError = clc.red,
+  clcWarn = clc.yellow;
 
 function getUserName () {
   var username;
@@ -95,6 +96,7 @@ module.exports = function (options) {
     })
     .then(response => {
       if (!response) {
+        console.log(clcWarn('Aborting'));
         process.exit(0);
       }
 

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -35,7 +35,7 @@ function PluginsManager (kuzzle) {
   /**
    * Initialize configured plugin in config/defaultPlugins.json and config/customPlugins.json
    *
-   * @param {Object} options
+   * @param {Object} [options]
    * @returns {Promise}
    */
   this.init = function (options) {
@@ -68,7 +68,7 @@ function PluginsManager (kuzzle) {
           pipeTimeout = this.config.common.pipeTimeout;
 
         if (!plugin.activated) {
-          !this.silent && console.log('Plugin', pluginName, 'deactivated. Skipping...');
+          this.silent || console.log('Plugin', pluginName, 'deactivated. Skipping...');
           callback();
           return true;
         }
@@ -100,7 +100,7 @@ function PluginsManager (kuzzle) {
           injectScope(plugin.object.scope, kuzzle.passport);
         }
 
-        !this.silent && console.log('Plugin', pluginName, 'started');
+        this.silent || console.log('Plugin', pluginName, 'started');
         callback();
       }, (err) => {
         if (err) {
@@ -442,10 +442,6 @@ function getPluginsList(kuzzle) {
     .search('plugins')
     .then(result => {
       result.hits.forEach(p => {
-        if (!p._source.config.loadedBy) {
-          p._source.config.loadedBy = 'all';
-        }
-
         plugins[p._id] = p._source;
       });
 

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -30,13 +30,17 @@ function PluginsManager (kuzzle) {
   this.routes = [];
   this.workers = {};
   this.config = kuzzle.config.plugins;
+  this.silent = false;
 
   /**
    * Initialize configured plugin in config/defaultPlugins.json and config/customPlugins.json
    *
+   * @param {Object} options
    * @returns {Promise}
    */
-  this.init = function () {
+  this.init = function (options) {
+    this.silent = options && options.silent;
+
     return getPluginsList(kuzzle)
       .then(plugins => {
         this.plugins = plugins;
@@ -64,7 +68,7 @@ function PluginsManager (kuzzle) {
           pipeTimeout = this.config.common.pipeTimeout;
 
         if (!plugin.activated) {
-          console.log('Plugin', pluginName, 'deactivated. Skipping...');
+          !this.silent && console.log('Plugin', pluginName, 'deactivated. Skipping...');
           callback();
           return true;
         }
@@ -96,7 +100,7 @@ function PluginsManager (kuzzle) {
           injectScope(plugin.object.scope, kuzzle.passport);
         }
 
-        console.log('Plugin', pluginName, 'started');
+        !this.silent && console.log('Plugin', pluginName, 'started');
         callback();
       }, (err) => {
         if (err) {

--- a/lib/api/kuzzle.js
+++ b/lib/api/kuzzle.js
@@ -102,7 +102,7 @@ function Kuzzle () {
   this.start = function () {
 
     return this.internalEngine.init()
-      .then(() => this.pluginsManager.init(true))
+      .then(() => this.pluginsManager.init())
       .then(() => this.pluginsManager.run())
       .then(() => this.services.init())
       .then(() => this.indexCache.init())

--- a/lib/api/remoteActions/action.js
+++ b/lib/api/remoteActions/action.js
@@ -50,7 +50,7 @@ Action.prototype.initTimeout = function () {
 };
 
 Action.prototype.timeOutCB = function () {
-  console.log('Unable to connect to Kuzzle.'); // eslint-disable-line no-console
+  console.log('Unable to connect to Kuzzle'); // eslint-disable-line no-console
   process.exit(1);
 };
 

--- a/lib/api/remoteActions/action.js
+++ b/lib/api/remoteActions/action.js
@@ -50,7 +50,7 @@ Action.prototype.initTimeout = function () {
 };
 
 Action.prototype.timeOutCB = function () {
-  console.log('could not contact Kuzzle in time. Aborting.'); // eslint-disable-line no-console
+  console.log('Unable to connect to Kuzzle.'); // eslint-disable-line no-console
   process.exit(1);
 };
 

--- a/lib/api/remoteActions/index.js
+++ b/lib/api/remoteActions/index.js
@@ -37,6 +37,8 @@ module.exports = function RemoteActions (kuzzle) {
       .then(() => kuzzle.pluginsManager.init())
       .then(() => kuzzle.pluginsManager.run())
       .then(() => {
+        action.initTimeout();
+
         /** @type {Service[]} */
         kuzzle.services.list = {
           broker: new InternalBroker(kuzzle, {client: true}, kuzzle.config.services.internalBroker)
@@ -54,12 +56,11 @@ module.exports = function RemoteActions (kuzzle) {
         kuzzle.services.list.broker.listen(request.requestId, onListenCB);
         kuzzle.services.list.broker.send(kuzzle.config.queues.remoteActionsQueue, request);
 
-        action.initTimeout();
         return action.deferred.promise;
       })
       .catch(error => {
         error.message = `Failed to execute CLI action: ${error.message}`;
-        console.error(error);
+
         if (params && params.debug) {
           console.log(error.stack);
         }

--- a/lib/api/remoteActions/index.js
+++ b/lib/api/remoteActions/index.js
@@ -34,7 +34,7 @@ module.exports = function RemoteActions (kuzzle) {
     kuzzle.pluginsManager = new PluginsManager(kuzzle);
 
     return kuzzle.internalEngine.init()
-      .then(() => kuzzle.pluginsManager.init())
+      .then(() => kuzzle.pluginsManager.init({silent: true}))
       .then(() => kuzzle.pluginsManager.run())
       .then(() => {
         action.initTimeout();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.0.0-RC6",
+  "version": "1.0.0-RC6.1",
   "apiVersion": "1.0",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",

--- a/test/api/remoteActions/action.test.js
+++ b/test/api/remoteActions/action.test.js
@@ -167,7 +167,7 @@ describe('Tests: remoteActionController action client', () => {
         action.timeOutCB();
 
         should(consoleSpy).be.calledOnce();
-        should(consoleSpy).be.calledWithExactly('could not contact Kuzzle in time. Aborting.');
+        should(consoleSpy).be.calledWithExactly('Unable to connect to Kuzzle');
         should(processSpy).be.calledOnce();
         should(processSpy).be.calledWithExactly(1);
       });


### PR DESCRIPTION
* fix the `adminExist`result retrieval
* add a `silent` option to `pluginsManager.init`
* better `kuzzle createFirstAdmin` messages
* fix Kuzzle connection failure detection by starting the timeout before initializing the internal broker