### PR TITLE
[HOTFIX] Missing PartialError serialization

### DIFF
--- a/lib/api/controllers/bulkController.js
+++ b/lib/api/controllers/bulkController.js
@@ -25,7 +25,7 @@ function BulkController (kuzzle) {
     return engine.import(request)
       .then(response => {
         if (response.partialErrors && response.partialErrors.length > 0) {
-          request.setError(new PartialError('Some errors with provided rooms', response.partialErrors));
+          request.setError(new PartialError('Some data was not imported', response.partialErrors));
         }
 
         return response;

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "json-stable-stringify": "1.0.1",
     "json2yaml": "^1.1.0",
     "jsonwebtoken": "^7.2.1",
-    "kuzzle-common-objects": "^2.1.2",
+    "kuzzle-common-objects": "^2.1.3",
     "lodash": "4.17.4",
     "mkdirp": "0.5.1",
     "moment": "2.17.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.0.0-RC9.3",
+  "version": "1.0.0-RC9.4",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {


### PR DESCRIPTION
# Description

Use the latest `kuzzle-common-objects` module version to embark a critical bugfix (https://github.com/kuzzleio/kuzzle-common-objects/issues/20)

Also fix a partial error message when using the `import` route of the bulk controller.

# Solved Issues
https://github.com/kuzzleio/kuzzle-common-objects/issues/20, #702 
