### PR TITLE
Add debug mode -old-

### DIFF
--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -1,4 +1,5 @@
 var
+  debug = require('debug')('kuzzle:plugins'),
   GatewayTimeoutError = require('kuzzle-common-objects').errors.GatewayTimeoutError,
   PluginImplementationError = require('kuzzle-common-objects').errors.PluginImplementationError,
   PluginContext = require('./pluginContext'),
@@ -88,6 +89,8 @@ function PluginsManager (kuzzle) {
       }
 
       pluginConfiguration[plugin] = p;
+
+      debug('[%s] loading configuration:\n%O', plugin, p);
     });
 
     return pluginConfiguration;
@@ -117,7 +120,13 @@ function PluginsManager (kuzzle) {
           return true;
         }
 
+        if (!plugin.name) {
+          plugin.name = pluginName
+        }
+
         if (plugin.config.threads) {
+          debug('[%s] starting worker with %d treads', pluginName, plugin.config.threads);
+
           initWorkers(plugin, pluginName, this.kuzzle.config)
             .then(() => callback())
             .catch(err => {
@@ -129,6 +138,8 @@ function PluginsManager (kuzzle) {
         }
 
         try {
+          debug('[%s] starting plugin in %s mode', pluginName, plugin.config.privileged ? 'privileged' : 'standard');
+
           plugin.object.init(
             plugin.config,
             plugin.config.privileged ? new PrivilegedPluginContext(kuzzle) : new PluginContext(kuzzle)
@@ -156,7 +167,7 @@ function PluginsManager (kuzzle) {
           injectScope(plugin.object.scope, kuzzle.passport);
         }
 
-        this.silent || console.log('Plugin', pluginName, 'started'); // eslint-disable-line no-console
+        debug('[%s] plugin started', pluginName);
         callback();
       }, (err) => {
         if (err) {
@@ -175,6 +186,8 @@ function PluginsManager (kuzzle) {
    * @returns {Promise}
    */
   this.trigger = function pluginTrigger (event, data) {
+    debug('trigger "%s" event', event);
+
     return triggerPipes.call(this, event, data)
       .then(modifiedData => {
         // Execute in parallel Hook and Worker because we don't have to wait or execute in a particular order
@@ -358,6 +371,7 @@ function initHooks (plugin, kuzzle) {
 function initControllers (controllers, routes, plugin, pluginName) {
   var controllerImported = Object.keys(plugin.object.controllers).every(controller => {
     var description = plugin.object.controllers[controller];
+    debug('[%s][%s] starting controller registration', plugin.name, controller);
 
     if (typeof description !== 'object' || description === null || Array.isArray(description)) {
       // eslint-disable-next-line no-console
@@ -366,6 +380,8 @@ function initControllers (controllers, routes, plugin, pluginName) {
     }
 
     return Object.keys(description).every(action => {
+      debug('[%s][%s][%s] starting action controller registration', plugin.name, controller, action);
+
       if (typeof description[action] !== 'string' || description[action].length === 0) {
         // eslint-disable-next-line no-console
         console.error(`[Plugin Manager] Error loading ${pluginName}: invalid action description (expected non-empty string): ${action}`);
@@ -429,8 +445,11 @@ function initControllers (controllers, routes, plugin, pluginName) {
           return false;
         }
 
+
         route.url = '/' + pluginName + route.url;
         route.controller = pluginName + '/' + route.controller;
+
+        debug('[%s] binding HTTP route "%s" to controller "%s"', pluginName, route.url, route.controller);
         routes.push(route);
       }
     });
@@ -553,6 +572,8 @@ function triggerWorkers(event, data) {
  * @param plugins - list of installed plugins to load
  */
 function loadPlugins(plugins) {
+  debug('loading plugins:\n%O', plugins);
+
   _.forEach(plugins, (plugin, name) => {
     try {
       plugin.object = new (require(name))();
@@ -574,6 +595,8 @@ function loadPlugins(plugins) {
  * @param {function} fn - function to attach
  */
 function registerPipe(pipes, plugin, warnDelay, timeoutDelay, event, fn) {
+  debug('[%s] register pipe on event "%s"', plugin.name, event);
+
   if (!pipes[event]) {
     pipes[event] = [];
   }
@@ -625,6 +648,8 @@ function registerPipe(pipes, plugin, warnDelay, timeoutDelay, event, fn) {
  * @param {function} fn - function to attach
  */
 function registerHook(kuzzle, plugin, event, fn) {
+  debug('[%s] register hook on event "%s"', plugin.name, event);
+
   kuzzle.on(event, (message) => {
     try {
       plugin.object[fn](message, event);

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -121,7 +121,7 @@ function PluginsManager (kuzzle) {
         }
 
         if (!plugin.name) {
-          plugin.name = pluginName
+          plugin.name = pluginName;
         }
 
         if (plugin.config.threads) {

--- a/lib/services/broker/index.js
+++ b/lib/services/broker/index.js
@@ -1,4 +1,5 @@
 var
+  debug = require('debug')('kuzzle:broker'),
   WSBrokerClient = require('./wsBrokerClient'),
   WSBrokerServer = require('./wsBrokerServer');
 
@@ -10,6 +11,7 @@ var
  */
 module.exports = function Broker (brokerType, client, notifyOnListen) {
   return function brokerInit (kuzzle, opts, config) {
+    debug('[%s] initialize broker service as %s', brokerType, client ? 'client' : 'server');
 
     if (opts && opts.client !== undefined) {
       client = opts.client;

--- a/lib/services/broker/wsBrokerClient.js
+++ b/lib/services/broker/wsBrokerClient.js
@@ -181,19 +181,7 @@ WSBrokerClient.prototype._connect = function wSBrokerClientConnect () {
     this.onConnectHandlers.forEach(f => f());
     this.client.state = 'connected';
 
-    if (this._pingRequestIntervalId) {
-      clearTimeout(this._pingRequestIntervalId)
-      this._pingRequestIntervalId = null;
-    }
-
-    if (this._pingRequestTimeoutId) {
-      clearTimeout(this._pingRequestTimeoutId)
-      this._pingRequestTimeoutId = null;
-    }
-
-    this.client.socket.removeAllListeners('pong')
-    this.client.socket.on('pong', handlePongResponse.bind(this))
-
+    resetPing.call(this)
     pingRequest.call(this)
 
     if (!this.client.connected.promise.isFulfilled()) {
@@ -212,6 +200,8 @@ WSBrokerClient.prototype._connect = function wSBrokerClientConnect () {
     }
     this.close();
 
+    resetPing.call(this)
+
     this.onCloseHandlers.forEach(f => f());
 
     this.pluginsManager.trigger(this.eventName + ':socketClosed',
@@ -226,11 +216,6 @@ WSBrokerClient.prototype._connect = function wSBrokerClientConnect () {
       this.retryTimer = null;
     }
 
-    if (this._pingRequestIntervalId) {
-      clearTimeout(this._pingRequestIntervalId)
-      this._pingRequestIntervalId = null;
-    }
-
     if (this.reconnect) {
       this.retryTimer = setTimeout(() => this._connect(), this.client.retryInterval);
     }
@@ -240,6 +225,8 @@ WSBrokerClient.prototype._connect = function wSBrokerClientConnect () {
     debug('[%s] broker client received an error: %s', this.eventName, err);
 
     this.close();
+
+    resetPing.call(this);
 
     this.onErrorHandlers.forEach(f => f());
 
@@ -258,16 +245,6 @@ WSBrokerClient.prototype._connect = function wSBrokerClientConnect () {
     if (this.retryTimer) {
       clearTimeout(this.retryTimer);
       this.retryTimer = null;
-    }
-
-    if (this._pingRequestIntervalId) {
-      clearTimeout(this._pingRequestIntervalId)
-      this._pingRequestIntervalId = null;
-    }
-
-    if (this._pingRequestTimeoutId) {
-      clearTimeout(this._pingRequestTimeoutId)
-      this._pingRequestTimeoutId = null;
     }
 
     if (this.reconnect) {
@@ -331,17 +308,33 @@ function getDeferredPromise() {
   return {resolve, reject, promise};
 }
 
+function resetPing() {
+  debug('[%s] broker client reset ping requests status', this.eventName);
+
+  if (this.client && this.client.socket) {
+    this.client.socket.removeAllListeners('pong')
+  }
+
+  if (this._pingRequestIntervalId) {
+    clearTimeout(this._pingRequestIntervalId)
+    this._pingRequestIntervalId = null;
+  }
+
+  if (this._pingRequestTimeoutId) {
+    clearTimeout(this._pingRequestTimeoutId)
+    this._pingRequestTimeoutId = null;
+  }
+}
+
 function pingRequest() {
   debug('[%s] broker client sending ping request to server', this.eventName);
 
+  this.client.socket.on('pong', handlePongResponse.bind(this))
   this.client.socket.ping();
 
   this._pingRequestTimeoutId = setTimeout(() => {
     debug('[%s] ping timed out, disconnecting from server', this.eventName);
 
-    // this.client.state = 'timed-out'
-
-    this.client.socket.removeAllListeners('pong')
     this.client.socket.emit('error', new Error('Connection to server timed out'))
 
   }, this._pingTimeout)

--- a/lib/services/broker/wsBrokerClient.js
+++ b/lib/services/broker/wsBrokerClient.js
@@ -177,9 +177,6 @@ WSBrokerClient.prototype._connect = function wSBrokerClientConnect () {
 
     this.onConnectHandlers.forEach(f => f());
     this.client.state = 'connected';
-    if (!this.client.connected.promise.isFulfilled()) {
-      return this.client.connected.resolve(this.client.socket);
-    }
 
     if (this.pingTimeout) {
       clearTimeout(this.pingTimeout)
@@ -187,6 +184,10 @@ WSBrokerClient.prototype._connect = function wSBrokerClientConnect () {
     }
 
     this.ping();
+
+    if (!this.client.connected.promise.isFulfilled()) {
+      return this.client.connected.resolve(this.client.socket);
+    }
 
     this.pluginsManager.trigger('log:warn', `[${this.eventName}] Node is connected while it was previously already.`);
   });

--- a/lib/services/broker/wsBrokerClient.js
+++ b/lib/services/broker/wsBrokerClient.js
@@ -18,12 +18,14 @@ function WSBrokerClient (brokerType, options, pluginsManager, notifyOnListen) {
   this.pluginsManager = pluginsManager;
   this.eventName = brokerType;
   this.notifyOnListen = notifyOnListen;
+  this.pingTimeout = null;
 
   this.client = {
     socket: null,
     connected: null,
     state: 'disconnected',
-    retryInterval: options.retryInterval || 1000
+    retryInterval: options.retryInterval || 1000,
+    pingInterval: options.pingInterval || 1000 * 60
   };
 
   this.handlers = {};
@@ -179,6 +181,13 @@ WSBrokerClient.prototype._connect = function wSBrokerClientConnect () {
       return this.client.connected.resolve(this.client.socket);
     }
 
+    if (this.pingTimeout) {
+      clearTimeout(this.pingTimeout)
+      this.pingTimeout = null;
+    }
+
+    this.ping();
+
     this.pluginsManager.trigger('log:warn', `[${this.eventName}] Node is connected while it was previously already.`);
   });
 
@@ -203,6 +212,11 @@ WSBrokerClient.prototype._connect = function wSBrokerClientConnect () {
     if (this.retryTimer) {
       clearTimeout(this.retryTimer);
       this.retryTimer = null;
+    }
+
+    if (this.pingTimeout) {
+      clearTimeout(this.pingTimeout)
+      this.pingTimeout = null;
     }
 
     if (this.reconnect) {
@@ -233,6 +247,12 @@ WSBrokerClient.prototype._connect = function wSBrokerClientConnect () {
       clearTimeout(this.retryTimer);
       this.retryTimer = null;
     }
+
+    if (this.pingTimeout) {
+      clearTimeout(this.pingTimeout)
+      this.pingTimeout = null;
+    }
+
     if (this.reconnect) {
       this.retryTimer = setTimeout(() => this._connect(), this.client.retryInterval);
     }
@@ -247,6 +267,23 @@ WSBrokerClient.prototype._connect = function wSBrokerClientConnect () {
  */
 WSBrokerClient.prototype.broadcast = function wSBrokerClientBroadcast (room, data) {
   return emit.call(this, 'broadcast', room, data);
+};
+
+/**
+ * Sends `ping` to the server.
+ */
+WSBrokerClient.prototype.ping = function wSBrokerClientPing () {
+  debug('[%s] broker client sending ping request to server', this.eventName);
+
+  try {
+    this.client.socket.ping()
+  }
+  catch (error) {
+    debug('[%s] ping errored !', this.eventName, error);
+    this.client.socket.emit('error', new Error('PING FAILED'))
+  }
+
+  this.pingTimeout = setTimeout(() => this.ping(), this.client.pingInterval)
 };
 
 

--- a/lib/services/broker/wsBrokerClient.js
+++ b/lib/services/broker/wsBrokerClient.js
@@ -19,7 +19,7 @@ function WSBrokerClient (brokerType, options, pluginsManager, notifyOnListen) {
   this.eventName = brokerType;
   this.notifyOnListen = notifyOnListen;
 
-  this._pingTimeout = options.pingTimeout || 100;
+  this._pingTimeout = options.pingInterval || 50;
   this._pingInterval = options.pingInterval || 1000 * 60;
   this._pingRequestTimeoutId = null;
   this._pingRequestIntervalId = null;
@@ -151,10 +151,6 @@ WSBrokerClient.prototype._connect = function wSBrokerClientConnect () {
 
   debug('[%s] initialize broker client connection on socket "%s"', this.eventName, this.server.address);
 
-  this.client.socket.on('pong', () => {
-    debug('[%s] broker client pong received', this.eventName);
-  });
-
   this.client.socket.on('message', msg => {
     msg = JSON.parse(msg);
 
@@ -190,6 +186,10 @@ WSBrokerClient.prototype._connect = function wSBrokerClientConnect () {
       this._pingRequestIntervalId = null;
     }
 
+    if (this._pingRequestTimeoutId) {
+      clearTimeout(this._pingRequestTimeoutId)
+      this._pingRequestTimeoutId = null;
+    }
 
     this.client.socket.removeAllListeners('pong')
     this.client.socket.on('pong', handlePongResponse.bind(this))
@@ -265,6 +265,11 @@ WSBrokerClient.prototype._connect = function wSBrokerClientConnect () {
       this._pingRequestIntervalId = null;
     }
 
+    if (this._pingRequestTimeoutId) {
+      clearTimeout(this._pingRequestTimeoutId)
+      this._pingRequestTimeoutId = null;
+    }
+
     if (this.reconnect) {
       this.retryTimer = setTimeout(() => this._connect(), this.client.retryInterval);
     }
@@ -334,17 +339,21 @@ function pingRequest() {
   this._pingRequestTimeoutId = setTimeout(() => {
     debug('[%s] ping timed out, disconnecting from server', this.eventName);
 
-    this.client.state = 'timed-out'
+    // this.client.state = 'timed-out'
 
-    this.client.socket.emit('close', 1000)
+    this.client.socket.removeAllListeners('pong')
+    this.client.socket.emit('error', new Error('Connection to server timed out'))
+
   }, this._pingTimeout)
 }
 
 function handlePongResponse() {
   debug('[%s] broker client received pong from server', this.eventName);
 
-  clearTimeout(this._pingRequestTimeoutId)
-  this._pingRequestTimeoutId = null
+  if (this._pingRequestTimeoutId) {
+    clearTimeout(this._pingRequestTimeoutId)
+    this._pingRequestTimeoutId = null
+  }
 
   this._pingRequestIntervalId = setTimeout(() => {
     pingRequest.call(this)

--- a/lib/services/broker/wsBrokerClient.js
+++ b/lib/services/broker/wsBrokerClient.js
@@ -18,14 +18,17 @@ function WSBrokerClient (brokerType, options, pluginsManager, notifyOnListen) {
   this.pluginsManager = pluginsManager;
   this.eventName = brokerType;
   this.notifyOnListen = notifyOnListen;
-  this.pingTimeout = null;
+
+  this._pingTimeout = options.pingTimeout || 100;
+  this._pingInterval = options.pingInterval || 1000 * 60;
+  this._pingRequestTimeoutId = null;
+  this._pingRequestIntervalId = null;
 
   this.client = {
     socket: null,
     connected: null,
     state: 'disconnected',
-    retryInterval: options.retryInterval || 1000,
-    pingInterval: options.pingInterval || 1000 * 60
+    retryInterval: options.retryInterval || 1000
   };
 
   this.handlers = {};
@@ -148,6 +151,10 @@ WSBrokerClient.prototype._connect = function wSBrokerClientConnect () {
 
   debug('[%s] initialize broker client connection on socket "%s"', this.eventName, this.server.address);
 
+  this.client.socket.on('pong', () => {
+    debug('[%s] broker client pong received', this.eventName);
+  });
+
   this.client.socket.on('message', msg => {
     msg = JSON.parse(msg);
 
@@ -178,12 +185,16 @@ WSBrokerClient.prototype._connect = function wSBrokerClientConnect () {
     this.onConnectHandlers.forEach(f => f());
     this.client.state = 'connected';
 
-    if (this.pingTimeout) {
-      clearTimeout(this.pingTimeout)
-      this.pingTimeout = null;
+    if (this._pingRequestIntervalId) {
+      clearTimeout(this._pingRequestIntervalId)
+      this._pingRequestIntervalId = null;
     }
 
-    this.ping();
+
+    this.client.socket.removeAllListeners('pong')
+    this.client.socket.on('pong', handlePongResponse.bind(this))
+
+    pingRequest.call(this)
 
     if (!this.client.connected.promise.isFulfilled()) {
       return this.client.connected.resolve(this.client.socket);
@@ -215,9 +226,9 @@ WSBrokerClient.prototype._connect = function wSBrokerClientConnect () {
       this.retryTimer = null;
     }
 
-    if (this.pingTimeout) {
-      clearTimeout(this.pingTimeout)
-      this.pingTimeout = null;
+    if (this._pingRequestIntervalId) {
+      clearTimeout(this._pingRequestIntervalId)
+      this._pingRequestIntervalId = null;
     }
 
     if (this.reconnect) {
@@ -249,9 +260,9 @@ WSBrokerClient.prototype._connect = function wSBrokerClientConnect () {
       this.retryTimer = null;
     }
 
-    if (this.pingTimeout) {
-      clearTimeout(this.pingTimeout)
-      this.pingTimeout = null;
+    if (this._pingRequestIntervalId) {
+      clearTimeout(this._pingRequestIntervalId)
+      this._pingRequestIntervalId = null;
     }
 
     if (this.reconnect) {
@@ -269,24 +280,6 @@ WSBrokerClient.prototype._connect = function wSBrokerClientConnect () {
 WSBrokerClient.prototype.broadcast = function wSBrokerClientBroadcast (room, data) {
   return emit.call(this, 'broadcast', room, data);
 };
-
-/**
- * Sends `ping` to the server.
- */
-WSBrokerClient.prototype.ping = function wSBrokerClientPing () {
-  debug('[%s] broker client sending ping request to server', this.eventName);
-
-  try {
-    this.client.socket.ping()
-  }
-  catch (error) {
-    debug('[%s] ping errored !', this.eventName, error);
-    this.client.socket.emit('error', new Error('PING FAILED'))
-  }
-
-  this.pingTimeout = setTimeout(() => this.ping(), this.client.pingInterval)
-};
-
 
 /**
  *
@@ -331,4 +324,29 @@ function getDeferredPromise() {
   });
 
   return {resolve, reject, promise};
+}
+
+function pingRequest() {
+  debug('[%s] broker client sending ping request to server', this.eventName);
+
+  this.client.socket.ping();
+
+  this._pingRequestTimeoutId = setTimeout(() => {
+    debug('[%s] ping timed out, disconnecting from server', this.eventName);
+
+    this.client.state = 'timed-out'
+
+    this.client.socket.emit('close', 1000)
+  }, this._pingTimeout)
+}
+
+function handlePongResponse() {
+  debug('[%s] broker client received pong from server', this.eventName);
+
+  clearTimeout(this._pingRequestTimeoutId)
+  this._pingRequestTimeoutId = null
+
+  this._pingRequestIntervalId = setTimeout(() => {
+    pingRequest.call(this)
+  }, this._pingInterval)
 }

--- a/lib/services/broker/wsBrokerClient.js
+++ b/lib/services/broker/wsBrokerClient.js
@@ -1,4 +1,5 @@
 var
+  debug = require('debug')('kuzzle:broker:client'),
   path = require('path'),
   Promise = require('bluebird'),
   WS = require('ws'),
@@ -43,7 +44,7 @@ function WSBrokerClient (brokerType, options, pluginsManager, notifyOnListen) {
   else {
     throw new InternalError('No endpoint configuration given to connect.');
   }
-  
+
   this.ws = () => new WS(this.server.address, {perMessageDeflate: false});
 
   this.reconnect = true;
@@ -79,6 +80,8 @@ WSBrokerClient.prototype.listen = function wSBrokerClientListen (room, cb) {
     return false;
   }
 
+  debug('[%s] broker client subscribed to room "%s"', this.eventName, room);
+
   if (this.handlers[room] === undefined) {
     this.handlers[room] = [];
   }
@@ -103,6 +106,8 @@ WSBrokerClient.prototype.unsubscribe = function wSBrokerClientUnsubscribe (room)
     this.pluginsManager.trigger('log:error', `No socket for broker ${this.eventName}`);
     return false;
   }
+
+  debug('[%s] broker client unsubscribed to room "%s"', this.eventName, room);
 
   if (this.handlers[room]) {
     delete this.handlers[room];
@@ -139,8 +144,12 @@ WSBrokerClient.prototype.close = function wSBrokerClientClose () {
 WSBrokerClient.prototype._connect = function wSBrokerClientConnect () {
   this.client.socket = this.ws();
 
+  debug('[%s] initialize broker client connection on socket "%s"', this.eventName, this.server.address);
+
   this.client.socket.on('message', msg => {
     msg = JSON.parse(msg);
+
+    debug('[%s] broker client received a message:\n%O', this.eventName, msg);
 
     if (msg.room && this.handlers[msg.room]) {
       this.handlers[msg.room].forEach(cb => cb(msg.data));
@@ -148,6 +157,8 @@ WSBrokerClient.prototype._connect = function wSBrokerClientConnect () {
   });
 
   this.client.socket.on('open', () => {
+    debug('[%s] broker client connected', this.eventName);
+
     this.pluginsManager.trigger(this.eventName + ':connected', 'Connected to Kuzzle server');
 
     // if we were already listening to some rooms, subscribe again to the server
@@ -172,6 +183,8 @@ WSBrokerClient.prototype._connect = function wSBrokerClientConnect () {
   });
 
   this.client.socket.on('close', code => {
+    debug('[%s] broker client received a exit code: %s', this.eventName, code);
+
     // Automatically reconnect except if this.close() was called
     if (this.client.state === 'disconnected') {
       return false;
@@ -198,6 +211,8 @@ WSBrokerClient.prototype._connect = function wSBrokerClientConnect () {
   });
 
   this.client.socket.on('error', err => {
+    debug('[%s] broker client received an error: %s', this.eventName, err);
+
     this.close();
 
     this.onErrorHandlers.forEach(f => f());
@@ -255,6 +270,8 @@ function emit (mode, room, data) {
     this.pluginsManager.trigger('log:error', `No socket for broker ${this.eventName}`);
     return false;
   }
+
+  debug('[%s] broker client %s a message in room "%s":\n%O', this.eventName, mode, room, data);
 
   return this.client.socket.send(JSON.stringify({
     action: mode,

--- a/lib/services/broker/wsBrokerServer.js
+++ b/lib/services/broker/wsBrokerServer.js
@@ -1,4 +1,5 @@
 var
+  debug = require('debug')('kuzzle:broker:server'),
   fs = require('fs'),
   http = require('http'),
   net = require('net'),
@@ -35,7 +36,10 @@ function WSBrokerServer (brokerType, options, pluginsManager) {
 
     if (options.socket) {
       server.on('error', error => {
+
         if(error.code !== 'EADDRINUSE') {
+          debug('[%s] broker server received an error:\n%O', this.eventName, error);
+
           throw error;
         }
 
@@ -45,8 +49,12 @@ function WSBrokerServer (brokerType, options, pluginsManager) {
         })
           .on('error', e => {
             if (e.code !== 'ECONNREFUSED') {
+              debug('[%s] broker server can\'t open requested socket, seem to be already used by another process', this.eventName);
+
               throw e;
             }
+
+            debug('[%s] broker server can\'t open requested socket, seem to be unused, trying to recreate it', this.eventName);
 
             fs.unlinkSync(options.socket);
 
@@ -60,13 +68,20 @@ function WSBrokerServer (brokerType, options, pluginsManager) {
             }
           });
       });
+
+      debug('[%s] initialize broker server through socket "%s"', this.eventName, options.socket);
+
       server.listen(options.socket, initCB);
     }
     else if (options.port) {
       if (options.host) {
+        debug('[%s] initialize broker server through net port "%s" on host "%s"', this.eventName, options.port, options.host);
+
         server.listen(options.port, options.host, initCB);
       }
       else {
+        debug('[%s] initialize broker server through net port "%s"', this.eventName, options.port, options.host);
+
         server.listen(options.port, initCB);
       }
     }
@@ -97,8 +112,13 @@ WSBrokerServer.prototype.init = function wSBrokerServerInit () {
   return new Promise(resolve => {
     this.ws(() => {
       this.wss.on('connection', clientSocket => {
+
+        debug('[%s][%s] broker server received a connection', this.eventName, clientSocket.upgradeReq.headers['sec-websocket-key']);
+
         clientSocket.on('message', msg => {
           msg = JSON.parse(msg);
+
+          debug('[%s][%s] received a message though broker server connection:\n%O', this.eventName, clientSocket.upgradeReq.headers['sec-websocket-key'], msg);
 
           switch (msg.action) {
             // the listen action is called by the client to inform the server it
@@ -137,16 +157,22 @@ WSBrokerServer.prototype.init = function wSBrokerServerInit () {
         });
 
         clientSocket.on('close', (code, message) => {
+          debug('[%s][%s] broker server connection closed with code "%s" and message:\n%O', this.eventName, clientSocket.upgradeReq.headers['sec-websocket-key'], code, message);
+
           this.pluginsManager.trigger('log:info', `client disconnected [${code}] ${message}`);
           removeClient.call(this, clientSocket);
         });
 
         clientSocket.on('error', err => {
+          debug('[%s][%s] broker server connection errored:\n%O', this.eventName, clientSocket.upgradeReq.headers['sec-websocket-key'], err);
+
           this.pluginsManager.trigger('log:error', err);
         });
       });
 
       this.wss.on('error', error => {
+        debug('[%s] broker server errored:\n%O', this.eventName, error);
+
         this.pluginsManager.trigger('log:error', `Connection error: [${error.code}] ${error.message}`);
         this.onErrorHandlers.forEach(f => f());
       });
@@ -173,6 +199,8 @@ WSBrokerServer.prototype.broadcast = function wSBrokerServerBroadcast (room, dat
       room: room,
       data: data
     });
+
+  debug('[%s] broadcast message though broker server in room "%s":\n%O', this.eventName, room, data);
 
   if (!this.rooms[room]) {
     return -1;
@@ -207,6 +235,8 @@ WSBrokerServer.prototype.broadcast = function wSBrokerServerBroadcast (room, dat
 WSBrokerServer.prototype.send = function wSBrokerServerSend (room, data, emitterSocket) {
   var clientSocket;
 
+  debug('[%s] sending message though broker server in room "%s":\n%O', this.eventName, room, data);
+
   if (!this.rooms[room]) {
     return;
   }
@@ -237,6 +267,8 @@ WSBrokerServer.prototype.send = function wSBrokerServerSend (room, data, emitter
  * @returns {int} the number of triggered callbacks ; -1 if the room does not exist
  */
 WSBrokerServer.prototype.dispatch = function wSBrokerServerDispatch (room, data) {
+  debug('[%s] broker server dispatching data to room "%s":\n%O', this.eventName, room, data);
+
   if (!this.handlers[room]) {
     return -1;
   }
@@ -252,6 +284,8 @@ WSBrokerServer.prototype.dispatch = function wSBrokerServerDispatch (room, data)
  * @param {function} cb The callback to execute
  */
 WSBrokerServer.prototype.listen = function wSBrokerServerListen (room, cb) {
+  debug('[%s] broker server subscribed to room "%s"', this.eventName, room);
+
   if (this.handlers[room] === undefined) {
     this.handlers[room] = [];
   }
@@ -288,6 +322,8 @@ WSBrokerServer.prototype.waitForClients = function wSBrokerServerWaitForClients 
  * @param {string} room
  */
 WSBrokerServer.prototype.unsubscribe = function wSBrokerServerUnsubscribe (room) {
+  debug('[%s] broker server unsubscribed to room "%s"', this.eventName, room);
+
   if (this.handlers[room]) {
     delete this.handlers[room];
   }

--- a/lib/services/broker/wsBrokerServer.js
+++ b/lib/services/broker/wsBrokerServer.js
@@ -113,12 +113,12 @@ WSBrokerServer.prototype.init = function wSBrokerServerInit () {
     this.ws(() => {
       this.wss.on('connection', clientSocket => {
 
-        debug('[%s][%s] broker server received a connection', this.eventName, clientSocket.upgradeReq.headers['sec-websocket-key']);
+        debug('[%s][%s] broker server received a connection', this.eventName, clientSocket.upgradeReq ? clientSocket.upgradeReq.headers['sec-websocket-key'] : 'unknown identifier');
 
         clientSocket.on('message', msg => {
           msg = JSON.parse(msg);
 
-          debug('[%s][%s] received a message though broker server connection:\n%O', this.eventName, clientSocket.upgradeReq.headers['sec-websocket-key'], msg);
+          debug('[%s][%s] received a message though broker server connection:\n%O', this.eventName, clientSocket.upgradeReq ? clientSocket.upgradeReq.headers['sec-websocket-key'] : 'unknown identifier', msg);
 
           switch (msg.action) {
             // the listen action is called by the client to inform the server it
@@ -157,14 +157,14 @@ WSBrokerServer.prototype.init = function wSBrokerServerInit () {
         });
 
         clientSocket.on('close', (code, message) => {
-          debug('[%s][%s] broker server connection closed with code "%s" and message:\n%O', this.eventName, clientSocket.upgradeReq.headers['sec-websocket-key'], code, message);
+          debug('[%s][%s] broker server connection closed with code "%s" and message:\n%O', this.eventName, clientSocket.upgradeReq ? clientSocket.upgradeReq.headers['sec-websocket-key'] : 'unknown identifier', code, message);
 
           this.pluginsManager.trigger('log:info', `client disconnected [${code}] ${message}`);
           removeClient.call(this, clientSocket);
         });
 
         clientSocket.on('error', err => {
-          debug('[%s][%s] broker server connection errored:\n%O', this.eventName, clientSocket.upgradeReq.headers['sec-websocket-key'], err);
+          debug('[%s][%s] broker server connection errored:\n%O', this.eventName, clientSocket.upgradeReq ? clientSocket.upgradeReq.headers['sec-websocket-key'] : 'unknown identifier', err);
 
           this.pluginsManager.trigger('log:error', err);
         });

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "compare-versions": "^3.0.0",
     "crypto-md5": "^1.0.0",
     "denque": "^1.1.0",
+    "debug": "^2.6.0",
     "dumpme": "^1.0.0",
     "easy-circular-list": "^1.0.13",
     "elasticsearch": "12.0.1",


### PR DESCRIPTION
Add debug mode in kuzzle for `plugins` and `broker` (should be extended)

## How to enable debug mode:
```shell
# enable node development mode
export NODE_ENV=development

# enable debug for all kuzzle messages
export DEBUG=kuzzle:*
# enable debug for kuzzle plugings messages
export DEBUG=kuzzle:plugins
# enable debug for both kuzzle plugings and all broker messages
export DEBUG=kuzzle:plugins,kuzzle:broker:*

# restart kuzzle to take effect
pm2 restart all
```

*see more usages here: https://www.npmjs.com/package/debug#wildcards*

## Available debugs labels

* kuzzle:plugins
* kuzzle:broker
* kuzzle:broker:client
* kuzzle:broker:server
