### PR TITLE
Add pm2 logs to travis tests

### DIFF
--- a/docker-compose/scripts/run-test.sh
+++ b/docker-compose/scripts/run-test.sh
@@ -28,5 +28,6 @@ fi
 echo "[$(date --rfc-3339 seconds)] - Starting Kuzzle..."
 
 pm2 start --silent /config/pm2.json
+pm2 logs &
 npm test
 npm run codecov


### PR DESCRIPTION
# Description

Adds PM2 logs to travis tests allowing the team to easily track down problems when they occur
