### PR TITLE
#617 add get*Mapping and set*Mapping for users/roles/profiles

### DIFF
--- a/features/HTTP.feature
+++ b/features/HTTP.feature
@@ -170,6 +170,15 @@ Feature: Test HTTP API
     Then I create a restricted user "restricteduser1" with id "restricteduser1-id"
 
   @usingHttp @cleanSecurity
+  Scenario: Role mapping
+    Given I get the role schema
+    Then The mapping should contain "controllers" field of type "object"
+    When I change the role schema
+    Then I get the role schema
+    Then The mapping should contain "foo" field of type "text"
+    And The mapping should contain "bar" field of type "keyword"
+
+  @usingHttp @cleanSecurity
   Scenario: Create/get/search/update/delete role
     When I create a new role "role1" with id "test"
     Then I'm able to find a role with id "test"
@@ -196,6 +205,16 @@ Feature: Test HTTP API
   @usingHttp @cleanSecurity
   Scenario: creating a profile with an empty set of roles triggers an error
     Then I cannot create a profile with an empty set of roles
+
+  @usingHttp @cleanSecurity
+  Scenario: Profile mapping
+    Given I get the profile schema
+    Then The mapping should contain a nested "policies" field with property "_id" of type "keyword"
+    And The mapping should contain a nested "policies" field with property "roleId" of type "text"
+    When I change the profile schema
+    Then I get the profile schema
+    Then The mapping should contain "foo" field of type "text"
+    And The mapping should contain "bar" field of type "keyword"
 
   @usingHttp @cleanSecurity
   Scenario: create, get and delete a profile
@@ -229,6 +248,16 @@ Feature: Test HTTP API
     And I create a new profile "profile2" with id "profile2"
     Then I'm able to find rights for profile "profile2"
     Then I'm not able to find rights for profile "fake-profile"
+
+  @usingHttp @cleanSecurity
+  Scenario: User mapping
+    Given I get the user schema
+    Then The mapping should contain "password" field of type "keyword"
+    And The mapping should contain "profileIds" field of type "keyword"
+    When I change the user schema
+    Then I get the user schema
+    Then The mapping should contain "foo" field of type "text"
+    And The mapping should contain "bar" field of type "keyword"
 
   @usingHttp @cleanSecurity
   Scenario: user crudl

--- a/features/HTTP.feature
+++ b/features/HTTP.feature
@@ -96,7 +96,7 @@ Feature: Test HTTP API
   Scenario: Change mapping
     When I write the document "documentGrace"
     Then I don't find a document with "Grace" in field "firstName"
-    Then I change the schema
+    Then I change the mapping
     When I write the document "documentGrace"
     And I refresh the index
     Then I find a document with "Grace" in field "newFirstName"
@@ -171,10 +171,10 @@ Feature: Test HTTP API
 
   @usingHttp @cleanSecurity
   Scenario: Role mapping
-    Given I get the role schema
+    Given I get the role mapping
     Then The mapping should contain "controllers" field of type "object"
-    When I change the role schema
-    Then I get the role schema
+    When I change the role mapping
+    Then I get the role mapping
     Then The mapping should contain "foo" field of type "text"
     And The mapping should contain "bar" field of type "keyword"
 
@@ -208,11 +208,11 @@ Feature: Test HTTP API
 
   @usingHttp @cleanSecurity
   Scenario: Profile mapping
-    Given I get the profile schema
+    Given I get the profile mapping
     Then The mapping should contain a nested "policies" field with property "_id" of type "keyword"
     And The mapping should contain a nested "policies" field with property "roleId" of type "text"
-    When I change the profile schema
-    Then I get the profile schema
+    When I change the profile mapping
+    Then I get the profile mapping
     Then The mapping should contain "foo" field of type "text"
     And The mapping should contain "bar" field of type "keyword"
 
@@ -251,11 +251,11 @@ Feature: Test HTTP API
 
   @usingHttp @cleanSecurity
   Scenario: User mapping
-    Given I get the user schema
+    Given I get the user mapping
     Then The mapping should contain "password" field of type "keyword"
     And The mapping should contain "profileIds" field of type "keyword"
-    When I change the user schema
-    Then I get the user schema
+    When I change the user mapping
+    Then I get the user mapping
     Then The mapping should contain "foo" field of type "text"
     And The mapping should contain "bar" field of type "keyword"
 

--- a/features/Websocket.feature
+++ b/features/Websocket.feature
@@ -98,7 +98,7 @@ Feature: Test websocket API
   Scenario: Change mapping
     When I write the document "documentGrace"
     Then I don't find a document with "Grace" in field "firstName"
-    Then I change the schema
+    Then I change the mapping
     When I write the document "documentGrace"
     And I refresh the index
     Then I find a document with "Grace" in field "newFirstName"
@@ -283,10 +283,10 @@ Feature: Test websocket API
 
   @usingWebsocket @cleanSecurity
   Scenario: Role mapping
-    Given I get the role schema
+    Given I get the role mapping
     Then The mapping should contain "controllers" field of type "object"
-    When I change the role schema
-    Then I get the role schema
+    When I change the role mapping
+    Then I get the role mapping
     Then The mapping should contain "foo" field of type "text"
     And The mapping should contain "bar" field of type "keyword"
 
@@ -320,11 +320,11 @@ Feature: Test websocket API
 
   @usingWebsocket @cleanSecurity
   Scenario: Profile mapping
-    Given I get the profile schema
+    Given I get the profile mapping
     Then The mapping should contain a nested "policies" field with property "_id" of type "keyword"
     And The mapping should contain a nested "policies" field with property "roleId" of type "text"
-    When I change the profile schema
-    Then I get the profile schema
+    When I change the profile mapping
+    Then I get the profile mapping
     Then The mapping should contain "foo" field of type "text"
     And The mapping should contain "bar" field of type "keyword"
 
@@ -361,11 +361,11 @@ Feature: Test websocket API
 
   @usingWebsocket @cleanSecurity
   Scenario: User mapping
-    Given I get the user schema
+    Given I get the user mapping
     Then The mapping should contain "password" field of type "keyword"
     And The mapping should contain "profileIds" field of type "keyword"
-    When I change the user schema
-    Then I get the user schema
+    When I change the user mapping
+    Then I get the user mapping
     Then The mapping should contain "foo" field of type "text"
     And The mapping should contain "bar" field of type "keyword"
 

--- a/features/Websocket.feature
+++ b/features/Websocket.feature
@@ -282,6 +282,15 @@ Feature: Test websocket API
     Then I create a restricted user "restricteduser1" with id "restricteduser1-id"
 
   @usingWebsocket @cleanSecurity
+  Scenario: Role mapping
+    Given I get the role schema
+    Then The mapping should contain "controllers" field of type "object"
+    When I change the role schema
+    Then I get the role schema
+    Then The mapping should contain "foo" field of type "text"
+    And The mapping should contain "bar" field of type "keyword"
+
+  @usingWebsocket @cleanSecurity
   Scenario: Create/get/search/update/delete role
     When I create a new role "role1" with id "test"
     Then I'm able to find a role with id "test"
@@ -308,6 +317,16 @@ Feature: Test websocket API
   @usingWebsocket @cleanSecurity
   Scenario: creating a profile with an empty set of roles triggers an error
     Then I cannot create a profile with an empty set of roles
