### PR TITLE
enable debug mode in dev/travis env

### DIFF
--- a/docker-compose/dev.yml
+++ b/docker-compose/dev.yml
@@ -26,6 +26,7 @@ services:
       - kuzzle_services__memoryStorage__node__host=redis
       - kuzzle_services__proxyBroker__host=proxy
       - NODE_ENV=development
+      - DEBUG=kuzzle:*
 
   redis:
     image: redis:3.2

--- a/docker-compose/test.yml
+++ b/docker-compose/test.yml
@@ -23,6 +23,7 @@ services:
       - kuzzle_services__memoryStorage__node__host=redis
       - kuzzle_services__proxyBroker__host=proxy
       - NODE_ENV=development
+      - DEBUG=kuzzle:*
       # Travis env var must be propagated into the container
       - TRAVIS
       - TRAVIS_COMMIT


### PR DESCRIPTION
Enable by default `debug` mode in develop & tests docker-compose files