### PR TITLE
[HOTFIX] Support search results with no _source entries

### DIFF
--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -183,7 +183,7 @@ function ElasticSearch (kuzzle, options, config) {
    * @returns {Promise} resolve documents matching the filter
    */
   this.search = function elasticsearchSearch (request) {
-    var esRequest = getElasticsearchRequest(request, this.kuzzle);
+    const esRequest = getElasticsearchRequest(request, this.kuzzle);
 
     // todo add condition once the 'trash' feature has been implemented
     addActiveFilter(esRequest);
@@ -1128,7 +1128,7 @@ function flattenSearchResults(result) {
   }
 
   result.hits = result.hits.map(obj => {
-    if (obj._source._kuzzle_info) {
+    if (obj._source && obj._source._kuzzle_info) {
       // Move _kuzzle_info from the document body to the root
       obj._kuzzle_info = obj._source._kuzzle_info;
       delete obj._source._kuzzle_info;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.0.0-RC9.4",
+  "version": "1.0.0-RC9.5",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -148,7 +148,20 @@ describe('Test: ElasticSearch service', () => {
 
   describe('#search', () => {
     it('should be able to search documents', () => {
-      elasticsearch.client.search.returns(Promise.resolve({total: 0, hits: []}));
+      elasticsearch.client.search.returns(Promise.resolve({total: 0, hits: [{_id: 'foo', _source: {foo: 'bar'}}]}));
+
+      request.input.body = filter;
+      return elasticsearch.search(request)
+        .then(result => {
+          should(elasticsearch.client.search.firstCall.args[0].body).be.deepEqual(filterAfterActiveAdded);
+          should(result).be.an.Object();
+          should(result.total).be.exactly(0);
+          should(result.hits).be.an.Array();
+        });
+    });
+
+    it('should handle search results without a _source property', () => {
+      elasticsearch.client.search.returns(Promise.resolve({total: 0, hits: [{_id: 'foo'}]}));
 
       request.input.body = filter;
       return elasticsearch.search(request)


### PR DESCRIPTION
# Description

When passing options to Elasticsearch disabling the `_source` retrieval while performing search queries (e.g. with `stored_fields: []` or with `_source: false`), Kuzzle responds with an `InternalError` error, because it tries to fetch information from `_source._kuzzle_info`.

This PR solves this problem by handling Kuzzle's metadata in search results only if there is a `_source` property present.

# Solved issue

#707 
