### PR TITLE
Add extraParams argument to getElasticsearchRequest

### DIFF
--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -272,7 +272,7 @@ function ElasticSearch (kuzzle, options, config) {
    * @returns {Promise} resolve an object that contains _id
    */
   this.create = function elasticsearchCreate (request) {
-    var esRequest = getElasticsearchRequest(request, kuzzle);
+    var esRequest = getElasticsearchRequest(request, kuzzle, ['refresh']);
 
     if (esRequest.body._routing) {
       return Promise.reject(new BadRequestError('Kuzzle does not support "_routing" in create action.'));
@@ -347,7 +347,7 @@ function ElasticSearch (kuzzle, options, config) {
    * @returns {Promise} resolve an object that contains _id
    */
   this.createOrReplace = function elasticsearchCreateOrReplace (request) {
-    var esRequest = getElasticsearchRequest(request, kuzzle);
+    var esRequest = getElasticsearchRequest(request, kuzzle, ['refresh']);
 
     if (esRequest.body._routing) {
       return Promise.reject(new BadRequestError('Kuzzle does not support "_routing" in createOrReplace action.'));
@@ -388,7 +388,7 @@ function ElasticSearch (kuzzle, options, config) {
    * @returns {Promise} resolve an object that contains _id
    */
   this.update = function elasticsearchUpdate (request) {
-    var esRequest = getElasticsearchRequest(request, kuzzle);
+    var esRequest = getElasticsearchRequest(request, kuzzle, ['refresh']);
 
     if (esRequest.body._routing) {
       return Promise.reject(new BadRequestError('Kuzzle does not support "_routing" in update action.'));
@@ -428,7 +428,7 @@ function ElasticSearch (kuzzle, options, config) {
    */
   this.replace = function elasticsearchReplace (request) {
     var
-      esRequest = getElasticsearchRequest(request, kuzzle),
+      esRequest = getElasticsearchRequest(request, kuzzle, ['refresh']),
       existQuery = {
         index: esRequest.index,
         type: esRequest.type,
@@ -480,7 +480,7 @@ function ElasticSearch (kuzzle, options, config) {
    * @returns {Promise} resolve an object that contains _id
    */
   this.delete = function elasticsearchDelete (request) {
-    var esRequest = getElasticsearchRequest(request, kuzzle);
+    var esRequest = getElasticsearchRequest(request, kuzzle, ['refresh']);
 
     if (esRequest.hasOwnProperty('refresh')) {
       if (this.esVersion && compareVersions(this.esVersion.number, '5.0.0') < 0) {
@@ -511,12 +511,12 @@ function ElasticSearch (kuzzle, options, config) {
       esRequestSearch = getElasticsearchRequest(request, kuzzle, ['from', 'size', 'scroll']),
       esRequestBulk = getElasticsearchRequest(request, kuzzle, ['refresh']);
 
-    esRequestBulk.body = [];
-    esRequestSearch.scroll = '30s';
-
     if (!esRequestSearch.body.query || !(esRequestSearch.body.query instanceof Object)) {
       return Promise.reject(new BadRequestError('Query cannot be empty'));
     }
+
+    esRequestBulk.body = [];
+    esRequestSearch.scroll = '30s';
 
     return getAllIdsFromQuery.call(this, esRequestSearch)
       .then(ids => {
@@ -541,26 +541,28 @@ function ElasticSearch (kuzzle, options, config) {
    */
   this.deleteByQueryFromTrash = function elasticsearchDeleteByQueryFromTrash (requestObject) {
     var
-      esRequest = getElasticsearchRequest(requestObject, kuzzle),
-      bodyBulk = [];
+      esRequestSearch = getElasticsearchRequest(requestObject, kuzzle, ['from', 'size', 'scroll']),
+      esRequestBulk = getElasticsearchRequest(requestObject, kuzzle, ['refresh']);
 
-    if (esRequest.body.query === null) {
+    if (esRequestSearch.body.query === null) {
       return Promise.reject(new BadRequestError('null is not a valid document ID'));
     }
 
-    esRequest.scroll = '30s';
-    return getPaginatedIdsFromQuery.call(this, esRequest)
+    esRequestBulk.body = [];
+    esRequestSearch.scroll = '30s';
+
+    return getPaginatedIdsFromQuery.call(this, esRequestSearch)
       .then(ids => {
         return new Promise((resolve, reject) => {
           ids.forEach(id => {
-            bodyBulk.push({delete: {_index: esRequest.index, _type: esRequest.type, _id: id}});
+            esRequestBulk.body.push({delete: {_index: esRequestBulk.index, _type: esRequestBulk.type, _id: id}});
           });
 
-          if (bodyBulk.length === 0) {
+          if (esRequestBulk.body.length === 0) {
             return resolve({ids: []});
           }
-          return this.client.bulk({body: bodyBulk})
-            .then(() => refreshIndexIfNeeded.call(this, esRequest, {ids: ids}))
+          return this.client.bulk(esRequestBulk)
+            .then(() => refreshIndexIfNeeded.call(this, esRequestBulk, {ids: ids}))
             .catch(error => reject(this.formatESError(error)));
         });
       });
@@ -613,9 +615,8 @@ function ElasticSearch (kuzzle, options, config) {
   this.import = function elasticsearchImport (request) {
     var
       nameActions = ['index', 'create', 'update', 'delete'],
-      optionalAttributes = ['consistency', 'refresh', 'routing', 'timeout', 'fields'],
-      esRequest = getElasticsearchRequest(request, kuzzle, ['refresh']),
-      bulkData,
+      esRequest = getElasticsearchRequest(request, kuzzle, ['consistency', 'refresh', 'timeout', 'fields']),
+      bulkRequest,
       error = null;
 
     if (esRequest.hasOwnProperty('refresh')) {
@@ -634,18 +635,20 @@ function ElasticSearch (kuzzle, options, config) {
       return Promise.reject(new BadRequestError('import must specify a body attribute "bulkData" of type Object.'));
     }
 
-    bulkData = {
+    bulkRequest = {
       body: esRequest.body.bulkData
     };
 
-    optionalAttributes.forEach(attr => {
-      if (esRequest[attr] !== undefined) {
-        bulkData[attr] = esRequest[attr];
-      }
-    });
+    Object.keys(esRequest)
+      .filter(key => {
+        return key !== 'body';
+      })
+      .forEach(key => {
+        bulkRequest[key] = esRequest[key];
+      });
 
     // set missing index & type if possible
-    bulkData.body.forEach(item => {
+    bulkRequest.body.forEach(item => {
       var action = Object.keys(item)[0];
       if (nameActions.indexOf(action) !== -1) {
         if (!item[action]._type && esRequest.type) {
@@ -675,7 +678,7 @@ function ElasticSearch (kuzzle, options, config) {
       return Promise.reject(error);
     }
 
-    return this.client.bulk(bulkData)
+    return this.client.bulk(bulkRequest)
       .then(response => refreshIndexIfNeeded.call(this, esRequest, response))
       .then(result => {
         // If some errors occured during the Bulk, we send a "Partial Error" response :
@@ -986,9 +989,8 @@ function getElasticsearchRequest(request, kuzzle, extraParams) {
     data.id = request.input.resource._id;
   }
 
-  ['from', 'size', 'scroll', 'scrollId', 'refresh'].forEach(argumentName => {
-    if (typeof request.input.args[argumentName] !== 'undefined' &&
-        extraParams.includes(argumentName)) {
+  extraParams.forEach(argumentName => {
+    if (typeof request.input.args[argumentName] !== 'undefined') {
       data[argumentName] = request.input.args[argumentName];
     }
   });

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -508,28 +508,29 @@ function ElasticSearch (kuzzle, options, config) {
    */
   this.deleteByQuery = function elasticsearchDeleteByQuery (request) {
     var
-      esRequest = getElasticsearchRequest(request, kuzzle, ['from', 'size', 'scroll']),
-      bodyBulk = [];
+      esRequestSearch = getElasticsearchRequest(request, kuzzle, ['from', 'size', 'scroll']),
+      esRequestBulk = getElasticsearchRequest(request, kuzzle, ['refresh']);
 
-    esRequest.scroll = '30s';
+    esRequestBulk.body = [];
+    esRequestSearch.scroll = '30s';
 
-    if (!esRequest.body.query || !(esRequest.body.query instanceof Object)) {
+    if (!esRequestSearch.body.query || !(esRequestSearch.body.query instanceof Object)) {
       return Promise.reject(new BadRequestError('Query cannot be empty'));
     }
 
-    return getAllIdsFromQuery.call(this, esRequest)
+    return getAllIdsFromQuery.call(this, esRequestSearch)
       .then(ids => {
         ids.forEach(id => {
-          bodyBulk.push({update: {_index: esRequest.index, _type: esRequest.type, _id: id}});
-          bodyBulk.push({doc: {_kuzzle_info: { active: false, deletedAt: Date.now() }}});
+          esRequestBulk.body.push({update: {_index: esRequestBulk.index, _type: esRequestBulk.type, _id: id}});
+          esRequestBulk.body.push({doc: {_kuzzle_info: { active: false, deletedAt: Date.now() }}});
         });
 
-        if (bodyBulk.length === 0) {
+        if (esRequestBulk.body.length === 0) {
           return Promise.resolve({ids: []});
         }
 
-        return this.client.bulk({body: bodyBulk})
-          .then(() => refreshIndexIfNeeded.call(this, esRequest, {ids: ids}))
+        return this.client.bulk(esRequestBulk)
+          .then(() => refreshIndexIfNeeded.call(this, esRequestBulk, {ids: ids}))
           .catch(error => Promise.reject(this.formatESError(error)));
       });
   };

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -170,7 +170,7 @@ function ElasticSearch (kuzzle, options, config) {
    * @returns {Promise} resolve documents matching the scroll id
    */
   this.scroll = function elasticsearchScroll (request) {
-    var esRequest = getElasticsearchRequest(request, this.kuzzle);
+    var esRequest = getElasticsearchRequest(request, this.kuzzle, ['scroll', 'scrollId']);
 
     return this.client.scroll(esRequest)
       .then(result => flattenSearchResults(result))
@@ -183,7 +183,7 @@ function ElasticSearch (kuzzle, options, config) {
    * @returns {Promise} resolve documents matching the filter
    */
   this.search = function elasticsearchSearch (request) {
-    var esRequest = getElasticsearchRequest(request, this.kuzzle);
+    var esRequest = getElasticsearchRequest(request, this.kuzzle, ['from', 'size', 'scroll']);
 
     // todo add condition once the 'trash' feature has been implemented
     addActiveFilter(esRequest);
@@ -508,7 +508,7 @@ function ElasticSearch (kuzzle, options, config) {
    */
   this.deleteByQuery = function elasticsearchDeleteByQuery (request) {
     var
-      esRequest = getElasticsearchRequest(request, kuzzle),
+      esRequest = getElasticsearchRequest(request, kuzzle, ['from', 'size', 'scroll']),
       bodyBulk = [];
 
     esRequest.scroll = '30s';
@@ -613,7 +613,7 @@ function ElasticSearch (kuzzle, options, config) {
     var
       nameActions = ['index', 'create', 'update', 'delete'],
       optionalAttributes = ['consistency', 'refresh', 'routing', 'timeout', 'fields'],
-      esRequest = getElasticsearchRequest(request, kuzzle),
+      esRequest = getElasticsearchRequest(request, kuzzle, ['refresh']),
       bulkData,
       error = null;
 
@@ -961,10 +961,14 @@ module.exports = ElasticSearch;
  *
  * @param {Request} request
  * @param {Kuzzle} kuzzle
+ * @param {Array} extraParams [optional] An array of String values corresponding
+ *                            to the extra params from the Kuzzle Request to be
+ *                            included in the Elasticsearch Request.
  * @return {object} data the data with cleaned attributes
  */
-function getElasticsearchRequest(request, kuzzle) {
+function getElasticsearchRequest(request, kuzzle, extraParams) {
   var data = {};
+  extraParams = extraParams || new Array();
 
   if (request.input.resource.index) {
     if (request.input.resource.index === kuzzle.internalEngine.index) {
@@ -982,7 +986,8 @@ function getElasticsearchRequest(request, kuzzle) {
   }
 
   ['from', 'size', 'scroll', 'scrollId', 'refresh'].forEach(argumentName => {
-    if (typeof request.input.args[argumentName] !== 'undefined') {
+    if (typeof request.input.args[argumentName] !== 'undefined' &&
+        extraParams.includes(argumentName)) {
       data[argumentName] = request.input.args[argumentName];
     }
   });

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -131,7 +131,8 @@ describe('Test: ElasticSearch service', () => {
         request.input.args[arg] = arg;
       });
 
-      preparedData = getElasticsearchRequest.call(elasticsearch, request, kuzzle);
+      preparedData = getElasticsearchRequest.call(elasticsearch, request, kuzzle,
+        ['from', 'size', 'scroll', 'scrollId', 'refresh']);
 
       should(preparedData.type).be.exactly(request.input.resource.collection);
       should(preparedData.id).be.exactly(request.input.resource._id);


### PR DESCRIPTION
# Description
So far, `getElasticsearchRequest` just checked for a hardcoded list of extra-params in the Request to clone to the resulting ES request. Yet, some of these params were not good for certain ES action, resulting in the action to fail.
The `getElasticsearchRequest` function now accepts an optional `extraParams` argument that specifies which of these parameters are actually desired in the resulting ES request. This way, the caller is in charge of whitelisting the desired parameters based on the ES action to be called with the resulting ES request.

If the `extraParams` argument is not specified or left empty, no extra param will be added to the resulting ES request.

# Related Issues
Fixes #682 
Fixes #625 