### PR TITLE
Protect document creation to avoid collision with http routes

### DIFF
--- a/lib/api/controllers/documentController.js
+++ b/lib/api/controllers/documentController.js
@@ -116,10 +116,7 @@ function DocumentController (kuzzle) {
 
     assertHasBody(request);
     assertHasIndexAndCollection(request);
-
-    if (request.input.resource._id) {
-      assertIdStartsNotUnderscore(request);
-    }
+    assertIdStartsNotUnderscore(request);
 
     return kuzzle.validation.validationPromise(request, false)
       .then(newRequest => {

--- a/lib/api/controllers/documentController.js
+++ b/lib/api/controllers/documentController.js
@@ -8,6 +8,7 @@ let
   assertBodyHasAttribute = require('./util/requestAssertions').assertBodyHasAttribute,
   assertHasIndexAndCollection = require('./util/requestAssertions').assertHasIndexAndCollection,
   assertBodyAttributeType = require('./util/requestAssertions').assertBodyAttributeType,
+  assertIdStartsNotUnderscore = require('./util/requestAssertions').assertIdStartsNotUnderscore,
   Request = require('kuzzle-common-objects').Request,
   Promise = require('bluebird'),
   PartialError = require('kuzzle-common-objects').errors.PartialError;
@@ -17,7 +18,7 @@ let
  * @constructor
  */
 function DocumentController (kuzzle) {
-  var engine = kuzzle.services.list.storageEngine;
+  const engine = kuzzle.services.list.storageEngine;
 
   /**
    * @param {Request} request
@@ -111,10 +112,14 @@ function DocumentController (kuzzle) {
    */
   this.create = function documentCreate (request) {
     /** @type KuzzleRequest */
-    var modifiedRequest;
+    let modifiedRequest;
 
     assertHasBody(request);
     assertHasIndexAndCollection(request);
+
+    if (request.input.resource._id) {
+      assertIdStartsNotUnderscore(request);
+    }
 
     return kuzzle.validation.validationPromise(request, false)
       .then(newRequest => {
@@ -151,11 +156,12 @@ function DocumentController (kuzzle) {
    */
   this.createOrReplace = function documentCreateOrReplace (request) {
     /** @type KuzzleRequest */
-    var modifiedRequest;
+    let modifiedRequest;
 
     assertHasBody(request);
     assertHasIndexAndCollection(request);
     assertHasId(request);
+    assertIdStartsNotUnderscore(request);
 
     return kuzzle.validation.validationPromise(request, false)
       .then(newRequest => {
@@ -199,7 +205,7 @@ function DocumentController (kuzzle) {
    */
   this.update = function documentUpdate (request) {
     /** @type KuzzleRequest */
-    var modifiedRequest;
+    let modifiedRequest;
 
     assertHasBody(request);
     assertHasIndexAndCollection(request);
@@ -237,7 +243,7 @@ function DocumentController (kuzzle) {
    */
   this.replace = function documentReplace (request) {
     /** @type KuzzleRequest */
-    var modifiedRequest;
+    let modifiedRequest;
 
     assertHasBody(request);
     assertHasIndexAndCollection(request);

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -403,10 +403,7 @@ function SecurityController (kuzzle) {
     assertHasBody(request);
     assertBodyHasAttribute(request, 'profileIds');
     assertBodyAttributeType(request, 'profileIds', 'array');
-
-    if (request.input.resource._id) {
-      assertIdStartsNotUnderscore(request);
-    }
+    assertIdStartsNotUnderscore(request);
 
     pojoUser = request.input.body;
     pojoUser._id = request.input.resource._id || uuid.v4();
@@ -429,10 +426,7 @@ function SecurityController (kuzzle) {
 
     assertHasBody(request);
     assertBodyHasNotAttribute(request, 'profileIds');
-
-    if (request.input.resource._id) {
-      assertIdStartsNotUnderscore(request);
-    }
+    assertIdStartsNotUnderscore(request);
 
     pojoUser = request.input.body;
     pojoUser._id = request.input.resource._id || uuid.v4();
@@ -525,10 +519,7 @@ function SecurityController (kuzzle) {
     let reset;
 
     assertHasBody(request);
-
-    if (request.input.resource._id) {
-      assertIdStartsNotUnderscore(request);
-    }
+    assertIdStartsNotUnderscore(request);
 
     reset = request.input.args.reset || false;
 

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var
-  _ = require('lodash'),
+const _ = require('lodash'),
   uuid = require('node-uuid'),
   Promise = require('bluebird'),
   formatProcessing = require('../core/auth/formatProcessing'),
@@ -15,7 +14,8 @@ var
   assertBodyHasAttribute = require('./util/requestAssertions').assertBodyHasAttribute,
   assertBodyHasNotAttribute = require('./util/requestAssertions').assertBodyHasNotAttribute,
   assertBodyAttributeType = require('./util/requestAssertions').assertBodyAttributeType,
-  assertHasId = require('./util/requestAssertions').assertHasId;
+  assertHasId = require('./util/requestAssertions').assertHasId,
+  assertIdStartsNotUnderscore = require('./util/requestAssertions').assertIdStartsNotUnderscore;
 
 /**
  * @param {Kuzzle} kuzzle
@@ -164,6 +164,7 @@ function SecurityController (kuzzle) {
   this.createRole = function securityCreateRole (request) {
     assertHasBody(request);
     assertHasId(request);
+    assertIdStartsNotUnderscore(request);
 
     return createOrReplaceRole.call(kuzzle, request, {method: 'create'})
       .then(role => formatProcessing.formatRoleForSerialization(role));
@@ -176,7 +177,7 @@ function SecurityController (kuzzle) {
    * @returns {Promise<Object>}
    */
   this.deleteRole = function securityDeleteRole (request) {
-    var role;
+    let role;
 
     assertHasId(request);
 
@@ -233,6 +234,7 @@ function SecurityController (kuzzle) {
     assertBodyHasAttribute(request, 'policies');
     assertBodyAttributeType(request, 'policies', 'array');
     assertHasId(request);
+    assertIdStartsNotUnderscore(request);
 
     return createOrReplaceProfile(kuzzle, request, {method: 'createOrReplace'})
       .then(profile => formatProcessing.formatProfileForSerialization(profile));
@@ -249,6 +251,7 @@ function SecurityController (kuzzle) {
     assertBodyHasAttribute(request, 'policies');
     assertBodyAttributeType(request, 'policies', 'array');
     assertHasId(request);
+    assertIdStartsNotUnderscore(request);
 
     return createOrReplaceProfile(kuzzle, request, {method: 'create'})
       .then(profile => formatProcessing.formatProfileForSerialization(profile));
@@ -274,7 +277,7 @@ function SecurityController (kuzzle) {
    * @returns {Promise<Object>}
    */
   this.searchProfiles = function securitySearchProfiles (request) {
-    var roles = [];
+    let roles = [];
 
     checkSearchPageLimit(request, kuzzle.config.limits.documentsFetchCount);
 
@@ -394,13 +397,16 @@ function SecurityController (kuzzle) {
    * @returns {Promise<Object>}
    */
   this.createUser = function securityCreateUser (request) {
-    var
-      user = new User(),
-      pojoUser;
+    const user = new User();
+    let pojoUser;
 
     assertHasBody(request);
     assertBodyHasAttribute(request, 'profileIds');
     assertBodyAttributeType(request, 'profileIds', 'array');
+
+    if (request.input.resource._id) {
+      assertIdStartsNotUnderscore(request);
+    }
 
     pojoUser = request.input.body;
     pojoUser._id = request.input.resource._id || uuid.v4();
@@ -423,6 +429,10 @@ function SecurityController (kuzzle) {
 
     assertHasBody(request);
     assertBodyHasNotAttribute(request, 'profileIds');
+
+    if (request.input.resource._id) {
+      assertIdStartsNotUnderscore(request);
+    }
 
     pojoUser = request.input.body;
     pojoUser._id = request.input.resource._id || uuid.v4();
@@ -491,11 +501,12 @@ function SecurityController (kuzzle) {
    * @returns {Promise<Object>}
    */
   this.createOrReplaceUser = function securityCreateOrReplaceUser (request) {
-    var user = new User();
+    const user = new User();
 
     assertHasBody(request);
     assertBodyHasAttribute(request, 'profileIds');
     assertHasId(request);
+    assertIdStartsNotUnderscore(request);
 
     user._id = request.input.resource._id;
 
@@ -511,9 +522,13 @@ function SecurityController (kuzzle) {
    * @returns {Promise<Object>}
    */
   this.createFirstAdmin = function securityCreateFirstAdmin (request) {
-    var reset;
+    let reset;
 
     assertHasBody(request);
+
+    if (request.input.resource._id) {
+      assertIdStartsNotUnderscore(request);
+    }
 
     reset = request.input.args.reset || false;
 
@@ -525,10 +540,7 @@ function SecurityController (kuzzle) {
 
         delete request.input.args.reset;
         request.input.body.profileIds = ['admin'];
-
-        if (!request.input.resource._id) {
-          request.input.resource._id = uuid.v4();
-        }
+        request.input.resource._id = request.input.resource._id || uuid.v4();
 
         return kuzzle.funnel.controllers.security.createOrReplaceUser(request);
       })
@@ -584,7 +596,7 @@ module.exports = SecurityController;
  * @returns {Promise<Role>}
  */
 function createOrReplaceRole (request, opts) {
-  var role = this.repositories.role.getRoleFromRequest(request);
+  const role = this.repositories.role.getRoleFromRequest(request);
 
   return this.repositories.role.validateAndSaveRole(role, opts);
 }
@@ -606,7 +618,7 @@ function createOrReplaceProfile (kuzzle, request, opts) {
  * @returns {Promise.<*>}
  */
 function resetRoles () {
-  var promises;
+  let promises;
 
   promises = ['admin', 'default', 'anonymous'].map(id => {
     return this.internalEngine.createOrReplace('roles', id, this.config.security.standard.roles[id]);

--- a/lib/api/controllers/util/requestAssertions.js
+++ b/lib/api/controllers/util/requestAssertions.js
@@ -80,7 +80,7 @@ module.exports = {
   /**
    * @param {Request} request
    */
-  assertIdStartsNotUnderscore: function requestAssertHasId (request) {
+  assertIdStartsNotUnderscore: function requestAssertIdStartsNotUnderscore (request) {
     if (request.input.resource._id && request.input.resource._id.charAt(0) === '_') {
       throw new BadRequestError(`${request.input.controller}:${request.input.action} must not specify an _id that starts with an underscore (_).`);
     }

--- a/lib/api/controllers/util/requestAssertions.js
+++ b/lib/api/controllers/util/requestAssertions.js
@@ -80,6 +80,15 @@ module.exports = {
   /**
    * @param {Request} request
    */
+  assertIdStartsNotUnderscore: function requestAssertHasId (request) {
+    if (request.input.resource._id.indexOf('_') === 0) {
+      throw new BadRequestError(`${request.input.controller}:${request.input.action} must not specify an _id that starts with an underscore (_).`);
+    }
+  },
+
+  /**
+   * @param {Request} request
+   */
   assertHasIndex: function requestAssertHasIndex (request) {
     if (!request.input.resource.index) {
       throw new BadRequestError(`${request.input.controller}:${request.input.action} must specify an index.`);

--- a/lib/api/controllers/util/requestAssertions.js
+++ b/lib/api/controllers/util/requestAssertions.js
@@ -81,7 +81,7 @@ module.exports = {
    * @param {Request} request
    */
   assertIdStartsNotUnderscore: function requestAssertHasId (request) {
-    if (request.input.resource._id.indexOf('_') === 0) {
+    if (request.input.resource._id && request.input.resource._id.charAt(0) === '_') {
       throw new BadRequestError(`${request.input.controller}:${request.input.action} must not specify an _id that starts with an underscore (_).`);
     }
   },


### PR DESCRIPTION
For instance, if a document is created with the _id , it would conflict with the _create route.
Underscores can't be the first character of an _id.