### PR TITLE
The security/searchProfiles has a misleading argument

### DIFF
--- a/features/step_definitions/profiles.js
+++ b/features/step_definitions/profiles.js
@@ -197,12 +197,12 @@ var apiSteps = function () {
 
   this.Then(/^I'm able to find "([\d]*)" profiles(?: containing the role with id "([^"]*)")?$/, function (profilesCount, roleId, callback) {
     var body = {
-        policies: []
+        roles: []
       },
       main;
 
     if (roleId) {
-      body.policies.push(this.idPrefix + roleId);
+      body.roles.push(this.idPrefix + roleId);
     }
 
     main = function (callbackAsync) {

--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -185,11 +185,6 @@ function cleanSecurity (callback) {
     })
     .then(() => {
       return this.api.searchProfiles({
-        query: {
-          match_all: {
-            boost: 1
-          }
-        },
         from: 0,
         size: 9999
       });

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -288,8 +288,8 @@ function SecurityController (kuzzle) {
 
     checkSearchPageLimit(request, kuzzle.config.limits.documentsFetchCount);
 
-    if (request.input.body && request.input.body.policies) {
-      roles = request.input.body.policies;
+    if (request.input.body && request.input.body.roles) {
+      roles = request.input.body.roles;
     }
 
     return kuzzle.repositories.profile.searchProfiles(roles, request.input.args.from, request.input.args.size)

--- a/lib/api/core/models/repositories/profileRepository.js
+++ b/lib/api/core/models/repositories/profileRepository.js
@@ -131,12 +131,7 @@ ProfileRepository.prototype.searchProfiles = function profileRepositorySearchPro
   var query = {query: {}};
 
   if (roles && Array.isArray(roles) && roles.length) {
-    query.query.bool = {
-      should: []
-    };
-    roles.forEach(roleId => {
-      query.query.bool.should.push({terms: { 'policies.roleId': [ roleId ] }});
-    });
+    query.query = {terms: {'policies.roleId': roles}};
   }
 
   return this.search(query, from, offsetSize);

--- a/lib/api/core/models/repositories/roleRepository.js
+++ b/lib/api/core/models/repositories/roleRepository.js
@@ -181,7 +181,7 @@ RoleRepository.prototype.deleteRole = function roleRepositoryDeleteRole (role) {
     return Promise.reject(new BadRequestError(role._id + ' is one of the basic roles of Kuzzle, you cannot delete it, but you can edit it.'));
   }
 
-  return this.kuzzle.repositories.profile.searchProfiles([ role._id ], 0, 1)
+  return this.kuzzle.repositories.profile.searchProfiles([role._id], 0, 1)
     .then(response => {
       if (response.total > 0) {
         return Promise.reject(new BadRequestError('The role "' + role._id + '" cannot be deleted since it is used by some profile.'));

--- a/test/api/controllers/securityController/profiles.test.js
+++ b/test/api/controllers/securityController/profiles.test.js
@@ -197,7 +197,7 @@ describe('Test: security controller - profiles', () => {
     it('should return a object containing an array of profiles on searchProfile call with hydrate', () => {
       kuzzle.repositories.profile.searchProfiles = sandbox.stub().returns(Promise.resolve({total: 1, hits: [{_id: 'test', policies: [ {roleId: 'default'} ]}]}));
 
-      return securityController.searchProfiles(new Request({body: {policies: ['role1']}}))
+      return securityController.searchProfiles(new Request({body: {roles: ['role1']}}))
         .then(response => {
           should(response).be.instanceof(Object);
           should(response.hits).be.an.Array();
@@ -210,7 +210,7 @@ describe('Test: security controller - profiles', () => {
     it('should throw an error if the number of documents per page exceeds server limits', () => {
       kuzzle.config.limits.documentsFetchCount = 1;
 
-      request = new Request({body: {policies: ['role1']}});
+      request = new Request({body: {roles: ['role1']}});
       request.input.args.from = 0;
       request.input.args.size = 10;
 

--- a/test/api/core/models/repositories/profileRepository.test.js
+++ b/test/api/core/models/repositories/profileRepository.test.js
@@ -369,14 +369,11 @@ describe('Test: repositories/profileRepository', () => {
       profileRepository.searchProfiles(['role1', 'role2']);
       should(profileRepository.search)
         .be.calledTwice()
-        .be.calledWith({query: {
-          bool: {
-            should: [
-              {terms: {'policies.roleId': ['role1']}},
-              {terms: {'policies.roleId': ['role2']}}
-            ]
+        .be.calledWith({
+          query: {
+            terms: {'policies.roleId': ['role1', 'role2']}
           }
-        }});
+        });
     });
   });
 


### PR DESCRIPTION
The searchProfiles route expects an array of `roles` but the argument name is `policies`; this is misleading.

Boyscout:

Simplify the searchProfiles request made by the Repository