### PR TITLE
[Hotfix] Core dump and overload system

### DIFF
--- a/lib/api/controllers/cli/dump.js
+++ b/lib/api/controllers/cli/dump.js
@@ -5,7 +5,7 @@
 var
   Promise = require('bluebird'),
   path = require('path'),
-  fs = require('fs'),
+  fs = require('fs-extra'),
   os = require('os'),
   mkdirp = require('mkdirp'),
   Request = require('kuzzle-common-objects').Request,

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -209,9 +209,9 @@ function FunnelController (kuzzle) {
 
           request.input.body.suffix = 'handled-'.concat(errorType.toLowerCase(), '-', errorMessage);
 
-          if (!this.lastDumpedErrors[request.data.body.suffix] || this.lastDumpedErrors[request.data.body.suffix] < lastSeen - MIN_TIME_BEFORE_DUMP_PREV_ERROR) {
+          if (!this.lastDumpedErrors[request.input.body.suffix] || this.lastDumpedErrors[request.input.body.suffix] < lastSeen - MIN_TIME_BEFORE_DUMP_PREV_ERROR) {
             kuzzle.cliController.actions.dump(request);
-            this.lastDumpedErrors[request.data.body.suffix] = lastSeen;
+            this.lastDumpedErrors[request.input.body.suffix] = lastSeen;
           }
         }
       });

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -340,16 +340,16 @@ function FunnelController (kuzzle) {
  */
 function playCachedRequests(kuzzle, funnel) {
   // If there is room to play bufferized requests, do it now. If not, retry later
-  let quantityToInject = funnel.cachedItems > 0 ?
-    Math.min(funnel.cachedItems, kuzzle.config.limits.concurrentRequests - funnel.concurrentRequests)
-    : 0;
+  const quantityToInject = Math.min(funnel.cachedItems, kuzzle.config.limits.concurrentRequests - funnel.concurrentRequests);
 
-  for(let i = 0; i < quantityToInject; i++) {
-    let cachedItem = funnel.requestsCache.shift();
-    funnel.execute(cachedItem.request, cachedItem.callback);
+  if (quantityToInject > 0) {
+    for (let i = 0; i < quantityToInject; i++) {
+      let cachedItem = funnel.requestsCache.shift();
+      funnel.execute(cachedItem.request, cachedItem.callback);
+    }
+
+    funnel.cachedItems -= quantityToInject;
   }
-
-  funnel.cachedItems -= quantityToInject;
 
   if (funnel.cachedItems > 0) {
     setTimeout(() => playCachedRequests(kuzzle, funnel), 0);

--- a/lib/api/kuzzle.js
+++ b/lib/api/kuzzle.js
@@ -189,7 +189,7 @@ function registerErrorHandlers(kuzzle) {
   process.removeAllListeners('unhandledRejection');
   process.on('unhandledRejection', (err) => {
     console.error(`ERROR: unhandledRejection: ${err.message}`, err.stack); // eslint-disable-line no-console
-    request.data.body.suffix = 'unhandled-rejection';
+    request.input.body.suffix = 'unhandled-rejection';
     kuzzle.cliController.actions.dump(request)
       .finally(() => {
         process.exit(1);
@@ -199,7 +199,7 @@ function registerErrorHandlers(kuzzle) {
   process.removeAllListeners('uncaughtException');
   process.on('uncaughtException', (err) => {
     console.error(`ERROR: uncaughtException: ${err.message}`, err.stack); // eslint-disable-line no-console
-    request.data.body.suffix = 'uncaught-exception';
+    request.input.body.suffix = 'uncaught-exception';
     kuzzle.cliController.actions.dump(request)
       .finally(() => {
         process.exit(1);
@@ -210,7 +210,7 @@ function registerErrorHandlers(kuzzle) {
     process.removeAllListeners(signal);
     process.on(signal, () => {
       console.error(`ERROR: Caught signal: ${signal}`); // eslint-disable-line no-console
-      request.data.body.suffix = 'signal-'.concat(signal.toLowerCase());
+      request.input.body.suffix = 'signal-'.concat(signal.toLowerCase());
       kuzzle.cliController.actions.dump(request)
         .finally(() => {
           process.exit(coreDumpSigals[signal] + 128);
@@ -222,7 +222,7 @@ function registerErrorHandlers(kuzzle) {
   process.removeAllListeners('SIGTRAP');
   process.on('SIGTRAP', () => {
     console.error('ERROR: Caught signal: SIGTRAP'); // eslint-disable-line no-console
-    request.data.body.suffix = 'signal-sigtrap';
+    request.input.body.suffix = 'signal-sigtrap';
     kuzzle.cliController.actions.dump(request);
   });
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "elasticsearch": "12.1.3",
     "espresso-logic-minimizer": "^1.0.5",
     "eventemitter2": "^3.0.0",
+    "fs-extra": "^1.0.0",
     "ioredis": "^2.5.0",
     "js-combinatorics": "^0.5.2",
     "json-stable-stringify": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.0.0-RC9.2",
+  "version": "1.0.0-RC9.3",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {


### PR DESCRIPTION
Fixed issues:

* Bad request structure in core dump
* Re-install `fs-extra` that provides the `copySync` method (should try to remove it afterward)
* Fix overload management that was producing errors when the overload mechanism was triggered

Hotfix: should be merged on master and bump the version to `1.0.0-RC9.3`