### PR TITLE
Change method for refreshInternal from GET to POST

### DIFF
--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -17,7 +17,6 @@ module.exports = [
   {verb: 'get', url: '/:index/_autoRefresh', controller: 'index', action: 'getAutoRefresh'},
   {verb: 'get', url: '/:index/_exists', controller: 'index', action: 'exists'},
   {verb: 'get', url: '/_list', controller: 'index', action: 'list'},
-  {verb: 'get', url: '/_refreshInternal', controller: 'index', action: 'refreshInternal'},
 
   {verb: 'get', url: '/_listSubscriptions', controller: 'realtime', action: 'list'},
 
@@ -108,6 +107,7 @@ module.exports = [
   {verb: 'post', url: '/_getStats', controller: 'server', action: 'getStats'},
 
   {verb: 'post', url: '/:index/_refresh', controller: 'index', action: 'refresh'},
+  {verb: 'post', url: '/_refreshInternal', controller: 'index', action: 'refreshInternal'},
   {verb: 'post', url: '/:index/_autoRefresh', controller: 'index', action: 'setAutoRefresh'},
 
   {verb: 'post', url: '/:index/:collection/_count', controller: 'document', action: 'count'},


### PR DESCRIPTION
Breaking change:

Change the HTTP method used to call `index:refreshInternal` from `GET` to `POST`.