+
+  @usingWebsocket @cleanSecurity
+  Scenario: Profile mapping
+    Given I get the profile schema
+    Then The mapping should contain a nested "policies" field with property "_id" of type "keyword"
+    And The mapping should contain a nested "policies" field with property "roleId" of type "text"
+    When I change the profile schema
+    Then I get the profile schema
+    Then The mapping should contain "foo" field of type "text"
+    And The mapping should contain "bar" field of type "keyword"
 
   @usingWebsocket @cleanSecurity
   Scenario: create, get and delete a profile
@@ -339,6 +358,16 @@ Feature: Test websocket API
     And I create a new profile "profile2" with id "profile2"
     Then I'm able to find rights for profile "profile2"
     Then I'm not able to find rights for profile "fake-profile"
+
+  @usingWebsocket @cleanSecurity
+  Scenario: User mapping
+    Given I get the user schema
+    Then The mapping should contain "password" field of type "keyword"
+    And The mapping should contain "profileIds" field of type "keyword"
+    When I change the user schema
+    Then I get the user schema
+    Then The mapping should contain "foo" field of type "text"
+    And The mapping should contain "bar" field of type "keyword"
 
   @usingWebsocket @cleanSecurity
   Scenario: user crudl

--- a/features/step_definitions/all.js
+++ b/features/step_definitions/all.js
@@ -54,4 +54,37 @@ module.exports = function () {
       return callback(err);
     }
   });
+
+  this.Then(/^The mapping should contain a nested "(.*?)" field with property "(.*?)" of type "(.*?)"$/, function (field, prop, type, callback) {
+    if (! this.result[field]) {
+      return callback(new Error('Field ' + field + ' not found in mapping'));
+    }
+    if (! this.result[field].properties) {
+      return callback(new Error('No properties found for field ' + field));
+    }
+    if (! this.result[field].properties[prop]) {
+      return callback(new Error(field + '.' + prop + ' not found in mapping'));
+    }
+    if (! this.result[field].properties[prop].type) {
+      return callback(new Error('No type found for field ' + field + '.' + prop));
+    }
+    if (this.result[field].properties[prop].type !== type) {
+      return callback(new Error('Bad type for field ' + field + '.' + prop + ':\nExpected: ' + type + '\nActual: ' + this.result[field].type));
+    }
+    callback();
+  });
+
+  this.Then(/^The mapping should contain "(.*?)" field of type "(.*?)"$/, function (field, type, callback) {
+    if (! this.result[field]) {
+      return callback(new Error('Field ' + field + ' not found in mapping'));
+    }
+    if (! this.result[field].type) {
+      return callback(new Error('No type found for field ' + field));
+    }
+    if (this.result[field].type !== type) {
+      return callback(new Error('Bad type for field ' + field + ':\nExpected: ' + type + '\nActual: ' + this.result[field].type));
+    }
+    callback();
+  });
+
 };

--- a/features/step_definitions/collections.js
+++ b/features/step_definitions/collections.js
@@ -45,7 +45,7 @@ var apiSteps = function () {
     callback('Expected to find the collection <' + collection + '> in this collections list: ' + JSON.stringify(this.result.collections));
   });
 
