### PR TITLE
add a warning documentation to the default config file

### DIFF
--- a/default.config.js
+++ b/default.config.js
@@ -1,4 +1,11 @@
 /**
+ * /!\ DO NOT MODIFY THIS FILE
+ *
+ * To customize your Kuzzle installation, create a
+ * ".kuzzlerc" file and put your overrides there.
+ * Please check the ".kuzzlerc.sample" file to get
+ * started.
+ *
  * @class KuzzleConfiguration
  */
 module.exports = {


### PR DESCRIPTION
To avoid common mistakes, this PR simply adds instructions in `default.config.js` on how to override Kuzzle default configuration.