### PR TITLE
Set Request's context.user with the user loaded in the funnel

### DIFF
--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -21,7 +21,7 @@ function AuthController (kuzzle) {
    * Logs the current user out
    *
    * @param {Request} request
-   * @returns {Promise<Object>}
+   * @returns {Promise<object>}
    */
   this.logout = function authLogout (request) {
     return kuzzle.repositories.token.expire(request.context.token)
@@ -74,39 +74,29 @@ function AuthController (kuzzle) {
    * Returns the user identified by the given jwt token
    *
    * @param {Request} request
-   * @returns {Promise<Object>}
+   * @returns {Promise<object>}
    */
   this.getCurrentUser = function authGetCurrentUser (request) {
-    var userRequest = new Request({
-      controller: 'security',
-      action: 'getUser',
-      _id: request.context.token.userId
-    }, request.context);
-
-    return kuzzle.funnel.controllers.security.getUser(userRequest);
+    return Promise.resolve(request.context.user);
   };
 
   /**
    * Returns the rights of the user identified by the given jwt token
    *
    * @param {Request} request
-   * @returns {Promise<Object>}
+   * @returns {Promise<object>}
    */
   this.getMyRights = function getMyRights (request) {
-    var rightRequest = new Request({
-      controller: 'security',
-      action: 'getUser',
-      _id: request.context.token.userId
-    }, request.context);
-
-    return kuzzle.funnel.controllers.security.getUserRights(rightRequest);
+    return request.context.user.getRights(kuzzle)
+      .then(rights => Object.keys(rights).reduce((array, item) => array.concat(rights[item]), []))
+      .then(rights => Promise.resolve({hits: rights, total: rights.length}));
   };
 
   /**
    * Checks the validity of a token.
    *
    * @param {Request} request
-   * @returns {Promise<Object>}
+   * @returns {Promise<object>}
    */
   this.checkToken = function authCheckToken (request) {
     assertHasBody(request, 'auth:checkToken');
@@ -127,7 +117,7 @@ function AuthController (kuzzle) {
    * Updates the current user if it is not anonymous
    *
    * @param {Request} request
-   * @returns {Promise<Object>}
+   * @returns {Promise<object>}
    */
   this.updateSelf = function authUpdateSelf (request) {
     if (request.context.user._id === kuzzle.repositories.user.anonymous()._id) {

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -5,7 +5,6 @@ var
   _ = require('lodash'),
   UnauthorizedError = require('kuzzle-common-objects').errors.UnauthorizedError,
   InternalError = require('kuzzle-common-objects').errors.InternalError,
-  Request = require('kuzzle-common-objects').Request,
   Token = require('../core/models/security/token'),
   formatProcessing = require('../core/auth/formatProcessing'),
   assertHasBody = require('./util/requestAssertions').assertHasBody,
@@ -77,7 +76,7 @@ function AuthController (kuzzle) {
    * @returns {Promise<object>}
    */
   this.getCurrentUser = function authGetCurrentUser (request) {
-    return Promise.resolve(request.context.user);
+    return formatProcessing.formatUserForSerialization(kuzzle, request.context.user);
   };
 
   /**
@@ -129,7 +128,7 @@ function AuthController (kuzzle) {
     assertBodyHasNotAttribute(request, 'profileIds', 'auth:updateSelf');
 
     return kuzzle.repositories.user.persist(_.extend(request.context.user, request.input.body), {database: {method: 'update'}})
-      .then(updatedUser => formatProcessing.formatUserForSerialization(kuzzle, updatedUser, true));
+      .then(updatedUser => formatProcessing.formatUserForSerialization(kuzzle, updatedUser));
   };
 }
 

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -102,7 +102,6 @@ function AuthController (kuzzle) {
     return kuzzle.funnel.controllers.security.getUserRights(rightRequest);
   };
 
-
   /**
    * Checks the validity of a token.
    *
@@ -131,16 +130,15 @@ function AuthController (kuzzle) {
    * @returns {Promise<Object>}
    */
   this.updateSelf = function authUpdateSelf (request) {
-    if (request.context.token._id === kuzzle.repositories.token.anonymous()._id) {
-      throw new UnauthorizedError('User must be connected in order to call updateSelf');
+    if (request.context.user._id === kuzzle.repositories.user.anonymous()._id) {
+      throw new UnauthorizedError('User must be connected in order to call auth:updateSelf');
     }
 
     assertHasBody(request, 'auth:updateSelf');
     assertBodyHasNotAttribute(request, '_id', 'auth:updateSelf');
     assertBodyHasNotAttribute(request, 'profileIds', 'auth:updateSelf');
 
-    return kuzzle.repositories.user.load(request.context.token.userId)
-      .then(user => kuzzle.repositories.user.persist(_.extend(user, request.input.body), {database: {method: 'update'}}))
+    return kuzzle.repositories.user.persist(_.extend(request.context.user, request.input.body), {database: {method: 'update'}})
       .then(updatedUser => formatProcessing.formatUserForSerialization(kuzzle, updatedUser, true));
   };
 }

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -200,7 +200,11 @@ function FunnelController (kuzzle) {
         request.context.token = userToken;
         return kuzzle.repositories.user.load(request.context.token.userId);
       })
-      .then(user => user.isActionAllowed(request, kuzzle))
+      .then(user => {
+        request.context.user = user;
+
+        return user.isActionAllowed(request, kuzzle);
+      })
       .then(isAllowed => {
         if (!isAllowed) {
           // anonymous user => we throw a 401 (Unauthorised) error

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -198,6 +198,7 @@ function FunnelController (kuzzle) {
     return kuzzle.repositories.token.verifyToken(request.input.jwt)
       .then(userToken => {
         request.context.token = userToken;
+
         return kuzzle.repositories.user.load(request.context.token.userId);
       })
       .then(user => {

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -216,7 +216,7 @@ function FunnelController (kuzzle) {
           }
           // logged-in user with insufficient permissions => we throw a 403 (Forbidden) error
           return Promise.reject(new ForbiddenError(
-            `Forbidden action [${request.input.index}/${request.input.collection}/${request.input.controller}/${request.input.action}] for user ${request.context.token.userId}`)
+            `Forbidden action [${request.input.index}/${request.input.collection}/${request.input.controller}/${request.input.action}] for user ${request.context.user._id}`)
           );
         }
       });

--- a/lib/api/controllers/indexController.js
+++ b/lib/api/controllers/indexController.js
@@ -33,12 +33,11 @@ function IndexController (kuzzle) {
 
     return engine.listIndexes()
       .then(res => {
+        var promises;
+
         indexes = res.indexes.filter(index => _.includes(request.input.body.indexes, index));
 
-        return kuzzle.repositories.user.load(request.context.token.userId);
-      })
-      .then(user => {
-        var promises = indexes.map(index => user.isActionAllowed(new Request({controller: 'index', action: 'delete', index}, request.context), kuzzle)
+        promises = indexes.map(index => request.context.user.isActionAllowed(new Request({controller: 'index', action: 'delete', index}, request.context), kuzzle)
           .then(isAllowed => {
             if (isAllowed) {
               allowedIndexes.push(index);

--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -171,38 +171,35 @@ function HotelClerk (kuzzle) {
    */
   this.listSubscriptions = function hotelClerkListSubscriptions (request) {
     return new Promise(resolve => {
-      kuzzle.repositories.user.load(request.context.token.userId)
-        .then(user => {
-          var list = {};
+      var list = {};
 
-          async.each(Object.keys(this.rooms), (roomId, callback) => {
-            var room = this.rooms[roomId];
-            var rightRequest = new Request({
-              action: 'search',
-              controller: 'document',
-              index: room.index,
-              collection: room.collection
-            }, request.context);
+      async.each(Object.keys(this.rooms), (roomId, callback) => {
+        var room = this.rooms[roomId];
+        var rightRequest = new Request({
+          action: 'search',
+          controller: 'document',
+          index: room.index,
+          collection: room.collection
+        }, request.context);
 
-            return user.isActionAllowed(rightRequest, kuzzle)
-              .then(isAllowed => {
-                if (!isAllowed) {
-                  return callback(null);
-                }
+        return request.context.user.isActionAllowed(rightRequest, kuzzle)
+          .then(isAllowed => {
+            if (!isAllowed) {
+              return callback(null);
+            }
 
-                if (!list[room.index]) {
-                  list[room.index] = {};
-                }
+            if (!list[room.index]) {
+              list[room.index] = {};
+            }
 
-                if (!list[room.index][room.collection]) {
-                  list[room.index][room.collection] = {};
-                }
+            if (!list[room.index][room.collection]) {
+              list[room.index][room.collection] = {};
+            }
 
-                list[room.index][room.collection][roomId] = room.customers.length;
-                callback(null);
-              });
-          }, () => resolve(list));
-        });
+            list[room.index][room.collection][roomId] = room.customers.length;
+            callback(null);
+          });
+      }, () => resolve(list));
     });
   };
 

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -296,7 +296,7 @@ function ElasticSearch (kuzzle, options, config) {
 
     // Add metadata
     esRequest.body._kuzzle_info = {
-      author: request.context.token.userId ? String(request.context.token.userId) : null,
+      author: request.context.user._id ? String(request.context.user._id) : null,
       createdAt: Date.now(),
       updatedAt: null,
       updater: null,
@@ -377,7 +377,7 @@ function ElasticSearch (kuzzle, options, config) {
 
     // Add metadata
     esRequest.body._kuzzle_info = {
-      author: request.context.token.userId ? String(request.context.token.userId) : null,
+      author: request.context.user._id ? String(request.context.user._id) : null,
       createdAt: Date.now(),
       updatedAt: null,
       updater: null,
@@ -420,7 +420,7 @@ function ElasticSearch (kuzzle, options, config) {
     esRequest.body._kuzzle_info = {
       active: true,
       updatedAt: Date.now(),
-      updater: request.context.token.userId ? String(request.context.token.userId) : null
+      updater: request.context.user._id ? String(request.context.user._id) : null
     };
 
     esRequest.body = {doc: esRequest.body};
@@ -463,7 +463,7 @@ function ElasticSearch (kuzzle, options, config) {
 
     // Add metadata
     esRequest.body._kuzzle_info = {
-      author: request.context.token.userId ? String(request.context.token.userId) : null,
+      author: request.context.user._id ? String(request.context.user._id) : null,
       createdAt: Date.now(),
       updatedAt: null,
       updater: null,

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -240,7 +240,7 @@ describe('Test the auth controller', () => {
 
   describe('#getCurrentUser', () => {
     it('should return the user given in the context', () => {
-      var req = new Request({body: {}}, {token: {userId: 'admin'}});
+      var req = new Request({body: {}}, {token: {userId: 'admin'}, user: {_id: 'admin'}});
 
       return kuzzle.funnel.controllers.auth.getCurrentUser(req)
         .then(response => {
@@ -250,7 +250,7 @@ describe('Test the auth controller', () => {
     });
 
     it('should return a falsey response if the current user is unknown', () => {
-      return should(kuzzle.funnel.controllers.auth.getCurrentUser(new Request({body: {}}, {token: { userId: 'unknown_user'}}))).be.rejected();
+      return should(kuzzle.funnel.controllers.auth.getCurrentUser(new Request({body: {}}, {token: {userId: 'unknown_user', user: {_id: 'unknown_user'}}}))).be.rejected();
     });
   });
 
@@ -335,7 +335,10 @@ describe('Test the auth controller', () => {
     });
 
     it('should return a valid response', () => {
-      return kuzzle.funnel.controllers.auth.updateSelf(new Request({body: {foo: 'bar'}}, {token: {userId: 'admin', _id: 'admin'}}))
+      return kuzzle.funnel.controllers.auth.updateSelf(new Request(
+        {body: {foo: 'bar'}},
+        {token: {userId: 'admin', _id: 'admin'}, user: {_id: 'admin'}}
+      ))
         .then(response => {
           should(response).be.instanceof(Object);
           should(persistOptions.database.method).be.exactly('update');
@@ -347,7 +350,7 @@ describe('Test the auth controller', () => {
       should(() => {
         kuzzle.funnel.controllers.auth.updateSelf(new Request(
           {body: {foo: 'bar', profileIds: ['test']}},
-          {token: {userId: 'admin', _id: 'admin'}}
+          {token: {userId: 'admin', _id: 'admin'}, user: {_id: 'admin'}}
         ));
       }).throw(BadRequestError);
     });
@@ -356,20 +359,20 @@ describe('Test the auth controller', () => {
       should(() => {
         kuzzle.funnel.controllers.auth.updateSelf(new Request(
           {body: {foo: 'bar', _id: 'test'}},
-          {token: {userId: 'admin', _id: 'admin'}}
+          {token: {userId: 'admin', _id: 'admin'}, user: {_id: 'admin'}}
         ));
       }).throw(BadRequestError);
     });
 
     it('should throw an error if current user is anonymous', () => {
       should(() => {
-        kuzzle.funnel.controllers.auth.updateSelf(new Request({body: {foo: 'bar'}}, {token: {userId: '-1'}}));
+        kuzzle.funnel.controllers.auth.updateSelf(new Request({body: {foo: 'bar'}}, {token: {userId: '-1'}, user: {_id: '-1'}}));
       }).throw(UnauthorizedError);
     });
   });
 
   describe('#getMyRights', () => {
-    var req = new Request({body: {}}, {token: {userId: 'test'}});
+    var req = new Request({body: {}}, {token: {userId: 'test'}, user: {_id: 'test'}});
 
     it('should be able to get current user\'s rights', () => {
       var loadUserStub = userId => {

--- a/test/api/controllers/indexController.test.js
+++ b/test/api/controllers/indexController.test.js
@@ -44,15 +44,6 @@ describe('Test: index controller', () => {
       isActionAllowedStub.onCall(3).returns(Promise.resolve(false));
       isActionAllowedStub.returns(Promise.resolve(true));
 
-      kuzzle.repositories = {
-        user: {
-          load: sinon.spy(() => {
-            return Promise.resolve({
-              isActionAllowed: isActionAllowedStub
-            });
-          })
-        }
-      };
       indexController = new IndexController(kuzzle);
     });
 
@@ -61,15 +52,15 @@ describe('Test: index controller', () => {
         indexes: ['a', 'c', 'e', 'g', 'i']
       };
       request.context.token = {userId: '42'};
+      request.context.user = {
+        isActionAllowed: isActionAllowedStub
+      };
 
       return indexController.mDelete(request)
         .then(response => {
           var engine = kuzzle.services.list.storageEngine;
 
           try {
-            should(kuzzle.repositories.user.load).be.calledOnce();
-            should(kuzzle.repositories.user.load).be.calledWith('42');
-
             should(isActionAllowedStub).have.callCount(5);
 
             should(engine.deleteIndexes).be.calledOnce();

--- a/test/api/controllers/realtimeController.test.js
+++ b/test/api/controllers/realtimeController.test.js
@@ -17,7 +17,8 @@ describe('Test: subscribe controller', () => {
   beforeEach(() => {
     kuzzle = new KuzzleMock();
     realtimeController = new RealtimeController(kuzzle);
-    request = new Request({index: 'test', collection: 'collection', controller: 'realtime', body: {}});
+    request = new Request({index: 'test', collection: 'collection', controller: 'realtime', body: {}}, {user: {_id: '42'}});
+    kuzzle.repositories.user.anonymous = sinon.stub();
   });
 
   afterEach(() => {
@@ -142,6 +143,8 @@ describe('Test: subscribe controller', () => {
 
   describe('#list', () => {
     it('should call the proper hotelClerk method',() => {
+      kuzzle.repositories.user.anonymous.returns({_id: '-1'});
+
       return realtimeController.list(request)
         .then(result => {
           should(result).be.match(foo);

--- a/test/api/core/hotelClerk/listSubscriptions.test.js
+++ b/test/api/core/hotelClerk/listSubscriptions.test.js
@@ -42,7 +42,10 @@ describe('Test: hotelClerk.listSubscription', () => {
   });
 
   it('should return a correct list according to subscribe on filter', () => {
-    kuzzle.repositories.user.load = sandbox.stub().returns(Promise.resolve({_id: 'user', isActionAllowed: sandbox.stub().returns(Promise.resolve(true))}));
+    request.context.user = {
+      _id: 'user',
+      isActionAllowed: sandbox.stub().returns(Promise.resolve(true))
+    };
 
     hotelClerk.rooms[roomName] = {index, collection, roomId: 'foobar', customers: ['foo']};
 
@@ -68,9 +71,11 @@ describe('Test: hotelClerk.listSubscription', () => {
         index, collection: 'foo', roomId: 'foobar', customers: ['foo', 'bar']
       }
     };
-    kuzzle.repositories.user.load = sandbox.stub().returns(Promise.resolve({_id: 'user', isActionAllowed: r => {
-      return Promise.resolve(r.input.resource.collection === 'foo');
-    }}));
+
+    request.context.user = {
+      _id: 'user',
+      isActionAllowed: sandbox.spy(r => Promise.resolve(r.input.resource.collection === 'foo'))
+    };
 
     return hotelClerk.listSubscriptions(request)
       .then(response => {

--- a/test/api/core/hotelClerk/removeRooms.test.js
+++ b/test/api/core/hotelClerk/removeRooms.test.js
@@ -34,12 +34,7 @@ describe('Test: hotelClerk.removeRooms', () => {
     kuzzle.hotelClerk = new HotelClerk(kuzzle);
     kuzzle.dsl = new Dsl();
 
-    context = {
-      connectionId,
-      token: {
-        userId: ''
-      }
-    };
+    context = {connectionId, token: {userId: ''}, user: {_id: ''}};
 
   });
 

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -106,11 +106,7 @@ describe('Test: ElasticSearch service', () => {
       collection,
       index,
       body: documentAda
-    }, {
-      token: {
-        userId: 'test'
-      }
-    });
+    }, {token: {userId: 'test'}, user: {_id: 'test'}});
     elasticsearch.init();
   });
 


### PR DESCRIPTION
fix #424 

:warning: Only requests going through the `Funnel Controller` will have the user set (or when the request is built with a complete context).