### PR TITLE
CLI createFirstAdmin Refactor

### DIFF
--- a/bin/commands/createFirstAdmin.js
+++ b/bin/commands/createFirstAdmin.js
@@ -72,7 +72,7 @@ function commandCreateFirstAdmin (options) {
     clcError = clcOk = clcQuestion = string => string;
   }
 
-  return kuzzle.cli.do('adminExists', params)
+  return kuzzle.cli.do('adminExists', {})
     .then(adminExists => {
       if (adminExists.result.exists) {
         console.log('An administrator account already exists.');
@@ -102,9 +102,10 @@ function commandCreateFirstAdmin (options) {
 
       return kuzzle.cli.do('createFirstAdmin', {
         _id: username,
+        reset: resetRoles,
         body: {
+          username,
           password,
-          reset: resetRoles
         }
       }, {pid: params.pid, debug: options.parent.debug});
     })

--- a/lib/api/cli/index.js
+++ b/lib/api/cli/index.js
@@ -59,16 +59,25 @@ function CliActions (kuzzle) {
         let
           onListenCB = action.onListenCB.bind(action),
           raw = action.prepareData(data),
+          beforeEvent = kuzzle.funnel.getEventName('cli', 'before', actionIdentifier),
           request;
 
         Object.assign(raw, {controller: 'actions', action: actionIdentifier});
 
-        request = new Request(raw);
+        request = new Request(raw, {protocol: 'cli'});
 
-        kuzzle.services.list.broker.listen(request.id, onListenCB);
-        kuzzle.services.list.broker.send(kuzzle.config.queues.cliQueue, request.serialize());
+        kuzzle.pluginsManager.trigger(beforeEvent, request)
+          .then(updatedRequest => {
+            kuzzle.services.list.broker.listen(updatedRequest.id, onListenCB);
+            kuzzle.services.list.broker.send(kuzzle.config.queues.cliQueue, updatedRequest.serialize());
+          });
 
         return action.deferred.promise;
+      })
+      .then(response => {
+        let afterEvent = kuzzle.funnel.getEventName('cli', 'after', actionIdentifier);
+
+        return kuzzle.pluginsManager.trigger(afterEvent, response);
       })
       .catch(error => {
         if (params && params.debug) {

--- a/lib/api/controllers/cli/adminExists.js
+++ b/lib/api/controllers/cli/adminExists.js
@@ -1,0 +1,25 @@
+const Request = require('kuzzle-common-objects').Request;
+let _kuzzle;
+
+/**
+ * Process an adminExists request inside kuzzle
+ *
+ * @param {Request} request Original CLI Request
+ * @returns {Promise}
+ */
+function cliRunAdminExists(request) {
+  let cliRequest = request.serialize();
+
+  Object.assign(cliRequest.data, {
+    controller: 'server',
+    action: 'adminExists'
+  });
+
+  return _kuzzle.funnel.processRequest(new Request(cliRequest.data, cliRequest.options))
+    .then(res => res.result);
+}
+
+module.exports = function cliAdminExists (kuzzle) {
+  _kuzzle = kuzzle;
+  return cliRunAdminExists;
+};

--- a/lib/api/controllers/cli/createFirstAdmin.js
+++ b/lib/api/controllers/cli/createFirstAdmin.js
@@ -1,0 +1,25 @@
+const Request = require('kuzzle-common-objects').Request;
+let _kuzzle;
+
+/**
+ * Process a createFirstAdmin request inside kuzzle
+ *
+ * @param {Request} request Original CLI Request
+ * @returns {Promise}
+ */
+function cliRunCreateFirstAdmin(request) {
+  let cliRequest = request.serialize();
+
+  Object.assign(cliRequest.data, {
+    controller: 'security',
+    action: 'createFirstAdmin'
+  });
+
+  return _kuzzle.funnel.processRequest(new Request(cliRequest.data, cliRequest.options))
+    .then(res => res.result);
+}
+
+module.exports = function cliCreateFirstAdmin (kuzzle) {
+  _kuzzle = kuzzle;
+  return cliRunCreateFirstAdmin;
+};

--- a/lib/api/controllers/cliController.js
+++ b/lib/api/controllers/cliController.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var
   NotFoundError = require('kuzzle-common-objects').errors.NotFoundError,
   Request = require('kuzzle-common-objects').Request;
@@ -11,8 +13,8 @@ function CliController (kuzzle) {
 
   this.init = () => {
     this.actions = {
-      adminExists: request => kuzzle.funnel.controllers.server.adminExists(request),
-      createFirstAdmin: request => kuzzle.funnel.controllers.security.createFirstAdmin(request),
+      adminExists: require('./cli/adminExists')(kuzzle),
+      createFirstAdmin: require('./cli/createFirstAdmin')(kuzzle),
       cleanDb: require('./cli/cleanDb')(kuzzle),
       clearCache: require('./cli/clearCache')(kuzzle),
       dump:require('./cli/dump')(kuzzle),

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -248,7 +248,7 @@ function FunnelController (kuzzle) {
     this.requestHistory.push(request);
 
     let
-      beforeEvent = getEventName(request.input.controller, 'before', request.input.action),
+      beforeEvent = this.getEventName(request.input.controller, 'before', request.input.action),
       modifiedRequest;
 
     return kuzzle.pluginsManager.trigger(beforeEvent, request)
@@ -258,7 +258,7 @@ function FunnelController (kuzzle) {
         return this.controllers[request.input.controller][request.input.action](newRequest);
       })
       .then(responseData => {
-        let afterEvent = getEventName(request.input.controller, 'after', request.input.action);
+        let afterEvent = this.getEventName(request.input.controller, 'after', request.input.action);
 
         modifiedRequest.setResult(responseData, request.status === 102 ? 200 : request.status);
 
@@ -273,6 +273,12 @@ function FunnelController (kuzzle) {
         kuzzle.statistics.failedRequest(request);
         return Promise.reject(error);
       });
+  };
+
+  this.getEventName = function getEventName(controller, prefix, action) {
+    var event = controller === 'memoryStorage' ? 'ms' : controller;
+
+    return event + ':' + prefix + capitalizeFirstLetter(action);
   };
 }
 
@@ -310,12 +316,6 @@ function playCachedRequests(kuzzle, funnel) {
       funnel.lastOverloadTime = now;
     }
   }
-}
-
-function getEventName(controller, prefix, action) {
-  var event = controller === 'memoryStorage' ? 'ms' : controller;
-
-  return event + ':' + prefix + capitalizeFirstLetter(action);
 }
 
 /**

--- a/test/api/controllers/cliController.test.js
+++ b/test/api/controllers/cliController.test.js
@@ -12,6 +12,8 @@ describe('lib/api/controllers/cliController', () => {
     kuzzle,
     cli,
     reset,
+    adminExistsStub,
+    createFirstAdminStub,
     cleanDbStub,
     clearCacheStub,
     managePluginsStub,
@@ -21,12 +23,16 @@ describe('lib/api/controllers/cliController', () => {
   beforeEach(() => {
     var requireMock = sinon.stub();
 
+    adminExistsStub = sinon.stub();
+    createFirstAdminStub = sinon.stub();
     cleanDbStub = sinon.stub();
     clearCacheStub = sinon.stub();
     managePluginsStub = sinon.stub();
     dataStub = sinon.stub();
     dumpStub = sinon.stub();
 
+    requireMock.withArgs('./cli/adminExists').returns(() => adminExistsStub);
+    requireMock.withArgs('./cli/createFirstAdmin').returns(() => createFirstAdminStub);
     requireMock.withArgs('./cli/cleanDb').returns(() => cleanDbStub);
     requireMock.withArgs('./cli/clearCache').returns(() => clearCacheStub);
     requireMock.withArgs('./cli/managePlugins').returns(() => managePluginsStub);
@@ -49,8 +55,8 @@ describe('lib/api/controllers/cliController', () => {
     it('should set the actions and register itself to Kuzzle broker', () => {
       cli.init();
 
-      should(cli.actions.adminExists).be.a.Function();
-      should(cli.actions.createFirstAdmin).be.a.Function();
+      should(cli.actions.adminExists).be.exactly(adminExistsStub);
+      should(cli.actions.createFirstAdmin).be.exactly(createFirstAdminStub);
       should(cli.actions.cleanDb).be.exactly(cleanDbStub);
       should(cli.actions.clearCache).be.exactly(clearCacheStub);
       should(cli.actions.managePlugins).be.exactly(managePluginsStub);

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -70,7 +70,8 @@ function KuzzleMock () {
     handleErrorDump: sinon.spy(),
     execute: sinon.spy(),
     processRequest: sinon.stub(),
-    checkRights: sinon.stub()
+    checkRights: sinon.stub(),
+    getEventName: sinon.spy()
   };
 
   this.hooks = {


### PR DESCRIPTION
fixes https://github.com/kuzzleio/sdk-javascript/issues/162

## Changes related to CLI:

* CLI Requests sent to Kuzzle are done now through protocol identifier `cli`
* On CLI action, kuzzle fire brefore/after event (eg `cli:beforeCreateFirstAdmin`) 
* `adminExists` and `createFirstAdmin` CLI actions call internal actions through `funnelController` to trigger all related events