### PR TITLE
Use same port for both websocket/socketio/http protocols

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,14 +26,14 @@ We use most of the [NPM Coding Style](https://docs.npmjs.com/misc/coding-style) 
 
 For development only, we built a specific docker-compose file: `docker-compose/dev.yml`. You can use it to profile, debug, test a variable on the fly, add breakpoints and so on, thanks to [chrome-devtools](https://developer.chrome.com/devtools).  
 Check the logs at the start of Kuzzle using the development docker image to get the appropriate debug URL.
-  
+
 How to run the development stack (needs Docker 1.10+ and Docker Compose 1.8+):
 
 ```
 docker-compose -f docker-compose/dev.yml up
 ```
 
-You can now access to `http://localhost:7511` for the standard Kuzzle HTTP, WebSocket and Socket.io APIs
+You can now access to `http://localhost:7512` for the standard Kuzzle HTTP, WebSocket and Socket.io APIs
 
 Everytime a modification is detected in the source files, the server is automatically restarted and a new debug URL is provided.
 

--- a/docker-compose/dev.yml
+++ b/docker-compose/dev.yml
@@ -4,7 +4,7 @@ services:
   proxy:
     image: kuzzleio/proxy:develop
     ports:
-      - "7511-7513:7511-7513"
+      - "7512:7512"
 
   kuzzle:
     image: kuzzleio/dev

--- a/docker-compose/haproxy/haproxy.cfg
+++ b/docker-compose/haproxy/haproxy.cfg
@@ -18,7 +18,7 @@ defaults
     timeout tunnel      2h
 
 frontend kuzzle_https
-    bind *:7511 ssl crt /etc/ssl/private/snakeoil.pem
+    bind *:7512 ssl crt /etc/ssl/private/snakeoil.pem
     default_backend https
     mode        http
     option      httpclose
@@ -30,4 +30,4 @@ backend https
     mode http
     option forwardfor
     option httpclose
-    server kuzzleproxy proxy:7511 maxconn 32768 check
+    server kuzzleproxy proxy:7512 maxconn 32768 check

--- a/docker-compose/haproxy/haproxy.cfg
+++ b/docker-compose/haproxy/haproxy.cfg
@@ -26,37 +26,8 @@ frontend kuzzle_https
     tcp-request inspect-delay 500ms
     tcp-request content accept if HTTP
 
-frontend kuzzle_socketio
-    bind *:7512 ssl crt /etc/ssl/private/snakeoil.pem
-    default_backend socketio
-    mode        http
-    option      httpclose
-    option      forwardfor
-    tcp-request inspect-delay 500ms
-    tcp-request content accept if HTTP
-
-frontend kuzzle_websocket
-    bind *:7513 ssl crt /etc/ssl/private/snakeoil.pem
-    default_backend websocket
-    mode        http
-    option      httpclose
-    option      forwardfor
-    tcp-request inspect-delay 500ms
-    tcp-request content accept if HTTP
-
 backend https
-    server kuzzleproxy proxy:7511 maxconn 100 check
-
-backend socketio
     mode http
     option forwardfor
     option httpclose
-
-    server kuzzleproxy proxy:7512 maxconn 32768 check
-
-backend websocket
-    mode http
-    option forwardfor
-    option httpclose
-
-    server kuzzleproxy proxy:7513 maxconn 32768 check
+    server kuzzleproxy proxy:7511 maxconn 32768 check

--- a/docker-compose/test.yml
+++ b/docker-compose/test.yml
@@ -4,7 +4,7 @@ services:
   proxy:
     image: kuzzleio/proxy${DOCKER_PROXY_TAG}
     ports:
-      - "7511-7513:7511-7513"
+      - "7512:7512"
 
   kuzzle:
     image: kuzzleio/dev

--- a/features/support/apiHttp.js
+++ b/features/support/apiHttp.js
@@ -10,7 +10,7 @@ var
 var ApiHttp = function () {
   this.world = null;
 
-  this.baseUri = `${config.scheme}://${config.host}:${config.ports.rest}`;
+  this.baseUri = `${config.scheme}://${config.host}:${config.port}`;
 
   this.util = {
     getIndex: index => typeof index !== 'string' ? this.world.fakeIndex : index,

--- a/features/support/apiWebsocket.js
+++ b/features/support/apiWebsocket.js
@@ -15,7 +15,7 @@ var initSocket = function (socketName) {
   }
 
   if (!this.listSockets[socketName]) {
-    socket = io(`${config.scheme}://${config.host}:${config.ports.io}`, {
+    socket = io(`${config.scheme}://${config.host}:${config.port}`, {
       'force new connection': true
     });
     this.listSockets[socketName] = socket;

--- a/features/support/config.js
+++ b/features/support/config.js
@@ -6,5 +6,5 @@ var
 module.exports = rc('kuzzle', {
   scheme: 'http',
   host: kuzzleConfig.services.proxyBroker.host,
-  port: 7511
+  port: 7512
 });

--- a/features/support/config.js
+++ b/features/support/config.js
@@ -6,9 +6,5 @@ var
 module.exports = rc('kuzzle', {
   scheme: 'http',
   host: kuzzleConfig.services.proxyBroker.host,
-  ports: {
-    rest: 7511,
-    io: 7512,
-    ws: 7513
-  }
+  port: 7511
 });

--- a/lib/api/core/swagger.js
+++ b/lib/api/core/swagger.js
@@ -20,14 +20,14 @@ module.exports = function generateSwagger (kuzzle) {
     var route = _.assign({}, _route);
     route.url = '/_plugin' + route.url;
     routes.push(route);
-  });  
+  });
 
   swagger = {
     basePath: '/',
     consumes: [
       'application/json'
     ],
-    host: 'sandbox.kuzzle.io:7511',
+    host: 'sandbox.kuzzle.io:7512',
     info: {
       contact: {
         email: 'hello@kuzzle.io',
@@ -47,12 +47,12 @@ module.exports = function generateSwagger (kuzzle) {
     schemes: [
       'http'
     ],
-    swagger: '2.0',    
+    swagger: '2.0',
     paths: {}
   };
 
   routes.forEach(route => {
-    var 
+    var
       reg = /:([^\/]*)/g, // since url parameters got the following form "/:parameterName/:otherParameter" this reg captures, all chars following : which are not a / char
       m;
 
@@ -63,11 +63,11 @@ module.exports = function generateSwagger (kuzzle) {
       swagger.paths[route.url_] = {};
     }
 
-    if (swagger.paths[route.url_][route.verb] === undefined) {    
+    if (swagger.paths[route.url_][route.verb] === undefined) {
 
       if (route.infos === undefined) {
         route.infos = {};
-      } 
+      }
 
       if (route.infos.description === undefined) {
         route.infos.description = 'Controller: ' + route.controller + '. Action: ' + route.action + '.';

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "should": "11.1.0",
     "should-sinon": "0.0.5",
     "sinon": "1.17.6",
-    "socket.io-client": "1.4.8"
+    "socket.io-client": "1.7.2"
   },
   "engines": {
     "node": ">= 4.4.5",

--- a/vagrant/vagrant.yml
+++ b/vagrant/vagrant.yml
@@ -25,7 +25,7 @@ virtualmachine:
     # List of ports to be forwarded to your host:
     # override with empty array if you do not want to forward ports
     # (in that case, you will need a private IP address to use Kuzzle - see above)
-    forwarded_port: { 7511: 7511, 8081: 7511, 7512: 7512, 1883: 1883, 5672: 5672, 15672: 15672, 61613: 61613 }
+    forwarded_port: { 7511: 7511, 8081: 7511, 1883: 1883, 5672: 5672, 15672: 15672, 61613: 61613 }
 
   ### END Network Settings
 

--- a/vagrant/vagrant.yml
+++ b/vagrant/vagrant.yml
@@ -25,7 +25,7 @@ virtualmachine:
     # List of ports to be forwarded to your host:
     # override with empty array if you do not want to forward ports
     # (in that case, you will need a private IP address to use Kuzzle - see above)
-    forwarded_port: { 7511: 7511, 8081: 7511, 1883: 1883, 5672: 5672, 15672: 15672, 61613: 61613 }
+    forwarded_port: { 7512: 7512, 8081: 7512, 1883: 1883, 5672: 5672, 15672: 15672, 61613: 61613 }
 
   ### END Network Settings
 


### PR DESCRIPTION
following https://github.com/kuzzleio/kuzzle-proxy/pull/48

Kuzzle Proxy will now expose a unique port (7512) for both 3 core protocols.

This PR fixes the embed documentation as well as the feature tests settings.

(NB: tests will work only after the related PR on Proxy will be merged and deployed)