### PR TITLE
Do not call the callback of a plugin pipe if it times out

### DIFF
--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -581,7 +581,8 @@ function registerPipe(pipes, plugin, warnDelay, timeoutDelay, event, fn) {
   pipes[event].push((data, callback) => {
     var
       pipeWarnTimer,
-      pipeTimeoutTimer;
+      pipeTimeoutTimer,
+      timedOut = false;
 
     if (warnDelay) {
       pipeWarnTimer = setTimeout(() => {
@@ -594,6 +595,7 @@ function registerPipe(pipes, plugin, warnDelay, timeoutDelay, event, fn) {
         var errorMsg = `Timeout error. Pipe plugin ${plugin.name} exceeded ${timeoutDelay}ms to execute. Aborting pipe`;
         this.trigger('log:error', errorMsg);
 
+        timedOut = true;
         callback(new GatewayTimeoutError(errorMsg));
       }, timeoutDelay);
     }
@@ -607,7 +609,9 @@ function registerPipe(pipes, plugin, warnDelay, timeoutDelay, event, fn) {
           clearTimeout(pipeTimeoutTimer);
         }
 
-        callback(err, object);
+        if (!timedOut) {
+          callback(err, object);
+        }
       });
     }
     catch (error) {


### PR DESCRIPTION
This fix check if our plugin pipe has timed out before calling it's callback with a result.
In case of time out it already call it with the error