### PR TITLE
Fix #622: token disappear from cache

### DIFF
--- a/lib/api/core/auth/tokenManager.js
+++ b/lib/api/core/auth/tokenManager.js
@@ -5,6 +5,16 @@ const
   Request = require('kuzzle-common-objects').Request,
   SortedArray = require('sorted-array');
 
+/*
+ Maximum delay of a setTimeout call. If larger than this value,
+ it's replaced by 1 (see setTimeout documentation)
+ Since this behavior is harmful to this garbage collector,
+ TIMEOUT_MAX is used as an upper limit to the calculated GC delay.
+
+ Until this constant is exposed in NodeJS' API, we have to manually set it.
+ */
+const TIMEOUT_MAX = Math.pow(2, 31) - 1;
+
 /**
  * Authentication token white-list.
  *
@@ -35,11 +45,13 @@ function TokenManager (kuzzle) {
 
   this.runTimer = () => {
     if (this.tokens.array.length > 0) {
+      let delay = Math.min(this.tokens.array[0].expiresAt - Date.now() + 1000, TIMEOUT_MAX);
+
       if (this.timer) {
         clearTimeout(this.timer);
       }
 
-      this.timer = setTimeout(this.checkTokensValidity, this.tokens.array[0].expiresAt - Date.now() + 1000);
+      this.timer = setTimeout(this.checkTokensValidity, delay);
     }
   };
 

--- a/lib/api/core/auth/tokenManager.js
+++ b/lib/api/core/auth/tokenManager.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var
+const
   RequestContext = require('kuzzle-common-objects').models.RequestContext,
   Request = require('kuzzle-common-objects').Request,
   SortedArray = require('sorted-array');
@@ -39,7 +39,7 @@ function TokenManager (kuzzle) {
         clearTimeout(this.timer);
       }
 
-      this.timer = setTimeout(this.checkTokensValidity, Date.now() - this.tokens.array[0].expiresAt);
+      this.timer = setTimeout(this.checkTokensValidity, this.tokens.array[0].expiresAt - Date.now() + 1000);
     }
   };
 

--- a/lib/api/core/auth/tokenManager.js
+++ b/lib/api/core/auth/tokenManager.js
@@ -45,7 +45,7 @@ function TokenManager (kuzzle) {
 
   this.runTimer = () => {
     if (this.tokens.array.length > 0) {
-      let delay = Math.min(this.tokens.array[0].expiresAt - Date.now() + 1000, TIMEOUT_MAX);
+      let delay = Math.min(this.tokens.array[0].expiresAt - Date.now(), TIMEOUT_MAX);
 
       if (this.timer) {
         clearTimeout(this.timer);

--- a/lib/api/core/models/repositories/repository.js
+++ b/lib/api/core/models/repositories/repository.js
@@ -258,7 +258,7 @@ Repository.prototype.deleteFromDatabase = function repositoryDeleteFromDatabase 
  *   ttl: if provided, overrides the default ttl set on the repository for the current operation.
  *
  * @param {object} object the object to persist
- * @param {object} opts optional options for the current operation
+ * @param {object} [opts] optional options for the current operation
  * @returns {Promise}
  */
 Repository.prototype.persistToCache = function repositoryPersistToCache (object, opts) {

--- a/lib/api/core/models/repositories/tokenRepository.js
+++ b/lib/api/core/models/repositories/tokenRepository.js
@@ -104,7 +104,7 @@ TokenRepository.prototype.generateToken = function tokenRepositoryGenerateToken 
       expiresAt: Date.now() + expiresIn
     });
 
-    return this.persistToCache(token)
+    return this.persistToCache(token, {ttl: expiresIn / 1000})
       .then(() => {
         this.kuzzle.tokenManager.add(token, request.context);
 


### PR DESCRIPTION
Fix #622: JWT are stored in cache with a default TTL making tokens disappear if not used after a time. This leads to connections being erroneously reset even when setting long token expiration time.

# Fixes

* provide to the cache the token expiration delay (in seconds)  when writing a newly created token into it

# Unrelated
* fix a bug in the token garbage collector, where the timer was set with a negative value forcing the GC to run permanently, instead of running right after the most short-lived token has expired
* fix a bug in the token garbage collector, when if the most short-lived token expires in more than 24.8 days (2^31-1 milliseconds), then the GC process is run every 1 ms (see http://devdocs.io/node~6_lts/timers#timers_settimeout_callback_delay_args). In this case, the GC will set the delay to this upper limit, even if it means performing a check for nothing every 24.8 days :)