### PR TITLE
let plugins handle their errors log

### DIFF
--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -105,8 +105,6 @@ function execute (request, callback) {
       return Promise.resolve(response);
     })
     .catch(err => {
-      kuzzle.pluginsManager.trigger('log:error', err);
-
       request.setError(err);
       kuzzle.funnel.handleErrorDump(err);
 


### PR DESCRIPTION
This PR removes the systematic logging of errors coming out of PluginContext::execute.

Cf this situation:

From a plugin:

```js
class MyController {
  myFunc () {
    const request = new Request({
      controller: 'document',
      action: 'get',
      index: 'index',
      collection: 'collection',
      _id: 'id'
    });
    
    return _context.accessors.execute(request)
      .then(response => {
        return response.status;
      })
      .catch(error => {
        if (error instanceof _context.errors.NotFoundError) {
          return 404;
        }
        
        throw error;
      });
  }
}
```

In this scenario, the catch attempts to silent the 404 error but it will still be logged by the plugin context.
