### PR TITLE
embeds notfound errors from the internal storage service

### DIFF
--- a/lib/services/internalEngine/index.js
+++ b/lib/services/internalEngine/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*
   This is a light database service used by Kuzzle's core components, namely
   the plugins manager and the repositories.
@@ -394,10 +392,7 @@ function handleError(error) {
   }
 
   if (error.status === 404) {
-    let kuzzleError = new NotFoundError(error);
-
-    kuzzleError.message = `Not found: ${error.body._type}/${error.body._id}`;
-    return Promise.reject(kuzzleError);
+    return Promise.reject(new NotFoundError(`Not found: ${error.body._type}/${error.body._id}`));
   }
 
   return Promise.reject(new InternalError(error));

--- a/lib/services/internalEngine/index.js
+++ b/lib/services/internalEngine/index.js
@@ -23,9 +23,10 @@
 var
   _ = require('lodash'),
   Promise = require('bluebird'),
-  NotFoundError = require('kuzzle-common-objects').Errors.notFoundError,
   Elasticsearch = require('elasticsearch'),
   KuzzleError = require('kuzzle-common-objects').Errors.kuzzleError,
+  NotFoundError = require('kuzzle-common-objects').Errors.notFoundError,
+  InternalError = require('kuzzle-common-objects').Errors.internalError,
   ServiceUnavailableError = require('kuzzle-common-objects').Errors.serviceUnavailableError,
   InternalEngineBootstrap = require('./bootstrap');
 
@@ -386,11 +387,15 @@ function handleError(error) {
     return Promise.reject(new ServiceUnavailableError('Elasticsearch service is not connected'));
   }
 
-  if (error instanceof Error || error instanceof KuzzleError) {
+  if (error instanceof KuzzleError) {
     return Promise.reject(error);
   }
 
-  return Promise.reject(new Error(error));
+  if (error.status === 404) {
+    return Promise.reject(new NotFoundError(error));
+  }
+
+  return Promise.reject(new InternalError(error));
 }
 
 module.exports = InternalEngine;

--- a/lib/services/internalEngine/index.js
+++ b/lib/services/internalEngine/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /*
   This is a light database service used by Kuzzle's core components, namely
   the plugins manager and the repositories.
@@ -392,7 +394,10 @@ function handleError(error) {
   }
 
   if (error.status === 404) {
-    return Promise.reject(new NotFoundError(error));
+    let kuzzleError = new NotFoundError(error);
+
+    kuzzleError.message = `Not found: ${error.body._type}/${error.body._id}`;
+    return Promise.reject(kuzzleError);
   }
 
   return Promise.reject(new InternalError(error));


### PR DESCRIPTION
Makes the internal engine service embeds `NotFound` errors from Elasticsearch into a proper kuzzle `NotFoundError`.

This allows better logged messages.

Example, with the [updated logger plugin](https://github.com/kuzzleio/kuzzle-plugin-logger/pull/12), when attempting to delete an unexisting user:

**before**

`2016-12-02T13:16:47+00:00 ERROR [LOG:ERROR] (404) Not Found -`

**after**

```
2016-12-02T13:19:35+00:00 ERROR [LOG:ERROR] (404) Not found: users/foobar
NotFoundError: Not found: users/foobar
    at NotFoundError.KuzzleError (/var/app/node_modules/kuzzle-common-objects/errors/kuzzleError.js:12:19)
    at new NotFoundError (/var/app/node_modules/kuzzle-common-objects/errors/notFoundError.js:6:15)
    at handleError (/var/app/lib/services/internalEngine/index.js:397:23)
    at /var/app/lib/services/internalEngine/index.js:284:23
    at tryCallOne (/var/app/node_modules/elasticsearch/node_modules/promise/lib/core.js:37:12)
    at /var/app/node_modules/elasticsearch/node_modules/promise/lib/core.js:123:15
    at flush (/var/app/node_modules/elasticsearch/node_modules/promise/node_modules/asap/raw.js:50:29)
    at nextTickCallbackWith0Args (node.js:420:9)
    at process._tickDomainCallback (node.js:390:13) -
```

