### PR TITLE
Remove ES 2.x support and enforce use of ES 5+

### DIFF
--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -124,8 +124,11 @@ function ElasticSearch (kuzzle, options, config) {
 
     return Promise.resolve(this.client.info())
       .then(response => {
-        // This information will be usefull alongside the api version in order to allow ES 5.x features
         this.esVersion = response.version;
+
+        if (this.esVersion && compareVersions(this.esVersion.number, '5.0.0') < 0) {
+          return Promise.reject(`Your elasticsearch version is ${this.esVersion.number}; Only elasticsearch version 5.0.0 and above are supported.`);
+        }
 
         return Promise.resolve(self);
       });
@@ -284,9 +287,6 @@ function ElasticSearch (kuzzle, options, config) {
     }
 
     if (esRequest.hasOwnProperty('refresh')) {
-      if (this.esVersion && compareVersions(this.esVersion.number, '5.0.0') < 0) {
-        return Promise.reject(new BadRequestError(`Refresh parameter is not supported by the version "${this.esVersion.number}" of Elasticsearch`));
-      }
       if (compareVersions(config.apiVersion, '5.0') < 0) {
         return Promise.reject(new BadRequestError(`Refresh parameter is not supported by the version "${config.apiVersion}" of Elasticsearch API`));
       }
@@ -359,9 +359,6 @@ function ElasticSearch (kuzzle, options, config) {
     }
 
     if (esRequest.hasOwnProperty('refresh')) {
-      if (this.esVersion && compareVersions(this.esVersion.number, '5.0.0') < 0) {
-        return Promise.reject(new BadRequestError(`Refresh parameter is not supported by the version "${this.esVersion.number}" of Elasticsearch`));
-      }
       if (compareVersions(config.apiVersion, '5.0') < 0) {
         return Promise.reject(new BadRequestError(`Refresh parameter is not supported by the version "${config.apiVersion}" of Elasticsearch API`));
       }
@@ -400,9 +397,6 @@ function ElasticSearch (kuzzle, options, config) {
     }
 
     if (esRequest.hasOwnProperty('refresh')) {
-      if (this.esVersion && compareVersions(this.esVersion.number, '5.0.0') < 0) {
-        return Promise.reject(new BadRequestError(`Refresh parameter is not supported by the version "${this.esVersion.number}" of Elasticsearch`));
-      }
       if (compareVersions(config.apiVersion, '5.0') < 0) {
         return Promise.reject(new BadRequestError(`Refresh parameter is not supported by the version "${config.apiVersion}" of Elasticsearch API`));
       }
@@ -445,9 +439,6 @@ function ElasticSearch (kuzzle, options, config) {
     }
 
     if (esRequest.hasOwnProperty('refresh')) {
-      if (this.esVersion && compareVersions(this.esVersion.number, '5.0.0') < 0) {
-        return Promise.reject(new BadRequestError(`Refresh parameter is not supported by the version "${this.esVersion.number}" of Elasticsearch`));
-      }
       if (compareVersions(config.apiVersion, '5.0') < 0) {
         return Promise.reject(new BadRequestError(`Refresh parameter is not supported by the version "${config.apiVersion}" of Elasticsearch API`));
       }
@@ -488,9 +479,6 @@ function ElasticSearch (kuzzle, options, config) {
     var esRequest = getElasticsearchRequest(request, kuzzle, ['refresh']);
 
     if (esRequest.hasOwnProperty('refresh')) {
-      if (this.esVersion && compareVersions(this.esVersion.number, '5.0.0') < 0) {
-        return Promise.reject(new BadRequestError(`Refresh parameter is not supported by the version "${this.esVersion.number}" of Elasticsearch`));
-      }
       if (compareVersions(config.apiVersion, '5.0') < 0) {
         return Promise.reject(new BadRequestError(`Refresh parameter is not supported by the version "${config.apiVersion}" of Elasticsearch API`));
       }
@@ -625,9 +613,6 @@ function ElasticSearch (kuzzle, options, config) {
       error = null;
 
     if (esRequest.hasOwnProperty('refresh')) {
-      if (this.esVersion && compareVersions(this.esVersion.number, '5.0.0') < 0) {
-        return Promise.reject(new BadRequestError(`Refresh parameter is not supported by the version "${this.esVersion.number}" of Elasticsearch`));
-      }
       if (compareVersions(config.apiVersion, '5.0') < 0) {
         return Promise.reject(new BadRequestError(`Refresh parameter is not supported by the version "${config.apiVersion}" of Elasticsearch API`));
       }

--- a/lib/services/internalEngine/bootstrap.js
+++ b/lib/services/internalEngine/bootstrap.js
@@ -46,7 +46,9 @@ InternalEngineBootstrap.prototype.createRolesCollection = function internalEngin
 
   return this.engine.updateMapping('roles', {
     properties: {
-      controllers: {enabled: false}
+      controllers: {
+        enabled: false
+      }
     }
   })
     .then(() => {
@@ -67,7 +69,9 @@ InternalEngineBootstrap.prototype.createPluginsCollection = function internalEng
 
   return this.engine.updateMapping('plugins', {
     properties: {
-      config: {enabled: false}
+      config: {
+        enabled: false
+      }
     }
   });
 };
@@ -82,8 +86,7 @@ InternalEngineBootstrap.prototype.createProfilesCollection = function internalEn
       policies: {
         properties: {
           roleId: {
-            index: 'not_analyzed',
-            type: 'string'
+            type: 'keyword'
           }
         }
       }
@@ -112,12 +115,11 @@ InternalEngineBootstrap.prototype.createUsersCollection = function internalEngin
   return this.engine.updateMapping('users', {
     properties: {
       profileIds: {
-        index: 'not_analyzed',
-        type: 'string'
+        type: 'keyword'
       },
       password: {
         index: 'no',
-        type: 'string'
+        type: 'keyword'
       }
     }
   })
@@ -136,12 +138,10 @@ InternalEngineBootstrap.prototype.createValidationCollection = function internal
   return this.engine.updateMapping('validations', {
     properties: {
       index: {
-        index: 'not_analyzed',
-        type: 'string'
+        type: 'keyword'
       },
       collection: {
-        index: 'not_analyzed',
-        type: 'string'
+        type: 'keyword'
       },
       validation: {
         enabled: false

--- a/test/services/internalEngine/bootstrap.test.js
+++ b/test/services/internalEngine/bootstrap.test.js
@@ -220,8 +220,7 @@ describe('services/internalEngine/bootstrap.js', () => {
                   policies: {
                     properties: {
                       roleId: {
-                        index: 'not_analyzed',
-                        type: 'string'
+                        type: 'keyword'
                       }
                     }
                   }
@@ -278,12 +277,11 @@ describe('services/internalEngine/bootstrap.js', () => {
               .be.calledWithMatch('users', {
                 properties: {
                   profileIds: {
-                    index: 'not_analyzed',
-                    type: 'string'
+                    type: 'keyword'
                   },
                   password: {
                     index: 'no',
-                    type: 'string'
+                    type: 'keyword'
                   }
                 }
               });


### PR DESCRIPTION
* Remove ES 2.x support
* Enforce use of ES 5+
* Adapt mapping to use `keywords` instead of `not_analyzed` strings

fixes #628
documentation: https://github.com/kuzzleio/documentation/pull/149