### PR TITLE
Fix server:getConfig route

### DIFF
--- a/features/HTTP.feature
+++ b/features/HTTP.feature
@@ -4,6 +4,10 @@ Feature: Test HTTP API
   Scenario: Get server information
     When I get server informations
 
+  @usingHttp
+  Scenario: Get server configuration
+    When I get server configuration
+
   @usingHttp @cleanValidations
   Scenario: Publish a realtime message
     When I publish a message

--- a/features/Websocket.feature
+++ b/features/Websocket.feature
@@ -4,6 +4,10 @@ Feature: Test websocket API
   Scenario: Get server information
     When I get server informations
 
+  @usingWebsocket
+  Scenario: Get server configuration
+    When I get server configuration
+
   @usingWebsocket @cleanValidations
   Scenario: Publish a realtime message
     When I publish a message

--- a/features/step_definitions/serverController.js
+++ b/features/step_definitions/serverController.js
@@ -15,6 +15,23 @@ var apiSteps = function () {
       })
       .catch(error => callback(error));
   });
+
+  this.When(/^I get server configuration$/, function (callback) {
+    this.api.getServerConfig()
+      .then(body => {
+        if (body.error) {
+          return callback(new Error(body.error.message));
+        }
+
+        if (!body.result) {
+          return callback(new Error('No result provided'));
+        }
+
+        this.result = body.result;
+        callback();
+      })
+      .catch(error => callback(error));
+  });
 };
 
 module.exports = apiSteps;

--- a/features/support/apiHttp.js
+++ b/features/support/apiHttp.js
@@ -556,10 +556,16 @@ ApiHttp.prototype.getServerInfo = function () {
     method: 'GET'
   };
 
-  return this.callApi(options)
-    .then(res => {
-      return res;
-    });
+  return this.callApi(options);
+};
+
+ApiHttp.prototype.getServerConfig = function () {
+  const options = {
+    url: this.apiBasePath('_getConfig'),
+    method: 'GET'
+  };
+
+  return this.callApi(options);
 };
 
 ApiHttp.prototype.login = function (strategy, credentials) {

--- a/features/support/apiRT.js
+++ b/features/support/apiRT.js
@@ -548,6 +548,18 @@ ApiRT.prototype.getServerInfo = function () {
   return this.send(msg);
 };
 
+ApiRT.prototype.getServerConfig = function () {
+  const
+    msg = {
+      controller: 'server',
+      action: 'getConfig',
+      body: {}
+    };
+
+  return this.send(msg);
+};
+
+
 ApiRT.prototype.login = function (strategy, credentials) {
   const
     msg = {

--- a/lib/api/controllers/serverController.js
+++ b/lib/api/controllers/serverController.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var
+const
   _ = require('lodash'),
   Promise = require('bluebird'),
   os = require('os');
@@ -44,7 +44,7 @@ function ServerController (kuzzle) {
    * @returns {Promise<Object>}
    */
   this.getConfig = function serverGetConfig () {
-    var pluginsConfig = {};
+    const pluginsConfig = {};
 
     const promises = Object.keys(kuzzle.pluginsManager.plugins).map(id => {
       return kuzzle.internalEngine.get('plugins', id);
@@ -110,7 +110,7 @@ function ServerController (kuzzle) {
       };
 
     Object.keys(kuzzle.funnel.controllers).forEach(controller => {
-      var actionList = {};
+      const actionList = {};
 
       Object.keys(kuzzle.funnel.controllers[controller]).forEach(action => {
         var routeDescription = {};

--- a/lib/api/controllers/serverController.js
+++ b/lib/api/controllers/serverController.js
@@ -44,25 +44,10 @@ function ServerController (kuzzle) {
    * @returns {Promise<Object>}
    */
   this.getConfig = function serverGetConfig () {
-    const pluginsConfig = {};
-
-    const promises = Object.keys(kuzzle.pluginsManager.plugins).map(id => {
-      return kuzzle.internalEngine.get('plugins', id);
+    return Promise.resolve({
+      kuzzle: _.assignIn({}, kuzzle.config),
+      plugins: kuzzle.pluginsManager.getPluginsFeatures()
     });
-
-    return Promise.all(promises)
-      .then(responses => {
-        responses.forEach(entry => {
-          pluginsConfig[entry._id] = entry._source;
-        });
-        return {
-          kuzzle: _.assignIn({}, kuzzle.config),
-          plugins: {
-            config: pluginsConfig,
-            routes: _.assignIn([], kuzzle.pluginsManager.routes)
-          }
-        };
-      });
   };
 
   /**


### PR DESCRIPTION
# Description

The `server:getConfig` route was broken, looking for unexisting plugins configuration in the storage engine.

# Solved issue

#712 
