### PR TITLE
Fix node inspector

### DIFF
--- a/docker-compose/config/pm2-dev.json
+++ b/docker-compose/config/pm2-dev.json
@@ -5,6 +5,6 @@
     "args"         : ["start"],
     "watch"        : ["lib", "config", "bin", "default.config.js"],
     "ignore_watch" : ["node_modules"],
-    "node_args": "--debug=7000"
+    "node_args": "--inspect"
   }]
 }

--- a/docker-compose/dev.yml
+++ b/docker-compose/dev.yml
@@ -19,6 +19,7 @@ services:
       - elasticsearch
     ports:
       - "8080:8080"
+      - "9229:9229"
     environment:
       - kuzzle_services__db__host=elasticsearch
       - kuzzle_services__internalCache__node__host=redis

--- a/docker-compose/scripts/run-dev.sh
+++ b/docker-compose/scripts/run-dev.sh
@@ -24,7 +24,6 @@ fi
 
 echo "[$(date --rfc-3339 seconds)] - Starting Kuzzle..."
 
-pm2 start --silent /config/pm2.json
-nohup node-inspector --web-port=8080 --debug-port=7000 > /dev/null 2>&1&
+pm2 start /config/pm2.json
 pm2 sendSignal -s SIGUSR1 KuzzleServer
-pm2 logs --lines 0 --raw
+pm2 logs --lines 2

--- a/docker-compose/scripts/run-dev.sh
+++ b/docker-compose/scripts/run-dev.sh
@@ -25,5 +25,4 @@ fi
 echo "[$(date --rfc-3339 seconds)] - Starting Kuzzle..."
 
 pm2 start /config/pm2.json
-pm2 sendSignal -s SIGUSR1 KuzzleServer
 pm2 logs --lines 2


### PR DESCRIPTION
* Remove node-inspector (doesn't work with node 6)
* Use the built-in debugger with `--inspect`
* The output is something like:
```
kuzzle_1         | /root/.pm2/logs/KuzzleServer-error-0.log last 2 lines:
kuzzle_1         | 0|KuzzleSe | To start debugging, open the following URL in Chrome:
kuzzle_1         | 0|KuzzleSe |     chrome-devtools://devtools/remote/serve_file/@60cd6e859b9f557d2312f5bf532f6aec5f284980/inspector.html?experiments=true&v8only=true&ws=127.0.0.1:9229/472b7e02-f672-4dac-b3be-25750dd24593
```

You just have to copy/past the url `chrome-devtools://`