-  this.Then(/^I change the schema(?: in index "([^"]*)")?$/, function (index, callback) {
+  this.Then(/^I change the mapping(?: in index "([^"]*)")?$/, function (index, callback) {
     this.api.updateMapping()
       .then(body => {
         if (body.error !== null) {

--- a/features/step_definitions/profiles.js
+++ b/features/step_definitions/profiles.js
@@ -2,7 +2,7 @@ var
   async = require('async');
 
 var apiSteps = function () {
-  this.When(/^I get the profile schema$/, function (callback) {
+  this.When(/^I get the profile mapping$/, function (callback) {
     this.api.getProfileMapping()
       .then(function (response) {
         if (response.error) {
@@ -25,7 +25,7 @@ var apiSteps = function () {
       });
   });
 
-  this.Then(/^I change the profile schema$/, function (callback) {
+  this.Then(/^I change the profile mapping$/, function (callback) {
     this.api.updateProfileMapping()
       .then(body => {
         if (body.error !== null) {

--- a/features/step_definitions/profiles.js
+++ b/features/step_definitions/profiles.js
@@ -2,6 +2,44 @@ var
   async = require('async');
 
 var apiSteps = function () {
+  this.When(/^I get the profile schema$/, function (callback) {
+    this.api.getProfileMapping()
+      .then(function (response) {
+        if (response.error) {
+          return callback(new Error(response.error.message));
+        }
+
+        if (!response.result) {
+          return callback(new Error('No result provided'));
+        }
+
+        if (!response.result.mapping) {
+          return callback(new Error('No mapping provided'));
+        }
+
+        this.result = response.result.mapping;
+        callback();
+      }.bind(this))
+      .catch(function (error) {
+        callback(error);
+      });
+  });
+
+  this.Then(/^I change the profile schema$/, function (callback) {
+    this.api.updateProfileMapping()
+      .then(body => {
+        if (body.error !== null) {
+          callback(new Error(body.error.message));
+          return false;
+        }
+
+        callback();
+      })
+      .catch(function (error) {
+        callback(new Error(error));
+      });
+  });
+
   this.When(/^I create a new profile "([^"]*)" with id "([^"]*)"$/, {timeout: 20 * 1000}, function (profile, id, callback) {
     if (!this.profiles[profile]) {
       return callback('Fixture for profile ' + profile + ' does not exists');

--- a/features/step_definitions/role.js
+++ b/features/step_definitions/role.js
@@ -2,6 +2,44 @@ var
   async = require('async');
 
 var apiSteps = function () {
+  this.When(/^I get the role schema$/, function (callback) {
+    this.api.getRoleMapping()
+      .then(function (response) {
+        if (response.error) {
+          return callback(new Error(response.error.message));
+        }
+
+        if (!response.result) {
+          return callback(new Error('No result provided'));
+        }
+
+        if (!response.result.mapping) {
+          return callback(new Error('No mapping provided'));
+        }
+
+        this.result = response.result.mapping;
+        callback();
+      }.bind(this))
+      .catch(function (error) {
+        callback(error);
+      });
+  });
+
+  this.Then(/^I change the role schema$/, function (callback) {
+    this.api.updateRoleMapping()
+      .then(body => {
+        if (body.error !== null) {
+          callback(new Error(body.error.message));
+          return false;
+        }
+
+        callback();
+      })
+      .catch(function (error) {
+        callback(new Error(error));
+      });
+  });
+
   this.When(/^I create a new role "([^"]*)" with id "([^"]*)"$/, function (role, id, callback) {
     if (!this.roles[role]) {
       return callback('Fixture for role ' + role + ' does not exist');

--- a/features/step_definitions/role.js
+++ b/features/step_definitions/role.js
@@ -2,7 +2,7 @@ var
   async = require('async');
 
 var apiSteps = function () {
-  this.When(/^I get the role schema$/, function (callback) {
+  this.When(/^I get the role mapping$/, function (callback) {
     this.api.getRoleMapping()
       .then(function (response) {
         if (response.error) {
@@ -25,7 +25,7 @@ var apiSteps = function () {
       });
   });
 
-  this.Then(/^I change the role schema$/, function (callback) {
+  this.Then(/^I change the role mapping$/, function (callback) {
     this.api.updateRoleMapping()
       .then(body => {
         if (body.error !== null) {

--- a/features/step_definitions/users.js
+++ b/features/step_definitions/users.js
@@ -3,6 +3,44 @@ var
   async = require('async');
 
 module.exports = function () {
+  this.When(/^I get the user schema$/, function (callback) {
+    this.api.getUserMapping()
+      .then(function (response) {
+        if (response.error) {
+          return callback(new Error(response.error.message));
+        }
+
+        if (!response.result) {
+          return callback(new Error('No result provided'));
+        }
+
+        if (!response.result.mapping) {
+          return callback(new Error('No mapping provided'));
+        }
+
+        this.result = response.result.mapping;
+        callback();
+      }.bind(this))
+      .catch(function (error) {
+        callback(error);
+      });
+  });
+
+  this.Then(/^I change the user schema$/, function (callback) {
+    this.api.updateUserMapping()
+      .then(body => {
+        if (body.error !== null) {
+          callback(new Error(body.error.message));
+          return false;
+        }
+
+        callback();
+      })
+      .catch(function (error) {
+        callback(new Error(error));
+      });
+  });
+
   this.When(/^I (can't )?create a (new )?(restricted )?user "(.*?)" with id "(.*?)"$/, {timeout: 20000}, function (not, isNew, isRestricted, user, id, callback) {
     var
       userObject = this.users[user],

--- a/features/step_definitions/users.js
+++ b/features/step_definitions/users.js
@@ -3,7 +3,7 @@ var
   async = require('async');
 
 module.exports = function () {
-  this.When(/^I get the user schema$/, function (callback) {
+  this.When(/^I get the user mapping$/, function (callback) {
     this.api.getUserMapping()
       .then(function (response) {
         if (response.error) {
@@ -26,7 +26,7 @@ module.exports = function () {
       });
   });
 
-  this.Then(/^I change the user schema$/, function (callback) {
+  this.Then(/^I change the user mapping$/, function (callback) {
     this.api.updateUserMapping()
       .then(body => {
         if (body.error !== null) {

--- a/features/support/apiHttp.js
+++ b/features/support/apiHttp.js
@@ -323,6 +323,63 @@ ApiHttp.prototype.updateMapping = function (index) {
   return this.callApi(options);
 };
 
+ApiHttp.prototype.getProfileMapping = function () {
+  var options = {
+    url: this.apiPath('/profiles/_mapping'),
+    method: 'GET'
+  };
+
+  return this.callApi(options);
+};
+
+ApiHttp.prototype.updateProfileMapping = function () {
+  var options = {
+    url: this.apiPath('/profiles/_mapping'),
+    method: 'PUT',
+    body: this.world.securitySchema
+  };
+
+  return this.callApi(options);
+};
+
+ApiHttp.prototype.getRoleMapping = function () {
+  var options = {
+    url: this.apiPath('/roles/_mapping'),
+    method: 'GET'
+  };
+
+  return this.callApi(options);
+};
+
+ApiHttp.prototype.updateRoleMapping = function () {
+  var options = {
+    url: this.apiPath('/roles/_mapping'),
+    method: 'PUT',
+    body: this.world.securitySchema
+  };
+
+  return this.callApi(options);
+};
+
+ApiHttp.prototype.getUserMapping = function () {
+  var options = {
+    url: this.apiPath('/users/_mapping'),
+    method: 'GET'
+  };
+
+  return this.callApi(options);
+};
+
+ApiHttp.prototype.updateUserMapping = function () {
+  var options = {
+    url: this.apiPath('/users/_mapping'),
+    method: 'PUT',
+    body: this.world.securitySchema
+  };
+
+  return this.callApi(options);
+};
+
 ApiHttp.prototype.getStats = function (dates) {
   var options = {
     url: this.apiPath('_getStats'),

--- a/features/support/apiHttp.js
+++ b/features/support/apiHttp.js
@@ -317,7 +317,7 @@ ApiHttp.prototype.updateMapping = function (index) {
   var options = {
     url: this.apiPath(((typeof index !== 'string') ? this.world.fakeIndex : index) + '/' + this.world.fakeCollection + '/_mapping'),
     method: 'PUT',
-    body: this.world.schema
+    body: this.world.mapping
   };
 
   return this.callApi(options);
@@ -336,7 +336,7 @@ ApiHttp.prototype.updateProfileMapping = function () {
   var options = {
     url: this.apiPath('/profiles/_mapping'),
     method: 'PUT',
-    body: this.world.securitySchema
+    body: this.world.securitymapping
   };
 
   return this.callApi(options);
@@ -355,7 +355,7 @@ ApiHttp.prototype.updateRoleMapping = function () {
   var options = {
     url: this.apiPath('/roles/_mapping'),
     method: 'PUT',
-    body: this.world.securitySchema
+    body: this.world.securitymapping
   };
 
   return this.callApi(options);
@@ -374,7 +374,7 @@ ApiHttp.prototype.updateUserMapping = function () {
   var options = {
     url: this.apiPath('/users/_mapping'),
     method: 'PUT',
-    body: this.world.securitySchema
+    body: this.world.securitymapping
   };
 
   return this.callApi(options);

--- a/features/support/apiRT.js
+++ b/features/support/apiRT.js
@@ -186,7 +186,7 @@ ApiRT.prototype.updateMapping = function (index) {
       collection: this.world.fakeCollection,
       index: index || this.world.fakeIndex,
       action: 'updateMapping',
-      body: this.world.schema
+      body: this.world.mapping
     };
 
   return this.send(msg);
@@ -207,7 +207,7 @@ ApiRT.prototype.updateProfileMapping = function () {
     msg = {
       controller: 'security',
       action: 'updateProfileMapping',
-      body: this.world.securitySchema
+      body: this.world.securitymapping
     };
 
   return this.send(msg);
@@ -228,7 +228,7 @@ ApiRT.prototype.updateRoleMapping = function () {
     msg = {
       controller: 'security',
       action: 'updateRoleMapping',
-      body: this.world.securitySchema
+      body: this.world.securitymapping
     };
 
   return this.send(msg);
@@ -249,7 +249,7 @@ ApiRT.prototype.updateUserMapping = function () {
     msg = {
       controller: 'security',
       action: 'updateUserMapping',
-      body: this.world.securitySchema
+      body: this.world.securitymapping
     };
 
   return this.send(msg);

--- a/features/support/apiRT.js
+++ b/features/support/apiRT.js
@@ -192,6 +192,69 @@ ApiRT.prototype.updateMapping = function (index) {
   return this.send(msg);
 };
 
+ApiRT.prototype.getProfileMapping = function () {
+  var
+    msg = {
+      controller: 'security',
+      action: 'getProfileMapping'
+    };
+
+  return this.send(msg);
+};
+
+ApiRT.prototype.updateProfileMapping = function () {
+  var
+    msg = {
+      controller: 'security',
+      action: 'updateProfileMapping',
+      body: this.world.securitySchema
+    };
+
+  return this.send(msg);
+};
+
+ApiRT.prototype.getRoleMapping = function () {
+  var
+    msg = {
+      controller: 'security',
+      action: 'getRoleMapping'
+    };
+
+  return this.send(msg);
+};
+
+ApiRT.prototype.updateRoleMapping = function () {
+  var
+    msg = {
+      controller: 'security',
+      action: 'updateRoleMapping',
+      body: this.world.securitySchema
+    };
+
+  return this.send(msg);
+};
+
+ApiRT.prototype.getUserMapping = function () {
+  var
+    msg = {
+      controller: 'security',
+      action: 'getUserMapping'
+    };
+
+  return this.send(msg);
+};
+
+ApiRT.prototype.updateUserMapping = function () {
+  var
+    msg = {
+      controller: 'security',
+      action: 'updateUserMapping',
+      body: this.world.securitySchema
+    };
+
+  return this.send(msg);
+};
+
 ApiRT.prototype.bulkImport = function (bulk, index, collection) {
   var
     msg = {

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -73,6 +73,20 @@ module.exports = function () {
       }
     };
 
+    this.securitySchema = {
+      properties: {
+        foo: {
+          type: 'string',
+          copy_to: 'bar'
+        },
+        bar: {
+          type: 'string',
+          store: true,
+          index: 'not_analyzed'
+        }
+      }
+    };
+
     this.metadata = {
       iwant: 'to break free',
       we: ['will', 'rock', 'you']

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -59,7 +59,7 @@ module.exports = function () {
     ];
 
 
-    this.schema = {
+    this.mapping = {
       properties: {
         firstName: {
           type: 'string',
@@ -73,7 +73,7 @@ module.exports = function () {
       }
     };
 
-    this.securitySchema = {
+    this.securitymapping = {
       properties: {
         foo: {
           type: 'string',

--- a/lib/api/controllers/cli/adminExists.js
+++ b/lib/api/controllers/cli/adminExists.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Request = require('kuzzle-common-objects').Request;
 let _kuzzle;
 

--- a/lib/api/controllers/cli/createFirstAdmin.js
+++ b/lib/api/controllers/cli/createFirstAdmin.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Request = require('kuzzle-common-objects').Request;
 let _kuzzle;
 

--- a/lib/api/controllers/collectionController.js
+++ b/lib/api/controllers/collectionController.js
@@ -26,6 +26,7 @@ function CollectionController (kuzzle) {
    * @returns {Promise<Object>}
    */
   this.updateMapping = function collectionUpdateMapping (request) {
+    assertHasBody(request);
     return engine.updateMapping(request)
       .then(response => {
         kuzzle.indexCache.add(request.input.resource.index, request.input.resource.collection);

--- a/lib/api/controllers/collectionController.js
+++ b/lib/api/controllers/collectionController.js
@@ -35,16 +35,6 @@ function CollectionController (kuzzle) {
   };
 
   /**
-   * Update the users collection mapping
-
-   * @param {Request} request
-   * @returns {Promise}
-   */
-  this.updateUserMapping = function collectionUpdateUserMapping (request) {
-    return kuzzle.internalEngine.updateMapping('users', request.input.body);
-  };
-
-  /**
    * Get the collection mapping
    *
    * @param {Request} request
@@ -54,16 +44,6 @@ function CollectionController (kuzzle) {
     assertHasIndexAndCollection(request, 'collection:getMapping');
 
     return engine.getMapping(request);
-  };
-
-  /**
-   * Get the user mapping
-   *
-   * @returns {Promise}
-   */
-  this.getUserMapping = function collectionGetUserMapping () {
-    return kuzzle.internalEngine.getMapping({index: kuzzle.internalEngine.index, type: 'users'})
-      .then(response => ({mapping: response[kuzzle.internalEngine.index].mappings.users.properties}));
   };
 
   /**

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -19,6 +19,47 @@ var
  */
 function SecurityController (kuzzle) {
   /**
+   * Get the role mapping
+   *
+   * @returns {Promise}
+   */
+  this.getRoleMapping = function securityGetRoleMapping () {
+    return kuzzle.internalEngine.getMapping({index: kuzzle.internalEngine.index, type: 'roles'})
+      .then(response => ({mapping: response[kuzzle.internalEngine.index].mappings.roles.properties}));
+  };
+
+  /**
+   * Update the roles collection mapping
+
+   * @param {Request} request
+   * @returns {Promise}
+   */
+  this.updateRoleMapping = function securityUpdateRoleMapping (request) {
+    return kuzzle.internalEngine.updateMapping('roles', request.input.body);
+  };
+
+  /**
+   * Get the profile mapping
+   *
+   * @returns {Promise}
+   */
+  this.getProfileMapping = function securityGetProfileMapping () {
+    return kuzzle.internalEngine.getMapping({index: kuzzle.internalEngine.index, type: 'profiles'})
+      .then(response => {
+        return Promise.resolve({mapping: response[kuzzle.internalEngine.index].mappings.profiles.properties});
+      });
+  };
+
+  /**
+   * Update the profiles collection mapping
+
+   * @param {Request} request
+   * @returns {Promise}
+   */
+  this.updateProfileMapping = function securityUpdateProfileMapping (request) {
+    return kuzzle.internalEngine.updateMapping('profiles', request.input.body);
+  };
+
   /**
    * Get the user mapping
    *
@@ -39,6 +80,7 @@ function SecurityController (kuzzle) {
     return kuzzle.internalEngine.updateMapping('users', request.input.body);
   };
 
+  /**
    * Get a specific role according to the given id
    *
    * @param {Request} request

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -45,9 +45,7 @@ function SecurityController (kuzzle) {
    */
   this.getProfileMapping = function securityGetProfileMapping () {
     return kuzzle.internalEngine.getMapping({index: kuzzle.internalEngine.index, type: 'profiles'})
-      .then(response => {
-        return Promise.resolve({mapping: response[kuzzle.internalEngine.index].mappings.profiles.properties});
-      });
+      .then(response => ({mapping: response[kuzzle.internalEngine.index].mappings.profiles.properties}));
   };
 
   /**

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -35,6 +35,7 @@ function SecurityController (kuzzle) {
    * @returns {Promise}
    */
   this.updateRoleMapping = function securityUpdateRoleMapping (request) {
+    assertHasBody(request);
     return kuzzle.internalEngine.updateMapping('roles', request.input.body);
   };
 
@@ -55,6 +56,7 @@ function SecurityController (kuzzle) {
    * @returns {Promise}
    */
   this.updateProfileMapping = function securityUpdateProfileMapping (request) {
+    assertHasBody(request);
     return kuzzle.internalEngine.updateMapping('profiles', request.input.body);
   };
 
@@ -75,6 +77,7 @@ function SecurityController (kuzzle) {
    * @returns {Promise}
    */
   this.updateUserMapping = function securityUpdateUserMapping (request) {
+    assertHasBody(request);
     return kuzzle.internalEngine.updateMapping('users', request.input.body);
   };
 

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -19,6 +19,26 @@ var
  */
 function SecurityController (kuzzle) {
   /**
+  /**
+   * Get the user mapping
+   *
+   * @returns {Promise}
+   */
+  this.getUserMapping = function securityGetUserMapping () {
+    return kuzzle.internalEngine.getMapping({index: kuzzle.internalEngine.index, type: 'users'})
+      .then(response => ({mapping: response[kuzzle.internalEngine.index].mappings.users.properties}));
+  };
+
+  /**
+   * Update the users collection mapping
+
+   * @param {Request} request
+   * @returns {Promise}
+   */
+  this.updateUserMapping = function securityUpdateUserMapping (request) {
+    return kuzzle.internalEngine.updateMapping('users', request.input.body);
+  };
+
    * Get a specific role according to the given id
    *
    * @param {Request} request

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -8,7 +8,6 @@ module.exports = [
   {verb: 'get', url: '/:index/:collection/_exists', controller: 'collection', action: 'exists'},
   {verb: 'get', url: '/:index/:collection/_mapping', controller: 'collection', action: 'getMapping'},
   {verb: 'get', url: '/:index/:collection/_specifications', controller: 'collection', action: 'getSpecifications'},
-  {verb: 'get', url: '/users/_mapping', controller: 'collection', action: 'getUserMapping'},
   {verb: 'get', url: '/:index/_list', controller: 'collection', action: 'list'},
   {verb: 'get', url: '/:index/_list/:type', controller: 'collection', action: 'list'},
 
@@ -25,6 +24,9 @@ module.exports = [
   {verb: 'get', url: '/roles/:_id', controller: 'security', action: 'getRole'},
   {verb: 'get', url: '/users/:_id', controller: 'security', action: 'getUser'},
   {verb: 'get', url: '/users/:_id/_rights', controller: 'security', action: 'getUserRights'},
+  {verb: 'get', url: '/profiles/_mapping', controller: 'security', action: 'getProfileMapping'},
+  {verb: 'get', url: '/roles/_mapping', controller: 'security', action: 'getRoleMapping'},
+  {verb: 'get', url: '/users/_mapping', controller: 'security', action: 'getUserMapping'},
 
   {verb: 'get', url: '/_adminExists', controller: 'server', action: 'adminExists'},
   {verb: 'get', url: '/_getAllStats', controller: 'server', action: 'getAllStats'},
@@ -237,7 +239,6 @@ module.exports = [
 
   {verb: 'put', url: '/:index/:collection', controller: 'collection', action: 'create'},
   {verb: 'put', url: '/:index/:collection/_mapping', controller: 'collection', action: 'updateMapping'},
-  {verb: 'put', url: '/users/_mapping', controller: 'collection', action: 'updateUserMapping'},
   {verb: 'put', url: '/_specifications', controller: 'collection', action: 'updateSpecifications'},
 
   {verb: 'put', url: '/:index/:collection/:_id', controller: 'document', action: 'createOrReplace'},
@@ -249,5 +250,8 @@ module.exports = [
   {verb: 'put', url: '/users/:_id', controller: 'security', action: 'createOrReplaceUser'},
   {verb: 'put', url: '/profiles/:_id/_update', controller: 'security', action: 'updateProfile'},
   {verb: 'put', url: '/roles/:_id/_update', controller: 'security', action: 'updateRole'},
-  {verb: 'put', url: '/users/:_id/_update', controller: 'security', action: 'updateUser'}
+  {verb: 'put', url: '/users/:_id/_update', controller: 'security', action: 'updateUser'},
+  {verb: 'put', url: '/profiles/_mapping', controller: 'security', action: 'updateProfileMapping'},
+  {verb: 'put', url: '/roles/_mapping', controller: 'security', action: 'updateRoleMapping'},
+  {verb: 'put', url: '/users/_mapping', controller: 'security', action: 'updateUserMapping'}
 ];

--- a/test/api/controllers/collectionController.test.js
+++ b/test/api/controllers/collectionController.test.js
@@ -53,19 +53,6 @@ describe('Test: collection controller', () => {
     });
   });
 
-  describe('#updateUserMapping', () => {
-    it('should update the user mapping', () => {
-      return collectionController.updateUserMapping(request)
-        .then(response => {
-          should(kuzzle.internalEngine.updateMapping).be.calledOnce();
-          should(kuzzle.internalEngine.updateMapping).be.calledWith('users', request.input.body);
-
-          should(response).be.instanceof(Object);
-          should(response).match(foo);
-        });
-    });
-  });
-
   describe('#getMapping', () => {
     it('should fulfill with a response object', () => {
       return collectionController.getMapping(request)
@@ -76,19 +63,6 @@ describe('Test: collection controller', () => {
 
           should(response).be.instanceof(Object);
           should(response).match(foo);
-        });
-    });
-  });
-
-  describe('#getUserMapping', () => {
-    it('should fulfill with a response object', () => {
-      return collectionController.getUserMapping(request)
-        .then(response => {
-          should(kuzzle.internalEngine.getMapping).be.calledOnce();
-          should(kuzzle.internalEngine.getMapping).be.calledWith({index: kuzzle.internalEngine.index, type: 'users'});
-
-          should(response).be.instanceof(Object);
-          should(response).match({mapping: {}});
         });
     });
   });

--- a/test/api/controllers/collectionController.test.js
+++ b/test/api/controllers/collectionController.test.js
@@ -37,7 +37,14 @@ describe('Test: collection controller', () => {
 
 
   describe('#updateMapping', () => {
+    it('should throw a BadRequestError if the body is missing', () => {
+      return should(() => {
+        collectionController.updateMapping(request);
+      }).throw(BadRequestError);
+    });
+
     it('should activate a hook on a mapping update call and add the collection to the cache', () => {
+      request.input.body = {foo: 'bar'};
       return collectionController.updateMapping(request)
         .then(response => {
 

--- a/test/api/controllers/documentController.test.js
+++ b/test/api/controllers/documentController.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var
   should = require('should'),
   sinon = require('sinon'),

--- a/test/api/controllers/securityController/profiles.test.js
+++ b/test/api/controllers/securityController/profiles.test.js
@@ -2,7 +2,7 @@ var
   should = require('should'),
   sinon = require('sinon'),
   sandbox = sinon.sandbox.create(),
-  Kuzzle = require('../../../../lib/api/kuzzle'),
+  KuzzleMock = require('../../../mocks/kuzzle.mock'),
   Request = require('kuzzle-common-objects').Request,
   BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
   NotFoundError = require('kuzzle-common-objects').errors.NotFoundError,
@@ -11,31 +11,58 @@ var
 describe('Test: security controller - profiles', () => {
   var
     kuzzle,
+    request,
     securityController;
 
   before(() => {
-    kuzzle = new Kuzzle();
+    kuzzle = new KuzzleMock();
     securityController = new SecurityController(kuzzle);
   });
 
   beforeEach(() => {
-    sandbox.stub(kuzzle.internalEngine, 'get').returns(Promise.resolve({}));
-
-    return kuzzle.services.init({whitelist: []})
-      .then(() => kuzzle.funnel.init())
-      .then(() => {
-        sandbox.stub(kuzzle.repositories.profile, 'buildProfileFromRequest').returns(Promise.resolve());
-        sandbox.stub(kuzzle.repositories.profile, 'hydrate').returns(Promise.resolve());
-      });
+    request = new Request({controller: 'security'});
+    kuzzle.internalEngine.get = sandbox.stub().returns(Promise.resolve({}));
+    kuzzle.internalEngine.getMapping = sinon.stub().returns(Promise.resolve({internalIndex: {mappings: {profiles: {properties: {}}}}}));
+    kuzzle.repositories.profile.buildProfileFromRequest = sandbox.stub().returns(Promise.resolve());
+    kuzzle.repositories.profile.hydrate = sandbox.stub().returns(Promise.resolve());
   });
 
   afterEach(() => {
     sandbox.restore();
   });
 
+  describe('#updateProfileMapping', () => {
+    var foo = {foo: 'bar'};
+
+    it('should update the profile mapping', () => {
+      return securityController.updateProfileMapping(request)
+        .then(response => {
+          should(kuzzle.internalEngine.updateMapping).be.calledOnce();
+          should(kuzzle.internalEngine.updateMapping).be.calledWith('profiles', request.input.body);
+
+          should(response).be.instanceof(Object);
+          should(response).match(foo);
+        });
+    });
+  });
+
+
+  describe('#getProfileMapping', () => {
+    it('should fulfill with a response object', () => {
+      return securityController.getProfileMapping(request)
+        .then(response => {
+          should(kuzzle.internalEngine.getMapping).be.calledOnce();
+          should(kuzzle.internalEngine.getMapping).be.calledWith({index: kuzzle.internalEngine.index, type: 'profiles'});
+
+          should(response).be.instanceof(Object);
+          should(response).match({mapping: {}});
+        });
+    });
+  });
+
   describe('#createOrReplaceProfile', () => {
     it('should resolve to an object on a createOrReplaceProfile call', () => {
-      sandbox.stub(kuzzle.repositories.profile, 'validateAndSaveProfile').returns(Promise.resolve({_id: 'test', _source: {}}));
+      kuzzle.repositories.profile.validateAndSaveProfile = sandbox.stub().returns(Promise.resolve({_id: 'test', _source: {}}));
 
       return securityController.createOrReplaceProfile(new Request({_id: 'test', body: {policies: [{roleId: 'role1'}]}}))
         .then(response => {
@@ -47,7 +74,7 @@ describe('Test: security controller - profiles', () => {
     it('should reject with an object in case of error', () => {
       var error = new Error('Mocked error');
 
-      sandbox.stub(kuzzle.repositories.profile, 'validateAndSaveProfile').returns(Promise.reject(error));
+      kuzzle.repositories.profile.validateAndSaveProfile = sandbox.stub().returns(Promise.reject(error));
 
       return should(securityController.createOrReplaceProfile(new Request({_id: 'test', body: {policies: ['role1']}})))
         .be.rejectedWith(error);
@@ -57,14 +84,14 @@ describe('Test: security controller - profiles', () => {
   describe('#createProfile', () => {
     it('should reject when a profile already exists with the id', () => {
       var error = new Error('Mocked error');
-      sandbox.stub(kuzzle.repositories.profile, 'validateAndSaveProfile').returns(Promise.reject(error));
+      kuzzle.repositories.profile.validateAndSaveProfile = sandbox.stub().returns(Promise.reject(error));
 
       return should(securityController.createProfile(new Request({_id: 'test',body: {policies: ['role1']}})))
         .be.rejectedWith(error);
     });
 
     it('should resolve to an object on a createProfile call', () => {
-      sandbox.stub(kuzzle.repositories.profile, 'validateAndSaveProfile').returns(Promise.resolve({_id: 'test', _source: {}}));
+      kuzzle.repositories.profile.validateAndSaveProfile = sandbox.stub().returns(Promise.resolve({_id: 'test', _source: {}}));
 
       return should(securityController.createProfile(new Request({_id: 'test', body: {policies: [{roleId:'role1'}]}})))
         .be.fulfilled();
@@ -79,7 +106,7 @@ describe('Test: security controller - profiles', () => {
 
   describe('#getProfile', () => {
     it('should resolve to an object on a getProfile call', () => {
-      sandbox.stub(kuzzle.repositories.profile, 'loadProfile').returns(Promise.resolve({_id: 'test', _source: {}}));
+      kuzzle.repositories.profile.loadProfile = sandbox.stub().returns(Promise.resolve({_id: 'test', _source: {}}));
 
       return securityController.getProfile(new Request({_id: 'test'}))
         .then(response => {
@@ -95,7 +122,7 @@ describe('Test: security controller - profiles', () => {
     });
 
     it('should reject NotFoundError on a getProfile call with a bad id', () => {
-      sandbox.stub(kuzzle.repositories.profile, 'loadProfile').returns(Promise.resolve(null));
+      kuzzle.repositories.profile.loadProfile = sandbox.stub().returns(Promise.resolve(null));
       return should(securityController.getProfile(new Request({_id: 'test'}))).be.rejectedWith(NotFoundError);
     });
   });
@@ -110,13 +137,13 @@ describe('Test: security controller - profiles', () => {
     it('should reject with an object in case of error', () => {
       var error = new Error('Mocked error');
 
-      sandbox.stub(kuzzle.repositories.profile, 'loadMultiFromDatabase').returns(Promise.reject(error));
+      kuzzle.repositories.profile.loadMultiFromDatabase = sandbox.stub().returns(Promise.reject(error));
 
       return should(securityController.mGetProfiles(new Request({body: {ids: ['test']}}))).be.rejectedWith(error);
     });
 
     it('should resolve to an object on a mGetProfiles call', () => {
-      sandbox.stub(kuzzle.repositories.profile, 'loadMultiFromDatabase').returns(Promise.resolve([{_id: 'test', policies: [{roleId: 'role'}]}]));
+      kuzzle.repositories.profile.loadMultiFromDatabase = sandbox.stub().returns(Promise.resolve([{_id: 'test', policies: [{roleId: 'role'}]}]));
 
       return securityController.mGetProfiles(new Request({body: {ids: ['test']}}))
         .then(response => {
@@ -131,7 +158,7 @@ describe('Test: security controller - profiles', () => {
     });
 
     it('should resolve to an object with roles on a mGetProfiles call with hydrate', () => {
-      sandbox.stub(kuzzle.repositories.profile, 'loadMultiFromDatabase').returns(Promise.resolve([{_id: 'test', _source: {}}]));
+      kuzzle.repositories.profile.loadMultiFromDatabase = sandbox.stub().returns(Promise.resolve([{_id: 'test', _source: {}}]));
 
       return securityController.mGetProfiles(new Request({
         body: {ids: ['test'], hydrate: true}
@@ -147,7 +174,7 @@ describe('Test: security controller - profiles', () => {
 
   describe('#searchProfiles', () => {
     it('should return an object containing an array of profiles on searchProfile call', () => {
-      sandbox.stub(kuzzle.repositories.profile, 'searchProfiles').returns(Promise.resolve({hits: [{_id: 'test'}]}));
+      kuzzle.repositories.profile.searchProfiles = sandbox.stub().returns(Promise.resolve({hits: [{_id: 'test'}]}));
 
       return securityController.searchProfiles(new Request({
         body: {}
@@ -160,7 +187,7 @@ describe('Test: security controller - profiles', () => {
     });
 
     it('should return a object containing an array of profiles on searchProfile call with hydrate', () => {
-      sandbox.stub(kuzzle.repositories.profile, 'searchProfiles').returns(Promise.resolve({total: 1, hits: [{_id: 'test', policies: [ {roleId: 'default'} ]}]}));
+      kuzzle.repositories.profile.searchProfiles = sandbox.stub().returns(Promise.resolve({total: 1, hits: [{_id: 'test', policies: [ {roleId: 'default'} ]}]}));
 
       return securityController.searchProfiles(new Request({body: {policies: ['role1']}}))
         .then(response => {
@@ -175,7 +202,7 @@ describe('Test: security controller - profiles', () => {
     it('should reject an error in case of error', () => {
       var error = new Error('Mocked error');
 
-      sandbox.stub(kuzzle.repositories.profile, 'searchProfiles').returns(Promise.reject(error));
+      kuzzle.repositories.profile.searchProfiles = sandbox.stub().returns(Promise.reject(error));
 
       return should(securityController.searchProfiles(new Request({body: {policies: ['foo']}}))).be.rejectedWith(error);
     });
@@ -183,8 +210,8 @@ describe('Test: security controller - profiles', () => {
 
   describe('#updateProfile', () => {
     it('should return a valid response', () => {
-      sandbox.stub(kuzzle.repositories.profile, 'loadProfile').returns(Promise.resolve({}));
-      sandbox.stub(kuzzle.repositories.profile, 'validateAndSaveProfile').returns(Promise.resolve({_id: 'test'}));
+      kuzzle.repositories.profile.loadProfile = sandbox.stub().returns(Promise.resolve({}));
+      kuzzle.repositories.profile.validateAndSaveProfile = sandbox.stub().returns(Promise.resolve({_id: 'test'}));
 
       return securityController.updateProfile(new Request({_id: 'test', body: {foo: 'bar'}}))
         .then(response => {
@@ -202,7 +229,7 @@ describe('Test: security controller - profiles', () => {
 
   describe('#deleteProfile', () => {
     it('should return an object with on deleteProfile call', () => {
-      sandbox.stub(kuzzle.repositories.profile, 'deleteProfile').returns(Promise.resolve({_id: 'test'}));
+      kuzzle.repositories.profile.deleteProfile = sandbox.stub().returns(Promise.resolve({_id: 'test'}));
 
       return securityController.deleteProfile(new Request({_id: 'test'}))
         .then(response => {
@@ -214,7 +241,7 @@ describe('Test: security controller - profiles', () => {
     it('should reject with an error in case of error', () => {
       var error = new Error('Mocked error');
 
-      sandbox.stub(kuzzle.repositories.profile, 'deleteProfile').returns(Promise.reject(error));
+      kuzzle.repositories.profile.deleteProfile = sandbox.stub().returns(Promise.reject(error));
 
       return should(securityController.deleteProfile(new Request({_id: 'test'}))).be.rejectedWith(error);
     });
@@ -222,7 +249,7 @@ describe('Test: security controller - profiles', () => {
 
   describe('#getProfileRights', () => {
     it('should resolve to an object on a getProfileRights call', () => {
-      var loadProfileStub = profileId => {
+      kuzzle.repositories.profile.loadProfile = profileId => {
         return Promise.resolve({
           _id: profileId,
           _source: {},
@@ -241,7 +268,6 @@ describe('Test: security controller - profiles', () => {
         });
       };
 
-      sandbox.stub(kuzzle.repositories.profile, 'loadProfile', loadProfileStub);
       return securityController.getProfileRights(new Request({_id: 'test'}))
         .then(response => {
           var filteredItem;
@@ -277,7 +303,7 @@ describe('Test: security controller - profiles', () => {
     });
 
     it('should reject NotFoundError on a getProfileRights call with a bad id', () => {
-      sandbox.stub(kuzzle.repositories.profile, 'loadProfile').returns(Promise.resolve(null));
+      kuzzle.repositories.profile.loadProfile = sandbox.stub().returns(Promise.resolve(null));
 
       return should(securityController.getProfileRights(new Request({_id: 'test'}))).be.rejectedWith(NotFoundError);
     });

--- a/test/api/controllers/securityController/profiles.test.js
+++ b/test/api/controllers/securityController/profiles.test.js
@@ -34,7 +34,14 @@ describe('Test: security controller - profiles', () => {
   describe('#updateProfileMapping', () => {
     var foo = {foo: 'bar'};
 
+    it('should throw a BadRequestError if the body is missing', () => {
+      return should(() => {
+        securityController.updateProfileMapping(request);
+      }).throw(BadRequestError);
+    });
+
     it('should update the profile mapping', () => {
+      request.input.body = foo;
       return securityController.updateProfileMapping(request)
         .then(response => {
           should(kuzzle.internalEngine.updateMapping).be.calledOnce();

--- a/test/api/controllers/securityController/roles.test.js
+++ b/test/api/controllers/securityController/roles.test.js
@@ -32,7 +32,14 @@ describe('Test: security controller - roles', () => {
   describe('#updateRoleMapping', () => {
     var foo = {foo: 'bar'};
 
+    it('should throw a BadRequestError if the body is missing', () => {
+      return should(() => {
+        securityController.updateRoleMapping(request);
+      }).throw(BadRequestError);
+    });
+
     it('should update the role mapping', () => {
+      request.input.body = foo;
       return securityController.updateRoleMapping(request)
         .then(response => {
           should(kuzzle.internalEngine.updateMapping).be.calledOnce();

--- a/test/api/controllers/securityController/roles.test.js
+++ b/test/api/controllers/securityController/roles.test.js
@@ -3,7 +3,7 @@ var
   Promise = require('bluebird'),
   sinon = require('sinon'),
   sandbox = sinon.sandbox.create(),
-  Kuzzle = require('../../../../lib/api/kuzzle'),
+  KuzzleMock = require('../../../mocks/kuzzle.mock'),
   Request = require('kuzzle-common-objects').Request,
   BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
   SecurityController = require('../../../../lib/api/controllers/securityController');
@@ -11,79 +11,56 @@ var
 describe('Test: security controller - roles', () => {
   var
     kuzzle,
-    error,
+    request,
     securityController;
 
   before(() => {
-    kuzzle = new Kuzzle();
+    kuzzle = new KuzzleMock();
     securityController = new SecurityController(kuzzle);
   });
 
   beforeEach(() => {
-    error = false;
-
-    sandbox.stub(kuzzle.internalEngine, 'get').returns(Promise.resolve({}));
-    return kuzzle.services.init({whitelist: []})
-      .then(() => kuzzle.funnel.init())
-      .then(() => {
-        sandbox.stub(kuzzle.repositories.role, 'validateAndSaveRole', role => {
-          if (role._id === 'alreadyExists') {
-            return Promise.reject(new Error('Mocked error'));
-          }
-
-          return Promise.resolve(role);
-        });
-
-        sandbox.stub(kuzzle.repositories.role, 'loadOneFromDatabase', id => {
-          if (id === 'badId') {
-            return Promise.resolve(null);
-          }
-
-          return Promise.resolve({
-            _index: kuzzle.internalEngine.index,
-            _type: 'roles',
-            _id: id,
-            _source: {}
-          });
-        });
-
-        sandbox.stub(kuzzle.repositories.role, 'loadMultiFromDatabase', ids => {
-          if (error) {
-            return Promise.reject(new Error('foobar'));
-          }
-
-          return Promise.resolve(ids.map(id => ({_id: id, _source: null})));
-        });
-
-        sandbox.stub(kuzzle.repositories.role, 'search', () => {
-          if (error) {
-            return Promise.reject(new Error(''));
-          }
-
-          return Promise.resolve({
-            hits: [{_id: 'test'}],
-            total: 1
-          });
-        });
-
-        sandbox.stub(kuzzle.repositories.role, 'deleteFromDatabase', () => {
-          if (error) {
-            return Promise.reject(new Error(''));
-          }
-
-          return Promise.resolve({_id: 'test'});
-        });
-        sandbox.mock(kuzzle.repositories.profile, 'profiles', {});
-        sandbox.mock(kuzzle.repositories.role, 'roles', {});
-      });
+    request = new Request({controller: 'security'});
+    kuzzle.internalEngine.get = sandbox.stub().returns(Promise.resolve({}));
+    kuzzle.internalEngine.getMapping = sinon.stub().returns(Promise.resolve({internalIndex: {mappings: {roles: {properties: {}}}}}));
   });
 
   afterEach(() => {
     sandbox.restore();
   });
 
+  describe('#updateRoleMapping', () => {
+    var foo = {foo: 'bar'};
+
+    it('should update the role mapping', () => {
+      return securityController.updateRoleMapping(request)
+        .then(response => {
+          should(kuzzle.internalEngine.updateMapping).be.calledOnce();
+          should(kuzzle.internalEngine.updateMapping).be.calledWith('roles', request.input.body);
+
+          should(response).be.instanceof(Object);
+          should(response).match(foo);
+        });
+    });
+  });
+
+
+  describe('#getRoleMapping', () => {
+    it('should fulfill with a response object', () => {
+      return securityController.getRoleMapping(request)
+        .then(response => {
+          should(kuzzle.internalEngine.getMapping).be.calledOnce();
+          should(kuzzle.internalEngine.getMapping).be.calledWith({index: kuzzle.internalEngine.index, type: 'roles'});
+
+          should(response).be.instanceof(Object);
+          should(response).match({mapping: {}});
+        });
+    });
+  });
+
   describe('#createOrReplaceRole', () => {
     it('should resolve to an object on a createOrReplaceRole call', () => {
+      kuzzle.repositories.role.validateAndSaveRole = sandbox.stub().returns(Promise.resolve({_id: 'test'}));
       return securityController.createOrReplaceRole(new Request({_id: 'test', body: {controllers: {}}}))
         .then(response => {
           should(response).be.instanceof(Object);
@@ -92,6 +69,7 @@ describe('Test: security controller - roles', () => {
     });
 
     it('should reject an error in case of error', () => {
+      kuzzle.repositories.role.validateAndSaveRole = sandbox.stub().returns(Promise.reject(new Error('Mocked error')));
       return should(securityController.createOrReplaceRole(new Request({_id: 'alreadyExists', body: {indexes: {}}})))
         .be.rejectedWith(new Error('Mocked error'));
     });
@@ -104,6 +82,7 @@ describe('Test: security controller - roles', () => {
     });
 
     it('should resolve to an object on a createRole call', () => {
+      kuzzle.repositories.role.validateAndSaveRole = sandbox.stub().returns(Promise.resolve({_id: 'test'}));
       return should(securityController.createRole(new Request({_id: 'test', body: {controllers: {}}})))
         .be.fulfilled();
     });
@@ -111,6 +90,8 @@ describe('Test: security controller - roles', () => {
 
   describe('#getRole', () => {
     it('should resolve to an object on a getRole call', () => {
+      kuzzle.repositories.role.loadRole = sandbox.stub().returns(Promise.resolve({_id: 'test'}));
+
       return securityController.getRole(new Request({_id: 'test'}))
         .then(response => {
           should(response).be.instanceof(Object);
@@ -119,6 +100,7 @@ describe('Test: security controller - roles', () => {
     });
 
     it('should reject NotFoundError on a getRole call with a bad id', () => {
+      kuzzle.repositories.role.loadRole = sandbox.stub().returns(Promise.resolve(null));
       return should(securityController.getRole(new Request({_id: 'badId'}))).be.rejected();
     });
   });
@@ -131,12 +113,13 @@ describe('Test: security controller - roles', () => {
     });
 
     it('should reject an error if loading roles fails', () => {
-      error = true;
+      kuzzle.repositories.role.loadMultiFromDatabase = sandbox.stub().returns(Promise.reject(new Error('foobar')));
 
       return should(securityController.mGetRoles(new Request({body: {ids: ['test']}}))).be.rejected();
     });
 
     it('should resolve to an object', done => {
+      kuzzle.repositories.role.loadMultiFromDatabase = sandbox.stub().returns(Promise.resolve([{_id: 'test', _source: null}]));
       securityController.mGetRoles(new Request({body: {ids: ['test']}}))
         .then(response => {
           should(response).be.instanceof(Object);
@@ -153,6 +136,11 @@ describe('Test: security controller - roles', () => {
 
   describe('#searchRoles', () => {
     it('should return response with an array of roles on searchRole call', () => {
+      kuzzle.repositories.role.searchRole = sandbox.stub().returns(Promise.resolve({
+        hits: [{_id: 'test'}],
+        total: 1
+      }));
+
       return securityController.searchRoles(new Request({body: {_id: 'test'}}))
         .then(response => {
           should(response).be.instanceof(Object);
@@ -162,14 +150,14 @@ describe('Test: security controller - roles', () => {
     });
 
     it('should reject an error in case of error', () => {
-      error = true;
-
+      kuzzle.repositories.role.searchRole = sandbox.stub().returns(Promise.reject(new Error('')));
       return should(securityController.searchRoles(new Request({_id: 'test'}))).be.rejected();
     });
   });
 
   describe('#updateRole', () => {
     it('should return a valid response', done => {
+      kuzzle.repositories.role.loadRole = sandbox.stub().returns(Promise.resolve({_id: 'test'}));
       kuzzle.repositories.role.roles = [];
 
       kuzzle.repositories.role.validateAndSaveRole = role => {
@@ -197,6 +185,7 @@ describe('Test: security controller - roles', () => {
     });
 
     it('should reject the promise if the role cannot be found in the database', () => {
+      kuzzle.repositories.role.loadRole = sandbox.stub().returns(Promise.resolve(null));
       return should(securityController.updateRole(new Request({_id: 'badId',body: {}}))).be.rejected();
     });
   });
@@ -204,20 +193,20 @@ describe('Test: security controller - roles', () => {
   describe('#deleteRole', () => {
     it('should return response with on deleteRole call', done => {
       var
-        spyDeleteRole,
         role = {my: 'role'};
 
-      sandbox.stub(kuzzle.repositories.role, 'getRoleFromRequest').returns(role);
-      spyDeleteRole = sandbox.stub(kuzzle.repositories.role, 'deleteRole').returns(Promise.resolve());
+      kuzzle.repositories.role.getRoleFromRequest = sandbox.stub().returns(role);
+      kuzzle.repositories.role.deleteRole = sandbox.stub().returns(Promise.resolve());
 
       securityController.deleteRole(new Request({_id: 'test',body: {}}))
         .then(() => {
-          should(spyDeleteRole.calledWith(role)).be.true();
+          should(kuzzle.repositories.role.deleteRole.calledWith(role)).be.true();
           done();
         });
     });
 
     it('should reject the promise if attempting to delete one of the core roles', () => {
+      kuzzle.repositories.role.deleteRole = sandbox.stub().returns(Promise.reject(new Error('admin is one of the basic roles of Kuzzle, you cannot delete it, but you can edit it.')));
       return should(securityController.deleteRole(new Request({_id: 'admin',body: {}}))).be.rejected();
     });
   });

--- a/test/api/controllers/securityController/users.test.js
+++ b/test/api/controllers/securityController/users.test.js
@@ -33,7 +33,14 @@ describe('Test: security controller - users', () => {
   describe('#updateUserMapping', () => {
     var foo = {foo: 'bar'};
 
+    it('should throw a BadRequestError if the body is missing', () => {
+      return should(() => {
+        securityController.updateUserMapping(request);
+      }).throw(BadRequestError);
+    });
+
     it('should update the user mapping', () => {
+      request.input.body = foo;
       return securityController.updateUserMapping(request)
         .then(response => {
           should(kuzzle.internalEngine.updateMapping).be.calledOnce();

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -116,8 +116,7 @@ function KuzzleMock () {
     init: sinon.stub().returns(Promise.resolve()),
     refresh: sinon.stub().returns(Promise.resolve()),
     search: sinon.stub().returns(Promise.resolve()),
-    updateMapping: sinon.stub().returns(Promise.resolve(foo)),
-    getMapping: sinon.stub().returns(Promise.resolve({internalIndex: {mappings: {users: {properties: {}}}}}))
+    updateMapping: sinon.stub().returns(Promise.resolve(foo))
   };
 
   this.once = sinon.stub();


### PR DESCRIPTION
**NB : need to wait merge of #616 before adding the last fix with asserts**

fix #617 
# Implemented actions
* move `getUserMapping` and `setUserMapping` actions form `collection` to `security` controller 
* add `getProfileMapping`, `getRoleMapping`, `setProfileMapping` and `setRoleMapping` actions

# Boy-scout 
* add `'use strict'` when missing
* refactor security controller unit-tests to use a Kuzzle Mock.
