### PR TITLE
Fix #692 Use repositories.validateAndSave* method to reset profiles and roles at createFirstAdmin action

### DIFF
--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -10,6 +10,8 @@ const _ = require('lodash'),
   SizeLimitError = require('kuzzle-common-objects').errors.SizeLimitError,
   Request = require('kuzzle-common-objects').Request,
   User = require('../core/models/security/user'),
+  Role = require('../core/models/security/role'),
+  Profile = require('../core/models/security/profile'),
   assertHasBody = require('./util/requestAssertions').assertHasBody,
   assertBodyHasAttribute = require('./util/requestAssertions').assertBodyHasAttribute,
   assertBodyHasNotAttribute = require('./util/requestAssertions').assertBodyHasNotAttribute,
@@ -614,10 +616,9 @@ function createOrReplaceProfile (kuzzle, request, opts) {
  * @returns {Promise.<*>}
  */
 function resetRoles () {
-  let promises;
-
-  promises = ['admin', 'default', 'anonymous'].map(id => {
-    return this.internalEngine.createOrReplace('roles', id, this.config.security.standard.roles[id]);
+  let promises = ['admin', 'default', 'anonymous'].map(id => {
+    let role = Object.assign(new Role(), {_id: id}, this.config.security.standard.roles[id]);
+    return this.repositories.role.validateAndSaveRole(role);
   });
 
   return Promise.all(promises);
@@ -628,10 +629,12 @@ function resetRoles () {
  * @returns {Promise.<*>}
  */
 function resetProfiles () {
-  return this.internalEngine
-    .createOrReplace('profiles', 'admin', {policies: [{roleId: 'admin', allowInternalIndex: true}]})
-    .then(() => this.internalEngine.createOrReplace('profiles', 'anonymous', {policies: [{roleId: 'anonymous'}]}))
-    .then(() => this.internalEngine.createOrReplace('profiles', 'default', {policies: [{roleId: 'default'}]}));
+  let promises = ['admin', 'default', 'anonymous'].map(id => {
+    let profile = Object.assign(new Profile(), {_id: id, policies: [{roleId: id}]});
+    return this.repositories.profile.validateAndSaveProfile(profile);
+  });
+
+  return Promise.all(promises);
 }
 
 /**

--- a/test/api/controllers/securityController/createFirstAdmin.test.js
+++ b/test/api/controllers/securityController/createFirstAdmin.test.js
@@ -83,18 +83,46 @@ describe('Test: security controller - createFirstAdmin', () => {
   });
 
   describe('#resetRoles', () => {
-    it('should call createOrReplace roles with all default roles', () => {
-      var
-        createOrReplace = sandbox.stub().returns(Promise.resolve()),
+    it('should call validateAndSaveRole with all default roles', () => {
+      const
+        validateAndSaveRole = sandbox.stub().returns(Promise.resolve()),
         mock = {
-          internalEngine: {
-            createOrReplace
+          repositories: {
+            role: {
+              validateAndSaveRole
+            }
           },
           config: {
             security: {
               standard: {
                 roles: {
-                  admin: 'admin', default: 'default', anonymous: 'anonymous'
+                  admin: {
+                    controllers: {
+                      foo: {
+                        actions: {
+                          bar: true
+                        }
+                      }
+                    }
+                  },
+                  default: {
+                    controllers: {
+                      baz: {
+                        actions: {
+                          yolo: true
+                        }
+                      }
+                    }
+                  },
+                  anonymous: {
+                    controllers: {
+                      anon: {
+                        actions: {
+                          ymous: true
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -104,10 +132,10 @@ describe('Test: security controller - createFirstAdmin', () => {
       return SecurityController.__get__('resetRoles').call(mock)
         .then(() => {
           try {
-            should(createOrReplace).have.callCount(3);
-            should(createOrReplace.firstCall).be.calledWith('roles', 'admin', 'admin');
-            should(createOrReplace.secondCall).be.calledWith('roles', 'default', 'default');
-            should(createOrReplace.thirdCall).be.calledWith('roles', 'anonymous', 'anonymous');
+            should(validateAndSaveRole).have.callCount(3);
+            should(validateAndSaveRole.firstCall).be.calledWithMatch({_id: 'admin', controllers: {foo: {actions: {bar: true}}}});
+            should(validateAndSaveRole.secondCall).be.calledWithMatch({_id: 'default', controllers: {baz: {actions: {yolo: true}}}});
+            should(validateAndSaveRole.thirdCall).be.calledWithMatch({_id: 'anonymous', controllers: {anon: {actions: {ymous: true}}}});
             return Promise.resolve();
           }
           catch (error) {
@@ -118,24 +146,28 @@ describe('Test: security controller - createFirstAdmin', () => {
   });
 
   describe('#resetProfiles', () => {
-    it('should call createOrReplace profiles with all default profiles and rights policies', () => {
-      var
-        createOrReplace = sandbox.stub().returns(Promise.resolve()),
-        mock = {internalEngine: {createOrReplace}};
+    it('should call validateAndSaveProfile with all default profiles and rights policies', () => {
+      const
+        validateAndSaveProfile = sandbox.stub().returns(Promise.resolve()),
+        mock = {repositories: {profile: {validateAndSaveProfile}}};
 
       return SecurityController.__get__('resetProfiles').call(mock)
         .then(() => {
 
           try {
-            should(createOrReplace).have.callCount(3);
-            should(createOrReplace.firstCall).be.calledWithMatch('profiles', 'admin', {
-              policies: [{
-                roleId: 'admin',
-                allowInternalIndex: true
-              }]
+            should(validateAndSaveProfile).have.callCount(3);
+            should(validateAndSaveProfile.firstCall).be.calledWithMatch({
+              _id: 'admin',
+              policies: [{roleId: 'admin'}]
             });
-            should(createOrReplace.secondCall).be.calledWithMatch('profiles', 'anonymous', {policies: [{roleId: 'anonymous'}]});
-            should(createOrReplace.thirdCall).be.calledWithMatch('profiles', 'default', {policies: [{roleId: 'default'}]});
+            should(validateAndSaveProfile.secondCall).be.calledWithMatch({
+              _id: 'default',
+              policies: [{roleId: 'default'}]
+            });
+            should(validateAndSaveProfile.thirdCall).be.calledWithMatch({
+              _id: 'anonymous',
+              policies: [{roleId: 'anonymous'}]
+            });
             return Promise.resolve();
           }
           catch (error) {


### PR DESCRIPTION
Fix #692

=> this will correctly clean the in-memory cache of profiles and roles definitions