### PR TITLE
Add new role & profile core events

### DIFF
--- a/lib/api/core/models/repositories/profileRepository.js
+++ b/lib/api/core/models/repositories/profileRepository.js
@@ -216,6 +216,7 @@ ProfileRepository.prototype.deleteProfile = function profileRepositoryDeleteProf
             delete this.profiles[profile._id];
           }
 
+          this.kuzzle.pluginsManager.trigger('core:profileRepository:delete', {_id: profile._id});
           return deleteResponse;
         });
 
@@ -252,6 +253,7 @@ ProfileRepository.prototype.validateAndSaveProfile = function profileRepositoryV
   return profile.validateDefinition()
     .then(() => {
       this.profiles[profile._id] = profile;
+      this.kuzzle.pluginsManager.trigger('core:profileRepository:save', {_id: profile._id, policies: profile.policies});
       return this.persistToDatabase(profile, opts);
     })
     .then(() => profile);

--- a/lib/api/core/models/repositories/roleRepository.js
+++ b/lib/api/core/models/repositories/roleRepository.js
@@ -165,6 +165,7 @@ RoleRepository.prototype.validateAndSaveRole = function roleRepositoryValidateAn
   return role.validateDefinition()
     .then(() => {
       this.roles[role._id] = role;
+      this.kuzzle.pluginsManager.trigger('core:roleRepository:save', {_id: role._id, controllers: role.controllers});
       return this.persistToDatabase(role, opts);
     })
     .then(() => role);
@@ -192,6 +193,7 @@ RoleRepository.prototype.deleteRole = function roleRepositoryDeleteRole (role) {
             delete this.roles[role._id];
           }
 
+          this.kuzzle.pluginsManager.trigger('core:roleRepository:delete', {_id: role._id});
           return deleteResponse;
         });
     });
@@ -206,10 +208,7 @@ RoleRepository.prototype.serializeToDatabase = function roleRepositorySerializeT
   var serializedRole = {};
 
   Object.keys(role).forEach((key) => {
-    if (key === 'closures') {
-      return false;
-    }
-    else if (key !== '_id') {
+    if (['_id', 'closures', 'restrictedTo'].indexOf(key) === -1) {
       serializedRole[key] = role[key];
     }
   });

--- a/lib/api/core/models/security/role.js
+++ b/lib/api/core/models/security/role.js
@@ -17,9 +17,8 @@ const
 function Role () {
   this.controllers = {};
 
-  // closures, allowInternalIndex and restrictedTo are computed for internal use only.
+  // closures and restrictedTo are computed for internal use only.
   this.closures = {};
-  this.allowInternalIndex = false;
 
   // Injected by Profile.getRoles, contains a profile's policies
   this.restrictedTo = [];


### PR DESCRIPTION
# Related Issue
Fix #694 

# Description
Add following core events to be triggered by plugins:
 * `core:roleRepository:save` 
* `core:roleRepository:delete`
* `core:profileRepository:save`
* `core:profileRepository:delete`

# Boyscout
* fix `RoleRepository.serializeToDatabase` method to keep only `role.controllers` attribute
* add a unit test for `RoleRepository.serializeToDatabase`
* add strict mode for unit test on `RoleRepository` and `ProfileRepository`