### PR TITLE
Fix #650: make README and CONTRIBUTING documentations up-to-date again

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,41 +3,40 @@
 Here are a few rules and guidelines to follow if you want to contribute to Kuzzle and, more importantly, if you want to see your pull requests accepted by Kuzzle team.
 
 ## Coding style
+
 We use most of the [NPM Coding Style](https://docs.npmjs.com/misc/coding-style) rules, except for these ones:
 
 * Semicolons at the end of lines
 * 'Comma first' rule is not followed
 
 ## Guidelines
+
 * Use promises instead of callbacks as often as you can.
 * If you add new functions, files or features to Kuzzle, then implements the corresponding unit and/or functional tests. We won't accept non-tested pull requests.
 * [Documentation and comments are more important than code](http://queue.acm.org/detail.cfm?id=1053354): comment your code, use jsdoc for every new function, add or update markdown documentation if need be. We won't accept non-documented pull requests.
 * Similar to the previous rule: documentation is important, but also is code readability. Write [self-describing code](https://en.wikipedia.org/wiki/Self-documenting).
 
-
 ## General rules and principles we'd like you to follow
-* If you plan to add new features to Kuzzle, make sure that this is for a general improvement to benefit a majority of Kuzzle users. If not, consider making an add-on instead (like a new Kuzzle service for instance).
+
+* If you plan to add new features to Kuzzle, make sure that this is for a general improvement to benefit a majority of Kuzzle users. If not, consider making a plugin instead (check our [plugin documentation](http://docs.kuzzle.io/plugin-reference/))
 * Follow the [KISS Principle](https://en.wikipedia.org/wiki/KISS_principle)
 * Follow [The Boy Scout Rule](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
 
 ## Tools
-For development only, we built a specific docker-compose file: `docker-compose/debug.yml`. You can use it to profile, debug, test a variable on the fly, add breakpoints and so on, thanks to [Node Inspector](https://github.com/node-inspector/node-inspector).  
 
-Run the stack with:
+For development only, we built a specific docker-compose file: `docker-compose/dev.yml`. You can use it to profile, debug, test a variable on the fly, add breakpoints and so on, thanks to [chrome-devtools](https://developer.chrome.com/devtools).  
+Check the logs at the start of Kuzzle using the development docker image to get the appropriate debug URL.
+  
+How to run the development stack (needs Docker 1.10+ and Docker Compose 1.8+):
 
 ```
-docker-compose -f docker-compose/debug.yml up
+docker-compose -f docker-compose/dev.yml up
 ```
 
-You can now access to:
+You can now access to `http://localhost` for the standard Kuzzle HTTP, WebSocket and Socket.io APIs
 
-* http://localhost:7511 for the standard Kuzzle HTTP API
-* ws://localhost:7512 for the Socket.io API
-* ws://localhost:7513 for the raw websocket API
-* http://127.0.0.1:8080/debug?port=7000 to debug the server
-
-Every times a modification is detected by [PM2](https://github.com/Unitech/pm2), the server is restarted and the debugger page is automatically refreshed with the code up to date and with previous placed breakpoints.
+Everytime a modification is detected in the source files, the server is automatically restarted and a new debug URL is provided.
 
 # Create a plugin
 
-See [plugins documentation](http://kuzzle.io/guide/#plugins)
+See our [plugins documentation](http://docs.kuzzle.io/plugin-reference/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ How to run the development stack (needs Docker 1.10+ and Docker Compose 1.8+):
 docker-compose -f docker-compose/dev.yml up
 ```
 
-You can now access to `http://localhost` for the standard Kuzzle HTTP, WebSocket and Socket.io APIs
+You can now access to `http://localhost:7511` for the standard Kuzzle HTTP, WebSocket and Socket.io APIs
 
 Everytime a modification is detected in the source files, the server is automatically restarted and a new debug URL is provided.
 

--- a/README.md
+++ b/README.md
@@ -4,96 +4,75 @@
 
 ![logo](http://kuzzle.io/themes/kuzzleio/images/kuzzle-logo-blue-500.png)
 
-# About Kuzzle
-
-For UI and linked objects developers, Kuzzle is an open-source solution that handles all the data management
-(CRUD, real-time storage, search, high-level features, etc;).
-
-Kuzzle features are accessible through a secured API. It can be used through a large choice of protocols such as HTTP, Websocket or MQTT.
-
-Kuzzle uses [Elasticsearch filter DSL](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-filters.html) (see [filters syntax](http://kuzzle.io/guide/#filtering-syntax) for more details) as filtering language, and [Redis](http://redis.io/) to manage filters cache.
+**A backend software, self-hostable and ready to use to power modern apps**
 
 # Installation
 
-## Using the all-in-one Docker recipe
+## Using Docker
 
 If you are running Docker and just want to get your own Kuzzle running, you can use the provided docker-compose file.
 
 Prerequisites:
 
-* [Docker](https://docs.docker.com/installation/#installation) (version >1.5.0)
-* [Docker Compose](https://docs.docker.com/compose/install/) (version >1.2.0)
+* [Docker](https://docs.docker.com/engine/installation/) (version >1.10.0)
+* [Docker Compose](https://docs.docker.com/compose/install/) (version >1.8.0)
 
 From Kuzzle's build repo:
 
-    $ wget https://raw.githubusercontent.com/kuzzleio/kuzzle-build/master/docker-compose/kuzzle-docker-compose.yml
-    $ docker-compose -f kuzzle-docker-compose.yml up
+    $ sudo sysctl -w vm.max_map_count=262144
+    $ wget http://kuzzle.io/docker-compose.yml
+    $ docker-compose up
 
-**Note:** Kuzzle need an access to the web to download plugins. If you are behind a proxy, you may use this [container](https://hub.docker.com/r/klabs/forgetproxy/) to configure docker accordingly.  
-More information about plugins [here](http://kuzzle.io/guide/#plugins)
 
-## Using Vagrant
+## Manual install
 
-If you are not running Docker on your system, you can pop a virtual machine to run Kuzzle.
+Check our complete installation guide [here](http://docs.kuzzle.io/guide/#manually-on-linux)
 
-Prerequisites:
-
-* [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
-* [Vagrant](https://www.vagrantup.com/)
-
-From the root directory:
-
-    $ vagrant up
-
-## Advanced installation
-
-Take a look at the documentationfor more installation ways. (Manual installation, update, add fixture, database reset and more):
-* [Linux](http://kuzzle.io/guide/#install-on-linux)
-* [Windows](http://kuzzle.io/guide/#install-on-windows)
 
 # Using Kuzzle
 
-Your applications can now connect to Kuzzle. We provide a few ways to do this:
+To use Kuzzle, all you have to do is to download one of our SDKs and use it in your application. Simple as that!  
+Check our complete [SDK Reference](http://docs.kuzzle.io/sdk-reference/) for further informations.
 
-* Using one of our [SDK](http://kuzzle.io/sdk-documentation/) ([Javascript](https://github.com/kuzzleio/sdk-javascript), [Android](https://github.com/kuzzleio/sdk-android), more coming soon...).
-* Directly, by accessing one of our [API](http://kuzzle.io/api-reference/) (HTTP, WebSocket and MQTT)
-
-You can also play with our [demos](http://kuzzle.io/demos-tutorials/) for a quick Kuzzle overview.
+You can also interface with Kuzzle directly, using its [exposed API](http://docs.kuzzle.io/api-reference/)  
 
 # Running Tests
+   
+### With a running Kuzzle inside a docker container
+
+Because functional tests need a running Kuzzle environment, if you're using docker to run Kuzzle, then they can only be started from inside a Kuzzle container.
+
+    $ docker exec -ti <kuzzle docker image> npm test
+
+### Using docker, without any Kuzzle instance running
+
+A docker-compose script is available to run tests on a non-running Kuzzle. This script will pop a Kuzzle stack using Docker, automatically run tests, and exit once done.
+
+    $ docker-compose -f docker-compose/test.yml up
+
+### With a manually installed and running Kuzzle
+
+From the Kuzzle source directory, launch the following command line:
 
     $ npm test
-Because functional tests need to be done in a running Kuzzle environment, it is recommended to run these tests from a Kuzzle container.
-
-Using Compose:
-
-```
-    $ docker-compose -f docker-compose/test.yml up
-```
-
-This command will pop all the stack for running Kuzzle, then execute unit test and functional test. When all tests are done, containers are destroyed.
-
-Using a Vagrant virtual machine:
-
-    $ vagrant ssh -c 'cp -fR /vagrant /tmp/ && cd /tmp/vagrant && docker-compose -p kuzzle -f docker-compose/test.yml up'
-
-You may also run unit and functional tests separately, or with additional arguments.
-For more information, check the [unit testing](test/README.md) and the [functional testing](features/README.md) documentation.
-
+    
 # Contributing to Kuzzle
 
-See [contributing documentation](./CONTRIBUTING.md)
+You're welcome to contribute to Kuzzle! To do so:
+
+1. fork our Kuzzle repository and install default plugins:
+
+```
+$ git submodule init
+$ git submodule update
+```
+
+2. Check our [contributing documentation](./CONTRIBUTING.md) to know about our coding and pull requests rules
 
 
 # Full documentation
 
-See [full documentation](http://kuzzle.io/guide/)
-
-
-# Acknowledgement
-
-Thanks to [Sails](https://github.com/balderdashy/sails) project for a good Node.js infrastructure example.
-
+See [full documentation](http://docs.kuzzle.io/)
 
 # License
 

--- a/features/README.md
+++ b/features/README.md
@@ -10,10 +10,3 @@ See the [Getting Started](../README.md) documentation for more information about
 
     $ npm run functional-testing
 
-If your Kuzzle instance uses a different configuration than the default one, you can make these tests point at other locations by editing the `.kuzzlerc` file at the root directory.
-
-## Running Functional Tests and report test coverage
-
-    $ npm run functional-testing && npm run crawl-coverage
-
-Coverage report will be stored in HTML human readable format: ```coverage/features/coverage.html```


### PR DESCRIPTION
Fix #650 

* README: update introduction, install instructions, URLs and tests documentation. Add a fork section to document how to install default plugins from git
* CONTRIBUTING: updarte documentation links and development instructions. Also anticipated the HTTP/WS/SocketIO port merging in the documentation.