### PR TITLE
Fix #412 Catch plugin loading errors

### DIFF
--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -448,10 +448,16 @@ function getPluginsList(kuzzle) {
  */
 function loadPlugins(plugins) {
   _.forEach(plugins, (plugin, name) => {
-    if (!plugin.path) {
-      plugin.object = new (require(name))();
-    } else {
-      plugin.object = new (require(plugin.path))();
+    try {
+      if (!plugin.path) {
+        plugin.object = new (require(name))();
+      } else {
+        plugin.object = new (require(plugin.path))();
+      }
+    }
+    catch(e) {
+      console.error(`ERROR: Unable to load plugin ${name}: ${e}`);
+      delete plugins[name];
     }
   });
 }

--- a/test/api/core/pluginsManager/init.test.js
+++ b/test/api/core/pluginsManager/init.test.js
@@ -2,25 +2,41 @@ var
   should = require('should'),
   rewire = require('rewire'),
   Promise = require('bluebird'),
+  sinon = require('sinon'),
   Kuzzle = require.main.require('lib/api/kuzzle'),
   PluginsManager = rewire('../../../../lib/api/core/plugins/pluginsManager');
 
-describe('PluginsManager: init()', () => {
+describe.only('PluginsManager: init()', () => {
   var
     kuzzle,
-    loadPluginsCalled,
     pluginsManager;
 
   before(() => {
     kuzzle = new Kuzzle();
     pluginsManager = new PluginsManager(kuzzle);
-    PluginsManager.__set__('loadPlugins', () => {
-      loadPluginsCalled = true;
-    });
   });
 
   it('should load plugins at init', () => {
-    loadPluginsCalled = false;
+    var loadPluginsStub = sinon.stub();
+
+    return PluginsManager.__with__({
+      getPluginsList: () => {
+        return Promise.resolve({
+          plugin1: {foo: 'bar'},
+          plugin2: {foo: 'baz'}
+        });
+      },
+      loadPlugins: loadPluginsStub
+    })(() => {
+      return pluginsManager.init()
+        .then(() => {
+          should(loadPluginsStub.called).be.true();
+          should(pluginsManager.plugins).match({ plugin1: { foo: 'bar' }, plugin2: { foo: 'baz' } });
+        });
+    });
+  });
+
+  it('should discard a plugin if it fails to load', () => {
     return PluginsManager.__with__({
       getPluginsList: () => {
         return Promise.resolve({
@@ -31,8 +47,7 @@ describe('PluginsManager: init()', () => {
     })(() => {
       return pluginsManager.init()
         .then(() => {
-          should(loadPluginsCalled).be.true();
-          should(pluginsManager.plugins).match({ plugin1: { foo: 'bar' }, plugin2: { foo: 'baz' } });
+          should(pluginsManager.plugins).match({});
         });
     });
   });

--- a/test/api/core/pluginsManager/init.test.js
+++ b/test/api/core/pluginsManager/init.test.js
@@ -6,7 +6,7 @@ var
   Kuzzle = require.main.require('lib/api/kuzzle'),
   PluginsManager = rewire('../../../../lib/api/core/plugins/pluginsManager');
 
-describe.only('PluginsManager: init()', () => {
+describe('PluginsManager: init()', () => {
   var
     kuzzle,
     pluginsManager;


### PR DESCRIPTION
Fixes #412 by adding a `try...catch` statement when requiring plugins dynamically. If a plugin fails to load, an error is printed on the console and the plugin is removed from the plugins list.