### PR TITLE
Refactor: controller plugins definition

### DIFF
--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -403,7 +403,7 @@ function initControllers (controllers, routes, plugin, pluginName) {
           return false;
         }
 
-        if (typeof route[key] !== 'string' || route[key].length === 0) {
+        if (typeof route[key] !== 'string' || (route[key].length === 0 && key !== 'url')) {
           // eslint-disable-next-line no-console
           console.error(`[Plugin Manager] Error initializing route ${route.url}: ${key} must be a non-empty string`);
           return false;

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -199,7 +199,7 @@ function PluginsManager (kuzzle) {
    */
   this.injectControllers = function pluginInjectControllers () {
     _.forEach(this.controllers, (controller, name) => {
-      kuzzle.funnel.controllers[name] = controller();
+      kuzzle.funnel.controllers[name] = controller;
     });
   };
 }
@@ -358,17 +358,83 @@ function initHooks (plugin, kuzzle) {
 }
 
 function initControllers (controllers, routes, plugin, pluginName) {
-  _.forEach(plugin.object.controllers, (controller, controllerName) => {
-    if (plugin.object[controller]) {
-      controllers[pluginName + '/' + controllerName] = plugin.object[controller].bind(plugin.object);
+  var controllerImported = Object.keys(plugin.object.controllers).every(controller => {
+    var description = plugin.object.controllers[controller];
+
+    if (typeof description !== 'object' || description === null || Array.isArray(description)) {
+      // eslint-disable-next-line no-console
+      console.error(`[Plugin Manager] Error loading plugin ${pluginName}: incorrect controller description type (expected object): \n${description}`);
+      return false;
     }
+
+    return Object.keys(description).every(action => {
+      if (typeof description[action] !== 'string' || description[action].length === 0) {
+        // eslint-disable-next-line no-console
+        console.error(`[Plugin Manager] Error loading ${pluginName}: invalid action description (expected non-empty string): ${action}`);
+        return false;
+      }
+
+      if (!plugin.object[description[action]] || typeof plugin.object[description[action]] !== 'function') {
+        // eslint-disable-next-line no-console
+        console.error(`[Plugin Manager] Error loading ${pluginName}: action ${pluginName}.${description[action]} is not a function`);
+        return false;
+      }
+
+      if (!controllers[`${pluginName}/${controller}`]) {
+        controllers[`${pluginName}/${controller}`] = {};
+      }
+
+      controllers[`${pluginName}/${controller}`][action] = plugin.object[description[action]];
+      return true;
+    });
   });
 
-  if (plugin.object.routes) {
+  if (!controllerImported) {
+    Object.keys(plugin.object.controllers).forEach(controller => {
+      delete controllers[`${pluginName}/${controller}`];
+    });
+  }
+  else if (plugin.object.routes) {
     plugin.object.routes.forEach(route => {
-      route.url = '/' + pluginName + route.url;
-      route.controller = pluginName + '/' + route.controller;
-      routes.push(route);
+      var valid = Object.keys(route).every(key => {
+        if (['verb', 'url', 'controller', 'action'].indexOf(key) === -1) {
+          // eslint-disable-next-line no-console
+          console.error(`[Plugin Manager] Error initializing route ${route.url}: unknown route definition ${key}`);
+          return false;
+        }
+
+        if (typeof route[key] !== 'string' || route[key].length === 0) {
+          // eslint-disable-next-line no-console
+          console.error(`[Plugin Manager] Error initializing route ${route.url}: ${key} must be a non-empty string`);
+          return false;
+        }
+
+        return true;
+      });
+
+      if (valid) {
+        if (!controllers[`${pluginName}/${route.controller}`]) {
+          // eslint-disable-next-line no-console
+          console.error(`[Plugin Manager] Error initializing route ${route.url}: undefined controller ${route.controller}`);
+          return false;
+        }
+
+        if (!controllers[`${pluginName}/${route.controller}`][route.action]) {
+          // eslint-disable-next-line no-console
+          console.error(`[Plugin Manager] Error initializing route ${route.url}: undefined action ${route.action}`);
+          return false;
+        }
+
+        if (['post', 'get'].indexOf(route.verb.toLowerCase()) === -1) {
+          // eslint-disable-next-line no-console
+          console.error(`[Plugin Manager] Error initializing route ${route.url}: only get and post actions are supported`);
+          return false;
+        }
+
+        route.url = '/' + pluginName + route.url;
+        route.controller = pluginName + '/' + route.controller;
+        routes.push(route);
+      }
     });
   }
 }

--- a/test/api/core/pluginsManager/run.test.js
+++ b/test/api/core/pluginsManager/run.test.js
@@ -322,18 +322,17 @@ describe('Test plugins manager run', () => {
 
   it('should attach controller actions on kuzzle object', () => {
     plugin.object.controllers = {
-      'foo': 'FooController'
+      'foo': {
+        'actionName': 'functionName'
+      }
     };
 
-    plugin.object.FooController = () => {};
-    pluginMock.expects('FooController').once().calledOn(plugin.object);
+    plugin.object.functionName = () => {};
 
     return pluginsManager.run()
       .then(() => {
-        should.not.exist(pluginsManager.controllers['testPlugin/dfoo']);
-        should(pluginsManager.controllers['testPlugin/foo']).be.a.Function();
-        pluginsManager.controllers['testPlugin/foo']();
-        pluginMock.verify();
+        should(pluginsManager.controllers['testPlugin/foo']).be.an.Object();
+        should(pluginsManager.controllers['testPlugin/foo'].actionName).be.exactly(plugin.object.functionName);
       });
   });
 
@@ -343,7 +342,13 @@ describe('Test plugins manager run', () => {
       {verb: 'post', url: '/bar', controller: 'foo', action: 'bar'}
     ];
 
-    plugin.object.controllers = ['foo'];
+    plugin.object.controllers = {
+      'foo': {
+        'bar': 'functionName'
+      }
+    };
+
+    plugin.object.functionName = () => {};
 
     return pluginsManager.run()
       .then(() => {
@@ -358,6 +363,69 @@ describe('Test plugins manager run', () => {
         should(pluginsManager.routes[0].action)
           .be.equal(pluginsManager.routes[0].action)
           .and.be.equal('bar');
+      });
+  });
+
+  it('should abort the controller initialization if the controller object is incorrectly defined', () => {
+    plugin.object.controllers = {
+      'foo': 'bar'
+    };
+
+    return pluginsManager.run()
+      .then(() => {
+        should(pluginsManager.controllers['testPlugin/foo']).be.undefined();
+      });
+  });
+
+  it('should abort the controller initialization if one of the controller action is not correctly defined', () => {
+    plugin.object.controllers = {
+      'foo': {
+        'actionName': []
+      }
+    };
+
+    return pluginsManager.run()
+      .then(() => {
+        should(pluginsManager.controllers['testPlugin/foo']).be.undefined();
+      });
+  });
+
+  it('should abort the controller initialization if one of the controller action target does not exist', () => {
+    plugin.object.controllers = {
+      'foo': {
+        'actionName': 'functionName',
+        'anotherActionName': 'does not exist'
+      }
+    };
+
+    plugin.object.functionName = () => {};
+
+    return pluginsManager.run()
+      .then(() => {
+        should(pluginsManager.controllers['testPlugin/foo']).be.undefined();
+      });
+  });
+
+  it('should not add an invalid route to the API', () => {
+    plugin.object.routes = [
+      {invalid: 'get', url: '/bar/:name', controller: 'foo', action: 'bar'},
+      {verb: 'post', url: ['/bar'], controller: 'foo', action: 'bar'},
+      {verb: 'invalid', url: '/bar', controller: 'foo', action: 'bar'},
+      {verb: 'get', url: '/bar/:name', controller: 'foo', action: 'invalid'},
+      {verb: 'get', url: '/bar/:name', controller: 'invalid', action: 'bar'},
+    ];
+
+    plugin.object.controllers = {
+      'foo': {
+        'bar': 'functionName'
+      }
+    };
+
+    plugin.object.functionName = () => {};
+
+    return pluginsManager.run()
+      .then(() => {
+        should(pluginsManager.routes).be.an.Array().and.length(0);
       });
   });
 


### PR DESCRIPTION
The current way of defining a controller plugin is a bit complicated and hard to document. 

To define a controller plugin, we need to expose a `controllers` object, detailing the controllers to add to the API, each one of them exposing a function, creating an object, containing actions.

Moreover, this architecture makes it difficult to understand  what the `action` of a HTTP route refers to.

In order to simplify the way controller plugins are defined, this PR proposes the following: 

* the plugin needs to expose a `controllers` object. This object simply describes the controllers to add using the following format:

```js
this.controllers = {
  controllerToAdd: {
    actionName: exposedFunctionName
  }
};
```

* `exposedFunctionName` function implementations must simply be exposed to Kuzzle

* no change done to `this.routes`: `route.controller` and `route.action` simply refer to the controller's description in `this.controllers`

This should bring controller plugins in line with the way other plugin types are defined (e.g. listener or pipe plugins).


This PR also adds a lot more tests to check a controller plugin validity, thus limiting potential crashes because of an invalid controller plugin.
