### PR TITLE
change overload event name

### DIFF
--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -76,7 +76,7 @@ function FunnelController (kuzzle) {
 
       if ((this.cachedItems > kuzzle.config.server.warningRetainedRequestsLimit) && (this.lastWarningTime === 0 || this.lastWarningTime < now - 500)) {
         let overloadPercentage = Math.round(10000 * this.cachedItems / kuzzle.config.server.maxRetainedRequests) / 100;
-        kuzzle.pluginsManager.trigger('server:overload', overloadPercentage);
+        kuzzle.pluginsManager.trigger('core:overload', overloadPercentage);
         kuzzle.pluginsManager.trigger('log:warn', '[!WARNING!] Kuzzle overloaded: ' + overloadPercentage + '%. Delaying requests...');
 
         this.overloadWarned = true;

--- a/test/api/controllers/funnelController/execute.test.js
+++ b/test/api/controllers/funnelController/execute.test.js
@@ -88,11 +88,11 @@ describe('funnelController.execute', () => {
     });
   });
 
-  describe('#server:overload hook', () => {
+  describe('#core:overload hook', () => {
     it('should fire the hook the first time Kuzzle is in overloaded state', /** @this {Mocha} */ function (done) {
       this.timeout(500);
 
-      kuzzle.once('server:overload', () => {
+      kuzzle.once('core:overload', () => {
         done();
       });
 
@@ -103,7 +103,7 @@ describe('funnelController.execute', () => {
     it('should fire the hook if the last one was fired more than 500ms ago', /** @this {Mocha} */ function (done) {
       this.timeout(500);
 
-      kuzzle.once('server:overload', () => {
+      kuzzle.once('core:overload', () => {
         done();
       });
 
@@ -114,16 +114,16 @@ describe('funnelController.execute', () => {
 
     it('should not fire the hook if one was fired less than 500ms ago', done => {
       var listener = () => {
-        done(new Error('server:overload hook fired unexpectedly'));
+        done(new Error('core:overload hook fired unexpectedly'));
       };
 
-      kuzzle.once('server:overload', listener);
+      kuzzle.once('core:overload', listener);
 
       funnel.overloaded = true;
       funnel.lastWarningTime = Date.now() - 200;
       funnel.execute(request, () => {});
       setTimeout(() => {
-        kuzzle.off('server:overload', listener);
+        kuzzle.off('core:overload', listener);
         done();
       }, 200);
     });


### PR DESCRIPTION
With the recent controllers normalization, the `server:overload` event seemed out of place, among other `server:xxx` events dedicated to the new `server` controller.

To make our API more consistent, I propose to rename this event to `core:overload`, so that it appears with other `core` events.