### PR TITLE
Allow to define 0 for thread in plugin config

### DIFF
--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -98,7 +98,7 @@ function PluginsManager (kuzzle) {
    * Attach events hooks and pipes given by plugins
    */
   this.run = function pluginRun () {
-    let pluginsWorker = _.pickBy(this.plugins, plugin => plugin.config.threads !== undefined);
+    let pluginsWorker = _.pickBy(this.plugins, plugin => plugin.config.threads);
 
     if (Object.keys(pluginsWorker).length > 0) {
       pm2Promise = pm2Init(this.workers, pluginsWorker, this.kuzzle.config);


### PR DESCRIPTION
In order to override the default config and because `rc` merge configuration with the default configuration, the only way to change a plugin threat into a normal plugin is to set the `threat` entry in config to 0.

Right now, it's just impossible to override this config and run a  plugin thread like a normal plugin.