### PR TITLE
[http] remove double stringification

### DIFF
--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -65,7 +65,7 @@ function RouterController (kuzzle) {
     });
 
     this.router.get('/swagger.json', (data, cb) => {
-      let content = JSON.stringify(generateSwagger(kuzzle));
+      let content = generateSwagger(kuzzle);
       cb(new HttpResponse(data.id, 'application/json', 200, content));
     });
 
@@ -99,13 +99,7 @@ function executeFromHttp(funnel, params, request, cb) {
   request.context.connectionId = 'http';
 
   funnel.execute(request, (err, result) => {
-    var indent = 0;
-
-    if (result.input.args.pretty) {
-      indent = 2;
-    }
-
-    cb(new HttpResponse(result.id, 'application/json', result.status, JSON.stringify(result.response, undefined, indent)));
+    cb(new HttpResponse(result.id, 'application/json', result.status, result.response));
   });
 }
 

--- a/lib/api/core/httpRouter/index.js
+++ b/lib/api/core/httpRouter/index.js
@@ -166,7 +166,7 @@ function replyWithError(cb, request, error) {
 
   request.setError(error);
 
-  httpResponse = new HttpResponse(request.id, 'application/json', request.status, JSON.stringify(request.response));
+  httpResponse = new HttpResponse(request.id, 'application/json', request.status, request.response);
 
   cb(httpResponse);
 }

