### PR TITLE
#590: force plugin developers to provide a Request object to the Request constructor

### DIFF
--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -1,4 +1,6 @@
-var
+'use strict';
+
+const
   _ = require('lodash'),
   Promise = require('bluebird'),
   PluginImplementationError = require('kuzzle-common-objects').errors.PluginImplementationError,
@@ -13,13 +15,13 @@ var
 function PluginContext(kuzzle) {
   // we have a circular dependency between Kuzzle and the plugins.
   // We cannot get Kuzzle constructor from the global scope
-  var Kuzzle = require('../../kuzzle');
+  const Kuzzle = require('../../kuzzle');
 
   this.accessors = {};
   this.config = kuzzle.config;
   this.constructors = {
     Dsl: require('../../dsl'),
-    Request,
+    Request: instantiateRequest,
     RequestContext,
     RequestInput,
     BaseValidationType: require('../validation/baseType')
@@ -95,10 +97,7 @@ function execute (request, callback) {
   var kuzzle = this;
 
   kuzzle.funnel.processRequest(request)
-    .then(response => {
-      request.setResult(response, request.status === 102 ? 200 : request.status);
-      callback(null, request);
-    })
+    .then(() => callback(null, request))
     .catch(err => {
       kuzzle.pluginsManager.trigger('log:error', err);
 
@@ -156,6 +155,27 @@ function createUser(userRepository, name, profile, userInfo) {
      to an internal Kuzzle object
      */
     .then(() => userInfo);
+}
+
+/**
+ * Instantiates a new Request object, using the provided one
+ * to set the context informations
+ *
+ * @throws
+ * @param {Request} request
+ * @param {Object} data
+ * @param {Object} [options]
+ * @return {Request}
+ */
+function instantiateRequest(request, data, options) {
+  if (!request || !(request instanceof Request)) {
+    throw new PluginImplementationError('A Request object must be provided');
+  }
+
+  options = options || {};
+  Object.assign(options, request.context.toJSON());
+
+  return new Request(data, options);
 }
 
 module.exports = PluginContext;

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -97,7 +97,7 @@ function execute (request, callback) {
   var kuzzle = this;
 
   kuzzle.funnel.processRequest(request)
-    .then(() => callback(null, request))
+    .then(response => callback(null, response))
     .catch(err => {
       kuzzle.pluginsManager.trigger('log:error', err);
 

--- a/test/api/core/pluginContext/pluginContext.test.js
+++ b/test/api/core/pluginContext/pluginContext.test.js
@@ -39,6 +39,10 @@ describe('Plugin Context', () => {
       should(new context.constructors.Request(new Request({}), {})).be.instanceOf(Request);
     });
 
+    it('should throw when trying to instante a Request object without providing a request object', () => {
+      should(function () { new context.constructors.Request({}); }).throw(PluginImplementationError);
+    });
+
     it('should expose all error objects as capitalized constructors', () => {
       var
         errors = require('kuzzle-common-objects').errors;

--- a/test/api/core/pluginContext/pluginContext.test.js
+++ b/test/api/core/pluginContext/pluginContext.test.js
@@ -36,7 +36,7 @@ describe('Plugin Context', () => {
       should(context.constructors.BaseValidationType).be.a.Function();
 
       should(new context.constructors.Dsl).be.instanceOf(Dsl);
-      should(new context.constructors.Request({})).be.instanceOf(Request);
+      should(new context.constructors.Request(new Request({}), {})).be.instanceOf(Request);
     });
 
     it('should expose all error objects as capitalized constructors', () => {


### PR DESCRIPTION
Fix #590 

Unrelated bugfix: 
* pluginContext.accessors.execute assumed the returned `response` from `funnel.processRequest` was a raw object, instead of the updated version of the provided `Request` object