### PR TITLE
Do not export sensitive configuration

### DIFF
--- a/lib/api/controllers/serverController.js
+++ b/lib/api/controllers/serverController.js
@@ -48,6 +48,10 @@ function ServerController (kuzzle) {
     // Already and more appropriately returned by server:info
     delete config.http;
 
+    // Not a good idea to export Kuzzle's salt, hash algorithm
+    // and default rights
+    delete config.security;
+
     return Promise.resolve(config);
   };
 


### PR DESCRIPTION
# Description

Even if the `server:getConfig` route should be considered usable only by administrators, I think it's a bad idea to export security information across the network, especially since we cannot check if the exported data is encrypted or if it's safe to export it.

This PR removes the `config.security` part of the exported Kuzzle configuration.

Another pull request will be submitted on our documentation system, featuring a warning on this route and updated examples.
