### PR TITLE
[MASTER] Hotfix #612: Request objects created by PluginContext do not replicate informations

### DIFF
--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -168,6 +168,8 @@ function createUser(userRepository, name, profile, userInfo) {
  * @return {Request}
  */
 function instantiateRequest(request, data, options) {
+  let target;
+
   if (!request || !(request instanceof Request)) {
     throw new PluginImplementationError('A Request object must be provided');
   }
@@ -175,7 +177,26 @@ function instantiateRequest(request, data, options) {
   options = options || {};
   Object.assign(options, request.context.toJSON());
 
-  return new Request(data, options);
+  target = new Request(data, options);
+
+  // forward informations from the provided request object
+  ['_id', 'index', 'collection'].forEach(resource => {
+    if (!target.input.resource[resource]) {
+      target.input.resource[resource] = request.input.resource[resource];
+    }
+  });
+
+  Object.keys(request.input.args).forEach(arg => {
+    if (!target.input.args[arg]) {
+      target.input.args[arg] = request.input.args[arg];
+    }
+  });
+
+  if (!target.input.jwt) {
+    target.input.jwt = request.input.jwt;
+  }
+
+  return target;
 }
 
 module.exports = PluginContext;

--- a/test/api/controllers/routerController/httpRequest.test.js
+++ b/test/api/controllers/routerController/httpRequest.test.js
@@ -231,7 +231,8 @@ describe('Test: routerController.httpRequest', () => {
         should(result.id).be.eql(httpRequest.requestId);
         should(result.content.headers['content-type']).be.eql('application/json');
         should(result.status).be.eql(404);
-        should(JSON.stringify(result.content.error)).startWith('{"status":404,"message":"API URL not found: /foo/bar"');
+        should(result.content.error.status).be.eql(404);
+        should(result.content.error.message).startWith('API URL not found: /foo/bar');
         done();
       }
       catch (e) {

--- a/test/api/core/pluginContext/pluginContext.test.js
+++ b/test/api/core/pluginContext/pluginContext.test.js
@@ -1,4 +1,6 @@
-var
+'use strict';
+
+const
   rewire = require('rewire'),
   should = require('should'),
   Promise = require('bluebird'),
@@ -41,6 +43,39 @@ describe('Plugin Context', () => {
 
     it('should throw when trying to instante a Request object without providing a request object', () => {
       should(function () { new context.constructors.Request({}); }).throw(PluginImplementationError);
+    });
+
+    it('should replicate the right request information', () => {
+      let
+        request = new Request({
+          action: 'action',
+          controller: 'controller',
+          foobar: 'foobar',
+          _id: '_id',
+          index: 'index',
+          collection: 'collection',
+          result: 'result',
+          error: new Error('error'),
+          status: 666,
+          jwt: 'jwt'
+        }, {
+          protocol: 'protocol',
+          connectionId: 'connectionId'
+        }),
+        pluginRequest = new context.constructors.Request(request, {});
+
+      should(pluginRequest.context.protocol).be.eql(request.context.protocol);
+      should(pluginRequest.context.connectionId).be.eql(request.context.connectionId);
+      should(pluginRequest.result).be.null();
+      should(pluginRequest.error).be.null();
+      should(pluginRequest.status).be.eql(102);
+      should(pluginRequest.input.action).be.null();
+      should(pluginRequest.input.controller).be.null();
+      should(pluginRequest.input.jwt).be.eql(request.input.jwt);
+      should(pluginRequest.input.args.foobar).be.eql(request.input.args.foobar);
+      should(pluginRequest.input.resource._id).be.eql(request.input.resource._id);
+      should(pluginRequest.input.resource.index).be.eql(request.input.resource.index);
+      should(pluginRequest.input.resource.collection).be.eql(request.input.resource.collection);
     });
 
     it('should expose all error objects as capitalized constructors', () => {


### PR DESCRIPTION
Fix #612:

Plugin developers expect newly created `Request` objects to contain important informations from the original request they provide to the constructor, such as:

* request.input.args
* request.input.resource
* request.input.jwt

### Unrelated change

* fix randomly failing unit test due to fields order from JSON.stringify() being unpredictable
