### PR TITLE
Add new request events

### DIFF
--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -250,7 +250,7 @@ function FunnelController (kuzzle) {
           );
         }
 
-        return kuzzle.pluginsManager.trigger('request:onAuthorized', request);
+        return triggerEvent(kuzzle, request, 'request:onAuthorized');
       });
   };
 
@@ -301,11 +301,11 @@ function FunnelController (kuzzle) {
       })
       .then(newRequest => {
         kuzzle.statistics.completedRequest(request);
-        return kuzzle.pluginsManager.trigger('request:onSuccess', newRequest);
+        return triggerEvent(kuzzle, newRequest, 'request:onSuccess');
       })
       .catch(error => {
         kuzzle.statistics.failedRequest(request);
-        return kuzzle.pluginsManager.trigger('request:onError', modifiedRequest)
+        return triggerEvent(kuzzle, modifiedRequest, 'request:onError')
           .finally(() => Promise.reject(error));
       })
       .finally(() => {
@@ -324,7 +324,7 @@ function FunnelController (kuzzle) {
    * @returns {string} event name
    */
   this.getEventName = function getEventName(controller, prefix, action) {
-    var event = controller === 'memoryStorage' ? 'ms' : controller;
+    const event = controller === 'memoryStorage' ? 'ms' : controller;
 
     return event + ':' + prefix + capitalizeFirstLetter(action);
   };

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -154,7 +154,7 @@ function FunnelController (kuzzle) {
       }
 
       this.checkRights(request)
-        .then(() => this.processRequest(request))
+        .then(modifiedRequest => this.processRequest(modifiedRequest))
         .then(processResult => callback(null, processResult))
         .catch(err => {
           // JSON.stringify(new NativeError()) === '{}', i.e. Error, SyntaxError, TypeError, ReferenceError, etc.
@@ -222,7 +222,7 @@ function FunnelController (kuzzle) {
    * Checks if a user has the necessary rights to execute the action
    *
    * @param {Request} request
-   * @return {Promise<Boolean>}
+   * @return {Promise<Request>}
    */
   this.checkRights = function checkRights (request) {
     return kuzzle.repositories.token.verifyToken(request.input.jwt)
@@ -249,6 +249,8 @@ function FunnelController (kuzzle) {
             `Forbidden action [${request.input.resource.index}/${request.input.resource.collection}/${request.input.controller}/${request.input.action}] for user ${request.context.user._id}`)
           );
         }
+
+        return kuzzle.pluginsManager.trigger('request:onAuthorized', request);
       });
   };
 
@@ -300,11 +302,12 @@ function FunnelController (kuzzle) {
       })
       .then(newRequest => {
         kuzzle.statistics.completedRequest(request);
-        return newRequest;
+        return kuzzle.pluginsManager.trigger('request:onSuccess', newRequest);
       })
       .catch(error => {
         kuzzle.statistics.failedRequest(request);
-        return Promise.reject(error);
+        return kuzzle.pluginsManager.trigger('request:onError', modifiedRequest)
+          .finally(() => Promise.reject(error));
       })
       .finally(() => {
         this.concurrentRequests--;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.0.0-RC9.1",
+  "version": "1.0.0-RC9.2",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {

--- a/test/api/controllers/funnelController/checkRights.test.js
+++ b/test/api/controllers/funnelController/checkRights.test.js
@@ -1,69 +1,66 @@
-var
+'use strict';
+
+const
   should = require('should'),
   Promise = require('bluebird'),
   sinon = require('sinon'),
-  sandbox = sinon.sandbox.create(),
   Request = require('kuzzle-common-objects').Request,
   ForbiddenError = require('kuzzle-common-objects').errors.ForbiddenError,
   UnauthorizedError = require('kuzzle-common-objects').errors.UnauthorizedError,
-  Kuzzle = require('../../../../lib/api/kuzzle');
+  KuzzleMock = require('../../../mocks/kuzzle.mock'),
+  FunnelController = require('../../../../lib/api/controllers/funnelController');
 
 describe('funnelController.processRequest', () => {
-  var
-    kuzzle;
-
-  before(() => {
-    kuzzle = new Kuzzle();
-  });
+  let
+    kuzzle,
+    funnel;
 
   beforeEach(() => {
-    sandbox.stub(kuzzle.repositories.token, 'verifyToken', () => {
-      return Promise.resolve({
-        userId: 'user'
+    kuzzle = new KuzzleMock();
+    funnel = new FunnelController(kuzzle);
+  });
+
+  it('should reject the promise with UnauthorizedError if an anonymous user is not allowed to execute the action', done => {
+    let request = new Request({controller: 'document', index: '@test', action: 'get'});
+    kuzzle.repositories.user.load.returns(Promise.resolve({_id: -1, isActionAllowed: sinon.stub().returns(Promise.resolve(false))}));
+    kuzzle.repositories.token.verifyToken.returns(Promise.resolve({userId: -1}));
+
+    funnel.checkRights(request)
+      .then(() => should.fail('fulfilled promise', 'rejected promise'))
+      .catch(err => {
+        should(err).be.instanceof(UnauthorizedError);
+        should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onAuthorized', request)).be.false();
+        done();
       });
-    });
-    sandbox.stub(kuzzle.internalEngine, 'get').returns(Promise.resolve({}));
-    return kuzzle.services.init({whitelist: []})
-      .then(() => {
-        kuzzle.funnel.init();
+  });
+
+  it('should reject the promise with UnauthorizedError if an authenticated user is not allowed to execute the action', done => {
+    let request = new Request({controller: 'document', index: '@test', action: 'get'});
+    kuzzle.repositories.user.load.returns(Promise.resolve({_id: 'user', isActionAllowed: sinon.stub().returns(Promise.resolve(false))}));
+    kuzzle.repositories.token.verifyToken.returns(Promise.resolve({user: 'user'}));
+
+    funnel.checkRights(request)
+      .then(() => should.fail('fulfilled promise', 'rejected promise'))
+      .catch(err => {
+        should(err).be.instanceof(ForbiddenError);
+        should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onAuthorized', request)).be.false();
+        done();
       });
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
-  it('should reject the promise with UnauthorizedError if an anonymous user is not allowed to execute the action', () => {
-    kuzzle.repositories.token.verifyToken.restore();
-    sandbox.stub(kuzzle.repositories.user, 'load').returns(Promise.resolve({_id: -1, isActionAllowed: sandbox.stub().returns(Promise.resolve(false))}));
-    sandbox.stub(kuzzle.repositories.token, 'verifyToken').returns(Promise.resolve({userId: -1}));
-
-    return should(kuzzle.funnel.checkRights(new Request({controller: 'document', index: '@test', action: 'get'})))
-      .be.rejectedWith(UnauthorizedError);
-  });
-
-  it('should reject the promise with UnauthorizedError if an authenticated user is not allowed to execute the action', () => {
-    kuzzle.repositories.token.verifyToken.restore();
-    sandbox.stub(kuzzle.repositories.user, 'load').returns(Promise.resolve({_id: 'user', isActionAllowed: sandbox.stub().returns(Promise.resolve(false))}));
-    sandbox.stub(kuzzle.repositories.token, 'verifyToken').returns(Promise.resolve({user: 'user'}));
-
-    return should(kuzzle.funnel.checkRights(new Request({controller: 'document', index: '@test', action: 'get'})))
-      .be.rejectedWith(ForbiddenError);
   });
 
   it('should resolve the promise ', () => {
-    var request = new Request({
+    const request = new Request({
       requestId: 'requestId',
       controller: 'index',
-      action: 'list',
-      collection: 'collection'
+      action: 'list'
     });
 
-    kuzzle.repositories.token.verifyToken.restore();
-    sandbox.stub(kuzzle.repositories.user, 'load').returns(Promise.resolve({_id: 'user', isActionAllowed: sandbox.stub().returns(Promise.resolve(true))}));
-    sandbox.stub(kuzzle.repositories.token, 'verifyToken').returns(Promise.resolve({user: 'user'}));
-    sandbox.stub(kuzzle.funnel.controllers.index, 'list').returns(Promise.resolve());
+    kuzzle.repositories.user.load.returns(Promise.resolve({_id: 'user', isActionAllowed: sinon.stub().returns(Promise.resolve(true))}));
+    kuzzle.repositories.token.verifyToken.returns(Promise.resolve({user: 'user'}));
 
-    return kuzzle.funnel.checkRights(request);
+    return funnel.checkRights(request)
+      .then(() => {
+        should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onAuthorized', request)).be.true();
+      });
   });
 });

--- a/test/api/controllers/funnelController/execute.test.js
+++ b/test/api/controllers/funnelController/execute.test.js
@@ -41,7 +41,7 @@ describe('funnelController.execute', () => {
         bar: sinon.spy()
       }
     };
-    funnel.checkRights = sinon.stub().returns(Promise.resolve());
+    funnel.checkRights = sinon.stub().returns(Promise.resolve(request));
     funnel.processRequest = sinon.stub().returnsArg(0);
   });
 


### PR DESCRIPTION
# Description

Add 3 new events to Kuzzle's event system, allowing plugin developers to plug global actions impacting every request processed by Kuzzle:

* `request:onAuthorized`: triggered whenever a request has been successfully granted by the rights system, and before any `<controller>:before<Action>` event
* `request:onSuccess`: triggered whenever a request succeeds. Triggered after any `<controller>:after<Action>` event
* `request:onError`: triggered whenever a request fails. Triggered after any `<controller>:after<Action>` event

# Other changes

* unit tests on the `funnel.checkRights` method now use the `KuzzleMock` object
* unit tests on the `funnel.processRequest` method now use the `KuzzleMock` object (code taken from this PR still in validation: https://github.com/kuzzleio/kuzzle/pull/674)

# Documentation 

https://github.com/kuzzleio/documentation/pull/104
