### PR TITLE
Fix #594 empty error on request constructor

### DIFF
--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -8,6 +8,7 @@ var
   CollectionController = require('./collectionController'),
   DocumentController = require('./documentController'),
   IndexController = require('./indexController'),
+  KuzzleError = require('kuzzle-common-objects').errors.KuzzleError,
   MemoryStorageController = require('./memoryStorageController'),
   RealtimeController = require('./realtimeController'),
   SecurityController = require('./securityController'),
@@ -94,7 +95,8 @@ function FunnelController (kuzzle) {
         .then(() => this.processRequest(request))
         .then(processResult => callback(null, processResult))
         .catch(err => {
-          kuzzle.pluginsManager.trigger('log:error', err);
+          // JSON.stringify(new NativeError()) === '{}', i.e. Error, SyntaxError, TypeError, ReferenceError, etc.
+          kuzzle.pluginsManager.trigger('log:error', err instanceof Error && !(err instanceof KuzzleError) ? err.stack : err);
 
           request.setError(err);
           callback(err, request);

--- a/test/api/controllers/funnelController/execute.test.js
+++ b/test/api/controllers/funnelController/execute.test.js
@@ -1,31 +1,32 @@
-var
+'use strict';
+
+const
   should = require('should'),
   sinon = require('sinon'),
-  sandbox = sinon.sandbox.create(),
   Promise = require('bluebird'),
   Request = require('kuzzle-common-objects').Request,
   ServiceUnavailableError = require('kuzzle-common-objects').errors.ServiceUnavailableError,
-  Kuzzle = require('../../../../lib/api/kuzzle'),
+  KuzzleMock = require('../../../mocks/kuzzle.mock'),
   rewire = require('rewire'),
   FunnelController = rewire('../../../../lib/api/controllers/funnelController');
 
 describe('funnelController.execute', () => {
-  var
+  let
+    now = Date.now(),
+    clock,
     kuzzle,
     funnel,
     request,
-    requestReplayed;
-
-  before(() => {
-    kuzzle = new Kuzzle();
-    kuzzle.config.server.warningRetainedRequestsLimit = -1;
-
-    FunnelController.__set__('playCachedRequests', () => {
-      requestReplayed = true;
-    });
-  });
+    reset;
 
   beforeEach(() => {
+    reset = FunnelController.__set__({
+      playCachedRequests: sinon.spy()
+    });
+
+    kuzzle = new KuzzleMock();
+    kuzzle.config.server.warningRetainedRequestsLimit = -1;
+
     request = new Request({
       controller: 'foo',
       action: 'bar'
@@ -34,24 +35,24 @@ describe('funnelController.execute', () => {
       token: null
     });
 
-    requestReplayed = false;
-
-    sandbox.stub(kuzzle.internalEngine, 'get').returns(Promise.resolve({}));
-    return kuzzle.services.init({whitelist: []})
-      .then(() => {
-        funnel = new FunnelController(kuzzle);
-        funnel.init();
-
-        funnel.checkRights = sinon.stub().returns(Promise.resolve());
-        funnel.processRequest = (r) => Promise.resolve(r);
-        sinon.spy(funnel, 'processRequest');
-
-        return null;
-      });
+    funnel = new FunnelController(kuzzle);
+    funnel.controllers = {
+      foo: {
+        bar: sinon.spy()
+      }
+    };
+    funnel.checkRights = sinon.stub().returns(Promise.resolve());
+    funnel.processRequest = sinon.stub().returnsArg(0);
   });
 
   afterEach(() => {
-    sandbox.restore();
+    reset();
+  });
+
+  after(() => {
+    if (clock) {
+      clock.restore();
+    }
   });
 
   describe('#normal state', () => {
@@ -62,6 +63,8 @@ describe('funnelController.execute', () => {
           // 102 is the default status of a request, it should be 200 when coming out from the execute
           should(res.status).be.exactly(102);
           should(res).be.instanceOf(Request);
+          should(funnel.processRequest)
+            .be.calledOnce();
           should(funnel.processRequest.calledOnce).be.true();
           done();
         } catch (error) {
@@ -70,115 +73,115 @@ describe('funnelController.execute', () => {
       });
     });
 
-    it('should forward any error occuring during the request execution', done => {
-      funnel.checkRights = sinon.stub().returns(Promise.reject(new Error('errored')));
+    it('should forward any error occurring during the request execution', done => {
+      const error = new ServiceUnavailableError('test');
+      funnel.checkRights = sinon.stub().returns(Promise.reject(error));
 
       funnel.execute(request, (err, res) => {
-        try {
-          should(err).be.instanceOf(Error);
-          should(res.status).be.exactly(500);
-          should(res.error.message).be.exactly('errored');
-          should(funnel.processRequest.calledOnce).be.false();
-          should(funnel.overloaded).be.false();
-          done();
-        } catch (error) {
-          done(error);
-        }
+        should(err).be.instanceOf(Error);
+        should(res.status).be.exactly(503);
+        should(res.error.message).be.exactly('test');
+        should(funnel.processRequest.calledOnce).be.false();
+        should(funnel.overloaded).be.false();
+        should(kuzzle.pluginsManager.trigger)
+          .be.calledOnce()
+          .be.calledWith('log:error', error);
+        done();
+      });
+    });
+
+    it('should forward the error stack in case a native error was thrown', done => {
+      const error = new Error('test');
+
+      funnel.checkRights.returns(Promise.reject(error));
+
+      funnel.execute(request, () => {
+        should(kuzzle.pluginsManager.trigger)
+          .be.calledOnce()
+          .be.calledWith('log:error', error.stack);
+        done();
+
       });
     });
   });
 
   describe('#core:overload hook', () => {
-    it('should fire the hook the first time Kuzzle is in overloaded state', /** @this {Mocha} */ function (done) {
-      this.timeout(500);
-
-      kuzzle.once('core:overload', () => {
-        done();
-      });
-
+    it('should fire the hook the first time Kuzzle is in overloaded state', /** @this {Mocha} */ () => {
       funnel.overloaded = true;
+
       funnel.execute(request, () => {});
+
+      should(kuzzle.pluginsManager.trigger)
+        .be.calledTwice()
+        .be.calledWith('core:overload');
     });
 
-    it('should fire the hook if the last one was fired more than 500ms ago', /** @this {Mocha} */ function (done) {
-      this.timeout(500);
-
-      kuzzle.once('core:overload', () => {
-        done();
-      });
-
+    it('should fire the hook if the last one was fired more than 500ms ago', () => {
       funnel.overloaded = true;
       funnel.lastWarningTime = Date.now() - 501;
       funnel.execute(request, () => {});
+
+      should(kuzzle.pluginsManager.trigger)
+        .be.calledTwice()
+        .be.calledWith('core:overload');
     });
 
-    it('should not fire the hook if one was fired less than 500ms ago', done => {
-      var listener = () => {
-        done(new Error('core:overload hook fired unexpectedly'));
-      };
-
-      kuzzle.once('core:overload', listener);
+    it('should not fire the hook if one was fired less than 500ms ago', () => {
+      clock = sinon.useFakeTimers(now);
 
       funnel.overloaded = true;
-      funnel.lastWarningTime = Date.now() - 200;
-      funnel.execute(request, () => {});
-      setTimeout(() => {
-        kuzzle.off('core:overload', listener);
-        done();
-      }, 200);
+      funnel.lastWarningTime = now;
+
+      setTimeout(() => funnel.execute(request, () => {}), 499);
+      clock.tick(510);
+
+      should(kuzzle.pluginsManager.trigger)
+        .have.callCount(0);
     });
   });
 
   describe('#overloaded state', () => {
-    it('should enter overloaded state if the maxConcurrentRequests property is reached', done => {
-      var callback = () => {
-        done(new Error('Request executed. It should have been queued instead'));
-      };
+    it('should enter overloaded state if the maxConcurrentRequests property is reached', () => {
+      const
+        callback = () => {};
 
       funnel.concurrentRequests = kuzzle.config.server.maxConcurrentRequests;
 
       funnel.execute(request, callback);
 
-      setTimeout(() => {
-        should(funnel.overloaded).be.true();
-        should(requestReplayed).be.true();
-        should(funnel.processRequest.called).be.false();
-        should(funnel.cachedItems).be.eql(1);
-        should(funnel.requestsCache.shift()).match({request, callback});
-        done();
-      }, 100);
+      should(funnel.overloaded).be.true();
+      should(funnel.processRequest.called).be.false();
+      should(funnel.cachedItems).be.eql(1);
+      should(funnel.requestsCache.shift()).match({request, callback});
+      should(FunnelController.__get__('playCachedRequests'))
+        .be.calledOnce();
     });
 
-    it('should not relaunch the request replayer background task if already in overloaded state', done => {
-      var callback = () => {
-        done(new Error('Request executed. It should have been queued instead'));
-      };
+    it('should not relaunch the request replayer background task if already in overloaded state', () => {
+      const callback = () => {};
 
       funnel.concurrentRequests = kuzzle.config.server.maxConcurrentRequests;
       funnel.overloaded = true;
 
       funnel.execute(request, callback);
 
-      setTimeout(() => {
-        should(funnel.overloaded).be.true();
-        should(requestReplayed).be.false();
-        should(funnel.processRequest.called).be.false();
-        should(funnel.cachedItems).be.eql(1);
-        should(funnel.requestsCache.shift()).match({request, callback});
-        done();
-      }, 100);
+      should(funnel.overloaded).be.true();
+      should(funnel.processRequest.called).be.false();
+      should(funnel.cachedItems).be.eql(1);
+      should(funnel.requestsCache.shift()).match({request, callback});
+      should(FunnelController.__get__('playCachedRequests'))
+        .have.callCount(0);
     });
 
-    it('should discard the request if the maxRetainedRequests property is reached', /** @this {Mocha} */ function (done) {
-      this.timeout(500);
-
+    it('should discard the request if the maxRetainedRequests property is reached', (done) => {
       funnel.concurrentRequests = kuzzle.config.server.maxConcurrentRequests;
       funnel.cachedItems = kuzzle.config.server.maxRetainedRequests;
       funnel.overloaded = true;
 
       funnel.execute(request, (err, res) => {
         should(funnel.overloaded).be.true();
-        should(requestReplayed).be.false();
+        should(FunnelController.__get__('playCachedRequests'))
+          .have.callCount(0);
         should(funnel.processRequest.called).be.false();
         should(funnel.cachedItems).be.eql(kuzzle.config.server.maxRetainedRequests);
         should(funnel.requestsCache.isEmpty()).be.true();

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -194,7 +194,8 @@ function KuzzleMock () {
       search: sinon.stub().returns(Promise.resolve())
     },
     token: {
-      anonymous: sinon.stub().returns({_id: 'anonymous'})
+      anonymous: sinon.stub().returns({_id: 'anonymous'}),
+      verifyToken: sinon.stub().returns(Promise.resolve())
     }
   };
 
@@ -272,12 +273,15 @@ function KuzzleMock () {
   };
 
   this.statistics = {
+    completedRequest: sinon.spy(),
     newConnection: sinon.stub(),
+    failedRequest: sinon.spy(),
     getAllStats: sinon.stub().returns(Promise.resolve(foo)),
     getLastStats: sinon.stub().returns(Promise.resolve(foo)),
     getStats: sinon.stub().returns(Promise.resolve(foo)),
     init: sinon.spy(),
-    dropConnection: sinon.stub()
+    dropConnection: sinon.stub(),
+    startRequest: sinon.spy()
   };
 
   this.tokenManager = {


### PR DESCRIPTION
fixes #594 

Actually, the problem is a bit broader than the one raised in the initial issue.

The logger runs as a worker. As such, messages are sent via `process.send`, which stringifies them.
```
> JSON.stringify(new Error('test'))
'{}'
```

=> The logger then receives an empty object for native errors.

NB: `KuzzleErrors` are not impacted the same way as their message, status and stack are explicitly overridden and therefore properly stringified.

I could not figure out a clean way to enforce the serialization at the pluginsManager level but this PR implements a workaround to at least catch a proper error output out of the funnel execute method. 