### PR TITLE
Logger one processs

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -41,7 +41,7 @@
     //   * from a local directory: the location of the package must be
     //     specified using the "path" property
     "kuzzle-plugin-logger": {
-      "version": "2.0.5",
+      "version": "2.0.7",
       "activated": true
     },
     "kuzzle-plugin-auth-passport-local": {

--- a/default.config.js
+++ b/default.config.js
@@ -21,7 +21,7 @@ module.exports = {
     },
 
     'kuzzle-plugin-logger': {
-      version: '2.0.5',
+      version: '2.0.7',
       activated: true
     },
     'kuzzle-plugin-auth-passport-local': {


### PR DESCRIPTION
Following https://github.com/kuzzleio/kuzzle-plugin-logger/pull/13/files

This PR sets by default one process for the logger, which should be good enough in most cases and limits memory usage.