### PR TITLE
#586: dynamic http options

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -6,6 +6,13 @@
   // file location to customize Kuzzle configuration
   // -------------------------------------------------------------------------
 
+  // The HTTP section lets you configure how Kuzzle should handle HTTP requests
+  "http": {
+    // accessControlAllowOrigin: sets the Access-Control-Allow-Origin header used to
+    //     send responses to the client
+    //     (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS)
+    "accessControlAllowOrigin": "*"
+  },
 
   // The plugins section let you define which plugins should be loaded on
   // Kuzzle first start.

--- a/default.config.js
+++ b/default.config.js
@@ -2,7 +2,16 @@
  * @class KuzzleConfiguration
  */
 module.exports = {
-  httpRoutes: require('./lib/config/httpRoutes'),
+  /*
+   routes: list of Kuzzle API exposed HTTP routes
+   accessControlAllowOrigin: sets the Access-Control-Allow-Origin header used to
+       send responses to the client
+       (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS)
+   */
+  http: {
+    routes: require('./lib/config/httpRoutes'),
+    accessControlAllowOrigin: '*'
+  },
 
   plugins: {
     common: {

--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -15,7 +15,7 @@ var
 function RouterController (kuzzle) {
   this.kuzzle = kuzzle;
   this.connections = {};
-  this.router = new HttpRouter();
+  this.router = new HttpRouter(kuzzle);
 
   /**
    * Declares a new connection on a given protocol. Called by proxyBroker.
@@ -65,17 +65,23 @@ function RouterController (kuzzle) {
     });
 
     this.router.get('/swagger.json', (data, cb) => {
-      let content = generateSwagger(kuzzle);
-      cb(new HttpResponse(data.id, 'application/json', 200, content));
+      data.response.setHeader('Content-Type', 'application/json');
+      cb(new HttpResponse(data.id, 200, {
+        content: generateSwagger(kuzzle),
+        headers: data.response.headers
+      }));
     });
 
     this.router.get('/swagger.yml', (data, cb) => {
-      let content = jsonToYaml.stringify(generateSwagger(kuzzle));
-      cb(new HttpResponse(data.id, 'application/yaml', 200, content));
+      data.response.setHeader('Content-Type', 'application/yaml');
+      cb(new HttpResponse(data.id, 200, {
+        content: jsonToYaml.stringify(generateSwagger(kuzzle)),
+        headers: data.response.headers
+      }));
     });
 
     // Register API routes
-    this.kuzzle.config.httpRoutes.forEach(route => {
+    this.kuzzle.config.http.routes.forEach(route => {
       this.router[route.verb](route.url, (data, cb) => {
         executeFromHttp(kuzzle.funnel, {controller: route.controller, action: route.action}, data, cb);
       });
@@ -99,7 +105,7 @@ function executeFromHttp(funnel, params, request, cb) {
   request.context.connectionId = 'http';
 
   funnel.execute(request, (err, result) => {
-    cb(new HttpResponse(result.id, 'application/json', result.status, result.response));
+    cb(new HttpResponse(result.id, result.status, result.response));
   });
 }
 

--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -64,20 +64,24 @@ function RouterController (kuzzle) {
       });
     });
 
-    this.router.get('/swagger.json', (data, cb) => {
-      data.response.setHeader('Content-Type', 'application/json');
-      cb(new HttpResponse(data.id, 200, {
-        content: generateSwagger(kuzzle),
-        headers: data.response.headers
-      }));
+    this.router.get('/swagger.json', (request, cb) => {
+      request.setResult(generateSwagger(kuzzle), {
+        status: 200,
+        raw: true,
+        headers: {'content-type': 'application/json'}
+      });
+
+      cb(new HttpResponse(request.id, 200, request.response));
     });
 
-    this.router.get('/swagger.yml', (data, cb) => {
-      data.response.setHeader('Content-Type', 'application/yaml');
-      cb(new HttpResponse(data.id, 200, {
-        content: jsonToYaml.stringify(generateSwagger(kuzzle)),
-        headers: data.response.headers
-      }));
+    this.router.get('/swagger.yml', (request, cb) => {
+      request.setResult(jsonToYaml.stringify(generateSwagger(kuzzle)), {
+        status: 200,
+        raw: true,
+        headers: {'content-type': 'application/yaml'}
+      });
+
+      cb(new HttpResponse(request.id, 200, request.response));
     });
 
     // Register API routes

--- a/lib/api/controllers/serverController.js
+++ b/lib/api/controllers/serverController.js
@@ -119,8 +119,8 @@ function ServerController (kuzzle) {
           actionList[action] = {name: action};
 
           // resolve associated http route for each actions
-          Object.keys(kuzzle.config.httpRoutes).forEach((key) => {
-            var route = kuzzle.config.httpRoutes[key];
+          Object.keys(kuzzle.config.http.routes).forEach((key) => {
+            var route = kuzzle.config.http.routes[key];
 
             if ((route.controller === controller || controller === 'memoryStorage' && route.controller === 'ms') && route.action === action) {
               routeDescription = route;

--- a/lib/api/core/entryPoints/httpResponse.js
+++ b/lib/api/core/entryPoints/httpResponse.js
@@ -2,14 +2,12 @@
  * Builds a HTTP response object
  *
  * @param {string} id - request id
- * @param {string} type - HTTP content type
  * @param {number} status - HTTP status code
  * @param {object} content
  * @constructor
  */
-function HttpResponse(id, type, status, content) {
+function HttpResponse(id, status, content) {
   this.id = id;
-  this.type = type;
   this.content = content;
   this.status = status;
 
@@ -20,7 +18,6 @@ HttpResponse.prototype.getResponse = function getResponse () {
   return {
     requestId: this.id,
     response: this.content,
-    type: this.type,
     status: this.status
   };
 };

--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -94,8 +94,7 @@ function HotelClerk (kuzzle) {
           c = this.rooms[roomId].channels[channel],
           stateMatch = c.state === 'all' || !notification.state || notification.action === 'publish' || c.state === notification.state,
           scopeMatch = c.scope === 'all' || !notification.scope || c.scope === notification.scope,
-          usersMatch = c.users === 'all' || notification.controller !== 'realtime' ||
-            c.users === 'in' && notification.action === 'subscribe' || c.users === 'out' && notification.action === 'unsubscribe';
+          usersMatch = c.users === 'all' || notification.getUserFlag() === 'none' || c.users === notification.getUserFlag();
 
         if (stateMatch && scopeMatch && usersMatch) {
           channels.push(channel);

--- a/lib/api/core/httpRouter/index.js
+++ b/lib/api/core/httpRouter/index.js
@@ -21,7 +21,16 @@ const CharsetRegex = /charset=([\w-]+)/i;
  *
  * @constructor
  */
-function Router() {
+function Router(kuzzle) {
+  this.kuzzle = kuzzle;
+
+  this.defaultHeaders = {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': kuzzle.config.http.accessControlAllowOrigin || '*',
+    'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
+  };
+
   this.routes = {
     GET: new RoutePart(),
     POST: new RoutePart(),
@@ -79,17 +88,32 @@ Router.prototype.delete = function routerGet(url, handler) {
  * @param {function} cb
  */
 Router.prototype.route = function route (httpRequest, cb) {
-  let
-    routeHandler;
+  let routeHandler;
 
   if (!this.routes[httpRequest.method]) {
     let request = new Request({requestId: httpRequest.requestId}, {}, 'rest');
-    return replyWithError(cb, request, new BadRequestError(`Unrecognized HTTP method ${httpRequest.method}`));
+    request.response.setHeaders(this.defaultHeaders);
+
+    if (httpRequest.method.toUpperCase() === 'OPTIONS') {
+      request.setResult({}, 200);
+
+      return this.kuzzle.pluginsManager.trigger('http:options', request)
+        .then(result => {
+          cb(new HttpResponse(result.id, result.status, result.response));
+          return null;
+        })
+        .catch(error => replyWithError(cb, request, error));
+    }
+    else {
+      return replyWithError(cb, request, new BadRequestError(`Unrecognized HTTP method ${httpRequest.method}`));
+    }
   }
 
   routeHandler = this.routes[httpRequest.method].getHandler(httpRequest);
 
   if (routeHandler.handler !== null) {
+    routeHandler.getRequest().response.setHeaders(this.defaultHeaders);
+
     if (httpRequest.content.length > 0) {
       if (!httpRequest.headers['content-type'] || httpRequest.headers['content-type'].startsWith('application/json')) {
         let encoding = CharsetRegex.exec(httpRequest.headers['content-type']);
@@ -166,7 +190,7 @@ function replyWithError(cb, request, error) {
 
   request.setError(error);
 
-  httpResponse = new HttpResponse(request.id, 'application/json', request.status, request.response);
+  httpResponse = new HttpResponse(request.id, request.status, request.response);
 
   cb(httpResponse);
 }

--- a/lib/api/core/httpRouter/index.js
+++ b/lib/api/core/httpRouter/index.js
@@ -104,16 +104,14 @@ Router.prototype.route = function route (httpRequest, cb) {
         })
         .catch(error => replyWithError(cb, request, error));
     }
-    else {
-      return replyWithError(cb, request, new BadRequestError(`Unrecognized HTTP method ${httpRequest.method}`));
-    }
+
+    return replyWithError(cb, request, new BadRequestError(`Unrecognized HTTP method ${httpRequest.method}`));
   }
 
   routeHandler = this.routes[httpRequest.method].getHandler(httpRequest);
+  routeHandler.getRequest().response.setHeaders(this.defaultHeaders);
 
   if (routeHandler.handler !== null) {
-    routeHandler.getRequest().response.setHeaders(this.defaultHeaders);
-
     if (httpRequest.content.length > 0) {
       if (!httpRequest.headers['content-type'] || httpRequest.headers['content-type'].startsWith('application/json')) {
         let encoding = CharsetRegex.exec(httpRequest.headers['content-type']);

--- a/lib/api/core/models/notificationObject.js
+++ b/lib/api/core/models/notificationObject.js
@@ -35,6 +35,19 @@ function NotificationObject(roomId, request, content) {
     .forEach(key => { this.result[key] = content[key]; });
 }
 
+NotificationObject.prototype.getUserFlag = function getUserFlag () {
+  if (this.controller === 'realtime') {
+    if (this.action === 'subscribe') {
+      return 'in';
+    }
+    else if (this.action === 'unsubscribe') {
+      return 'out';
+    }
+  }
+
+  return 'none';
+};
+
 NotificationObject.prototype.toJson = function notificationToJson () {
   var object = {
     error: null,
@@ -49,7 +62,8 @@ NotificationObject.prototype.toJson = function notificationToJson () {
     timestamp: this.timestamp,
     metadata: this.metadata,
     scope: this.scope,
-    state: this.state
+    state: this.state,
+    user: this.getUserFlag()
   };
 
   if (Object.keys(this.result).length > 0) {

--- a/lib/api/core/swagger.js
+++ b/lib/api/core/swagger.js
@@ -23,7 +23,7 @@ module.exports = function generateSwagger (kuzzle) {
   });  
 
   swagger = {
-    basePath: '/api',
+    basePath: '/',
     consumes: [
       'application/json'
     ],

--- a/lib/api/core/swagger.js
+++ b/lib/api/core/swagger.js
@@ -9,7 +9,7 @@ var _ = require('lodash');
 module.exports = function generateSwagger (kuzzle) {
   var swagger, routes = [];
 
-  kuzzle.config.httpRoutes.forEach(_route => {
+  kuzzle.config.http.routes.forEach(_route => {
     var route = _.assign({}, _route);
     routes.push(route);
   });

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "json-stable-stringify": "1.0.1",
     "json2yaml": "^1.1.0",
     "jsonwebtoken": "^7.1.7",
-    "kuzzle-common-objects": "^2.0.1",
+    "kuzzle-common-objects": "^2.1.0",
     "lodash": "4.16.3",
     "mkdirp": "0.5.1",
     "moment": "2.15.1",

--- a/test/api/controllers/routerController/httpRequest.test.js
+++ b/test/api/controllers/routerController/httpRequest.test.js
@@ -18,7 +18,10 @@ describe('Test: routerController.httpRequest', () => {
   before(() => {
     kuzzleStub = {
       config: {
-        httpRoutes: require('../../../../lib/config/httpRoutes')
+        http: {
+          routes: require('../../../../lib/config/httpRoutes'),
+          accessControlAllowOrigin: 'foobar'
+        }
       },
       pluginsManager: {
         routes: [
@@ -63,7 +66,8 @@ describe('Test: routerController.httpRequest', () => {
         should(response.input.action).be.eql('getrange');
         should(result).be.instanceOf(HttpResponse);
         should(result.id).be.eql(httpRequest.requestId);
-        should(result.type).be.eql('application/json');
+        should(result.content.headers['content-type']).be.eql('application/json');
+        should(result.content.headers['Access-Control-Allow-Origin']).be.eql('foobar');
         should(result.status).be.eql(1234);
         should(result.content).be.exactly(response.response);
         done();
@@ -85,7 +89,7 @@ describe('Test: routerController.httpRequest', () => {
         should(response.input.action).be.eql('updateProfile');
         should(result).be.instanceOf(HttpResponse);
         should(result.id).be.eql(httpRequest.requestId);
-        should(result.type).be.eql('application/json');
+        should(result.content.headers['content-type']).be.eql('application/json');
         should(result.status).be.eql(1234);
         should(result.content).be.exactly(response.response);
         done();
@@ -107,7 +111,7 @@ describe('Test: routerController.httpRequest', () => {
         should(response.input.action).be.eql('updateSelf');
         should(result).be.instanceOf(HttpResponse);
         should(result.id).be.eql(httpRequest.requestId);
-        should(result.type).be.eql('application/json');
+        should(result.content.headers['content-type']).be.eql('application/json');
         should(result.status).be.eql(1234);
         should(result.content).be.exactly(response.response);
         done();
@@ -128,7 +132,7 @@ describe('Test: routerController.httpRequest', () => {
         should(response.input.action).be.eql('delete');
         should(result).be.instanceOf(HttpResponse);
         should(result.id).be.eql(httpRequest.requestId);
-        should(result.type).be.eql('application/json');
+        should(result.content.headers['content-type']).be.eql('application/json');
         should(result.status).be.eql(1234);
         should(result.content).be.exactly(response.response);
         done();
@@ -149,7 +153,7 @@ describe('Test: routerController.httpRequest', () => {
         should(response.input.action).be.eql('info');
         should(result).be.instanceOf(HttpResponse);
         should(result.id).be.eql(httpRequest.requestId);
-        should(result.type).be.eql('application/json');
+        should(result.content.headers['content-type']).be.eql('application/json');
         should(result.status).be.eql(1234);
         should(result.content).be.exactly(response.response);
         done();
@@ -168,7 +172,7 @@ describe('Test: routerController.httpRequest', () => {
       try {
         should(result).be.instanceOf(HttpResponse);
         should(result.id).be.eql(httpRequest.requestId);
-        should(result.type).be.eql('application/json');
+        should(result.content.headers['content-type']).be.eql('application/json');
         should(result.status).be.eql(200);
         done();
       }
@@ -186,7 +190,7 @@ describe('Test: routerController.httpRequest', () => {
       try {
         should(result).be.instanceOf(HttpResponse);
         should(result.id).be.eql(httpRequest.requestId);
-        should(result.type).be.eql('application/yaml');
+        should(result.content.headers['content-type']).be.eql('application/yaml');
         should(result.status).be.eql(200);
         done();
       }
@@ -206,7 +210,7 @@ describe('Test: routerController.httpRequest', () => {
         should(response.input.action).be.eql('bar');
         should(result).be.instanceOf(HttpResponse);
         should(result.id).be.eql(httpRequest.requestId);
-        should(result.type).be.eql('application/json');
+        should(result.content.headers['content-type']).be.eql('application/json');
         should(result.status).be.eql(1234);
         should(result.content).be.exactly(response.response);
         done();
@@ -225,9 +229,9 @@ describe('Test: routerController.httpRequest', () => {
       try {
         should(result).be.instanceOf(HttpResponse);
         should(result.id).be.eql(httpRequest.requestId);
-        should(result.type).be.eql('application/json');
+        should(result.content.headers['content-type']).be.eql('application/json');
         should(result.status).be.eql(404);
-        should(JSON.stringify(result.content)).startWith('{"status":404,"error":{"status":404,"message":"API URL not found: /foo/bar"');
+        should(JSON.stringify(result.content.error)).startWith('{"status":404,"message":"API URL not found: /foo/bar"');
         done();
       }
       catch (e) {

--- a/test/api/core/hotelClerk/addToChannels.test.js
+++ b/test/api/core/hotelClerk/addToChannels.test.js
@@ -153,24 +153,24 @@ describe('Test: hotelClerk.addToChannels', () => {
       channels = {};
 
     request.users = 'all';
-    kuzzle.hotelClerk.addSubscription(new Request(request), context)
+    kuzzle.hotelClerk.addSubscription(new Request(request))
       .then(response => {
         roomId = response.roomId;
-        notification = new NotificationObject(response.roomId, new Request({collection: 'foo', body: dataGrace}));
+        notification = new NotificationObject(response.roomId, new Request({collection: 'foo', body: dataGrace}), {});
         notification.controller = 'realtime';
         channels.all = response.channel;
         request.users = 'in';
-        return kuzzle.hotelClerk.addSubscription(new Request(request), context);
+        return kuzzle.hotelClerk.addSubscription(new Request(request));
       })
       .then(response => {
         channels.in = response.channel;
         request.users = 'out';
-        return kuzzle.hotelClerk.addSubscription(new Request(request), context);
+        return kuzzle.hotelClerk.addSubscription(new Request(request));
       })
       .then(response => {
         channels.out = response.channel;
         request.users = 'none';
-        return kuzzle.hotelClerk.addSubscription(new Request(request), context);
+        return kuzzle.hotelClerk.addSubscription(new Request(request));
       })
       .then(response => {
         var eligibleChannels = [];

--- a/test/api/core/httpRouter/httpRouter.test.js
+++ b/test/api/core/httpRouter/httpRouter.test.js
@@ -3,6 +3,7 @@
 const
   should = require('should'),
   sinon = require('sinon'),
+  KuzzleMock = require('../../../mocks/kuzzle.mock'),
   InternalError = require('kuzzle-common-objects').errors.InternalError,
   HttpResponse = require('../../../../lib/api/core/entryPoints/httpResponse'),
   Router = require('../../../../lib/api/core/httpRouter'),
@@ -12,11 +13,13 @@ describe('core/httpRouter', () => {
   let
     router,
     handler,
+    kuzzleMock,
     callback,
     rq;
 
   beforeEach(() => {
-    router = new Router();
+    kuzzleMock = new KuzzleMock();
+    router = new Router(kuzzleMock);
     handler = sinon.stub();
     callback = sinon.stub();
     rq = {
@@ -116,6 +119,46 @@ describe('core/httpRouter', () => {
       should(handler.firstCall.args[0].input.args.baz).eql('%world');
     });
 
+    it('should trigger an event when handling an OPTIONS HTTP method', done => {
+      rq.url = '/';
+      rq.method = 'OPTIONS';
+      rq.headers['content-type'] = 'application/json';
+
+      router.route(rq, callback);
+
+      setTimeout(() => {
+        should(handler.called).be.false();
+        should(callback.calledOnce).be.true();
+        should(callback.firstCall.args[0]).be.instanceOf(HttpResponse);
+        should(callback.firstCall.args[0]).match({
+          id: rq.requestId,
+          status: 200
+        });
+
+        should(callback.firstCall.args[0]).have.property('content');
+        should(callback.firstCall.args[0].content.toJSON()).match({
+          raw: false,
+          requestId: rq.requestId,
+          content: {
+            status: 200,
+            error: null,
+            requestId: 'requestId',
+            result: {}
+          },
+          headers: {
+            'content-type': 'application/json',
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+            'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
+          }
+        });
+
+        should(kuzzleMock.pluginsManager.trigger.calledOnce).be.true();
+        should(kuzzleMock.pluginsManager.trigger.calledWith('http:options', sinon.match.instanceOf(Request))).be.true();
+        done();
+      }, 20);
+    });
+
     it('should return an error if the HTTP method is unknown', () => {
       router.post('/foo/bar', handler);
 
@@ -130,18 +173,28 @@ describe('core/httpRouter', () => {
       should(callback.firstCall.args[0]).be.instanceOf(HttpResponse);
       should(callback.firstCall.args[0]).match({
         id: rq.requestId,
-        type: 'application/json',
         status: 400
       });
 
+      should(callback.firstCall.args[0]).have.property('content');
       should(callback.firstCall.args[0].content.toJSON()).match({
-        status: 400,
-        error: {
+        raw: false,
+        requestId: rq.requestId,
+        content: {
           status: 400,
-          message: 'Unrecognized HTTP method FOOBAR'
+          error: {
+            status: 400,
+            message: 'Unrecognized HTTP method FOOBAR'
+          },
+          requestId: 'requestId',
+          result: null
         },
-        requestId: 'requestId',
-        result: null
+        headers: {
+          'content-type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+          'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
+        }
       });
     });
 
@@ -159,18 +212,28 @@ describe('core/httpRouter', () => {
       should(callback.firstCall.args[0]).be.instanceOf(HttpResponse);
       should(callback.firstCall.args[0]).match({
         id: rq.requestId,
-        type: 'application/json',
         status: 400
       });
 
+      should(callback.firstCall.args[0]).have.property('content');
       should(callback.firstCall.args[0].content.toJSON()).match({
-        status: 400,
-        error: {
+        raw: false,
+        requestId: rq.requestId,
+        content: {
           status: 400,
-          message: 'Unable to convert HTTP body to JSON'
+          error: {
+            status: 400,
+            message: 'Unable to convert HTTP body to JSON'
+          },
+          requestId: 'requestId',
+          result: null
         },
-        requestId: 'requestId',
-        result: null
+        headers: {
+          'content-type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+          'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
+        }
       });
     });
 
@@ -188,18 +251,28 @@ describe('core/httpRouter', () => {
       should(callback.firstCall.args[0]).be.instanceOf(HttpResponse);
       should(callback.firstCall.args[0]).match({
         id: rq.requestId,
-        type: 'application/json',
         status: 400
       });
 
+      should(callback.firstCall.args[0]).have.property('content');
       should(callback.firstCall.args[0].content.toJSON()).match({
-        status: 400,
-        error: {
+        raw: false,
+        requestId: rq.requestId,
+        content: {
           status: 400,
-          message: 'Invalid request content-type. Expected "application/json", got: "application/foobar"'
+          error: {
+            status: 400,
+            message: 'Invalid request content-type. Expected "application/json", got: "application/foobar"'
+          },
+          requestId: 'requestId',
+          result: null
         },
-        requestId: 'requestId',
-        result: null
+        headers: {
+          'content-type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+          'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
+        }
       });
     });
 
@@ -217,18 +290,28 @@ describe('core/httpRouter', () => {
       should(callback.firstCall.args[0]).be.instanceOf(HttpResponse);
       should(callback.firstCall.args[0]).match({
         id: rq.requestId,
-        type: 'application/json',
         status: 400
       });
 
+      should(callback.firstCall.args[0]).have.property('content');
       should(callback.firstCall.args[0].content.toJSON()).match({
-        status: 400,
-        error: {
+        raw: false,
+        requestId: rq.requestId,
+        content: {
           status: 400,
-          message: 'Invalid request charset. Expected "utf-8", got: "iso8859-1"'
+          error: {
+            status: 400,
+            message: 'Invalid request charset. Expected "utf-8", got: "iso8859-1"'
+          },
+          requestId: 'requestId',
+          result: null
         },
-        requestId: 'requestId',
-        result: null
+        headers: {
+          'content-type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+          'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
+        }
       });
     });
 
@@ -246,18 +329,28 @@ describe('core/httpRouter', () => {
       should(callback.firstCall.args[0]).be.instanceOf(HttpResponse);
       should(callback.firstCall.args[0]).match({
         id: rq.requestId,
-        type: 'application/json',
         status: 404
       });
 
+      should(callback.firstCall.args[0]).have.property('content');
       should(callback.firstCall.args[0].content.toJSON()).match({
-        status: 404,
-        error: {
+        raw: false,
+        requestId: rq.requestId,
+        content: {
           status: 404,
-          message: 'API URL not found: /foo/bar'
+          error: {
+            status: 404,
+            message: 'API URL not found: /foo/bar'
+          },
+          requestId: 'requestId',
+          result: null
         },
-        requestId: 'requestId',
-        result: null
+        headers: {
+          'content-type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+          'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
+        }
       });
     });
   });


### PR DESCRIPTION
Fix https://github.com/kuzzleio/kuzzle/issues/586

Pre-requisites:
* https://github.com/kuzzleio/kuzzle-common-objects/pull/13
* https://github.com/kuzzleio/kuzzle-plugin-socketio/pull/13
* https://github.com/kuzzleio/kuzzle-plugin-websocket/pull/11
* https://github.com/kuzzleio/kuzzle-proxy/pull/43


## Changes

* `accessControlAllowOrigin` is now a Kuzzle configuration, allowing to set static `Access-Control-Allow-Origin` headers
* Kuzzle configuration has been slightly modified: instead of a `httpRoutes` configuration, there is now a `http` object containing the following entries: `routes` and `accessControlAllowOrigin`
* Kuzzle now handles HTTP OPTIONS requests
* Upon receiving a HTTP OPTIONS request, Kuzzle builds a standard `Request` object containing the request response. It then triggers a pipe event named `http:options`, for plugins to modify that response, if needs be
* Update swagger routes to match the new Kuzzle response format

## Unrelated

* Fix a bug with notification channels calculation, occuring because of a side effect caused by the `publish` route moved to the `realtime` controller
* Fix swagger base API generated value
