### PR TITLE
Hotfix: change default maxMemoryLimit value for threaded plugins

### DIFF
--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -51,9 +51,9 @@ function PluginsManager (kuzzle) {
   };
 
   this.getPluginsFeatures = function plugingetPluginsFeatures () {
-    var pluginConfiguration = {};
+    let pluginConfiguration = {};
     Object.keys(this.plugins).forEach(plugin => {
-      var
+      let
         pluginInfo = this.plugins[plugin],
         p = {
           name: pluginInfo.name,
@@ -98,9 +98,7 @@ function PluginsManager (kuzzle) {
    * Attach events hooks and pipes given by plugins
    */
   this.run = function pluginRun () {
-    var pluginsWorker;
-
-    pluginsWorker = _.pickBy(this.plugins, plugin => plugin.config.threads !== undefined);
+    let pluginsWorker = _.pickBy(this.plugins, plugin => plugin.config.threads !== undefined);
 
     if (Object.keys(pluginsWorker).length > 0) {
       pm2Promise = pm2Init(this.workers, pluginsWorker, this.kuzzle.config);
@@ -108,7 +106,7 @@ function PluginsManager (kuzzle) {
 
     return new Promise((resolve, reject) => {
       async.forEachOf(this.plugins, (plugin, pluginName, callback) => {
-        var
+        const
           pipeWarnTime = this.config.common.pipeWarnTime,
           pipeTimeout = this.config.common.pipeTimeout;
 
@@ -215,7 +213,7 @@ function PluginsManager (kuzzle) {
 function initWorkers (plugin, pluginName, kuzzleConfig) {
   return pm2Promise
     .then(() => {
-      var pm2StartPromise = Promise.promisify(pm2.start, {context: pm2});
+      const pm2StartPromise = Promise.promisify(pm2.start, {context: pm2});
 
       return pm2StartPromise({
         name: kuzzleConfig.plugins.common.workerPrefix + pluginName,
@@ -223,7 +221,7 @@ function initWorkers (plugin, pluginName, kuzzleConfig) {
         execMode: 'cluster',
         instances: plugin.config.threads,
         killTimeout: plugin.config.killTimeout || 6000,
-        maxMemoryRestart: plugin.config.maxMemoryRestart || '100M',
+        maxMemoryRestart: plugin.config.maxMemoryRestart || '1G',
         watch: false
       });
     })
@@ -252,7 +250,7 @@ function pm2Init (workers, pluginsWorker, kuzzleConfig) {
   return Promise.fromNode(callback => pm2.connect(callback))
     .then(() => Promise.fromNode(callback => pm2.list(callback)))
     .then(list => {
-      var names = list
+      const names = list
         .filter(process => process.name.indexOf(kuzzleConfig.plugins.common.workerPrefix) !== -1)
         .map(process => process.pm_id);
 
@@ -263,7 +261,7 @@ function pm2Init (workers, pluginsWorker, kuzzleConfig) {
     .then(() => Promise.fromNode(callback => pm2.launchBus(callback)))
     .then(bus => {
       bus.on('ready', packet => {
-        var
+        const
           pluginName = packet.process.name.replace(kuzzleConfig.plugins.common.workerPrefix, ''),
           kuzConfig = Object.assign({}, kuzzleConfig);
 
@@ -472,9 +470,8 @@ function triggerHooks(emitter, event, data) {
  * @returns {Promise}
  */
 function triggerPipes(pipes, event, data) {
-  var
-    preparedPipes = [],
-    wildcardEvent = getWildcardEvent(event);
+  let preparedPipes = [];
+  const wildcardEvent = getWildcardEvent(event);
 
   if (pipes && pipes[event] && pipes[event].length) {
     preparedPipes = pipes[event];
@@ -507,7 +504,7 @@ function triggerPipes(pipes, event, data) {
  * @returns {String|Boolean} wildcard event
  */
 function getWildcardEvent (event) {
-  var indexDelimiter = event.indexOf(':');
+  const indexDelimiter = event.indexOf(':');
   if (indexDelimiter !== 1) {
     return event.substring(0, indexDelimiter+1) + '*';
   }
@@ -524,7 +521,7 @@ function getWildcardEvent (event) {
  * @returns {Promise}
  */
 function triggerWorkers(workers, event, data) {
-  var wildcardEvent = getWildcardEvent(event);
+  const wildcardEvent = getWildcardEvent(event);
 
   if (Object.keys(workers).length === 0) {
     return Promise.resolve(data);
@@ -560,7 +557,8 @@ function triggerWorkers(workers, event, data) {
 /**
  * Loads installed plugins in memory
  *
- * @param plugins - list of installed plugins to load
+ * @param {object} config - plugins configuration
+ * @param {string} rootPath - Kuzzle root directory
  */
 function loadPlugins(config, rootPath) {
   const pluginsDir = path.resolve(path.join(rootPath, 'plugins/enabled'));
@@ -640,7 +638,7 @@ function registerPipe(manager, plugin, warnDelay, timeoutDelay, event, fn) {
   }
 
   manager.pipes[event].push((data, callback) => {
-    var
+    let
       pipeWarnTimer,
       pipeTimeoutTimer,
       timedOut = false;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.0.0-RC9",
+  "version": "1.0.0-RC9.1",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {


### PR DESCRIPTION
# Description

Sets the default max memory limit value to 1Go instead of the previous 100Mo, which is too low.

# Solved issue

#677 
