### PR TITLE
Re-organize http routes to comply more with method meanings

### DIFF
--- a/features/support/apiHttp.js
+++ b/features/support/apiHttp.js
@@ -225,7 +225,7 @@ ApiHttp.prototype.create = function (body, index, collection, jwtToken) {
 
 ApiHttp.prototype.publish = function (body, index) {
   var options = {
-    url: this.apiPath(((typeof index !== 'string') ? this.world.fakeIndex : index) + '/' + this.world.fakeCollection),
+    url: this.apiPath(((typeof index !== 'string') ? this.world.fakeIndex : index) + '/' + this.world.fakeCollection + '/_publish'),
     method: 'POST',
     body
   };
@@ -401,8 +401,8 @@ ApiHttp.prototype.deleteIndexes = function () {
 
 ApiHttp.prototype.createIndex = function (index) {
   var options = {
-    url: this.apiPath(index),
-    method: 'PUT'
+    url: this.apiPath(index + '/_create'),
+    method: 'POST'
   };
 
   return this.callApi(options);
@@ -734,7 +734,7 @@ ApiHttp.prototype.validateDocument = function (index, collection, document) {
 ApiHttp.prototype.postDocument = function (index, collection, document) {
   var options = {
     url: this.apiPath(index + '/' + collection + '/_create'),
-    method: 'PUT',
+    method: 'POST',
     body: document
   };
 

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -171,7 +171,8 @@ function SecurityController (kuzzle) {
    */
   this.createOrReplaceProfile = function securityCreateOrReplaceProfile (request) {
     assertHasBody(request, 'security:createOrReplaceProfile');
-    assertHasBody(request, 'policies', 'security:createOrReplaceProfile');
+    assertBodyHasAttribute(request, 'policies', 'security:createOrReplaceProfile');
+    assertHasId(request, 'security:createOrReplaceProfile');
 
     if (!_.isArray(request.input.body.policies)) {
       throw new BadRequestError('createOrReplaceProfile must specify an array of "policies"');
@@ -189,7 +190,8 @@ function SecurityController (kuzzle) {
    */
   this.createProfile = function securityCreateProfile (request) {
     assertHasBody(request, 'security:createProfile');
-    assertHasBody(request, 'policies', 'security:createProfile');
+    assertBodyHasAttribute(request, 'policies', 'security:createProfile');
+    assertHasId(request, 'security:createProfile');
 
     if (!_.isArray(request.input.body.policies)) {
       throw new BadRequestError('createOrReplaceProfile must specify an array of "policies"');
@@ -446,10 +448,9 @@ function SecurityController (kuzzle) {
 
     assertHasBody(request, 'security:createOrReplaceUser');
     assertBodyHasAttribute(request, 'profileIds', 'security:createOrReplaceUser');
+    assertHasId(request, 'security:createOrReplaceUser');
 
-    if (request.input.resource._id) {
-      user._id = request.input.resource._id;
-    }
+    user._id = request.input.resource._id;
 
     return kuzzle.repositories.user.hydrate(user, request.input.body)
       .then(modifiedUser => kuzzle.repositories.user.persist(modifiedUser))

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -1,5 +1,5 @@
 module.exports = [
-  // GET
+  // GET (idempotent)
   {verb: 'get', url: '/users/_me', controller: 'auth', action: 'getCurrentUser'},
   {verb: 'get', url: '/users/_me/_rights', controller: 'auth', action: 'getMyRights'},
   {verb: 'get', url: '/_login/:strategy', controller: 'auth', action: 'login'},
@@ -14,8 +14,8 @@ module.exports = [
 
   {verb: 'get', url: '/:index/:collection/:_id', controller: 'document', action: 'get'},
 
-  {verb: 'get', url: '/:index/_autoRefresh', controller: 'index', action: 'getAutoRefresh'},
   {verb: 'get', url: '/:index/_exists', controller: 'index', action: 'exists'},
+  {verb: 'get', url: '/:index/_autoRefresh', controller: 'index', action: 'getAutoRefresh'},
   {verb: 'get', url: '/_list', controller: 'index', action: 'list'},
   {verb: 'get', url: '/_refreshInternal', controller: 'index', action: 'refreshInternal'},
 
@@ -93,6 +93,7 @@ module.exports = [
   {verb: 'get', url: '/ms/_zscore/:_id/:member', controller: 'ms', action: 'zscore'},
   {verb: 'get', url: '/ms/:_id', controller: 'ms', action: 'get'},
 
+
   // POST
   {verb: 'post', url: '/_login', controller: 'auth', action: 'login'},
   {verb: 'post', url: '/_checkToken', controller: 'auth', action: 'checkToken'},
@@ -107,12 +108,14 @@ module.exports = [
 
   {verb: 'post', url: '/_getStats', controller: 'server', action: 'getStats'},
 
+  {verb: 'post', url: '/:index/_create', controller: 'index', action: 'create'},
   {verb: 'post', url: '/:index/_refresh', controller: 'index', action: 'refresh'},
   {verb: 'post', url: '/:index/_autoRefresh', controller: 'index', action: 'setAutoRefresh'},
 
   {verb: 'post', url: '/:index/:collection/_count', controller: 'document', action: 'count'},
   {verb: 'post', url: '/:index/:collection/_create', controller: 'document', action: 'create'},
-  {verb: 'post', url: '/:index/:collection', controller: 'realtime', action: 'publish'},
+  {verb: 'post', url: '/:index/:collection/:_id/_create', controller: 'document', action: 'create'},
+  {verb: 'post', url: '/:index/:collection/_publish', controller: 'realtime', action: 'publish'},
   {verb: 'post', url: '/:index/:collection/_search', controller: 'document', action: 'search'},
   {verb: 'post', url: '/_scroll/:scrollId', controller: 'document', action: 'scroll'},
   {verb: 'post', url: '/:index/:collection/_validate', controller: 'document', action: 'validate'},
@@ -120,8 +123,8 @@ module.exports = [
   {verb: 'post', url: '/_createFirstAdmin', controller: 'security', action: 'createFirstAdmin'},
   {verb: 'post', url: '/profiles/:_id/_create', controller: 'security', action: 'createProfile'},
   {verb: 'post', url: '/roles/:_id/_create', controller: 'security', action: 'createRole'},
-  {verb: 'post', url: '/users/:_id/_createRestricted', controller: 'security', action: 'createRestrictedUser'},
   {verb: 'post', url: '/users/_createRestricted', controller: 'security', action: 'createRestrictedUser'},
+  {verb: 'post', url: '/users/:_id/_createRestricted', controller: 'security', action: 'createRestrictedUser'},
   {verb: 'post', url: '/users/_create', controller: 'security', action: 'createUser'},
   {verb: 'post', url: '/users/:_id/_create', controller: 'security', action: 'createUser'},
   {verb: 'post', url: '/profiles/_mget', controller: 'security', action: 'mGetProfiles'},
@@ -129,10 +132,6 @@ module.exports = [
   {verb: 'post', url: '/profiles/_search', controller: 'security', action: 'searchProfiles'},
   {verb: 'post', url: '/roles/_search', controller: 'security', action: 'searchRoles'},
   {verb: 'post', url: '/users/_search', controller: 'security', action: 'searchUsers'},
-  {verb: 'post', url: '/profiles/:_id', controller: 'security', action: 'updateProfile'},
-  {verb: 'post', url: '/roles/:_id', controller: 'security', action: 'updateRole'},
-  {verb: 'post', url: '/users/:_id', controller: 'security', action: 'updateUser'},
-
 
   {verb: 'post', url: '/ms/_append/:_id', controller: 'ms', action: 'append'},
   {verb: 'post', url: '/ms/_bgrewriteaof', controller: 'ms', action: 'bgrewriteaof'},
@@ -209,30 +208,30 @@ module.exports = [
 
 
   // DELETE
-  {verb: 'delete', url: '/:index/:collection/_truncate', controller: 'collection', action: 'truncate'},
   {verb: 'delete', url: '/:index/:collection/_specifications', controller: 'collection', action: 'deleteSpecifications'},
+  {verb: 'delete', url: '/:index/:collection/_truncate', controller: 'collection', action: 'truncate'},
 
-  {verb: 'delete', url: '/:index/:collection/_query', controller: 'document', action: 'deleteByQuery'},
   {verb: 'delete', url: '/:index/:collection/:_id', controller: 'document', action: 'delete'},
+  {verb: 'delete', url: '/:index/:collection/_query', controller: 'document', action: 'deleteByQuery'},
 
-  {verb: 'delete', url: '/_mdelete', controller: 'index', action: 'mDelete'},
   {verb: 'delete', url: '/:index', controller: 'index', action: 'delete'},
+  {verb: 'delete', url: '/_mdelete', controller: 'index', action: 'mDelete'},
 
-  {verb: 'delete', url: '/roles/:_id', controller: 'security', action: 'deleteRole'},
   {verb: 'delete', url: '/profiles/:_id', controller: 'security', action: 'deleteProfile'},
+  {verb: 'delete', url: '/roles/:_id', controller: 'security', action: 'deleteRole'},
   {verb: 'delete', url: '/users/:_id', controller: 'security', action: 'deleteUser'},
 
+  {verb: 'delete', url: '/ms/:_id', controller: 'ms', action: 'del'},
+  {verb: 'delete', url: '/ms', controller: 'ms', action: 'del'},
   {verb: 'delete', url: '/ms/_hdel/:_id', controller: 'ms', action: 'hdel'},
   {verb: 'delete', url: '/ms/_lrem/:_id', controller: 'ms', action: 'lrem'},
   {verb: 'delete', url: '/ms/_srem/:_id', controller: 'ms', action: 'srem'},
   {verb: 'delete', url: '/ms/_zrem/:_id', controller: 'ms', action: 'zrem'},
   {verb: 'delete', url: '/ms/_zremrangebylex/:_id', controller: 'ms', action: 'zremrangebylex'},
   {verb: 'delete', url: '/ms/_zremrangebyscore/:_id', controller: 'ms', action: 'zremrangebyscore'},
-  {verb: 'delete', url: '/ms/:_id', controller: 'ms', action: 'del'},
-  {verb: 'delete', url: '/ms', controller: 'ms', action: 'del'},
 
 
-  // PUT
+  // PUT (idempotent)
   {verb: 'put', url: '/_updateSelf', controller: 'auth', action: 'updateSelf'},
 
   {verb: 'put', url: '/:index/:collection', controller: 'collection', action: 'create'},
@@ -240,16 +239,14 @@ module.exports = [
   {verb: 'put', url: '/users/_mapping', controller: 'collection', action: 'updateUserMapping'},
   {verb: 'put', url: '/_specifications', controller: 'collection', action: 'updateSpecifications'},
 
-  {verb: 'put', url: '/:index', controller: 'index', action: 'create'},
-
-  {verb: 'put', url: '/profiles/:_id', controller: 'security', action: 'createOrReplaceProfile'},
-  {verb: 'put', url: '/profiles/:_id/_createOrReplace', controller: 'security', action: 'createOrReplaceProfile'},
-  {verb: 'put', url: '/roles/:_id', controller: 'security', action: 'createOrReplaceRole'},
-  {verb: 'put', url: '/roles/:_id/_createOrReplace', controller: 'security', action: 'createOrReplaceRole'},
-  {verb: 'put', url: '/users/:_id', controller: 'security', action: 'createOrReplaceUser'},
-
-  {verb: 'put', url: '/:index/:collection/:_id/_create', controller: 'document', action: 'create'},
   {verb: 'put', url: '/:index/:collection/:_id', controller: 'document', action: 'createOrReplace'},
   {verb: 'put', url: '/:index/:collection/:_id/_replace', controller: 'document', action: 'replace'},
-  {verb: 'put', url: '/:index/:collection/:_id/_update', controller: 'document', action: 'update'}
+  {verb: 'put', url: '/:index/:collection/:_id/_update', controller: 'document', action: 'update'},
+
+  {verb: 'put', url: '/profiles/:_id', controller: 'security', action: 'createOrReplaceProfile'},
+  {verb: 'put', url: '/roles/:_id', controller: 'security', action: 'createOrReplaceRole'},
+  {verb: 'put', url: '/users/:_id', controller: 'security', action: 'createOrReplaceUser'},
+  {verb: 'put', url: '/profiles/:_id/_update', controller: 'security', action: 'updateProfile'},
+  {verb: 'put', url: '/roles/:_id/_update', controller: 'security', action: 'updateRole'},
+  {verb: 'put', url: '/users/:_id/_update', controller: 'security', action: 'updateUser'}
 ];

--- a/test/api/controllers/routerController/httpRequest.test.js
+++ b/test/api/controllers/routerController/httpRequest.test.js
@@ -79,8 +79,8 @@ describe('Test: routerController.httpRequest', () => {
   });
 
   it('should register POST routes from the config/httpRoutes file', (done) => {
-    httpRequest.url = '/profiles/foobar';
-    httpRequest.method = 'POST';
+    httpRequest.url = '/profiles/foobar/_update';
+    httpRequest.method = 'PUT';
     httpRequest.content = '{"profileId": "foobar"}';
 
     routeController.router.route(httpRequest, result => {

--- a/test/api/controllers/securityController/profiles.test.js
+++ b/test/api/controllers/securityController/profiles.test.js
@@ -59,9 +59,8 @@ describe('Test: security controller - profiles', () => {
       var error = new Error('Mocked error');
       sandbox.stub(kuzzle.repositories.profile, 'validateAndSaveProfile').returns(Promise.reject(error));
 
-      return should(securityController.createProfile(new Request({
-        body: {_id: 'test', policies: ['role1']}
-      }))).be.rejectedWith(error);
+      return should(securityController.createProfile(new Request({_id: 'test',body: {policies: ['role1']}})))
+        .be.rejectedWith(error);
     });
 
     it('should resolve to an object on a createProfile call', () => {
@@ -73,7 +72,7 @@ describe('Test: security controller - profiles', () => {
 
     it('should throw an error if creating a profile with bad roles property form', () => {
       return should(() => {
-        securityController.createOrReplaceProfile(new Request({body: {roleId: 'test', policies: 'not-an-array-roleIds'}}));
+        securityController.createOrReplaceProfile(new Request({_id: 'badTest', body: {roleId: 'test', policies: 'not-an-array-roleIds'}}));
       }).throw(BadRequestError);
     });
   });


### PR DESCRIPTION
* Consider `createOrReplace` as the default action of `PUT` method (and remove them from url);
* Consider `POST` method has no default action (and add `_create` action when necessary);
* Change HTTP method depending on idem-potency (update in `PUT`, index creation in `POST`...);
* Change `createOrReplace` to always require an `_id`