### PR TITLE
Repair plugin routes loader

### DIFF
--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -137,8 +137,8 @@ function RouterController (kuzzle) {
 
     // create and mount a new router for our API
     this.router.use('/api', apiBase);
-    this.router.use('/api/' + kuzzle.config.apiVersion + '/_plugin', apiPlugin);
     this.router.use('/api/' + kuzzle.config.apiVersion, api);
+    this.router.use('/api/' + kuzzle.config.apiVersion + '/_plugin', apiPlugin);
 
     /**
      * @this {RouterController}

--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -137,8 +137,8 @@ function RouterController (kuzzle) {
 
     // create and mount a new router for our API
     this.router.use('/api', apiBase);
-    this.router.use('/api/' + kuzzle.config.apiVersion, api);
     this.router.use('/api/' + kuzzle.config.apiVersion + '/_plugin', apiPlugin);
+    this.router.use('/api/' + kuzzle.config.apiVersion, api);
 
     /**
      * @this {RouterController}


### PR DESCRIPTION
Hi,

just spotted a bug while loading routes with GET verb. It was leading to an error instead of searching in plugins routes...

This repaired on my instance, and I don't expect any border effect ?

Regards