### PR TITLE
Update node prerequisite in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,8 +85,7 @@
     "socket.io-client": "1.7.2"
   },
   "engines": {
-    "node": ">= 4.4.5",
-    "npm": ">= 2.14.4"
+    "node": ">= 6.9.1"
   },
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
Kuzzle does not start anymore with Node 4.x, Node 6.x is now mandatory.