### PR TITLE
MemoryStorage.set should not consider the value "0" as undefined

### DIFF
--- a/lib/api/controllers/memoryStorageController.js
+++ b/lib/api/controllers/memoryStorageController.js
@@ -692,7 +692,7 @@ function extractArgumentsFromRequestForSet (request) {
   kassert.assertHasId(request);
   kassert.assertHasBody(request);
 
-  if (!request.input.body.value || ['boolean', 'object'].indexOf(typeof request.input.body.value) !== -1) {
+  if (['undefined', 'boolean', 'object'].indexOf(typeof request.input.body.value) !== -1) {
     throw new BadRequestError(`ms:${request.input.action} Accepts only scalar values (number, string)`);
   }
 


### PR DESCRIPTION
# Description

The way the `ms.set` controller action test the provided value to ensure the request is well-formed is wrong, and a provided value of `0` throws an unexpected error, instead of being treated as a valid input.

This bug occurs only on the `rc.x` branch as it impacts only the refactored memory storage controller.