### PR TITLE
Hotfix dockerhub build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,23 +8,23 @@ COPY ./docker-compose/config/pm2.json /config/pm2.json
 
 WORKDIR /var/app
 
-RUN apt-get update && apt-get install -y \
-      build-essential \
-      curl \
-      git \
-      g++ \
-      gdb \
-      python \
-    && npm install \
-    && git submodule sync \
-    && ./install-plugins.sh \
-    && apt-get clean \
-    && apt-get remove -y \
-      build-essential \
-      g++ \
-      python \
-    && apt-get autoremove -y \
-    && chmod 755 /run.sh \
-    && rm -rf /var/lib/apt/lists/*
+RUN  apt-get update \
+  && apt-get install -y \
+    build-essential \
+    curl \
+    git \
+    g++ \
+    gdb \
+    python \
+  && npm install \
+  && sh /install-plugins.sh \
+  && apt-get clean \
+  && apt-get remove -y \
+    build-essential \
+    g++ \
+    python \
+  && apt-get autoremove -y \
+  && chmod 755 /run.sh \
+  && rm -rf /var/lib/apt/lists/*
 
 CMD ["/run.sh"]

--- a/docker-compose/scripts/install-plugins.sh
+++ b/docker-compose/scripts/install-plugins.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 WORKING_DIR=$(pwd)
 PLUGINS_DIR=plugins/enabled
 


### PR DESCRIPTION
This PR fixes the automatic Docker hub failing following the plugins install update.

Problem is the .git directory is excluded from Docker build context in .dockerignore (which is a good thing) and all git submodule xx commands fail.
Luckilly, Docker Hub does a recursive checkout already and the default plugins are already in place.

The documentation should warn the end-user they need to have their git submodules updated before building the container;