### PR TITLE
Fix mapping for profile:

### DIFF
--- a/features/HTTP.feature
+++ b/features/HTTP.feature
@@ -265,8 +265,7 @@ Feature: Test HTTP API
   @usingHttp @cleanSecurity
   Scenario: Profile mapping
     Given I get the profile mapping
-    Then The mapping should contain a nested "policies" field with property "_id" of type "keyword"
-    And The mapping should contain a nested "policies" field with property "roleId" of type "text"
+    Then The mapping should contain a nested "policies" field with property "roleId" of type "keyword"
     When I change the profile mapping
     Then I get the profile mapping
     Then The mapping should contain "foo" field of type "text"

--- a/features/Websocket.feature
+++ b/features/Websocket.feature
@@ -389,8 +389,7 @@ Feature: Test websocket API
   @usingWebsocket @cleanSecurity
   Scenario: Profile mapping
     Given I get the profile mapping
-    Then The mapping should contain a nested "policies" field with property "_id" of type "keyword"
-    And The mapping should contain a nested "policies" field with property "roleId" of type "text"
+    Then The mapping should contain a nested "policies" field with property "roleId" of type "keyword"
     When I change the profile mapping
     Then I get the profile mapping
     Then The mapping should contain "foo" field of type "text"

--- a/lib/services/internalEngine/bootstrap.js
+++ b/lib/services/internalEngine/bootstrap.js
@@ -81,7 +81,7 @@ InternalEngineBootstrap.prototype.createProfilesCollection = function internalEn
     properties: {
       policies: {
         properties: {
-          _id: {
+          roleId: {
             index: 'not_analyzed',
             type: 'string'
           }

--- a/test/services/internalEngine/bootstrap.test.js
+++ b/test/services/internalEngine/bootstrap.test.js
@@ -219,7 +219,7 @@ describe('services/internalEngine/bootstrap.js', () => {
                 properties: {
                   policies: {
                     properties: {
-                      _id: {
+                      roleId: {
                         index: 'not_analyzed',
                         type: 'string'
                       }


### PR DESCRIPTION
after #344, `_id` had beend renamed by `roleId` in policies definition, but it was not reported to the profile's mapping in Elastic.