--- a/test/api/controllers/routerController/httpRequest.test.js
+++ b/test/api/controllers/routerController/httpRequest.test.js
@@ -65,7 +65,7 @@ describe('Test: routerController.httpRequest', () => {
         should(result.id).be.eql(httpRequest.requestId);
         should(result.type).be.eql('application/json');
         should(result.status).be.eql(1234);
-        should(result.content).be.eql(JSON.stringify(response.response));
+        should(result.content).be.exactly(response.response);
         done();
       }
       catch (e) {
@@ -87,7 +87,7 @@ describe('Test: routerController.httpRequest', () => {
         should(result.id).be.eql(httpRequest.requestId);
         should(result.type).be.eql('application/json');
         should(result.status).be.eql(1234);
-        should(result.content).be.eql(JSON.stringify(response.response));
+        should(result.content).be.exactly(response.response);
         done();
       }
       catch (e) {
@@ -109,7 +109,7 @@ describe('Test: routerController.httpRequest', () => {
         should(result.id).be.eql(httpRequest.requestId);
         should(result.type).be.eql('application/json');
         should(result.status).be.eql(1234);
-        should(result.content).be.eql(JSON.stringify(response.response));
+        should(result.content).be.exactly(response.response);
         done();
       }
       catch (e) {
@@ -130,7 +130,7 @@ describe('Test: routerController.httpRequest', () => {
         should(result.id).be.eql(httpRequest.requestId);
         should(result.type).be.eql('application/json');
         should(result.status).be.eql(1234);
-        should(result.content).be.eql(JSON.stringify(response.response));
+        should(result.content).be.exactly(response.response);
         done();
       }
       catch (e) {
@@ -151,7 +151,7 @@ describe('Test: routerController.httpRequest', () => {
         should(result.id).be.eql(httpRequest.requestId);
         should(result.type).be.eql('application/json');
         should(result.status).be.eql(1234);
-        should(result.content).be.eql(JSON.stringify(response.response));
+        should(result.content).be.exactly(response.response);
         done();
       }
       catch (e) {
@@ -208,7 +208,7 @@ describe('Test: routerController.httpRequest', () => {
         should(result.id).be.eql(httpRequest.requestId);
         should(result.type).be.eql('application/json');
         should(result.status).be.eql(1234);
-        should(result.content).be.eql(JSON.stringify(response.response));
+        should(result.content).be.exactly(response.response);
         done();
       }
       catch (e) {
@@ -227,7 +227,7 @@ describe('Test: routerController.httpRequest', () => {
         should(result.id).be.eql(httpRequest.requestId);
         should(result.type).be.eql('application/json');
         should(result.status).be.eql(404);
-        should(result.content).startWith('{"status":404,"error":{"status":404,"message":"API URL not found: /foo/bar"');
+        should(JSON.stringify(result.content)).startWith('{"status":404,"error":{"status":404,"message":"API URL not found: /foo/bar"');
         done();
       }
       catch (e) {

--- a/test/api/core/httpRouter/httpRouter.test.js
+++ b/test/api/core/httpRouter/httpRouter.test.js
@@ -133,7 +133,16 @@ describe('core/httpRouter', () => {
         type: 'application/json',
         status: 400
       });
-      should(callback.firstCall.args[0].content).startWith('{"status":400,"error":{"status":400,"message":"Unrecognized HTTP method FOOBAR"');
+
+      should(callback.firstCall.args[0].content.toJSON()).match({
+        status: 400,
+        error: {
+          status: 400,
+          message: 'Unrecognized HTTP method FOOBAR'
+        },
+        requestId: 'requestId',
+        result: null
+      });
     });
 
     it('should return an error if unable to parse the incoming JSON content', () => {
@@ -153,7 +162,16 @@ describe('core/httpRouter', () => {
         type: 'application/json',
         status: 400
       });
-      should(callback.firstCall.args[0].content).startWith('{"status":400,"error":{"status":400,"message":"Unable to convert HTTP body to JSON');
+
+      should(callback.firstCall.args[0].content.toJSON()).match({
+        status: 400,
+        error: {
+          status: 400,
+          message: 'Unable to convert HTTP body to JSON'
+        },
+        requestId: 'requestId',
+        result: null
+      });
     });
 
     it('should return an error if the content-type is not JSON', () => {
@@ -173,7 +191,16 @@ describe('core/httpRouter', () => {
         type: 'application/json',
         status: 400
       });
-      should(callback.firstCall.args[0].content).startWith('{"status":400,"error":{"status":400,"message":"Invalid request content-type');
+
+      should(callback.firstCall.args[0].content.toJSON()).match({
+        status: 400,
+        error: {
+          status: 400,
+          message: 'Invalid request content-type. Expected "application/json", got: "application/foobar"'
+        },
+        requestId: 'requestId',
+        result: null
+      });
     });
 
     it('should send an error if the charset is not utf-8', () => {
@@ -193,7 +220,16 @@ describe('core/httpRouter', () => {
         type: 'application/json',
         status: 400
       });
-      should(callback.firstCall.args[0].content).startWith('{"status":400,"error":{"status":400,"message":"Invalid request charset');
+
+      should(callback.firstCall.args[0].content.toJSON()).match({
+        status: 400,
+        error: {
+          status: 400,
+          message: 'Invalid request charset. Expected "utf-8", got: "iso8859-1"'
+        },
+        requestId: 'requestId',
+        result: null
+      });
     });
 
     it('should return an error if the route does not exist', () => {
@@ -201,7 +237,7 @@ describe('core/httpRouter', () => {
 
       rq.url = '/foo/bar';
       rq.method = 'PUT';
-      rq.headers['content-type'] = 'application/foobar';
+      rq.headers['content-type'] = 'application/json';
       rq.content = '{"foo": "bar"}';
 
       router.route(rq, callback);
@@ -213,7 +249,16 @@ describe('core/httpRouter', () => {
         type: 'application/json',
         status: 404
       });
-      should(callback.firstCall.args[0].content).startWith('{"status":404,"error":{"status":404,"message":"API URL not found');
+
+      should(callback.firstCall.args[0].content.toJSON()).match({
+        status: 404,
+        error: {
+          status: 404,
+          message: 'API URL not found: /foo/bar'
+        },
+        requestId: 'requestId',
+        result: null
+      });
     });
   });
 });


### PR DESCRIPTION
Linked to https://github.com/kuzzleio/kuzzle-proxy/pull/41

Do not double JSON stringify the httpresponse result sent to the proxy.
As a consequence, the prettify option cannot be handled in Kuzzle anymore and had to be moved to the proxy.

:warning: This pr and [its counterpart on the proxy](https://github.com/kuzzleio/kuzzle-proxy/pull/41) need to be merged at the same time.