### PR TITLE
[HOTFIX] Fix document.scroll method

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -348,7 +348,11 @@
       "aliases": ["storageEngine"],
       "host": "elasticsearch",
       "port": 9200,
-      "apiVersion": "5.0"
+      "apiVersion": "5.0",
+      "defaults": {
+        // Time to live of a paginated search
+        "scrollTTL": "15s"
+      }
     }
   },
 

--- a/default.config.js
+++ b/default.config.js
@@ -165,7 +165,10 @@ module.exports = {
       backend: 'elasticsearch',
       host: 'localhost',
       port: 9200,
-      apiVersion: '5.0'
+      apiVersion: '5.0',
+      defaults: {
+        scrollTTL: '15s'
+      }
     },
 
     garbageCollector: {

--- a/features/HTTP.feature
+++ b/features/HTTP.feature
@@ -146,7 +146,7 @@ Feature: Test HTTP API
     When I write the document "documentGrace"
     And I refresh the index
     Then I find a document with "Grace" in field "firstName" with scroll "5m"
-    And I be able to scroll previous search
+    And I am able to scroll previous search
 
   @usingHttp
   Scenario: Change mapping

--- a/features/Websocket.feature
+++ b/features/Websocket.feature
@@ -160,7 +160,7 @@ Feature: Test websocket API
     When I write the document "documentGrace"
     And I refresh the index
     Then I find a document with "Grace" in field "firstName" with scroll "5m"
-    And I be able to scroll previous search
+    And I am able to scroll previous search
 
   @usingWebsocket
   Scenario: Change mapping

--- a/features/step_definitions/readDocument.js
+++ b/features/step_definitions/readDocument.js
@@ -139,9 +139,9 @@ var apiSteps = function () {
       });
   });
 
