### PR TITLE
store canonical filters to allow cluster sync

### DIFF
--- a/lib/api/dsl/storage/index.js
+++ b/lib/api/dsl/storage/index.js
@@ -285,7 +285,7 @@ function addFilter(filtersObj, index, collection, filters) {
     created = !filtersObj[id];
 
   if (created) {
-    filtersObj[id] = new Filter(id, index, collection);
+    filtersObj[id] = new Filter(id, index, collection, filters);
   }
 
   return {created, id};

--- a/lib/api/dsl/storage/objects/filter.js
+++ b/lib/api/dsl/storage/objects/filter.js
@@ -12,18 +12,21 @@
  * @property {string} id
  * @property {string} index
  * @property {string} collection
+ * @property {Array<Array<Object>>} canonical - filters in its canonical form
  * @property {Array<Subfilter>} subfilters
  * @property {Number} fidx - maps to the filters test table
  *
  * @param {string} id - filter unique id
  * @param {string} index
  * @param {string} collection
+ * @param {Array<Array<Object>>} filters
  * @constructor
  */
-function Filter(id, index, collection) {
+function Filter(id, index, collection, filters) {
   this.id = id;
   this.index = index;
   this.collection = collection;
+  this.filters = filters;
   this.subfilters = [];
   this.fidx = -1;
 

--- a/lib/api/dsl/storage/objects/filter.js
+++ b/lib/api/dsl/storage/objects/filter.js
@@ -12,7 +12,7 @@
  * @property {string} id
  * @property {string} index
  * @property {string} collection
- * @property {Array<Array<Object>>} canonical - filters in its canonical form
+ * @property {Array<Array<Object>>} filters in their canonical form
  * @property {Array<Subfilter>} subfilters
  * @property {Number} fidx - maps to the filters test table
  *


### PR DESCRIPTION
When a node joins a Kuzzle cluster, it requests the master node for a full snapshot in order to synchronize itself.

This PR allows the realtime engine to store filters in their canonical form, allowing the master node to provide the new node with it.