### PR TITLE
[MASTER] #596 - Request provided with the http:options event should contain HTTP headers

### DIFF
--- a/lib/api/core/httpRouter/index.js
+++ b/lib/api/core/httpRouter/index.js
@@ -95,6 +95,7 @@ Router.prototype.route = function route (httpRequest, cb) {
     request.response.setHeaders(this.defaultHeaders);
 
     if (httpRequest.method.toUpperCase() === 'OPTIONS') {
+      Object.assign(request.input.args, httpRequest.headers);
       request.setResult({}, 200);
 
       return this.kuzzle.pluginsManager.trigger('http:options', request)

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "json-stable-stringify": "1.0.1",
     "json2yaml": "^1.1.0",
     "jsonwebtoken": "^7.1.7",
-    "kuzzle-common-objects": "^2.1.0",
+    "kuzzle-common-objects": "2.1.0",
     "lodash": "4.16.3",
     "mkdirp": "0.5.1",
     "moment": "2.15.1",

--- a/test/api/core/httpRouter/httpRouter.test.js
+++ b/test/api/core/httpRouter/httpRouter.test.js
@@ -122,7 +122,10 @@ describe('core/httpRouter', () => {
     it('should trigger an event when handling an OPTIONS HTTP method', done => {
       rq.url = '/';
       rq.method = 'OPTIONS';
-      rq.headers['content-type'] = 'application/json';
+      rq.headers = {
+        'content-type': 'application/json',
+        foo: 'bar'
+      };
 
       router.route(rq, callback);
 
@@ -155,6 +158,7 @@ describe('core/httpRouter', () => {
 
         should(kuzzleMock.pluginsManager.trigger.calledOnce).be.true();
         should(kuzzleMock.pluginsManager.trigger.calledWith('http:options', sinon.match.instanceOf(Request))).be.true();
+        should(kuzzleMock.pluginsManager.trigger.firstCall.args[1].input.args.foo).eql('bar');
         done();
       }, 20);
     });


### PR DESCRIPTION
Fix #596 