-  this.Then(/^I ?(don't)* be able to scroll previous search$/, function (dont) {
+  this.Then(/^I am ?(not)* able to scroll previous search$/, function (not) {
     if (!this.scrollId) {
-      if (!dont) {
+      if (!not) {
         return Promise.reject(new Error('No scroll id from previous search available'));
       }
 
@@ -151,7 +151,7 @@ var apiSteps = function () {
     return this.api.scroll(this.scrollId)
       .then(body => {
         if (body.error !== null) {
-          if (dont) {
+          if (not) {
             return Promise.resolve();
           }
 
@@ -159,15 +159,15 @@ var apiSteps = function () {
         }
 
         if (body.result && body.result.hits && body.result.hits.length > 0) {
-          if (dont) { return Promise.reject(new Error('A document exists for the scrollId')); }
+          if (not) { return Promise.reject(new Error('A document exists for the scrollId')); }
           return Promise.resolve();
         }
 
-        if (dont) { return Promise.resolve(); }
+        if (not) { return Promise.resolve(); }
         return Promise.reject(new Error('No result for scrollId search'));
       })
       .catch(error => {
-        if (dont) { return Promise.resolve(); }
+        if (not) { return Promise.resolve(); }
         return Promise.reject(error);
       });
   });

--- a/features/support/apiHttp.js
+++ b/features/support/apiHttp.js
@@ -1,4 +1,4 @@
-var
+const
   _ = require('lodash'),
   config = require('./config'),
   rp = require('request-promise'),
@@ -7,7 +7,7 @@ var
 /**
  * @constructor
  */
-var ApiHttp = function () {
+const ApiHttp = function () {
   this.world = null;
 
   this.baseUri = `${config.scheme}://${config.host}:${config.port}`;
@@ -23,7 +23,7 @@ ApiHttp.prototype.init = function (world) {
 };
 
 ApiHttp.prototype.getRequest = function (index, collection, controller, action, args) {
-  var
+  let
     url = '',
     queryString = [],
     verb = 'GET',
@@ -42,7 +42,7 @@ ApiHttp.prototype.getRequest = function (index, collection, controller, action, 
   }
 
   routes.some(route => {
-    var
+    const
       hits = [];
 
     // Try / Catch mechanism avoids to match routes that have not all
@@ -87,7 +87,7 @@ ApiHttp.prototype.getRequest = function (index, collection, controller, action, 
         // add extra aguments in the query string
         if (verb === 'GET') {
           _.difference(Object.keys(args.body), hits).forEach(key => {
-            var value = args.body[key];
+            const value = args.body[key];
 
             if (_.isArray(value)) {
               queryString = queryString.concat(value.map(v => key + '=' + encodeURIComponent(v)));
@@ -157,7 +157,7 @@ ApiHttp.prototype.callApi = function (options) {
 };
 
 ApiHttp.prototype.get = function (id, index) {
-  var options = {
+  const options = {
     url: this.apiPath(this.util.getIndex(index) + '/' + this.world.fakeCollection + '/' + id),
     method: 'GET'
   };
@@ -166,7 +166,7 @@ ApiHttp.prototype.get = function (id, index) {
 };
 
 ApiHttp.prototype.mGet = function(body, index, collection) {
-  var options = {
+  const options = {
     url: this.apiPath(this.util.getIndex(index) + '/' + this.util.getCollection(collection) + '/_mGet'),
     method: 'POST',
     body
@@ -176,8 +176,8 @@ ApiHttp.prototype.mGet = function(body, index, collection) {
 };
 
 ApiHttp.prototype.search = function (query, index, collection, args) {
-  var
-    qs,
+  let qs;
+  const
     options = {
       url: this.apiPath(this.util.getIndex(index) + '/' + this.util.getCollection(collection) + '/_search'),
       method: 'POST',
@@ -205,16 +205,17 @@ ApiHttp.prototype.search = function (query, index, collection, args) {
 };
 
 ApiHttp.prototype.scroll = function (scrollId, scroll = '1m') {
-  var options = {
-    url: this.apiPath(`_scroll/${scrollId}?scroll=${scroll}`),
-    method: 'POST'
+  const options = {
+    url: this.apiPath(`_scroll/${scrollId}`),
+    method: 'POST',
+    body: {scroll}
   };
 
   return this.callApi(options);
 };
 
 ApiHttp.prototype.count = function (query, index, collection) {
-  var options = {
+  const options = {
     url: this.apiPath(this.util.getIndex(index) + '/' + this.util.getCollection(collection) + '/_count'),
     method: 'POST',
     body: query
@@ -224,7 +225,7 @@ ApiHttp.prototype.count = function (query, index, collection) {
 };
 
 ApiHttp.prototype.create = function (body, index, collection, jwtToken, id) {
-  var
+  const
     url = id
       ? this.apiPath(this.util.getIndex(index) + '/' + this.util.getCollection(collection) + '/' + id + '/_create')
       : this.apiPath(this.util.getIndex(index) + '/' + this.util.getCollection(collection) + '/_create'),
@@ -244,7 +245,7 @@ ApiHttp.prototype.create = function (body, index, collection, jwtToken, id) {
 };
 
 ApiHttp.prototype.mCreate = function (body, index, collection, jwtToken) {
-  var options = {
+  const options = {
     url: this.apiPath(this.util.getIndex(index) + '/' + this.util.getCollection(collection) + '/_mCreate'),
     method: 'POST',
     body
@@ -260,7 +261,7 @@ ApiHttp.prototype.mCreate = function (body, index, collection, jwtToken) {
 };
 
 ApiHttp.prototype.publish = function (body, index) {
-  var options = {
+  const options = {
     url: this.apiPath(this.util.getIndex(index) + '/' + this.world.fakeCollection + '/_publish'),
     method: 'POST',
     body
@@ -270,7 +271,7 @@ ApiHttp.prototype.publish = function (body, index) {
 };
 
 ApiHttp.prototype.createOrReplace = function (body, index, collection) {
-  var options = {
+  const options = {
     url: this.apiPath(this.util.getIndex(index) + '/' + this.util.getCollection(collection) + '/' + body._id),
     method: 'PUT',
     body
@@ -282,7 +283,7 @@ ApiHttp.prototype.createOrReplace = function (body, index, collection) {
 };
 
 ApiHttp.prototype.mCreateOrReplace = function (body, index, collection) {
-  var options = {
+  const options = {
     url: this.apiPath(this.util.getIndex(index) + '/' + this.util.getCollection(collection) + '/_mCreateOrReplace'),
     method: 'PUT',
     body
@@ -292,7 +293,7 @@ ApiHttp.prototype.mCreateOrReplace = function (body, index, collection) {
 };
 
 ApiHttp.prototype.replace = function (body, index, collection) {
-  var options = {
+  const options = {
     url: this.apiPath(this.util.getIndex(index) + '/' + this.util.getCollection(collection) + '/' + body._id + '/_replace'),
     method: 'PUT',
     body
@@ -304,7 +305,7 @@ ApiHttp.prototype.replace = function (body, index, collection) {
 };
 
 ApiHttp.prototype.mReplace = function (body, index, collection) {
-  var options = {
+  const options = {
     url: this.apiPath(this.util.getIndex(index) + '/' + this.util.getCollection(collection) + '/_mReplace'),
     method: 'PUT',
     body
@@ -314,7 +315,7 @@ ApiHttp.prototype.mReplace = function (body, index, collection) {
 };
 
 ApiHttp.prototype.update = function (id, body, index) {
-  var options = {
+  const options = {
     url: this.apiPath(this.util.getIndex(index) + '/' + this.world.fakeCollection + '/' + id + '/_update'),
     method: 'PUT',
     body
@@ -326,7 +327,7 @@ ApiHttp.prototype.update = function (id, body, index) {
 };
 
 ApiHttp.prototype.mUpdate = function (body, index, collection) {
-  var options = {
+  const options = {
     url: this.apiPath(this.util.getIndex(index) + '/' + this.util.getCollection(collection) + '/_mUpdate'),
     method: 'PUT',
     body
@@ -336,7 +337,7 @@ ApiHttp.prototype.mUpdate = function (body, index, collection) {
 };
 
 ApiHttp.prototype.deleteById = function (id, index) {
-  var options = {
+  const options = {
     url: this.apiPath(this.util.getIndex(index) + '/' + this.world.fakeCollection + '/' + id),
     method: 'DELETE'
   };
@@ -345,7 +346,7 @@ ApiHttp.prototype.deleteById = function (id, index) {
 };
 
 ApiHttp.prototype.mDelete = function (body, index, collection) {
-  var options = {
+  const options = {
     url: this.apiPath(this.util.getIndex(index) + '/' + this.util.getCollection(collection) + '/_mDelete'),
     method: 'DELETE',
     body
@@ -355,7 +356,7 @@ ApiHttp.prototype.mDelete = function (body, index, collection) {
 };
 
 ApiHttp.prototype.deleteByQuery = function (query, index, collection) {
-  var options = {
+  const options = {
     url: this.apiPath(this.util.getIndex(index) + '/' + this.util.getCollection(collection) + '/_query'),
     method: 'DELETE',
     body: query
@@ -365,7 +366,7 @@ ApiHttp.prototype.deleteByQuery = function (query, index, collection) {
 };
 
 ApiHttp.prototype.bulkImport = function (bulk, index) {
-  var options = {
+  const options = {
     url: this.apiPath(this.util.getIndex(index) + '/' + this.world.fakeCollection + '/_bulk'),
     method: 'POST',
     body: {bulkData: bulk}
@@ -375,7 +376,7 @@ ApiHttp.prototype.bulkImport = function (bulk, index) {
 };
 
 ApiHttp.prototype.globalBulkImport = function (bulk) {
-  var options = {
+  const options = {
     url: this.apiPath('_bulk'),
     method: 'POST',
     body: {bulkData: bulk}
@@ -385,7 +386,7 @@ ApiHttp.prototype.globalBulkImport = function (bulk) {
 };
 
 ApiHttp.prototype.updateMapping = function (index) {
-  var options = {
+  const options = {
     url: this.apiPath(this.util.getIndex(index) + '/' + this.world.fakeCollection + '/_mapping'),
     method: 'PUT',
     body: this.world.mapping
@@ -395,7 +396,7 @@ ApiHttp.prototype.updateMapping = function (index) {
 };
 
 ApiHttp.prototype.getProfileMapping = function () {
-  var options = {
+  const options = {
     url: this.apiPath('/profiles/_mapping'),
     method: 'GET'
   };
@@ -404,7 +405,7 @@ ApiHttp.prototype.getProfileMapping = function () {
 };
 
 ApiHttp.prototype.updateProfileMapping = function () {
-  var options = {
+  const options = {
     url: this.apiPath('/profiles/_mapping'),
     method: 'PUT',
     body: this.world.securitymapping
@@ -414,7 +415,7 @@ ApiHttp.prototype.updateProfileMapping = function () {
 };
 
 ApiHttp.prototype.getRoleMapping = function () {
-  var options = {
+  const options = {
     url: this.apiPath('/roles/_mapping'),
     method: 'GET'
   };
@@ -423,7 +424,7 @@ ApiHttp.prototype.getRoleMapping = function () {
 };
 
 ApiHttp.prototype.updateRoleMapping = function () {
-  var options = {
+  const options = {
     url: this.apiPath('/roles/_mapping'),
     method: 'PUT',
     body: this.world.securitymapping
@@ -433,7 +434,7 @@ ApiHttp.prototype.updateRoleMapping = function () {
 };
 
 ApiHttp.prototype.getUserMapping = function () {
-  var options = {
+  const options = {
     url: this.apiPath('/users/_mapping'),
     method: 'GET'
   };
@@ -442,7 +443,7 @@ ApiHttp.prototype.getUserMapping = function () {
 };
 
 ApiHttp.prototype.updateUserMapping = function () {
-  var options = {
+  const options = {
     url: this.apiPath('/users/_mapping'),
     method: 'PUT',
     body: this.world.securitymapping
@@ -452,7 +453,7 @@ ApiHttp.prototype.updateUserMapping = function () {
 };
 
 ApiHttp.prototype.getStats = function (dates) {
-  var options = {
+  const options = {
     url: this.apiPath('_getStats'),
     method: 'POST',
     body: dates
@@ -462,7 +463,7 @@ ApiHttp.prototype.getStats = function (dates) {
 };
 
 ApiHttp.prototype.getLastStats = function () {
-  var options = {
+  const options = {
     url: this.apiPath('_getLastStats'),
     method: 'GET'
   };
@@ -471,7 +472,7 @@ ApiHttp.prototype.getLastStats = function () {
 };
 
 ApiHttp.prototype.getAllStats = function () {
-  var options = {
+  const options = {
     url: this.apiPath('_getAllStats'),
     method: 'GET'
   };
@@ -479,12 +480,8 @@ ApiHttp.prototype.getAllStats = function () {
   return this.callApi(options);
 };
 
-ApiHttp.prototype.listCollections = function (index, type) {
-  var options;
-
-  index = index || this.world.fakeIndex;
-
-  options = {
+ApiHttp.prototype.listCollections = function (index = this.world.fakeIndex, type) {
+  const options = {
     url: this.apiPath(index + '/_list'),
     method: 'GET'
   };
@@ -497,7 +494,7 @@ ApiHttp.prototype.listCollections = function (index, type) {
 };
 
 ApiHttp.prototype.now = function () {
-  var options = {
+  const options = {
     url: this.apiPath('_now'),
     method: 'GET'
   };
@@ -506,7 +503,7 @@ ApiHttp.prototype.now = function () {
 };
 
 ApiHttp.prototype.truncateCollection = function (index, collection) {
-  var options = {
+  const options = {
     url: this.apiPath(this.util.getIndex(index) + '/' + this.util.getCollection(collection) + '/_truncate'),
     method: 'DELETE'
   };
@@ -515,7 +512,7 @@ ApiHttp.prototype.truncateCollection = function (index, collection) {
 };
 
 ApiHttp.prototype.listIndexes = function () {
-  var options = {
+  const options = {
     url: this.apiPath('_list'),
     method: 'GET'
   };
@@ -524,7 +521,7 @@ ApiHttp.prototype.listIndexes = function () {
 };
 
 ApiHttp.prototype.deleteIndexes = function () {
-  var options = {
+  const options = {
     url: this.apiPath('_mdelete'),
     method: 'DELETE'
   };
@@ -533,7 +530,7 @@ ApiHttp.prototype.deleteIndexes = function () {
 };
 
 ApiHttp.prototype.createIndex = function (index) {
-  var options = {
+  const options = {
     url: this.apiPath(index + '/_create'),
     method: 'POST'
   };
@@ -542,7 +539,7 @@ ApiHttp.prototype.createIndex = function (index) {
 };
 
 ApiHttp.prototype.deleteIndex = function (index) {
-  var options = {
+  const options = {
     url: this.apiPath(index),
     method: 'DELETE'
   };
@@ -551,7 +548,7 @@ ApiHttp.prototype.deleteIndex = function (index) {
 };
 
 ApiHttp.prototype.getServerInfo = function () {
-  var options = {
+  const options = {
     url: this.apiBasePath('_serverInfo'),
     method: 'GET'
   };
@@ -563,7 +560,7 @@ ApiHttp.prototype.getServerInfo = function () {
 };
 
 ApiHttp.prototype.login = function (strategy, credentials) {
-  var options = {
+  const options = {
     url: this.apiPath('_login'),
     method: 'POST',
     body: {
@@ -577,7 +574,7 @@ ApiHttp.prototype.login = function (strategy, credentials) {
 };
 
 ApiHttp.prototype.logout = function (jwtToken) {
-  var options = {
+  const options = {
     url: this.apiPath('_logout'),
     method: 'GET',
     headers: {
@@ -589,7 +586,7 @@ ApiHttp.prototype.logout = function (jwtToken) {
 };
 
 ApiHttp.prototype.createOrReplaceRole = function (id, body) {
-  var options = {
+  const options = {
     url: this.apiPath('roles/' + id),
     method: 'PUT',
     body
@@ -599,7 +596,7 @@ ApiHttp.prototype.createOrReplaceRole = function (id, body) {
 };
 
 ApiHttp.prototype.getRole = function (id) {
-  var options = {
+  const options = {
     url: this.apiPath('roles/' + id),
     method: 'GET'
   };
@@ -608,7 +605,7 @@ ApiHttp.prototype.getRole = function (id) {
 };
 
 ApiHttp.prototype.mGetRoles = function (body) {
-  var options = {
+  const options = {
     url: this.apiPath('roles/_mGet'),
     method: 'POST',
     body
@@ -618,7 +615,7 @@ ApiHttp.prototype.mGetRoles = function (body) {
 };
 
 ApiHttp.prototype.searchRoles = function (body) {
-  var options = {
+  const options = {
     url: this.apiPath('roles/_search'),
     method: 'POST',
     body
@@ -628,7 +625,7 @@ ApiHttp.prototype.searchRoles = function (body) {
 };
 
 ApiHttp.prototype.deleteRole = function (id) {
-  var options = {
+  const options = {
     url: this.apiPath('roles/' + id),
     method: 'DELETE'
   };
@@ -637,7 +634,7 @@ ApiHttp.prototype.deleteRole = function (id) {
 };
 
 ApiHttp.prototype.createOrReplaceProfile = function (id, body) {
-  var options = {
+  const options = {
     url: this.apiPath('profiles/' + id),
     method: 'PUT',
     body
@@ -647,7 +644,7 @@ ApiHttp.prototype.createOrReplaceProfile = function (id, body) {
 };
 
 ApiHttp.prototype.getProfile = function (id) {
-  var options = {
+  const options = {
     url: this.apiPath('profiles/' + id),
     method: 'GET'
   };
@@ -656,7 +653,7 @@ ApiHttp.prototype.getProfile = function (id) {
 };
 
 ApiHttp.prototype.getProfileRights = function (id) {
-  var options = {
+  const options = {
     url: this.apiPath('profiles/' + id + '/_rights'),
     method: 'GET'
   };
@@ -665,7 +662,7 @@ ApiHttp.prototype.getProfileRights = function (id) {
 };
 
 ApiHttp.prototype.mGetProfiles= function (body) {
-  var options = {
+  const options = {
     url: this.apiPath('profiles/_mGet'),
     method: 'POST',
     body
@@ -675,7 +672,7 @@ ApiHttp.prototype.mGetProfiles= function (body) {
 };
 
 ApiHttp.prototype.searchProfiles = function (body) {
-  var options = {
+  const options = {
     url: this.apiPath('profiles/_search'),
     method: 'POST',
     body
@@ -685,7 +682,7 @@ ApiHttp.prototype.searchProfiles = function (body) {
 };
 
 ApiHttp.prototype.deleteProfile = function (id) {
-  var options = {
+  const options = {
     url: this.apiPath('profiles/' + id),
     method: 'DELETE'
   };
@@ -694,7 +691,7 @@ ApiHttp.prototype.deleteProfile = function (id) {
 };
 
 ApiHttp.prototype.searchValidations = function (body) {
-  var options = {
+  const options = {
     url: this.apiPath('validations/_search'),
     method: 'POST',
     body
@@ -704,7 +701,7 @@ ApiHttp.prototype.searchValidations = function (body) {
 };
 
 ApiHttp.prototype.getUser = function (id) {
-  var options = {
+  const options = {
     url: this.apiPath('users/' + id),
     method: 'GET'
   };
@@ -713,7 +710,7 @@ ApiHttp.prototype.getUser = function (id) {
 };
 
 ApiHttp.prototype.getUserRights = function (id) {
-  var options = {
+  const options = {
     url: this.apiPath('users/' + id + '/_rights'),
     method: 'GET'
   };
@@ -729,7 +726,7 @@ ApiHttp.prototype.getCurrentUser = function () {
 };
 
 ApiHttp.prototype.getMyRights = function () {
-  var options = {
+  const options = {
     url: this.apiPath('users/_me/_rights'),
     method: 'GET'
   };
@@ -761,7 +758,7 @@ ApiHttp.prototype.createOrReplaceUser = function (body, id) {
 };
 
 ApiHttp.prototype.createUser = function (body, id) {
-  var options = {
+  const options = {
     url: this.apiPath('users/' + id + '/_create'),
     method: 'POST',
     body
@@ -771,7 +768,7 @@ ApiHttp.prototype.createUser = function (body, id) {
 };
 
 ApiHttp.prototype.createRestrictedUser = function (body, id) {
-  var options = {
+  const options = {
     url: this.apiPath('users/' + id + '/_createRestricted'),
     method: 'POST',
     body
@@ -781,7 +778,7 @@ ApiHttp.prototype.createRestrictedUser = function (body, id) {
 };
 
 ApiHttp.prototype.updateSelf = function (body) {
-  var options = {
+  const options = {
     url: this.apiPath('_updateSelf'),
     method: 'PUT',
     body
@@ -826,7 +823,7 @@ ApiHttp.prototype.collectionExists = function (index, collection) {
 };
 
 ApiHttp.prototype.getSpecifications = function (index, collection) {
-  var options = {
+  const options = {
     url: this.apiPath(index + '/' + collection + '/_specifications'),
     method: 'GET'
   };
@@ -835,7 +832,7 @@ ApiHttp.prototype.getSpecifications = function (index, collection) {
 };
 
 ApiHttp.prototype.updateSpecifications = function (specifications) {
-  var options = {
+  const options = {
     url: this.apiPath('_specifications'),
     method: 'PUT',
     body: specifications
@@ -845,7 +842,7 @@ ApiHttp.prototype.updateSpecifications = function (specifications) {
 };
 
 ApiHttp.prototype.validateSpecifications = function (specifications) {
-  var options = {
+  const options = {
     url: this.apiPath('_validateSpecifications'),
     method: 'POST',
     body: specifications
@@ -855,7 +852,7 @@ ApiHttp.prototype.validateSpecifications = function (specifications) {
 };
 
 ApiHttp.prototype.validateDocument = function (index, collection, document) {
-  var options = {
+  const options = {
     url: this.apiPath(index + '/' + collection + '/_validate'),
     method: 'POST',
     body: document
@@ -865,7 +862,7 @@ ApiHttp.prototype.validateDocument = function (index, collection, document) {
 };
 
 ApiHttp.prototype.postDocument = function (index, collection, document) {
-  var options = {
+  const options = {
     url: this.apiPath(index + '/' + collection + '/_create'),
     method: 'POST',
     body: document
@@ -875,7 +872,7 @@ ApiHttp.prototype.postDocument = function (index, collection, document) {
 };
 
 ApiHttp.prototype.deleteSpecifications = function (index, collection) {
-  var options = {
+  const options = {
     url: this.apiPath(index + '/' + collection + '/_specifications'),
     method: 'DELETE'
   };

--- a/features/support/apiHttp.js
+++ b/features/support/apiHttp.js
@@ -204,12 +204,15 @@ ApiHttp.prototype.search = function (query, index, collection, args) {
   return this.callApi(options);
 };
 
-ApiHttp.prototype.scroll = function (scrollId, scroll = '1m') {
+ApiHttp.prototype.scroll = function (scrollId, scroll) {
   const options = {
     url: this.apiPath(`_scroll/${scrollId}`),
-    method: 'POST',
-    body: {scroll}
+    method: 'GET'
   };
+
+  if (scroll) {
+    options.url += '?scroll=' + scroll;
+  }
 
   return this.callApi(options);
 };

--- a/features/support/apiRT.js
+++ b/features/support/apiRT.js
@@ -177,13 +177,13 @@ ApiRT.prototype.search = function (query, index, collection, args) {
   return this.send(msg);
 };
 
-ApiRT.prototype.scroll = function (scrollId, scroll = '1m') {
+ApiRT.prototype.scroll = function (scrollId, scroll) {
   const
     msg = {
       controller: 'document',
       action: 'scroll',
       scrollId,
-      body: {scroll}
+      scroll
     };
 
   return this.send(msg);

--- a/features/support/apiRT.js
+++ b/features/support/apiRT.js
@@ -5,7 +5,7 @@
  * NOTE: must be added in api HTTP because the apiHttp file doesn't extend this ApiRT
  */
 
-var
+const
   _ = require('lodash'),
   ApiRT = function () {
     this.world = null;
@@ -18,7 +18,7 @@ ApiRT.prototype.send = function () {};
 ApiRT.prototype.sendAndListen = function () {};
 
 ApiRT.prototype.create = function (body, index, collection, jwtToken, id) {
-  var
+  const
     msg = {
       controller: 'document',
       collection: collection || this.world.fakeCollection,
@@ -41,7 +41,7 @@ ApiRT.prototype.create = function (body, index, collection, jwtToken, id) {
 };
 
 ApiRT.prototype.mCreate = function (body, index, collection, jwtToken) {
-  var
+  const
     msg = {
       controller: 'document',
       collection: collection || this.world.fakeCollection,
@@ -60,7 +60,7 @@ ApiRT.prototype.mCreate = function (body, index, collection, jwtToken) {
 };
 
 ApiRT.prototype.publish = function (body, index) {
-  var
+  const
     msg = {
       controller: 'realtime',
       collection: this.world.fakeCollection,
@@ -73,7 +73,7 @@ ApiRT.prototype.publish = function (body, index) {
 };
 
 ApiRT.prototype.createOrReplace = function (body, index, collection) {
-  var
+  const
     msg = {
       controller: 'document',
       collection: collection || this.world.fakeCollection,
@@ -91,7 +91,7 @@ ApiRT.prototype.createOrReplace = function (body, index, collection) {
 };
 
 ApiRT.prototype.mCreateOrReplace = function (body, index, collection) {
-  var
+  const
     msg = {
       controller: 'document',
       collection: collection || this.world.fakeCollection,
@@ -104,7 +104,7 @@ ApiRT.prototype.mCreateOrReplace = function (body, index, collection) {
 };
 
 ApiRT.prototype.replace = function (body, index, collection) {
-  var
+  const
     msg = {
       controller: 'document',
       collection: collection || this.world.fakeCollection,
@@ -122,7 +122,7 @@ ApiRT.prototype.replace = function (body, index, collection) {
 };
 
 ApiRT.prototype.mReplace = function (body, index, collection) {
-  var
+  const
     msg = {
       controller: 'document',
       collection: collection || this.world.fakeCollection,
@@ -135,7 +135,7 @@ ApiRT.prototype.mReplace = function (body, index, collection) {
 };
 
 ApiRT.prototype.get = function (id, index) {
-  var
+  const
     msg = {
       controller: 'document',
       collection: this.world.fakeCollection,
@@ -148,7 +148,7 @@ ApiRT.prototype.get = function (id, index) {
 };
 
 ApiRT.prototype.mGet = function(body, index, collection) {
-  var
+  const
     msg = {
       controller: 'document',
       collection: collection || this.world.fakeCollection,
@@ -161,7 +161,7 @@ ApiRT.prototype.mGet = function(body, index, collection) {
 };
 
 ApiRT.prototype.search = function (query, index, collection, args) {
-  var
+  const
     msg = {
       controller: 'document',
       collection: collection || this.world.fakeCollection,
@@ -178,19 +178,19 @@ ApiRT.prototype.search = function (query, index, collection, args) {
 };
 
 ApiRT.prototype.scroll = function (scrollId, scroll = '1m') {
-  var
+  const
     msg = {
       controller: 'document',
       action: 'scroll',
       scrollId,
-      scroll
+      body: {scroll}
     };
 
   return this.send(msg);
 };
 
 ApiRT.prototype.count = function (query, index, collection) {
-  var
+  const
     msg = {
       controller: 'document',
       collection: collection || this.world.fakeCollection,
@@ -203,7 +203,7 @@ ApiRT.prototype.count = function (query, index, collection) {
 };
 
 ApiRT.prototype.update = function (id, body, index) {
-  var
+  const
     msg = {
       controller: 'document',
       collection: this.world.fakeCollection,
@@ -217,7 +217,7 @@ ApiRT.prototype.update = function (id, body, index) {
 };
 
 ApiRT.prototype.mUpdate = function (body, index, collection) {
-  var
+  const
     msg = {
       controller: 'document',
       collection: collection || this.world.fakeCollection,
@@ -230,7 +230,7 @@ ApiRT.prototype.mUpdate = function (body, index, collection) {
 };
 
 ApiRT.prototype.deleteById = function (id, index) {
-  var
+  const
     msg = {
       controller: 'document',
       collection: this.world.fakeCollection,
@@ -243,7 +243,7 @@ ApiRT.prototype.deleteById = function (id, index) {
 };
 
 ApiRT.prototype.mDelete = function (body, index, collection) {
-  var
+  const
     msg = {
       controller: 'document',
       collection: collection || this.world.fakeCollection,
@@ -256,7 +256,7 @@ ApiRT.prototype.mDelete = function (body, index, collection) {
 };
 
 ApiRT.prototype.deleteByQuery = function (query, index, collection) {
-  var
+  const
     msg = {
       controller: 'document',
       collection: collection || this.world.fakeCollection,
@@ -269,7 +269,7 @@ ApiRT.prototype.deleteByQuery = function (query, index, collection) {
 };
 
 ApiRT.prototype.updateMapping = function (index) {
-  var
+  const
     msg = {
       controller: 'collection',
       collection: this.world.fakeCollection,
@@ -282,7 +282,7 @@ ApiRT.prototype.updateMapping = function (index) {
 };
 
 ApiRT.prototype.getProfileMapping = function () {
-  var
+  const
     msg = {
       controller: 'security',
       action: 'getProfileMapping'
@@ -292,7 +292,7 @@ ApiRT.prototype.getProfileMapping = function () {
 };
 
 ApiRT.prototype.updateProfileMapping = function () {
-  var
+  const
     msg = {
       controller: 'security',
       action: 'updateProfileMapping',
@@ -303,7 +303,7 @@ ApiRT.prototype.updateProfileMapping = function () {
 };
 
 ApiRT.prototype.getRoleMapping = function () {
-  var
+  const
     msg = {
       controller: 'security',
       action: 'getRoleMapping'
@@ -313,7 +313,7 @@ ApiRT.prototype.getRoleMapping = function () {
 };
 
 ApiRT.prototype.updateRoleMapping = function () {
-  var
+  const
     msg = {
       controller: 'security',
       action: 'updateRoleMapping',
@@ -324,7 +324,7 @@ ApiRT.prototype.updateRoleMapping = function () {
 };
 
 ApiRT.prototype.getUserMapping = function () {
-  var
+  const
     msg = {
       controller: 'security',
       action: 'getUserMapping'
@@ -334,7 +334,7 @@ ApiRT.prototype.getUserMapping = function () {
 };
 
 ApiRT.prototype.updateUserMapping = function () {
-  var
+  const
     msg = {
       controller: 'security',
       action: 'updateUserMapping',
@@ -345,7 +345,7 @@ ApiRT.prototype.updateUserMapping = function () {
 };
 
 ApiRT.prototype.bulkImport = function (bulk, index, collection) {
-  var
+  const
     msg = {
       controller: 'bulk',
       collection: collection || this.world.fakeCollection,
@@ -358,7 +358,7 @@ ApiRT.prototype.bulkImport = function (bulk, index, collection) {
 };
 
 ApiRT.prototype.globalBulkImport = function (bulk) {
-  var
+  const
     msg = {
       controller: 'bulk',
       action: 'import',
@@ -369,7 +369,7 @@ ApiRT.prototype.globalBulkImport = function (bulk) {
 };
 
 ApiRT.prototype.subscribe = function (filters, client) {
-  var
+  const
     msg = {
       controller: 'realtime',
       collection: this.world.fakeCollection,
@@ -387,7 +387,7 @@ ApiRT.prototype.subscribe = function (filters, client) {
 };
 
 ApiRT.prototype.unsubscribe = function (room, clientId) {
-  var
+  const
     msg = {
       clientId: clientId,
       controller: 'realtime',
@@ -404,7 +404,7 @@ ApiRT.prototype.unsubscribe = function (room, clientId) {
 };
 
 ApiRT.prototype.countSubscription = function () {
-  var
+  const
     clients = Object.keys(this.subscribedRooms),
     rooms = Object.keys(this.subscribedRooms[clients[0]]),
     msg = {
@@ -421,7 +421,7 @@ ApiRT.prototype.countSubscription = function () {
 };
 
 ApiRT.prototype.getStats = function (dates) {
-  var
+  const
     msg = {
       controller: 'server',
       action: 'getStats',
@@ -432,7 +432,7 @@ ApiRT.prototype.getStats = function (dates) {
 };
 
 ApiRT.prototype.getLastStats = function () {
-  var
+  const
     msg = {
       controller: 'server',
       action: 'getLastStats'
@@ -442,7 +442,7 @@ ApiRT.prototype.getLastStats = function () {
 };
 
 ApiRT.prototype.getAllStats = function () {
-  var
+  const
     msg = {
       controller: 'server',
       action: 'getAllStats'
@@ -452,7 +452,7 @@ ApiRT.prototype.getAllStats = function () {
 };
 
 ApiRT.prototype.listCollections = function (index, type) {
-  var
+  const
     msg = {
       controller: 'collection',
       index: index || this.world.fakeIndex,
@@ -464,7 +464,7 @@ ApiRT.prototype.listCollections = function (index, type) {
 };
 
 ApiRT.prototype.now = function () {
-  var
+  const
     msg = {
       controller: 'server',
       action: 'now'
@@ -474,7 +474,7 @@ ApiRT.prototype.now = function () {
 };
 
 ApiRT.prototype.truncateCollection = function (index, collection) {
-  var
+  const
     msg = {
       controller: 'collection',
       collection: collection || this.world.fakeCollection,
@@ -486,7 +486,7 @@ ApiRT.prototype.truncateCollection = function (index, collection) {
 };
 
 ApiRT.prototype.listSubscriptions = function () {
-  var
+  const
     msg = {
       controller: 'realtime',
       action: 'list'
@@ -496,7 +496,7 @@ ApiRT.prototype.listSubscriptions = function () {
 };
 
 ApiRT.prototype.deleteIndexes = function () {
-  var
+  const
     msg = {
       controller: 'index',
       action: 'mdelete'
@@ -506,7 +506,7 @@ ApiRT.prototype.deleteIndexes = function () {
 };
 
 ApiRT.prototype.listIndexes = function () {
-  var
+  const
     msg = {
       controller: 'index',
       action: 'list'
@@ -516,7 +516,7 @@ ApiRT.prototype.listIndexes = function () {
 };
 
 ApiRT.prototype.createIndex = function (index) {
-  var
+  const
     msg = {
       controller: 'index',
       action: 'create',
@@ -527,7 +527,7 @@ ApiRT.prototype.createIndex = function (index) {
 };
 
 ApiRT.prototype.deleteIndex = function (index) {
-  var
+  const
     msg = {
       controller: 'index',
       action: 'delete',
@@ -538,7 +538,7 @@ ApiRT.prototype.deleteIndex = function (index) {
 };
 
 ApiRT.prototype.getServerInfo = function () {
-  var
+  const
     msg = {
       controller: 'server',
       action: 'info',
@@ -549,7 +549,7 @@ ApiRT.prototype.getServerInfo = function () {
 };
 
 ApiRT.prototype.login = function (strategy, credentials) {
-  var
+  const
     msg = {
       controller: 'auth',
       action: 'login',
@@ -565,7 +565,7 @@ ApiRT.prototype.login = function (strategy, credentials) {
 };
 
 ApiRT.prototype.logout = function(jwtToken) {
-  var
+  const
     msg = {
       controller: 'auth',
       action: 'logout',
@@ -576,7 +576,7 @@ ApiRT.prototype.logout = function(jwtToken) {
 };
 
 ApiRT.prototype.createOrReplaceRole = function (id, body) {
-  var
+  const
     msg = {
       controller: 'security',
       action: 'createOrReplaceRole',
@@ -588,7 +588,7 @@ ApiRT.prototype.createOrReplaceRole = function (id, body) {
 };
 
 ApiRT.prototype.getRole = function (id) {
-  var
+  const
     msg = {
       controller: 'security',
       action: 'getRole',
@@ -599,7 +599,7 @@ ApiRT.prototype.getRole = function (id) {
 };
 
 ApiRT.prototype.mGetRoles = function (body) {
-  var
+  const
     msg = {
       controller: 'security',
       action: 'mGetRoles',
@@ -610,7 +610,7 @@ ApiRT.prototype.mGetRoles = function (body) {
 };
 
 ApiRT.prototype.searchRoles = function (body) {
-  var
+  const
     msg = {
       controller: 'security',
       action: 'searchRoles',
@@ -621,7 +621,7 @@ ApiRT.prototype.searchRoles = function (body) {
 };
 
 ApiRT.prototype.deleteRole = function (id) {
-  var
+  const
     msg = {
       controller: 'security',
       action: 'deleteRole',
@@ -632,7 +632,7 @@ ApiRT.prototype.deleteRole = function (id) {
 };
 
 ApiRT.prototype.createOrReplaceRole = function (id, body) {
-  var
+  const
     msg = {
       controller: 'security',
       action: 'createOrReplaceRole',
@@ -644,7 +644,7 @@ ApiRT.prototype.createOrReplaceRole = function (id, body) {
 };
 
 ApiRT.prototype.getProfile = function (id) {
-  var
+  const
     msg = {
       controller: 'security',
       action: 'getProfile',
@@ -655,7 +655,7 @@ ApiRT.prototype.getProfile = function (id) {
 };
 
 ApiRT.prototype.getProfileRights = function (id) {
-  var
+  const
     msg = {
       controller: 'security',
       action: 'getProfileRights',
@@ -666,7 +666,7 @@ ApiRT.prototype.getProfileRights = function (id) {
 };
 
 ApiRT.prototype.mGetProfiles = function (body) {
-  var
+  const
     msg = {
       controller: 'security',
       action: 'mGetProfiles',
@@ -677,7 +677,7 @@ ApiRT.prototype.mGetProfiles = function (body) {
 };
 
 ApiRT.prototype.createOrReplaceProfile = function (id, body) {
-  var
+  const
     msg = {
       controller: 'security',
       action: 'createOrReplaceProfile',
@@ -689,7 +689,7 @@ ApiRT.prototype.createOrReplaceProfile = function (id, body) {
 };
 
 ApiRT.prototype.searchProfiles = function (body) {
-  var
+  const
     msg = {
       controller: 'security',
       action: 'searchProfiles',
@@ -700,7 +700,7 @@ ApiRT.prototype.searchProfiles = function (body) {
 };
 
 ApiRT.prototype.deleteProfile = function (id) {
-  var
+  const
     msg = {
       controller: 'security',
       action: 'deleteProfile',
@@ -711,7 +711,7 @@ ApiRT.prototype.deleteProfile = function (id) {
 };
 
 ApiRT.prototype.searchValidations = function (body) {
-  var
+  const
     msg = {
       controller: 'collection',
       action: 'searchSpecifications',
@@ -788,7 +788,7 @@ ApiRT.prototype.updateSelf = function (body) {
 };
 
 ApiRT.prototype.createUser = function (body, id) {
-  var msg = {
+  const msg = {
     controller: 'security',
     action: 'createUser',
     body: body
@@ -801,7 +801,7 @@ ApiRT.prototype.createUser = function (body, id) {
 };
 
 ApiRT.prototype.createRestrictedUser = function (body, id) {
-  var msg = {
+  const msg = {
     controller: 'security',
     action: 'createRestrictedUser',
     body: body
@@ -830,7 +830,7 @@ ApiRT.prototype.refreshIndex = function (index) {
 };
 
 ApiRT.prototype.callMemoryStorage = function (command, args) {
-  var msg = {
+  const msg = {
     controller: 'ms',
     action: command
   };

--- a/lib/api/controllers/documentController.js
+++ b/lib/api/controllers/documentController.js
@@ -49,7 +49,7 @@ function DocumentController (kuzzle) {
    * @returns {Promise<Object>}
    */
   this.scroll = function documentScroll (request) {
-    if (!request.input.args.scroll) {
+    if (!request.input.body || !request.input.body.scroll) {
       throw new BadRequestError('document:scroll must specify an argument "scroll"');
     }
     if (!request.input.args.scrollId) {

--- a/lib/api/controllers/documentController.js
+++ b/lib/api/controllers/documentController.js
@@ -17,7 +17,7 @@ let
  * @constructor
  */
 function DocumentController (kuzzle) {
-  var engine = kuzzle.services.list.storageEngine;
+  const engine = kuzzle.services.list.storageEngine;
 
   /**
    * @param {Request} request
@@ -49,9 +49,6 @@ function DocumentController (kuzzle) {
    * @returns {Promise<Object>}
    */
   this.scroll = function documentScroll (request) {
-    if (!request.input.body || !request.input.body.scroll) {
-      throw new BadRequestError('document:scroll must specify an argument "scroll"');
-    }
     if (!request.input.args.scrollId) {
       throw new BadRequestError('document:scroll must specify an argument "scrollId"');
     }
@@ -111,7 +108,7 @@ function DocumentController (kuzzle) {
    */
   this.create = function documentCreate (request) {
     /** @type KuzzleRequest */
-    var modifiedRequest;
+    let modifiedRequest;
 
     assertHasBody(request);
     assertHasIndexAndCollection(request);
@@ -151,7 +148,7 @@ function DocumentController (kuzzle) {
    */
   this.createOrReplace = function documentCreateOrReplace (request) {
     /** @type KuzzleRequest */
-    var modifiedRequest;
+    let modifiedRequest;
 
     assertHasBody(request);
     assertHasIndexAndCollection(request);
@@ -199,7 +196,7 @@ function DocumentController (kuzzle) {
    */
   this.update = function documentUpdate (request) {
     /** @type KuzzleRequest */
-    var modifiedRequest;
+    let modifiedRequest;
 
     assertHasBody(request);
     assertHasIndexAndCollection(request);
@@ -237,7 +234,7 @@ function DocumentController (kuzzle) {
    */
   this.replace = function documentReplace (request) {
     /** @type KuzzleRequest */
-    var modifiedRequest;
+    let modifiedRequest;
 
     assertHasBody(request);
     assertHasIndexAndCollection(request);

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -12,6 +12,7 @@ module.exports = [
   {verb: 'get', url: '/:index/_list/:type', controller: 'collection', action: 'list'},
 
   {verb: 'get', url: '/:index/:collection/:_id', controller: 'document', action: 'get'},
+  {verb: 'get', url: '/_scroll/:scrollId', controller: 'document', action: 'scroll'},
 
   {verb: 'get', url: '/:index/_exists', controller: 'index', action: 'exists'},
   {verb: 'get', url: '/:index/_autoRefresh', controller: 'index', action: 'getAutoRefresh'},
@@ -119,7 +120,6 @@ module.exports = [
   {verb: 'post', url: '/:index/:collection/:_id/_create', controller: 'document', action: 'create'},
   {verb: 'post', url: '/:index/:collection/_publish', controller: 'realtime', action: 'publish'},
   {verb: 'post', url: '/:index/:collection/_search', controller: 'document', action: 'search'},
-  {verb: 'post', url: '/_scroll/:scrollId', controller: 'document', action: 'scroll'},
   {verb: 'post', url: '/:index/:collection/_mGet', controller: 'document', action: 'mGet'},
   {verb: 'post', url: '/:index/:collection/_mCreate', controller: 'document', action: 'mCreate'},
   {verb: 'post', url: '/:index/:collection/_validate', controller: 'document', action: 'validate'},

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -170,7 +170,11 @@ function ElasticSearch (kuzzle, options, config) {
    * @returns {Promise} resolve documents matching the scroll id
    */
   this.scroll = function elasticsearchScroll (request) {
-    var esRequest = getElasticsearchRequest(request, this.kuzzle);
+    const esRequest = getElasticsearchRequest(request, this.kuzzle);
+
+    if (!esRequest.scroll) {
+      esRequest.scroll = this.kuzzle.config.services.db.defaults.scrollTTL;
+    }
 
     return this.client.scroll(esRequest)
       .then(result => flattenSearchResults(result))

--- a/test/api/controllers/documentController.test.js
+++ b/test/api/controllers/documentController.test.js
@@ -72,7 +72,7 @@ describe('Test: document controller', () => {
 
   describe('#scroll', () => {
     it('should fulfill with an object', () => {
-      request.input.body = {scroll: '1m'};
+      request.input.args.scroll = '1m';
       request.input.args.scrollId = 'SomeScrollIdentifier';
 
       return documentController.scroll(request)
@@ -83,7 +83,7 @@ describe('Test: document controller', () => {
     });
 
     it('should reject an error in case of error', () => {
-      request.input.body = {scroll: '1m'};
+      request.input.args.scroll = '1m';
       request.input.args.scrollId = 'SomeScrollIdentifier';
 
       kuzzle.services.list.storageEngine.scroll.returns(Promise.reject(new Error('foobar')));

--- a/test/api/controllers/documentController.test.js
+++ b/test/api/controllers/documentController.test.js
@@ -72,7 +72,7 @@ describe('Test: document controller', () => {
 
   describe('#scroll', () => {
     it('should fulfill with an object', () => {
-      request.input.args.scroll = '1m';
+      request.input.body = {scroll: '1m'};
       request.input.args.scrollId = 'SomeScrollIdentifier';
 
       return documentController.scroll(request)
@@ -83,7 +83,7 @@ describe('Test: document controller', () => {
     });
 
     it('should reject an error in case of error', () => {
-      request.input.args.scroll = '1m';
+      request.input.body = {scroll: '1m'};
       request.input.args.scrollId = 'SomeScrollIdentifier';
 
       kuzzle.services.list.storageEngine.scroll.returns(Promise.reject(new Error('foobar')));

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -202,14 +202,14 @@ describe('Test: ElasticSearch service', () => {
 
   describe('#scroll', () => {
     it('should be able to scroll an old search', () => {
-      var req = new Request({
+      const req = new Request({
         scrollId: 'banana42'
       });
       elasticsearch.client.scroll.returns(Promise.resolve({total: 0, hits: []}));
 
       return elasticsearch.scroll(req)
         .then(result => {
-          should(elasticsearch.client.scroll.firstCall.args[0]).be.deepEqual({scrollId: 'banana42'});
+          should(elasticsearch.client.scroll.firstCall.args[0]).be.deepEqual({scrollId: 'banana42', scroll: '15s'});
           should(result).be.an.Object();
           should(result.total).be.exactly(0);
           should(result.hits).be.an.Array();


### PR DESCRIPTION
# Description

The `document.scroll` method is now a HTTP GET method, with the following format:

`GET http://<server>:<port>/_scroll/<scrollId>[?scroll=<scroll ttl>]`

The `scroll` parameter is now optional, and is defaulted to a value taken in Kuzzle configuration (path: `services.db.defaults.scrollTTL`)
The default has been set to 15s.

# Boyscout

* Rephrase the functional test case for the scroll API route
* Convert the websocket and HTTP functional tests APIs to ES6
