### PR TITLE
Bugfix: updating a document with no meta makes it unreachable

### DIFF
--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -22,7 +22,6 @@ var
  * @constructor
  */
 function ElasticSearch (kuzzle, options, config) {
-
   Object.defineProperties(this, {
     kuzzle: {
       value: kuzzle
@@ -419,6 +418,7 @@ function ElasticSearch (kuzzle, options, config) {
 
     // Add metadata
     esRequest.body._kuzzle_info = {
+      active: true,
       updatedAt: Date.now(),
       updater: request.context.token.userId ? String(request.context.token.userId) : null
     };
@@ -527,7 +527,6 @@ function ElasticSearch (kuzzle, options, config) {
       return Promise.reject(new BadRequestError('Query cannot be empty'));
     }
 
-    // todo do not delete the document but pass active to false
     return getAllIdsFromQuery.call(this, esRequest)
       .then(ids => {
         ids.forEach(id => {
@@ -978,7 +977,6 @@ function getElasticsearchRequest(request, kuzzle) {
   var data = {};
 
   if (request.input.resource.index) {
-    //TODO Protect internal index to avoid using this service from requests and core. this let allowInternalIndex policy obsolete
     if (request.input.resource.index === kuzzle.internalEngine.index) {
       throw new BadRequestError(`Cannot operate on Kuzzle internal index "${kuzzle.internalEngine.index}"`);
     }
@@ -1077,22 +1075,11 @@ function addActiveFilter(esRequest) {
       bool: {
         filter: {
           bool: {
-            should: [
-              {
-                term: {
-                  '_kuzzle_info.active': true
-                }
-              },
-              {
-                bool: {
-                  must_not: {
-                    exists: {
-                      'field': '_kuzzle_info'
-                    }
-                  }
-                }
+            must_not: {
+              term: {
+                '_kuzzle_info.active': false
               }
-            ],
+            }
           }
         }
       }


### PR DESCRIPTION
Fixes #583 with the following modifications:

* updating a document forces its `active` flag to `true`. This makes sense as updating a document, even if it has explicitly been put in the trashcan, should make it active again
* reverted the search and count added filters: instead of looking documents with a `active` flag set to true OR documents without metadata, excluding documents with incomplete metadata, it now excludes document with their `active` flag explicitly set to false. 