### PR TITLE
Fix bug:websocketClient clear ping timer on close if socket is down

### DIFF
--- a/lib/services/broker/wsBrokerClient.js
+++ b/lib/services/broker/wsBrokerClient.js
@@ -110,16 +110,21 @@ WSBrokerClient.prototype.listen = function wSBrokerClientListen (room, cb) {
  * @param {string} room
  */
 WSBrokerClient.prototype.unsubscribe = function wSBrokerClientUnsubscribe (room) {
-  if (!this.client.socket) {
-    this.pluginsManager.trigger('log:error', `No socket for broker ${this.eventName}`);
-    return false;
-  }
-
   debug('[%s] broker client unsubscribed to room "%s"', this.eventName, room);
 
   if (this.handlers[room]) {
     delete this.handlers[room];
   }
+
+  if (!this.client.socket) {
+    this.pluginsManager.trigger('log:error', `No socket for broker ${this.eventName}`);
+    return false;
+  }
+
+  if (this.client.state !== 'connected') {
+    this.pluginsManager.trigger('log:error', `Socket not ready for broker ${this.eventName}`);
+  }
+
   this.client.socket.send(JSON.stringify({
     action: 'unsubscribe',
     room: room
@@ -130,12 +135,12 @@ WSBrokerClient.prototype.unsubscribe = function wSBrokerClientUnsubscribe (room)
  * Closes the underlying Websocket.
  */
 WSBrokerClient.prototype.close = function wSBrokerClientClose () {
+  resetPing(this);
+
   if (!this.client.socket) {
     this.pluginsManager.trigger('log:error', `No socket for broker ${this.eventName}`);
     return false;
   }
-
-  resetPing(this);
 
   if (this.client.state === 'connected') {
     this.client.state = 'disconnected';


### PR DESCRIPTION
# Description

On `WsBrokerClient:close`, always clear the ping timers, regardless of the socket state.

# Linked issue

#700