### PR TITLE
Bugfix: controller plugins fire events when invoking the API

### DIFF
--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -90,7 +90,8 @@ function FunnelController (kuzzle) {
 
       this.pendingRequests[request.id] = request;
 
-      processRequest(kuzzle, this, request)
+      this.checkRights(request)
+        .then(() => this.processRequest(request))
         .then(processResult => callback(null, processResult))
         .catch(err => {
           kuzzle.pluginsManager.trigger('log:error', err);
@@ -186,83 +187,88 @@ function FunnelController (kuzzle) {
       });
     }
   };
-}
 
-/**
- * Execute the request immediately
- * @param {Kuzzle} kuzzle
- * @param {FunnelController} funnel
- * @param {Request} request
- */
-function processRequest(kuzzle, funnel, request) {
-  var controllers = funnel.controllers;
-
-  kuzzle.statistics.startRequest(request);
-
-  if (funnel.historized > kuzzle.config.server.maxRequestHistorySize) {
-    funnel.requestHistory.shift();
-  }
-  else {
-    funnel.historized++;
-  }
-
-  funnel.requestHistory.push(request);
-
-  if (
-    !controllers[request.input.controller]
-    || !controllers[request.input.controller][request.input.action]
-    || typeof controllers[request.input.controller][request.input.action] !== 'function'
-  ) {
-    return Promise.reject(new BadRequestError(`No corresponding action ${request.input.action} in controller ${request.input.controller}`));
-  }
-
-  return kuzzle.repositories.token.verifyToken(request.input.jwt)
-    .then(userToken => {
-      request.context.token = userToken;
-      return kuzzle.repositories.user.load(request.context.token.userId);
-    })
-    .then(user => user.isActionAllowed(request, kuzzle))
-    .then(isAllowed => {
-      var
-        modifiedRequest,
-        input = request.input,
-        beforeEvent = getEventName(input.controller, 'before', input.action),
-        afterEvent = getEventName(input.controller, 'after', input.action);
-
-      if (!isAllowed) {
-        // anonymous user => we throw a 401 (Unauthorised) error
-        if (request.context.token.userId === -1) {
-          return Promise.reject(new UnauthorizedError(
-            `Unauthorized action [${input.index}/${input.collection}/${input.controller}/${input.action}] for anonymous user`)
+  /**
+   * Checks if a user has the necessary rights to execute the action
+   *
+   * @param {Request} request
+   * @return {Promise<Boolean>}
+   */
+  this.checkRights = function checkRights (request) {
+    return kuzzle.repositories.token.verifyToken(request.input.jwt)
+      .then(userToken => {
+        request.context.token = userToken;
+        return kuzzle.repositories.user.load(request.context.token.userId);
+      })
+      .then(user => user.isActionAllowed(request, kuzzle))
+      .then(isAllowed => {
+        if (!isAllowed) {
+          // anonymous user => we throw a 401 (Unauthorised) error
+          if (request.context.token.userId === -1) {
+            return Promise.reject(new UnauthorizedError(
+              `Unauthorized action [${request.input.index}/${request.input.collection}/${request.input.controller}/${request.input.action}] for anonymous user`)
+            );
+          }
+          // logged-in user with insufficient permissions => we throw a 403 (Forbidden) error
+          return Promise.reject(new ForbiddenError(
+            `Forbidden action [${request.input.index}/${request.input.collection}/${request.input.controller}/${request.input.action}] for user ${request.context.token.userId}`)
           );
         }
-        // logged-in user with insufficient permissions => we throw a 403 (Forbidden) error
-        return Promise.reject(new ForbiddenError(
-          `Forbidden action [${input.index}/${input.collection}/${input.controller}/${input.action}] for user ${request.context.token.userId}`)
-        );
-      }
+      });
+  };
 
-      return kuzzle.pluginsManager.trigger(beforeEvent, request)
-        .then(newRequest => {
-          modifiedRequest = newRequest;
+  /**
+   * Execute the request immediately
+   * @param {KuzzleRequest} request
+   * @return {Promise}
+   */
+  this.processRequest = function processRequest(request) {
+    if (
+      !this.controllers[request.input.controller]
+      || !this.controllers[request.input.controller][request.input.action]
+      || typeof this.controllers[request.input.controller][request.input.action] !== 'function'
+    ) {
+      return Promise.reject(new BadRequestError(`No corresponding action ${request.input.action} in controller ${request.input.controller}`));
+    }
 
-          return controllers[request.input.controller][request.input.action](newRequest);
-        })
-        .then(responseData => {
-          modifiedRequest.setResult(responseData, request.status === 102 ? 200 : request.status);
+    kuzzle.statistics.startRequest(request);
 
-          return kuzzle.pluginsManager.trigger(afterEvent, modifiedRequest);
-        });
-    })
-    .then(newRequest => {
-      kuzzle.statistics.completedRequest(request);
+    if (this.historized > kuzzle.config.server.maxRequestHistorySize) {
+      this.requestHistory.shift();
+    }
+    else {
+      this.historized++;
+    }
 
-      return newRequest;
-    })
-    .catch(error => {
-      kuzzle.statistics.failedRequest(request);
-      return Promise.reject(error);
-    });
+    this.requestHistory.push(request);
+
+    let
+      beforeEvent = getEventName(request.input.controller, 'before', request.input.action),
+      modifiedRequest;
+
+    return kuzzle.pluginsManager.trigger(beforeEvent, request)
+      .then(newRequest => {
+        modifiedRequest = newRequest;
+
+        return this.controllers[request.input.controller][request.input.action](newRequest);
+      })
+      .then(responseData => {
+        let afterEvent = getEventName(request.input.controller, 'after', request.input.action);
+
+        modifiedRequest.setResult(responseData, request.status === 102 ? 200 : request.status);
+
+        return kuzzle.pluginsManager.trigger(afterEvent, modifiedRequest);
+      })
+      .then(newRequest => {
+        kuzzle.statistics.completedRequest(request);
+
+        return newRequest;
+      })
+      .catch(error => {
+        kuzzle.statistics.failedRequest(request);
+        return Promise.reject(error);
+      });
+  };
 }
 
 /**

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -2,7 +2,6 @@ var
   _ = require('lodash'),
   Promise = require('bluebird'),
   PluginImplementationError = require('kuzzle-common-objects').errors.PluginImplementationError,
-  BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
   Request = require('kuzzle-common-objects').Request,
   RequestContext = require('kuzzle-common-objects').models.RequestContext,
   RequestInput = require('kuzzle-common-objects').models.RequestInput;
@@ -95,7 +94,7 @@ function PluginContext(kuzzle) {
 function execute (request, callback) {
   var kuzzle = this;
 
-  processRequest(kuzzle, request)
+  kuzzle.funnel.processRequest(request)
     .then(response => {
       request.setResult(response, request.status === 102 ? 200 : request.status);
       callback(null, request);
@@ -110,27 +109,6 @@ function execute (request, callback) {
 
       return null;
     });
-}
-
-/**
- * Execute the request immediately
- *
- * @param {Kuzzle} kuzzle
- * @param {Request} request
- * @returns {Promise<*>}
- */
-function processRequest(kuzzle, request) {
-  var controllers = kuzzle.funnel.controllers;
-
-  if (
-    !controllers[request.input.controller]
-    || !controllers[request.input.controller][request.input.action]
-    || typeof controllers[request.input.controller][request.input.action] !== 'function'
-  ) {
-    return Promise.reject(new BadRequestError('No corresponding action ' + request.input.action + ' in controller ' + request.input.controller));
-  }
-
-  return controllers[request.input.controller][request.input.action](request);
 }
 
 /**

--- a/test/api/controllers/funnelController/checkRights.test.js
+++ b/test/api/controllers/funnelController/checkRights.test.js
@@ -4,7 +4,6 @@ var
   sinon = require('sinon'),
   sandbox = sinon.sandbox.create(),
   Request = require('kuzzle-common-objects').Request,
-  BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
   ForbiddenError = require('kuzzle-common-objects').errors.ForbiddenError,
   UnauthorizedError = require('kuzzle-common-objects').errors.UnauthorizedError,
   Kuzzle = require('../../../../lib/api/kuzzle');

--- a/test/api/controllers/funnelController/checkRights.test.js
+++ b/test/api/controllers/funnelController/checkRights.test.js
@@ -1,0 +1,70 @@
+var
+  should = require('should'),
+  Promise = require('bluebird'),
+  sinon = require('sinon'),
+  sandbox = sinon.sandbox.create(),
+  Request = require('kuzzle-common-objects').Request,
+  BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
+  ForbiddenError = require('kuzzle-common-objects').errors.ForbiddenError,
+  UnauthorizedError = require('kuzzle-common-objects').errors.UnauthorizedError,
+  Kuzzle = require('../../../../lib/api/kuzzle');
+
+describe('funnelController.processRequest', () => {
+  var
+    kuzzle;
+
+  before(() => {
+    kuzzle = new Kuzzle();
+  });
+
+  beforeEach(() => {
+    sandbox.stub(kuzzle.repositories.token, 'verifyToken', () => {
+      return Promise.resolve({
+        userId: 'user'
+      });
+    });
+    sandbox.stub(kuzzle.internalEngine, 'get').returns(Promise.resolve({}));
+    return kuzzle.services.init({whitelist: []})
+      .then(() => {
+        kuzzle.funnel.init();
+      });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should reject the promise with UnauthorizedError if an anonymous user is not allowed to execute the action', () => {
+    kuzzle.repositories.token.verifyToken.restore();
+    sandbox.stub(kuzzle.repositories.user, 'load').returns(Promise.resolve({_id: -1, isActionAllowed: sandbox.stub().returns(Promise.resolve(false))}));
+    sandbox.stub(kuzzle.repositories.token, 'verifyToken').returns(Promise.resolve({userId: -1}));
+
+    return should(kuzzle.funnel.checkRights(new Request({controller: 'document', index: '@test', action: 'get'})))
+      .be.rejectedWith(UnauthorizedError);
+  });
+
+  it('should reject the promise with UnauthorizedError if an authenticated user is not allowed to execute the action', () => {
+    kuzzle.repositories.token.verifyToken.restore();
+    sandbox.stub(kuzzle.repositories.user, 'load').returns(Promise.resolve({_id: 'user', isActionAllowed: sandbox.stub().returns(Promise.resolve(false))}));
+    sandbox.stub(kuzzle.repositories.token, 'verifyToken').returns(Promise.resolve({user: 'user'}));
+
+    return should(kuzzle.funnel.checkRights(new Request({controller: 'document', index: '@test', action: 'get'})))
+      .be.rejectedWith(ForbiddenError);
+  });
+
+  it('should resolve the promise ', () => {
+    var request = new Request({
+      requestId: 'requestId',
+      controller: 'index',
+      action: 'list',
+      collection: 'collection'
+    });
+
+    kuzzle.repositories.token.verifyToken.restore();
+    sandbox.stub(kuzzle.repositories.user, 'load').returns(Promise.resolve({_id: 'user', isActionAllowed: sandbox.stub().returns(Promise.resolve(true))}));
+    sandbox.stub(kuzzle.repositories.token, 'verifyToken').returns(Promise.resolve({user: 'user'}));
+    sandbox.stub(kuzzle.funnel.controllers.index, 'list').returns(Promise.resolve());
+
+    return kuzzle.funnel.checkRights(request);
+  });
+});

--- a/test/api/controllers/funnelController/execute.test.js
+++ b/test/api/controllers/funnelController/execute.test.js
@@ -5,7 +5,6 @@ var
   Promise = require('bluebird'),
   Request = require('kuzzle-common-objects').Request,
   ServiceUnavailableError = require('kuzzle-common-objects').errors.ServiceUnavailableError,
-  InternalError = require('kuzzle-common-objects').errors.InternalError,
   Kuzzle = require('../../../../lib/api/kuzzle'),
   rewire = require('rewire'),
   FunnelController = rewire('../../../../lib/api/controllers/funnelController');
@@ -14,25 +13,12 @@ describe('funnelController.execute', () => {
   var
     kuzzle,
     funnel,
-    processRequestCalled,
     request,
-    requestReplayed,
-    errorMe;
+    requestReplayed;
 
   before(() => {
-
     kuzzle = new Kuzzle();
     kuzzle.config.server.warningRetainedRequestsLimit = -1;
-
-    FunnelController.__set__('processRequest', (funnelKuzzle, controllers, funnelRequest) => {
-      processRequestCalled = true;
-
-      if (errorMe) {
-        return Promise.reject(new InternalError('errored on purpose'));
-      }
-
-      return Promise.resolve(funnelRequest);
-    });
 
     FunnelController.__set__('playCachedRequests', () => {
       requestReplayed = true;
@@ -40,10 +26,6 @@ describe('funnelController.execute', () => {
   });
 
   beforeEach(() => {
-    errorMe = false;
-    processRequestCalled = false;
-    requestReplayed = false;
-
     request = new Request({
       controller: 'foo',
       action: 'bar'
@@ -52,11 +34,19 @@ describe('funnelController.execute', () => {
       token: null
     });
 
+    requestReplayed = false;
+
     sandbox.stub(kuzzle.internalEngine, 'get').returns(Promise.resolve({}));
     return kuzzle.services.init({whitelist: []})
       .then(() => {
         funnel = new FunnelController(kuzzle);
         funnel.init();
+
+        funnel.checkRights = sinon.stub().returns(Promise.resolve());
+        funnel.processRequest = (request) => Promise.resolve(request);
+        sinon.spy(funnel, 'processRequest');
+
+        return null;
       });
   });
 
@@ -72,7 +62,7 @@ describe('funnelController.execute', () => {
           // 102 is the default status of a request, it should be 200 when coming out from the execute
           should(res.status).be.exactly(102);
           should(res).be.instanceOf(Request);
-          should(processRequestCalled).be.true();
+          should(funnel.processRequest.calledOnce).be.true();
           done();
         } catch (error) {
           done(error);
@@ -81,16 +71,15 @@ describe('funnelController.execute', () => {
     });
 
     it('should forward any error occuring during the request execution', done => {
-      errorMe = true;
+      funnel.checkRights = sinon.stub().returns(Promise.reject(new Error('errored')));
 
       funnel.execute(request, (err, res) => {
         try {
           should(err).be.instanceOf(Error);
           should(res.status).be.exactly(500);
-          should(res.error.message).be.exactly('errored on purpose');
-          should(processRequestCalled).be.true();
+          should(res.error.message).be.exactly('errored');
+          should(funnel.processRequest.calledOnce).be.false();
           should(funnel.overloaded).be.false();
-          should(requestReplayed).be.false();
           done();
         } catch (error) {
           done(error);
@@ -153,7 +142,7 @@ describe('funnelController.execute', () => {
       setTimeout(() => {
         should(funnel.overloaded).be.true();
         should(requestReplayed).be.true();
-        should(processRequestCalled).be.false();
+        should(funnel.processRequest.called).be.false();
         should(funnel.cachedItems).be.eql(1);
         should(funnel.requestsCache.shift()).match({request, callback});
         done();
@@ -173,7 +162,7 @@ describe('funnelController.execute', () => {
       setTimeout(() => {
         should(funnel.overloaded).be.true();
         should(requestReplayed).be.false();
-        should(processRequestCalled).be.false();
+        should(funnel.processRequest.called).be.false();
         should(funnel.cachedItems).be.eql(1);
         should(funnel.requestsCache.shift()).match({request, callback});
         done();
@@ -190,7 +179,7 @@ describe('funnelController.execute', () => {
       funnel.execute(request, (err, res) => {
         should(funnel.overloaded).be.true();
         should(requestReplayed).be.false();
-        should(processRequestCalled).be.false();
+        should(funnel.processRequest.called).be.false();
         should(funnel.cachedItems).be.eql(kuzzle.config.server.maxRetainedRequests);
         should(funnel.requestsCache.isEmpty()).be.true();
         should(err).be.instanceOf(ServiceUnavailableError);

--- a/test/api/controllers/funnelController/execute.test.js
+++ b/test/api/controllers/funnelController/execute.test.js
@@ -43,7 +43,7 @@ describe('funnelController.execute', () => {
         funnel.init();
 
         funnel.checkRights = sinon.stub().returns(Promise.resolve());
-        funnel.processRequest = (request) => Promise.resolve(request);
+        funnel.processRequest = (r) => Promise.resolve(r);
         sinon.spy(funnel, 'processRequest');
 
         return null;

--- a/test/api/controllers/funnelController/processRequest.test.js
+++ b/test/api/controllers/funnelController/processRequest.test.js
@@ -1,116 +1,140 @@
-var
+'use strict';
+
+const
   should = require('should'),
-  Promise = require('bluebird'),
   sinon = require('sinon'),
-  sandbox = sinon.sandbox.create(),
+  Promise = require('bluebird'),
   Request = require('kuzzle-common-objects').Request,
   BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
-  ForbiddenError = require('kuzzle-common-objects').errors.ForbiddenError,
-  UnauthorizedError = require('kuzzle-common-objects').errors.UnauthorizedError,
-  Kuzzle = require('../../../../lib/api/kuzzle'),
-  rewire = require('rewire'),
-  FunnelController = rewire('../../../../lib/api/controllers/funnelController');
+  Kuzzle = require('../../../../lib/api/kuzzle');
 
 describe('funnelController.processRequest', () => {
-  var
+  let
     kuzzle,
-    processRequest;
+    sandbox;
 
   before(() => {
     kuzzle = new Kuzzle();
-    processRequest = FunnelController.__get__('processRequest');
+    sandbox = sinon.sandbox.create();
+
+    // injects fake controllers for unit tests
+    kuzzle.funnel.controllers = {
+      'fakeController': {
+        ok: sinon.stub().returns(Promise.resolve()),
+        fail: sinon.stub()
+      }
+    }
   });
 
   beforeEach(() => {
-    sandbox.stub(kuzzle.repositories.token, 'verifyToken', () => {
-      return Promise.resolve({
-        userId: 'user'
-      });
-    });
-    sandbox.stub(kuzzle.internalEngine, 'get').returns(Promise.resolve({}));
-    return kuzzle.services.init({whitelist: []})
-      .then(() => {
-        kuzzle.funnel.init();
-      });
+    sandbox.stub(kuzzle.statistics, 'startRequest');
+    sandbox.stub(kuzzle.statistics, 'completedRequest');
+    sandbox.stub(kuzzle.statistics, 'failedRequest');
+    kuzzle.funnel.requestHistory.clear();
   });
 
   afterEach(() => {
     sandbox.restore();
   });
 
-  it('should reject the promise if no controller is specified', () => {
+  it('should reject the promise if no controller is specified', done => {
     var object = {
       action: 'create'
     };
 
-    var request = new Request(object);
-
-    return should(processRequest(kuzzle, kuzzle.funnel, request)).be.rejectedWith(BadRequestError);
+    kuzzle.funnel.processRequest(new Request(object))
+      .then(() => done('should have failed'))
+      .catch(e => {
+        should(e).be.instanceOf(BadRequestError);
+        should(kuzzle.funnel.requestHistory.isEmpty()).be.true();
+        should(kuzzle.statistics.startRequest.called).be.false();
+        done();
+      });
   });
 
-  it('should reject the promise if no action is specified', () => {
+  it('should reject the promise if no action is specified', done => {
     var object = {
       controller: 'write'
     };
 
-    var request = new Request(object);
-
-    return should(processRequest(kuzzle, kuzzle.funnel, request)).be.rejectedWith(BadRequestError);
+    kuzzle.funnel.processRequest(new Request(object))
+      .then(() => done('should have failed'))
+      .catch(e => {
+        should(e).be.instanceOf(BadRequestError);
+        should(kuzzle.funnel.requestHistory.isEmpty()).be.true();
+        should(kuzzle.statistics.startRequest.called).be.false();
+        done();
+      });
   });
 
-  it('should reject the promise if the controller doesn\'t exist', () => {
+  it('should reject the promise if the controller doesn\'t exist', done => {
     var object = {
       controller: 'toto',
       action: 'create'
     };
 
-    var request = new Request(object);
-
-    return should(processRequest(kuzzle, kuzzle.funnel, request)).be.rejectedWith(BadRequestError);
+    kuzzle.funnel.processRequest(new Request(object))
+      .then(() => done('should have failed'))
+      .catch(e => {
+        should(e).be.instanceOf(BadRequestError);
+        should(kuzzle.funnel.requestHistory.isEmpty()).be.true();
+        should(kuzzle.statistics.startRequest.called).be.false();
+        done();
+      });
   });
 
-  it('should reject the promise if the action doesn\'t exist', () => {
+  it('should reject the promise if the action doesn\'t exist', done => {
     var object = {
-      controller: 'write',
-      action: 'toto'
+      controller: 'foo',
+      action: 'bar'
     };
 
-    var request = new Request(object);
-
-    return should(processRequest(kuzzle, kuzzle.funnel, request)).be.rejectedWith(BadRequestError);
+    kuzzle.funnel.processRequest(new Request(object))
+      .then(() => done('should have failed'))
+      .catch(e => {
+        should(e).be.instanceOf(BadRequestError);
+        should(kuzzle.funnel.requestHistory.isEmpty()).be.true();
+        should(kuzzle.statistics.startRequest.called).be.false();
+        done();
+      });
   });
 
-  it('should reject the promise with UnauthorizedError if an anonymous user is not allowed to execute the action', () => {
-    kuzzle.repositories.token.verifyToken.restore();
-    sandbox.stub(kuzzle.repositories.user, 'load').returns(Promise.resolve({_id: -1, isActionAllowed: sandbox.stub().returns(Promise.resolve(false))}));
-    sandbox.stub(kuzzle.repositories.token, 'verifyToken').returns(Promise.resolve({userId: -1}));
-
-    return should(processRequest(kuzzle, kuzzle.funnel, new Request({controller: 'document', index: '@test', action: 'get'})))
-      .be.rejectedWith(UnauthorizedError);
-  });
-
-  it('should reject the promise with UnauthorizedError if an authenticated user is not allowed to execute the action', () => {
-    kuzzle.repositories.token.verifyToken.restore();
-    sandbox.stub(kuzzle.repositories.user, 'load').returns(Promise.resolve({_id: 'user', isActionAllowed: sandbox.stub().returns(Promise.resolve(false))}));
-    sandbox.stub(kuzzle.repositories.token, 'verifyToken').returns(Promise.resolve({user: 'user'}));
-
-    return should(processRequest(kuzzle, kuzzle.funnel, new Request({controller: 'document', index: '@test', action: 'get'})))
-      .be.rejectedWith(ForbiddenError);
-  });
-
-  it('should resolve the promise if everything is ok', () => {
+  it('should resolve the promise if everything is ok', done => {
     var request = new Request({
-      requestId: 'requestId',
-      controller: 'index',
-      action: 'list',
-      collection: 'collection'
+      controller: 'fakeController',
+      action: 'ok',
     });
 
-    kuzzle.repositories.token.verifyToken.restore();
-    sandbox.stub(kuzzle.repositories.user, 'load').returns(Promise.resolve({_id: 'user', isActionAllowed: sandbox.stub().returns(Promise.resolve(true))}));
-    sandbox.stub(kuzzle.repositories.token, 'verifyToken').returns(Promise.resolve({user: 'user'}));
-    sandbox.stub(kuzzle.funnel.controllers.index, 'list').returns(Promise.resolve());
+    kuzzle.funnel.processRequest(request)
+      .then(response => {
+        should(response).be.exactly(request);
+        should(kuzzle.funnel.requestHistory.toArray()).match([request]);
+        should(kuzzle.statistics.startRequest.called).be.true();
+        should(kuzzle.statistics.completedRequest.called).be.true();
+        should(kuzzle.statistics.failedRequest.called).be.false();
+        done();
+      })
+      .catch(e => done(e));
+  });
 
-    return processRequest(kuzzle, kuzzle.funnel, request);
+  it('should reject the promise if a controller action fails', done => {
+    var request = new Request({
+      controller: 'fakeController',
+      action: 'fail',
+    });
+
+    kuzzle.funnel.controllers.fakeController.fail.returns(Promise.reject(new Error('rejected')));
+
+    kuzzle.funnel.processRequest(request)
+      .then(() => done('should have failed'))
+      .catch(e => {
+        should(e).be.instanceOf(Error);
+        should(e.message).be.eql('rejected');
+        should(kuzzle.funnel.requestHistory.toArray()).match([request]);
+        should(kuzzle.statistics.startRequest.called).be.true();
+        should(kuzzle.statistics.completedRequest.called).be.false();
+        should(kuzzle.statistics.failedRequest.called).be.true();
+        done();
+      });
   });
 });

--- a/test/api/controllers/funnelController/processRequest.test.js
+++ b/test/api/controllers/funnelController/processRequest.test.js
@@ -23,7 +23,7 @@ describe('funnelController.processRequest', () => {
         ok: sinon.stub().returns(Promise.resolve()),
         fail: sinon.stub()
       }
-    }
+    };
   });
 
   beforeEach(() => {

--- a/test/api/core/pluginContext/pluginContext.test.js
+++ b/test/api/core/pluginContext/pluginContext.test.js
@@ -7,7 +7,6 @@ var
   PluginContext = rewire('../../../../lib/api/core/plugins/pluginContext'),
   PluginImplementationError = require('kuzzle-common-objects').errors.PluginImplementationError,
   Request = require('kuzzle-common-objects').Request,
-  BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
   _ = require('lodash');
 
 describe('Plugin Context', () => {
@@ -177,107 +176,54 @@ describe('Plugin Context', () => {
           }
         });
     });
-
-    describe('#execute', () => {
-      var
-        execute = PluginContext.__get__('execute'),
-        processRequest,
-        processRequestStub;
-
-      beforeEach(() => {
-        processRequestStub = sinon.stub();
-        processRequest = PluginContext.__get__('processRequest');
-        PluginContext.__set__('processRequest', processRequestStub);
-      });
-
-      afterEach(() => {
-        PluginContext.__set__('processRequest', processRequest);
-      });
-
-      it('should call the callback with a result if everything went well', done => {
-        var
-          request = new Request({requestId: 'request'}, {connectionId: 'connectionid'}),
-          callback = sinon.spy((err, res) => {
-            should(callback).be.calledOnce();
-            should(err).be.null();
-            should(res).match(request);
-
-            should(processRequestStub.firstCall.args[0]).be.eql(kuzzle);
-            should(processRequestStub.firstCall.args[1]).be.eql(request);
-
-            done();
-          });
-
-        processRequestStub.returns(Promise.resolve(request));
-
-        return execute.bind(kuzzle)(request, callback);
-      });
-
-      it('should call the callback with an error if something went wrong', done => {
-        var
-          request = new Request({body: {some: 'request'}}, {connectionId: 'connectionid'}),
-          error = new Error('error'),
-          callback = sinon.spy(
-            (err, res) => {
-              should(processRequestStub.firstCall.args[0]).be.eql(kuzzle);
-              should(processRequestStub.firstCall.args[1]).be.eql(request);
-
-              should(callback).be.calledOnce();
-              should(err).match(error);
-              should(res).match({});
-
-              return Promise.resolve().then(() => {
-                // allows handleErrorDump to be called
-                should(kuzzle.funnel.handleErrorDump).be.calledOnce();
-                should(kuzzle.funnel.handleErrorDump.firstCall.args[0]).match(error);
-
-                done();
-              });
-            });
-
-        processRequestStub.returns(Promise.reject(error));
-
-        return execute.bind(kuzzle)(request, callback);
-      });
-    });
-
-    describe('#processRequest', () => {
-      var
-        processRequest;
-
-      beforeEach(() => {
-        processRequest = PluginContext.__get__('processRequest');
-        kuzzle.funnel.controllers.customController = {
-          customAction: sinon.stub().returns(Promise.resolve())
-        };
-      });
-
-      it('should call a controller properly', () => {
-        var
-          request = new Request({
-            controller: 'customController',
-            action: 'customAction'
-          }, {connectionId: 'connectionid'});
-
-        return processRequest(kuzzle, request)
-          .then(() => {
-            should(kuzzle.funnel.controllers.customController.customAction).be.calledOnce();
-            should(kuzzle.funnel.controllers.customController.customAction.firstCall.args[0]).match(request);
-          });
-      });
-
-      it('should reject a promise if the requestObject has invalid information', () => {
-        var
-          request = new Request({
-            controller: 'customController',
-            action: 'notExistingAction'
-          }, {connectionId: 'connectionid'});
-
-        should(
-          processRequest(kuzzle, request)
-        ).be.rejectedWith(BadRequestError);
-      });
-    });
   });
 
+  describe('#execute', () => {
+    var
+      execute = PluginContext.__get__('execute');
+
+    it('should call the callback with a result if everything went well', done => {
+      var
+        request = new Request({requestId: 'request'}, {connectionId: 'connectionid'}),
+        callback = sinon.spy((err, res) => {
+          should(callback).be.calledOnce();
+          should(err).be.null();
+          should(res).match(request);
+
+          should(kuzzle.funnel.processRequest.firstCall.args[0]).be.eql(request);
+
+          done();
+        });
+
+      kuzzle.funnel.processRequest.returns(Promise.resolve(request));
+
+      return execute.bind(kuzzle)(request, callback);
+    });
+
+    it('should call the callback with an error if something went wrong', done => {
+      var
+        request = new Request({body: {some: 'request'}}, {connectionId: 'connectionid'}),
+        error = new Error('error'),
+        callback = sinon.spy(
+          (err, res) => {
+            should(kuzzle.funnel.processRequest.firstCall.args[0]).be.eql(request);
+
+            should(callback).be.calledOnce();
+            should(err).match(error);
+            should(res).match({});
+
+            return Promise.resolve().then(() => {
+              // allows handleErrorDump to be called
+              should(kuzzle.funnel.handleErrorDump).be.calledOnce();
+              should(kuzzle.funnel.handleErrorDump.firstCall.args[0]).match(error);
+
+              done();
+            });
+          });
+
+      kuzzle.funnel.processRequest.returns(Promise.reject(error));
+
+      return execute.bind(kuzzle)(request, callback);
+    });
+  });
 });

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -68,7 +68,9 @@ function KuzzleMock () {
     },
     init: sinon.spy(),
     handleErrorDump: sinon.spy(),
-    execute: sinon.spy()
+    execute: sinon.spy(),
+    processRequest: sinon.stub(),
+    checkRights: sinon.stub()
   };
 
   this.hooks = {


### PR DESCRIPTION
Controller plugins can invoke Kuzzle API. Prior to this PR, doing so wouldn't trigger the events normally attached to the invoked controller's action.

This PR restores this behavior, by refactoring the funnel controller a bit, exposing the `processRequest` method.
Rights are now checked separately by the new `checkRights` method, also exposed by the funnel, and currently only called by `funnel.execute`.

This way, controller plugins can still invoke the API without performing a right check, and triggering the controller's action events as expected.