### PR TITLE
[Hotfix] [Master] allow plugins routes to be used by the router

### DIFF
--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -137,8 +137,8 @@ function RouterController (kuzzle) {
 
     // create and mount a new router for our API
     this.router.use('/api', apiBase);
-    this.router.use('/api/' + kuzzle.config.apiVersion, api);
     this.router.use('/api/' + kuzzle.config.apiVersion + '/_plugin', apiPlugin);
+    this.router.use('/api/' + kuzzle.config.apiVersion, api);
 
     /**
      * @this {RouterController}


### PR DESCRIPTION
Plugins routes were not usable since the router have a route of type /:index/:collection/:id which is evaluated before all the /_plugin prefixed routes