### PR TITLE
plugin controller function should be called with the plugin context

### DIFF
--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -382,7 +382,7 @@ function initControllers (controllers, routes, plugin, pluginName) {
         controllers[`${pluginName}/${controller}`] = {};
       }
 
-      controllers[`${pluginName}/${controller}`][action] = plugin.object[description[action]];
+      controllers[`${pluginName}/${controller}`][action] = plugin.object[description[action]].bind(plugin.object);
       return true;
     });
   });

--- a/test/api/core/pluginsManager/run.test.js
+++ b/test/api/core/pluginsManager/run.test.js
@@ -332,7 +332,7 @@ describe('Test plugins manager run', () => {
     return pluginsManager.run()
       .then(() => {
         should(pluginsManager.controllers['testPlugin/foo']).be.an.Object();
-        should(pluginsManager.controllers['testPlugin/foo'].actionName).be.exactly(plugin.object.functionName);
+        should(pluginsManager.controllers['testPlugin/foo'].actionName).be.eql(plugin.object.functionName.bind(plugin.object));
       });
   });
 


### PR DESCRIPTION
This fix allows plugin controller functions to access to the plugin's context, instead of an empty one.