### PR TITLE
Kuz 698 auto http port

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -171,7 +171,10 @@
   // Configuration for Kuzzle server
   /*
   "server": {
-    // * http port: port on which Kuzzle will expose its REST api
+    // * http port: port on which Kuzzle will expose its REST api.
+    //   If unset or set to a falsy value (default), Kuzzle will use a random
+    //   available port within the *ephemeral port range* defined by
+    //   /proc/sys/net/ipv4/ip_local_port_range.
     // * http maxRequestSize: the size limit of a request. If it's a string, the
          value is passed to the "bytes" library (https://www.npmjs.com/package/bytes).
          If this is a number, then the value specifies the number of bytes.
@@ -182,7 +185,7 @@
     // * warningRetainedRequestsLimit: Number of bufferized requests after
     //   which Kuzzle will throw warnings to the logger
     "http": {
-      "port": 7511,
+      "port": false,
       "maxRequestSize": "1MB"
     },
     "maxConcurrentRequests": 50,

--- a/coverage/scripts/feature-coverage-download.js
+++ b/coverage/scripts/feature-coverage-download.js
@@ -1,8 +1,7 @@
 var
-  config = require('../../features/support/config')(),
+  config = require('../../features/support/config'),
   exec = require('child_process').exec;
   coverageDestination = 'coverage/features';
 
-var cmd = 'wget -m -k -nH -E -P ' + coverageDestination + ' --cut-dirs=1 ' + config.url + '/coverage';
-
+var cmd = `wget -m -k -nH -E -P ${coverageDestination} --cut-dirs=1 ${config.scheme}://${config.host}:${config.ports.rest}/coverage`;
 exec(cmd, function(error, stdout, stderr) {});

--- a/default.config.js
+++ b/default.config.js
@@ -111,7 +111,6 @@ module.exports = {
 
   server: {
     http: {
-      port: 7511,
       maxRequestSize: '1MB'
     },
     maxConcurrentRequests: 50,
@@ -147,7 +146,7 @@ module.exports = {
       retryInterval: 1000
     },
     proxyBroker: {
-      host: 'api',
+      host: 'localhost',
       port: 7331,
       retryInterval: 1000
     },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,22 @@
 proxy:
   image: kuzzleio/proxy:alpine
   ports:
-    - "7511:7511"
-    - "7512:7512"
-    - "7513:7513"
+    - "7511-7513:7511-7513"
 
 kuzzle:
   image: kuzzleio/kuzzle:1.0.0-RC6.2
   links:
     - elasticsearch
     - redis
-    - proxy:api
+    - proxy
 
 redis:
-  image: redis:3.0-alpine
+  image: redis:3.2-alpine
 
 elasticsearch:
   image: kuzzleio/elasticsearch:2.3.4
   environment:
     - kuzzle_services__db__host=elasticsearch
     - kuzzle_services__cache__node__host=redis
+    - kuzzle_services__proxyBroker__host=proxy
 

--- a/docker-compose/debug.yml
+++ b/docker-compose/debug.yml
@@ -1,9 +1,7 @@
 proxy:
   image: kuzzleio/proxy:alpine
   ports:
-    - "7511:7511"
-    - "7512:7512"
-    - "7513:7513"
+    - "7511-7513:7511-7513"
     - "8083:8080"
 
 kuzzle:
@@ -18,16 +16,17 @@ kuzzle:
   links:
     - elasticsearch
     - redis
-    - proxy:api
+    - proxy
   environment:
     - FEATURE_COVERAGE
     - kuzzle_services__db__host=elasticsearch
     - kuzzle_services__internalCache__node__host=redis
     - kuzzle_services__memoryStorage__node__host=redis
+    - kuzzle_services__proxyBroker__host=proxy
 
 
 redis:
-  image: redis:3.0-alpine
+  image: redis:3.2-alpine
 
 elasticsearch:
   image: kuzzleio/elasticsearch:2.3.4

--- a/docker-compose/debug.yml
+++ b/docker-compose/debug.yml
@@ -18,7 +18,7 @@ kuzzle:
     - redis
     - proxy
   environment:
-    - FEATURE_COVERAGE
+    - FEATURE_COVERAGE=1
     - kuzzle_services__db__host=elasticsearch
     - kuzzle_services__internalCache__node__host=redis
     - kuzzle_services__memoryStorage__node__host=redis

--- a/docker-compose/test-travis.yml
+++ b/docker-compose/test-travis.yml
@@ -1,9 +1,7 @@
 proxy:
   image: kuzzleio/proxy:alpine
   ports:
-    - "7511:7511"
-    - "7512:7512"
-    - "7513:7513"
+    - "7511-7513:7511-7513"
 
 kuzzle:
   image: kuzzleio/test:alpine
@@ -15,7 +13,7 @@ kuzzle:
   links:
     - elasticsearch
     - redis
-    - proxy:api
+    - proxy
   environment:
     - FEATURE_COVERAGE=1
     # Travis env var must be propagated into the container
@@ -29,9 +27,10 @@ kuzzle:
     - kuzzle_services__db__host=elasticsearch
     - kuzzle_services__internalCache__node__host=redis
     - kuzzle_services__memoryStorage__node__host=redis
+    - kuzzle_services__proxyBroker__host=proxy
 
 redis:
-  image: redis:3.0-alpine
+  image: redis:3.2-alpine
 
 elasticsearch:
   image: kuzzleio/elasticsearch:2.3.4

--- a/docker-compose/test.yml
+++ b/docker-compose/test.yml
@@ -1,9 +1,7 @@
 proxy:
   image: kuzzleio/proxy:alpine
   ports:
-    - "7511:7511"
-    - "7512:7512"
-    - "7513:7513"
+    - "7511-7513:7511-7513"
 
 kuzzle:
   image: kuzzleio/test:alpine
@@ -15,15 +13,16 @@ kuzzle:
   links:
     - elasticsearch
     - redis
-    - proxy:api
+    - proxy
   environment:
     - FEATURE_COVERAGE=1
     - kuzzle_services__db__host=elasticsearch
     - kuzzle_services__internalCache__node__host=redis
     - kuzzle_services__memoryStorage__node__host=redis
+    - kuzzle_services__proxyBroker__host=proxy
 
 redis:
-  image: redis:3.0-alpine
+  image: redis:3.2-alpine
 
 elasticsearch:
   image: kuzzleio/elasticsearch:2.3.4

--- a/features/support/apiREST.js
+++ b/features/support/apiREST.js
@@ -1,6 +1,6 @@
 var
   _ = require('lodash'),
-  config = require('./config')(),
+  config = require('./config'),
   rp = require('request-promise'),
   rewire = require('rewire'),
   RouterController = rewire('../../lib/api/controllers/routerController.js'),
@@ -8,13 +8,14 @@ var
 
 var ApiREST = function () {
   this.world = null;
+
+  this.baseUri = `${config.scheme}://${config.host}:${config.ports.rest}`;
 };
 
 ApiREST.prototype.init = function (world) {
   if (routes === undefined) {
     initRoutes.call(this);
   }
-
 
   this.world = world;
 };
@@ -130,11 +131,11 @@ ApiREST.prototype.getRequest = function (index, collection, controller, action, 
 ApiREST.prototype.disconnect = function () {};
 
 ApiREST.prototype.apiPath = function (path) {
-  return encodeURI(config.url + '/api/1.0/' + path);
+  return encodeURI(this.baseUri + '/api/1.0/' + path);
 };
 
 ApiREST.prototype.apiBasePath = function (path) {
-  return encodeURI(config.url + '/api/' + path);
+  return encodeURI(this.baseUri + '/api/' + path);
 };
 
 ApiREST.prototype.callApi = function (options) {

--- a/features/support/apiWebsocket.js
+++ b/features/support/apiWebsocket.js
@@ -1,6 +1,6 @@
 var
   _ = require('lodash'),
-  config = require('./config')(),
+  config = require('./config'),
   Promise = require('bluebird'),
   uuid = require('node-uuid'),
   io = require('socket.io-client'),
@@ -14,7 +14,9 @@ var initSocket = function (socketName) {
   }
 
   if (!this.listSockets[socketName]) {
-    socket = io(config.ws, { 'force new connection': true });
+    socket = io(`${config.scheme}://${config.host}:${config.ports.io}`, {
+      'force new connection': true
+    });
     this.listSockets[socketName] = socket;
 
     // the default socket is the socket with name 'client1'

--- a/features/support/config.js
+++ b/features/support/config.js
@@ -1,31 +1,13 @@
-/**
- * This file allow to retrieve configuration easily.
- * You can change these url in .kuzzlerc file in root folder or you can define environment variable like KUZZLE_URL, KUZZLE_MQTT_URL, KUZZLE_AMQP_URL, KUZZLE_STOMP_URL
- */
+var
+  rc = require('rc'),
+  kuzzleConfig = require('../../lib/config');
 
