### PR TITLE
Prevent plugins infinite loop caused by triggered before/after events

### DIFF
--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -285,7 +285,7 @@ function FunnelController (kuzzle) {
       beforeEvent = this.getEventName(request.input.controller, 'before', request.input.action),
       modifiedRequest;
 
-    return kuzzle.pluginsManager.trigger(beforeEvent, request)
+    return triggerEvent(kuzzle.pluginsManager.trigger, request, beforeEvent)
       .then(newRequest => {
         modifiedRequest = newRequest;
 
@@ -293,10 +293,9 @@ function FunnelController (kuzzle) {
       })
       .then(responseData => {
         let afterEvent = this.getEventName(request.input.controller, 'after', request.input.action);
-
         modifiedRequest.setResult(responseData, {status: request.status === 102 ? 200 : request.status});
 
-        return kuzzle.pluginsManager.trigger(afterEvent, modifiedRequest);
+        return triggerEvent(kuzzle.pluginsManager.trigger, modifiedRequest, afterEvent);
       })
       .then(newRequest => {
         kuzzle.statistics.completedRequest(request);
@@ -369,6 +368,24 @@ function playCachedRequests(kuzzle, funnel) {
  */
 function capitalizeFirstLetter(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+/**
+ * Triggers an event if the request has not already
+ * emitted it during its lifecycle
+ *
+ * @param {Function} emitter
+ * @param {KuzzleRequest} request
+ * @param {string} event
+ * @return {Promise.<KuzzleRequest>}
+ */
+function triggerEvent(emitter, request, event) {
+  if (request.hasTriggered(event)) {
+    return Promise.resolve(request);
+  }
+
+  request.triggers(event);
+  return emitter(event, request);
 }
 
 module.exports = FunnelController;

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -285,7 +285,7 @@ function FunnelController (kuzzle) {
       beforeEvent = this.getEventName(request.input.controller, 'before', request.input.action),
       modifiedRequest;
 
-    return triggerEvent(kuzzle.pluginsManager.trigger, request, beforeEvent)
+    return triggerEvent(kuzzle, request, beforeEvent)
       .then(newRequest => {
         modifiedRequest = newRequest;
 
@@ -295,7 +295,7 @@ function FunnelController (kuzzle) {
         let afterEvent = this.getEventName(request.input.controller, 'after', request.input.action);
         modifiedRequest.setResult(responseData, {status: request.status === 102 ? 200 : request.status});
 
-        return triggerEvent(kuzzle.pluginsManager.trigger, modifiedRequest, afterEvent);
+        return triggerEvent(kuzzle, modifiedRequest, afterEvent);
       })
       .then(newRequest => {
         kuzzle.statistics.completedRequest(request);
@@ -374,18 +374,18 @@ function capitalizeFirstLetter(string) {
  * Triggers an event if the request has not already
  * emitted it during its lifecycle
  *
- * @param {Function} emitter
+ * @param {Kuzzle} kuzzle
  * @param {KuzzleRequest} request
  * @param {string} event
  * @return {Promise.<KuzzleRequest>}
  */
-function triggerEvent(emitter, request, event) {
+function triggerEvent(kuzzle, request, event) {
   if (request.hasTriggered(event)) {
     return Promise.resolve(request);
   }
 
   request.triggers(event);
-  return emitter(event, request);
+  return kuzzle.pluginsManager.trigger(event, request);
 }
 
 module.exports = FunnelController;

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "json-stable-stringify": "1.0.1",
     "json2yaml": "^1.1.0",
     "jsonwebtoken": "^7.2.1",
-    "kuzzle-common-objects": "^2.1.2",
+    "kuzzle-common-objects": "git://github.com/kuzzleio/kuzzle-common-objects.git#2.x",
     "lodash": "4.17.4",
     "mkdirp": "0.5.1",
     "moment": "2.17.1",

--- a/test/api/controllers/funnelController/processRequest.test.js
+++ b/test/api/controllers/funnelController/processRequest.test.js
@@ -6,19 +6,20 @@ const
   Promise = require('bluebird'),
   Request = require('kuzzle-common-objects').Request,
   BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
-  Kuzzle = require('../../../../lib/api/kuzzle');
+  FunnelController = require('../../../../lib/api/controllers/funnelController'),
+  KuzzleMock = require('../../../mocks/kuzzle.mock');
 
 describe('funnelController.processRequest', () => {
   let
     kuzzle,
-    sandbox;
+    funnel;
 
-  before(() => {
-    kuzzle = new Kuzzle();
-    sandbox = sinon.sandbox.create();
+  beforeEach(() => {
+    kuzzle = new KuzzleMock();
+    funnel = new FunnelController(kuzzle);
 
     // injects fake controllers for unit tests
-    kuzzle.funnel.controllers = {
+    funnel.controllers = {
       'fakeController': {
         ok: sinon.stub().returns(Promise.resolve()),
         fail: sinon.stub()
@@ -26,115 +27,126 @@ describe('funnelController.processRequest', () => {
     };
   });
 
-  beforeEach(() => {
-    sandbox.stub(kuzzle.statistics, 'startRequest');
-    sandbox.stub(kuzzle.statistics, 'completedRequest');
-    sandbox.stub(kuzzle.statistics, 'failedRequest');
-    kuzzle.funnel.requestHistory.clear();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   it('should reject the promise if no controller is specified', done => {
-    var object = {
+    const object = {
       action: 'create'
     };
 
-    kuzzle.funnel.processRequest(new Request(object))
+    funnel.processRequest(new Request(object))
       .then(() => done('should have failed'))
       .catch(e => {
         should(e).be.instanceOf(BadRequestError);
-        should(kuzzle.funnel.requestHistory.isEmpty()).be.true();
+        should(funnel.requestHistory.isEmpty()).be.true();
         should(kuzzle.statistics.startRequest.called).be.false();
         done();
       });
   });
 
   it('should reject the promise if no action is specified', done => {
-    var object = {
-      controller: 'write'
+    const object = {
+      controller: 'document'
     };
 
-    kuzzle.funnel.processRequest(new Request(object))
+    funnel.processRequest(new Request(object))
       .then(() => done('should have failed'))
       .catch(e => {
         should(e).be.instanceOf(BadRequestError);
-        should(kuzzle.funnel.requestHistory.isEmpty()).be.true();
+        should(funnel.requestHistory.isEmpty()).be.true();
         should(kuzzle.statistics.startRequest.called).be.false();
         done();
       });
   });
 
   it('should reject the promise if the controller doesn\'t exist', done => {
-    var object = {
-      controller: 'toto',
+    const object = {
+      controller: 'foobar',
       action: 'create'
     };
 
-    kuzzle.funnel.processRequest(new Request(object))
+    funnel.processRequest(new Request(object))
       .then(() => done('should have failed'))
       .catch(e => {
         should(e).be.instanceOf(BadRequestError);
-        should(kuzzle.funnel.requestHistory.isEmpty()).be.true();
+        should(funnel.requestHistory.isEmpty()).be.true();
         should(kuzzle.statistics.startRequest.called).be.false();
         done();
       });
   });
 
   it('should reject the promise if the action doesn\'t exist', done => {
-    var object = {
+    const object = {
       controller: 'foo',
       action: 'bar'
     };
 
-    kuzzle.funnel.processRequest(new Request(object))
+    funnel.processRequest(new Request(object))
       .then(() => done('should have failed'))
       .catch(e => {
         should(e).be.instanceOf(BadRequestError);
-        should(kuzzle.funnel.requestHistory.isEmpty()).be.true();
+        should(funnel.requestHistory.isEmpty()).be.true();
         should(kuzzle.statistics.startRequest.called).be.false();
         done();
       });
   });
 
-  it('should resolve the promise if everything is ok', done => {
-    var request = new Request({
+  it('should resolve the promise if everything is ok', () => {
+    const request = new Request({
       controller: 'fakeController',
       action: 'ok',
     });
 
-    kuzzle.funnel.processRequest(request)
+    return should(funnel.processRequest(request)
       .then(response => {
         should(response).be.exactly(request);
-        should(kuzzle.funnel.requestHistory.toArray()).match([request]);
+        should(funnel.requestHistory.toArray()).match([request]);
+        should(kuzzle.pluginsManager.trigger).calledWith('fakeController:beforeOk');
+        should(kuzzle.pluginsManager.trigger).calledWith('fakeController:afterOk');
         should(kuzzle.statistics.startRequest.called).be.true();
         should(kuzzle.statistics.completedRequest.called).be.true();
         should(kuzzle.statistics.failedRequest.called).be.false();
-        done();
-      })
-      .catch(e => done(e));
+      })).be.fulfilled();
   });
 
   it('should reject the promise if a controller action fails', done => {
-    var request = new Request({
+    const request = new Request({
       controller: 'fakeController',
       action: 'fail',
     });
 
-    kuzzle.funnel.controllers.fakeController.fail.returns(Promise.reject(new Error('rejected')));
+    funnel.controllers.fakeController.fail.returns(Promise.reject(new Error('rejected')));
 
-    kuzzle.funnel.processRequest(request)
+    funnel.processRequest(request)
       .then(() => done('should have failed'))
       .catch(e => {
         should(e).be.instanceOf(Error);
         should(e.message).be.eql('rejected');
-        should(kuzzle.funnel.requestHistory.toArray()).match([request]);
+        should(funnel.requestHistory.toArray()).match([request]);
+        should(kuzzle.pluginsManager.trigger).calledWith('fakeController:beforeFail');
+        should(kuzzle.pluginsManager.trigger).not.be.calledWith('fakeController:afterFail');
         should(kuzzle.statistics.startRequest.called).be.true();
         should(kuzzle.statistics.completedRequest.called).be.false();
         should(kuzzle.statistics.failedRequest.called).be.true();
         done();
       });
+  });
+
+  it('should not trigger an event if the request has already triggered it', () => {
+    const request = new Request({
+      controller: 'fakeController',
+      action: 'ok',
+    });
+
+    request.triggers('fakeController:beforeOk');
+
+    return should(funnel.processRequest(request)
+      .then(response => {
+        should(response).be.exactly(request);
+        should(funnel.requestHistory.toArray()).match([request]);
+        should(kuzzle.pluginsManager.trigger).not.be.calledWith('fakeController:beforeOk');
+        should(kuzzle.pluginsManager.trigger).calledWith('fakeController:afterOk');
+        should(kuzzle.statistics.startRequest.called).be.true();
+        should(kuzzle.statistics.completedRequest.called).be.true();
+        should(kuzzle.statistics.failedRequest.called).be.false();
+      })).be.fulfilled();
   });
 });


### PR DESCRIPTION
# Description 

The funnel controller now emits before/after events only if the executed request has not already emitted them.

# Fixed issue

#591

# Other changes

* unit tests on `funnel.processRequest` now use the `KuzzleMock` object
* existing unit tests now verify that events are correctly triggered across different test scenarios

# Dependency

This change relies on an update on the `kuzzle-common-objects` module (see https://github.com/kuzzleio/kuzzle-common-objects/pull/18)