### PR TITLE
Hotfix #408 kuzzle create first admin fails

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,7 +39,7 @@
     "no-undef": 2,
     "no-undef-init": 1,
     "no-unreachable": 2,
-    "no-unused-expressions": 2,
+    "no-unused-expressions": [2, {"allowShortCircuit": true}],
     "no-useless-call": 2,
     "no-with": 2,
     "quotes": [2, "single"],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Rename a couple of DSL keywords to avoid confusion with Elasticsearch's DSL #392
 
-# 1.0.0-RC6
+# 1.0.0-RC6.1
 
 * Hotfix "createFirstAdmin" CLI command #409
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 # 1.0.0-RC6
 
+* Hotfix "createFirstAdmin" CLI command #409
+
+# 1.0.0-RC6
+
 * https://github.com/kuzzleio/kuzzle/releases/tag/1.0.0-RC6
 
 # 1.0.0-RC5

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -30,13 +30,17 @@ function PluginsManager (kuzzle) {
   this.routes = [];
   this.workers = {};
   this.config = kuzzle.config.plugins;
+  this.silent = false;
 
   /**
    * Initialize configured plugin in config/defaultPlugins.json and config/customPlugins.json
    *
+   * @param {Object} [options]
    * @returns {Promise}
    */
-  this.init = function () {
+  this.init = function (options) {
+    this.silent = options && options.silent;
+
     return getPluginsList(kuzzle)
       .then(plugins => {
         this.plugins = plugins;
@@ -64,7 +68,7 @@ function PluginsManager (kuzzle) {
           pipeTimeout = this.config.common.pipeTimeout;
 
         if (!plugin.activated) {
-          console.log('Plugin', pluginName, 'deactivated. Skipping...');
+          this.silent || console.log('Plugin', pluginName, 'deactivated. Skipping...');
           callback();
           return true;
         }
@@ -96,7 +100,7 @@ function PluginsManager (kuzzle) {
           injectScope(plugin.object.scope, kuzzle.passport);
         }
 
-        console.log('Plugin', pluginName, 'started');
+        this.silent || console.log('Plugin', pluginName, 'started');
         callback();
       }, (err) => {
         if (err) {
@@ -430,10 +434,6 @@ function getPluginsList(kuzzle) {
     .search('plugins')
     .then(result => {
       result.hits.forEach(p => {
-        if (!p._source.config.loadedBy) {
-          p._source.config.loadedBy = 'all';
-        }
-
         plugins[p._id] = p._source;
       });
 

--- a/lib/api/kuzzle.js
+++ b/lib/api/kuzzle.js
@@ -102,7 +102,7 @@ function Kuzzle () {
   this.start = function () {
 
     return this.internalEngine.init()
-      .then(() => this.pluginsManager.init(true))
+      .then(() => this.pluginsManager.init())
       .then(() => this.pluginsManager.run())
       .then(() => this.services.init())
       .then(() => this.indexCache.init())

--- a/lib/api/remoteActions/action.js
+++ b/lib/api/remoteActions/action.js
@@ -50,7 +50,7 @@ Action.prototype.initTimeout = function () {
 };
 
 Action.prototype.timeOutCB = function () {
-  console.log('could not contact Kuzzle in time. Aborting.'); // eslint-disable-line no-console
+  console.log('Unable to connect to Kuzzle'); // eslint-disable-line no-console
   process.exit(1);
 };
 

--- a/lib/api/remoteActions/index.js
+++ b/lib/api/remoteActions/index.js
@@ -34,9 +34,11 @@ module.exports = function RemoteActions (kuzzle) {
     kuzzle.pluginsManager = new PluginsManager(kuzzle);
 
     return kuzzle.internalEngine.init()
-      .then(() => kuzzle.pluginsManager.init())
+      .then(() => kuzzle.pluginsManager.init({silent: true}))
       .then(() => kuzzle.pluginsManager.run())
       .then(() => {
+        action.initTimeout();
+
         /** @type {Service[]} */
         kuzzle.services.list = {
           broker: new InternalBroker(kuzzle, {client: true}, kuzzle.config.services.internalBroker)
@@ -54,12 +56,11 @@ module.exports = function RemoteActions (kuzzle) {
         kuzzle.services.list.broker.listen(request.requestId, onListenCB);
         kuzzle.services.list.broker.send(kuzzle.config.queues.remoteActionsQueue, request);
 
-        action.initTimeout();
         return action.deferred.promise;
       })
       .catch(error => {
         error.message = `Failed to execute CLI action: ${error.message}`;
-        console.error(error);
+
         if (params && params.debug) {
           console.log(error.stack);
         }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.0.0-RC6",
+  "version": "1.0.0-RC6.1",
   "apiVersion": "1.0",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",

--- a/test/api/remoteActions/action.test.js
+++ b/test/api/remoteActions/action.test.js
@@ -167,7 +167,7 @@ describe('Tests: remoteActionController action client', () => {
         action.timeOutCB();
 
         should(consoleSpy).be.calledOnce();
-        should(consoleSpy).be.calledWithExactly('could not contact Kuzzle in time. Aborting.');
+        should(consoleSpy).be.calledWithExactly('Unable to connect to Kuzzle');
         should(processSpy).be.calledOnce();
         should(processSpy).be.calledWithExactly(1);
       });


### PR DESCRIPTION
* fix the `adminExist`result retrieval
* add a `silent` option to `pluginsManager.init`
* better `kuzzle createFirstAdmin` messages
* fix Kuzzle connection failure detection by starting the timeout before initializing the internal broker