-/** @type {Params} */
-var config = require('../../lib/config');
-
-/**
- * @returns {{url: string, ws: string}}
- */
-module.exports = function () {
-
-  var defaultUrls = {
-    url: 'http://api:7511',
-    ws: 'http://api:7512'
-  };
-
-  if (process.env.KUZZLE_URL) {
-    defaultUrls.url = process.env.KUZZLE_URL;
+module.exports = rc('kuzzle', {
+  scheme: 'http',
+  host: kuzzleConfig.services.proxyBroker.host,
+  ports: {
+    rest: 7511,
+    io: 7512,
+    ws: 7513
   }
-  if (process.env.KUZZLE_WS_URL) {
-    defaultUrls.url = process.env.KUZZLE_WS_URL;
-  }
-
-  if (config.port) {
-    defaultUrls.url = 'http://api:' + config.port;
-  }
-
-  return defaultUrls;
-};
+});

--- a/lib/api/core/entryPoints/http.js
+++ b/lib/api/core/entryPoints/http.js
@@ -1,5 +1,7 @@
 var
-  http = require('http');
+  freeport = require('freeport'),
+  http = require('http'),
+  Promise = require('bluebird');
 
 /**
  * Run a HTTP server and will use the router object to handle incoming requests
@@ -12,7 +14,6 @@ function HttpServer (kuzzle) {
 
 HttpServer.prototype.init = function () {
   var
-    port = this.kuzzle.config.server.http.port,
     server;
 
   this.kuzzle.router.initHttpRouter();
@@ -20,11 +21,24 @@ HttpServer.prototype.init = function () {
   server = http.createServer((request, response) => {
     this.kuzzle.router.routeHttp(request, response);
   });
-  server.listen(port);
 
-  this.kuzzle.pluginsManager.trigger('server:httpStarted', 'Starting: HTTP server on port ' + port);
+  return new Promise(resolve => {
+    if (this.kuzzle.config.server.http.port) {
+      server.listen(this.kuzzle.config.server.http.port);
+      return resolve();
+    }
 
-  return server;
+    return Promise.promisify(freeport)()
+      .then(port => {
+        this.kuzzle.config.server.http.port = port;
+        server.listen(port);
+        resolve();
+      });
+  })
+    .then(() => {
+      this.kuzzle.pluginsManager.trigger('server:httpStarted',
+        `Starting: HTTP server on port ${this.kuzzle.config.server.http.port}`);
+    });
 };
 
 module.exports = HttpServer;

--- a/lib/api/core/entryPoints/index.js
+++ b/lib/api/core/entryPoints/index.js
@@ -13,8 +13,10 @@ function EntryPoints (kuzzle) {
 }
 
 EntryPoints.prototype.init = function () {
-  this.proxy.init();
-  this.http.init();
+  return this.http.init()
+    .then(() => {
+      this.proxy.init();
+    });
 };
 
 module.exports = EntryPoints;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "elasticsearch": "11.0.1",
     "eventemitter2": "^2.1.0",
     "finalhandler": "0.5.0",
+    "freeport": "^1.0.5",
     "geolib": "j33f/Geolib",
     "ioredis": "^2.2.0",
     "json-stable-stringify": "1.0.1",

--- a/test/api/core/entryPoints/http.test.js
+++ b/test/api/core/entryPoints/http.test.js
@@ -33,18 +33,40 @@ describe('Test: entryPoints/http', () => {
       stubListen = sinon.spy(),
       spyCreateServer = sinon.stub().yields().returns({listen: stubListen});
 
-    HttpServer.__with__({
+    return HttpServer.__with__({
       http: {
         createServer: spyCreateServer
       }
     })(() => {
-      httpServer.init();
-
-      should(kuzzle.router.initHttpRouter).be.calledOnce();
-      should(spyCreateServer).be.calledOnce();
-      should(kuzzle.router.routeHttp).be.calledOnce();
-      should(stubListen).be.calledOnce();
-      should(stubListen).be.calledWithExactly(kuzzle.config.server.http.port);
+      return httpServer.init()
+        .then(() => {
+          should(kuzzle.router.initHttpRouter).be.calledOnce();
+          should(spyCreateServer).be.calledOnce();
+          should(kuzzle.router.routeHttp).be.calledOnce();
+          should(stubListen).be.calledOnce();
+          should(stubListen).be.calledWithExactly(kuzzle.config.server.http.port);
+        });
     });
   });
+
+  it('should use the port defined in the configuration if any', () => {
+    var
+      stubListen = sinon.spy(),
+      spyCreateServer = sinon.stub().yields().returns({listen: stubListen});
+
+    kuzzle.config.server.http.port = 999;
+
+    return HttpServer.__with__({
+      http: {
+        createServer: spyCreateServer
+      }
+    })(() => {
+      return httpServer.init()
+        .then(() => {
+          should(stubListen).calledOnce();
+          should(stubListen).calledWithExactly(999);
+        });
+    });
+  });
+
 });

--- a/test/api/core/entryPoints/index.test.js
+++ b/test/api/core/entryPoints/index.test.js
@@ -32,12 +32,14 @@ describe('Test: core/entryPoints', () => {
       kuzzle = new Kuzzle(),
       entryPoints = new EntryPoints(kuzzle, {httpPort: httpPort}),
       spyProxy = sandbox.stub(entryPoints.proxy, 'init'),
-      spyHttp = sandbox.stub(entryPoints.http, 'init');
+      spyHttp = sandbox.stub(entryPoints.http, 'init').resolves();
 
 
-    entryPoints.init();
+    return entryPoints.init()
+      .then(() => {
+        should(spyProxy.callCount).be.eql(1);
+        should(spyHttp.callCount).be.eql(1);
+      });
 
-    should(spyProxy.callCount).be.eql(1);
-    should(spyHttp.callCount).be.eql(1);
   });
 });


### PR DESCRIPTION
Kuzzle http port is configured by default to use 7511. This is the same port which is used by the proxy for its REST interface.
On a single host installation, this creates a port conflict.

As Kuzzle declares its http server port to the proxy, we can let it pick one random. This also ease the process of running several Kuzzle instances on a single host.