### PR TITLE
Remove PluginImplementationError from the diagtools whitelist

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -407,8 +407,7 @@
         "RangeError",
         "TypeError",
         "KuzzleError",
-        "InternalError",
-        "PluginImplementationError"
+        "InternalError"
       ]
     }
   }

--- a/default.config.js
+++ b/default.config.js
@@ -199,8 +199,7 @@ module.exports = {
         'RangeError',
         'TypeError',
         'KuzzleError',
-        'InternalError',
-        'PluginImplementationError'
+        'InternalError'
       ]
     }
   }


### PR DESCRIPTION
# Description

Currently, when diagtools are activated (which is the default), Kuzzle creates automatically a dump directory each time a plugin throws an error.

Since we (usually) don't provide support for plugins and since, depending on code quality, these plugins might throw often, creating a dump systematically is 1/ counterproductive and 2/ dangerous as too many coredumps fill up disk space quickly.

# Solved issue

#716 
