### PR TITLE
Install plugin if no version is found in DB

### DIFF
--- a/bin/commands/reset.js
+++ b/bin/commands/reset.js
@@ -15,12 +15,14 @@ function commandReset (options) {
     notice = string => options.parent.noColors ? string : clc.cyanBright(string),
     ok = string => options.parent.noColors ? string: clc.green.bold(string),
     userIsSure = false,
-    kuzzle = new Kuzzle();
+    kuzzle = new Kuzzle(),
+    fixturesContent,
+    mappingsContent;
 
   // check, if files are provided, if they exists
   if (params.fixtures) {
     try {
-      JSON.parse(fs.readFileSync(params.fixtures, 'utf8'));
+      fixturesContent = JSON.parse(fs.readFileSync(params.fixtures, 'utf8'));
     }
     catch (e) {
       console.log(error('[✖] The file ' + params.fixtures + ' cannot be opened... aborting.'));
@@ -30,7 +32,7 @@ function commandReset (options) {
 
   if (params.mappings) {
     try {
-      JSON.parse(fs.readFileSync(params.mappings, 'utf8'));
+      mappingsContent = JSON.parse(fs.readFileSync(params.mappings, 'utf8'));
     }
     catch (e) {
       console.log(error('[✖] The file ' + params.mappings + ' cannot be opened... aborting.'));
@@ -51,10 +53,12 @@ function commandReset (options) {
   if (userIsSure) {
     console.log(notice('[ℹ] Processing...\n'));
     return kuzzle.remoteActions.do('cleanDb', {}, {debug: options.parent.debug})
-      .then(() => kuzzle.remoteActions.do('data', {
-        fixtures: params.fixtures,
-        mappings: params.mappings
-      }, {debug: options.parent.debug}))
+      .then(() => {
+        return kuzzle.remoteActions.do('data', {
+          fixtures: fixturesContent,
+          mappings: mappingsContent
+        }, {debug: options.parent.debug});
+      })
       .then(() => {
         console.log(ok('[✔] Kuzzle is now like a virgin, touched for the very first time!'));
         process.exit(0);
@@ -65,7 +69,7 @@ function commandReset (options) {
       });
   }
 
-  console.log(notice('[ℹ] Nothing have been done... you do not look that sure...'));
+  console.log(notice('[ℹ] Nothing done: you do not look that sure...'));
 }
 
 module.exports = commandReset;

--- a/lib/api/controllers/remoteActions/data.js
+++ b/lib/api/controllers/remoteActions/data.js
@@ -12,23 +12,27 @@ function data (request) {
   var promises = [];
 
   if (request.data.body.fixtures) {
-    promises.push(_kuzzle.services.list.storageEngine.import(new RequestObject({
-      index: request.index,
-      collection: request.collection,
-      body: {
-        bulkData: request.data.body.fixtures
-      }
-    }))
-      .then(response => {
-        if (response.partialErrors
-          && response.partialErrors.length > 0
-        ) {
-          throw new Error(JSON.stringify(response.data.body));
-        }
+    Object.keys(request.data.body.fixtures).forEach((index => {
+      Object.keys(request.data.body.fixtures[index]).forEach((collection) => {
+        promises.push(_kuzzle.services.list.storageEngine.import(new RequestObject({
+          index: index,
+          collection: collection,
+          body: {
+            bulkData: request.data.body.fixtures[index][collection]
+          }
+        }))
+          .then(response => {
+            if (response.partialErrors
+              && response.partialErrors.length > 0
+            ) {
+              throw new Error(JSON.stringify(response.data.body));
+            }
 
-        return response.data.body;
-      })
-    );
+            return response.items;
+          })
+        );
+      });
+    }));
   }
 
   if (request.data.body.mappings) {

--- a/lib/api/core/plugins/packages/pluginPackage.js
+++ b/lib/api/core/plugins/packages/pluginPackage.js
@@ -169,7 +169,15 @@ PluginPackage.prototype.needsToBeDeleted = function pluginPackageNeedsToBeDelete
 
 PluginPackage.prototype.localVersion = function pluginPackageLocalVersion () {
   var
+    pkgjson;
+
+  try {
     pkgjson = require(`${this.kuzzle.rootPath}/node_modules/${this.name}/package.json`);
+  } catch (e) {
+    throw new Error('Wooops! Something went wrong while trying to read the '
+    + 'plugin version from local package. This may be due to a malformed '
+    + 'npm installation.', e.message);
+  }
 
   return pkgjson.version;
 };
@@ -196,7 +204,7 @@ PluginPackage.prototype.install = function pluginPackageInstall () {
 
   return Promise.promisify(exec)(`npm install ${pkg}`)
     .then(stdout => {
-      var regex = /^(\w+)@([0-9.]+) node_modules\/\w+$/;
+      var regex = /^([a-zA-Z0-9_\-]+)@([0-9.]+) node_modules\/[a-zA-Z0-9_\-]+$/;
 
       /*
          when using another installation method than npm repository,
@@ -237,7 +245,13 @@ PluginPackage.prototype.install = function pluginPackageInstall () {
           return false;
         });
     })
-    .then(() => {
+    .then((detectedVersionFromStdout) => {
+      if (!detectedVersionFromStdout) {
+        this.version = this.localVersion();
+      }
+      if (!this.version) {
+        throw new Error('An error occurred while detecting the installed version.');
+      }
       this.config = this.localConfiguration();
       return this.updateDbConfiguration(this.config);
     })

--- a/lib/api/core/plugins/packages/pluginPackage.js
+++ b/lib/api/core/plugins/packages/pluginPackage.js
@@ -214,7 +214,7 @@ PluginPackage.prototype.install = function pluginPackageInstall () {
          The only way for the time being is to parse the npm install
          response to get it.
       */
-      stdout.split(/\r?\n/)
+      return stdout.split(/\r?\n/)
         .reverse()
         .some(line => {
           var

--- a/lib/api/core/plugins/packages/pluginPackage.js
+++ b/lib/api/core/plugins/packages/pluginPackage.js
@@ -137,6 +137,9 @@ PluginPackage.prototype.needsInstall = function pluginPackageNeedsInstall () {
       if (config.deleted) {
         return false;
       }
+      if (!config.version) {
+        return true;
+      }
       return compareVersions(config.version, this.localVersion()) > 0;
     })
     .catch(error => {

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -70,9 +70,13 @@ describe('Test the auth controller', () => {
         sandbox.stub(kuzzle.repositories.token, 'generateToken', (user, gtcontext, opts) => {
           var
             token = new Token(),
-            expiresIn = ms(opts.expiresIn),
+            expiresIn,
             encodedToken = jwt.sign({_id: user._id}, kuzzle.config.security.jwt.secret, opts);
 
+          if (!opts.expiresIn) {
+            opts.expiresIn = 0;
+          }
+          expiresIn = ms(opts.expiresIn);
           _.assignIn(token, {
             _id: encodedToken,
             userId: user._id,

--- a/test/api/controllers/remoteActionsController/data.test.js
+++ b/test/api/controllers/remoteActionsController/data.test.js
@@ -10,6 +10,13 @@ var
 describe('Test: data handler', () => {
   var
     data,
+    fixtures = {
+      'index': {
+        'collection': [
+          {'action': {'param': 'value'}}
+        ]
+      }
+    },
     kuzzle;
 
   beforeEach(() => {
@@ -26,10 +33,10 @@ describe('Test: data handler', () => {
       req = new RequestObject({
         index: 'index',
         collection: 'collection',
-        body: {fixtures: 'fixtures'}
+        body: {fixtures: fixtures}
       });
 
-    kuzzle.services.list.storageEngine.import.resolves({data: {body: 'response'}});
+    kuzzle.services.list.storageEngine.import.resolves({items: 'response'});
 
     return data(req)
       .then(response => {
@@ -39,7 +46,7 @@ describe('Test: data handler', () => {
         should(kuzzle.services.list.storageEngine.import).be.calledOnce();
         should(importArg.index).be.exactly('index');
         should(importArg.collection).be.exactly('collection');
-        should(importArg.data.body).be.eql({bulkData: 'fixtures'});
+        should(importArg.data.body).be.eql({bulkData: fixtures.index.collection});
       });
   });
 
@@ -109,7 +116,7 @@ describe('Test: data handler', () => {
       index: 'index',
       collection: 'collection',
       body: {
-        fixtures: 'fixtures',
+        fixtures: fixtures,
         mappings: {
           index: { collection: 'mapping' }
         }

--- a/test/api/core/pluginsManager/packages/pluginPackage.test.js
+++ b/test/api/core/pluginsManager/packages/pluginPackage.test.js
@@ -237,6 +237,16 @@ describe('plugins/packages/pluginPackage', () => {
         });
     });
 
+    it('should return true if no version is found in the configuration from db', () => {
+      pkg.isInstalled = sinon.stub().returns(true);
+      pkg.dbConfiguration = sinon.stub().resolves({});
+
+      return pkg.needsInstall()
+        .then(result => {
+          should(result).be.true();
+        });
+    });
+
     it('should reject the promise if some unexpected error occurred', () => {
       pkg.isInstalled = sinon.stub().returns(true);
       pkg.dbConfiguration = sinon.stub().rejects(new Error('unexpected'));

--- a/test/api/core/pluginsManager/packages/pluginPackage.test.js
+++ b/test/api/core/pluginsManager/packages/pluginPackage.test.js
@@ -351,7 +351,7 @@ describe('plugins/packages/pluginPackage', () => {
       reset;
 
     beforeEach(() => {
-      pkg.localVersion = sinon.stub().returns('version');
+      pkg.localVersion = sinon.stub().returns('local version');
       pkg.localConfiguration = sinon.stub().returns('local configuration');
       pkg.updateDbConfiguration = sinon.stub().resolves();
 


### PR DESCRIPTION
Fixes #501 

- Fixes the version detection upon `npm install` stdout
- If no version is found in the definition fetched from the DB, it reinstalls the plugin. :warning: **Wondering if this is a good idea, feedback needed, plz** :warning: 
- If it fails detecting the version from `npm install` stout, it falls back to the version of the locally installed package. :warning: **Wondering if this is a good idea, feedback needed, plz** :warning: 