### PR TITLE
Add error stacktrace when a plugin fails to load

### DIFF
--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -585,7 +585,7 @@ function loadPlugins(config, rootPath) {
         plugin = loadPluginFromDirectory(path.resolve(pluginsDir, pluginDirName), config);
       }
     } catch (e) {
-      console.error(`Unable to load plugin ${pluginDirName}. ${e}`); // eslint-disable-line no-console
+      console.error(`Unable to load plugin ${pluginDirName}. ${e.message}\n${e.stack}`); // eslint-disable-line no-console
       return;
     }
 


### PR DESCRIPTION
Fix #672 

Print error stack trace when an exception is catched because a plugin fails to load.