### PR TITLE
Replace MD5 with HighwayHash

### DIFF
--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -1,8 +1,10 @@
-var
+'use strict';
+
+const
   _ = require('lodash'),
   async = require('async'),
   Promise = require('bluebird'),
-  crypto = require('crypto'),
+  highwayhash = require('highwayhash'),
   BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
   NotFoundError = require('kuzzle-common-objects').errors.NotFoundError,
   InternalError = require('kuzzle-common-objects').errors.InternalError,
@@ -61,13 +63,14 @@ function HotelClerk (kuzzle) {
    * if the room has a different name with same filter) or if there is an error during room creation
    */
   this.addSubscription = function hotelClerkAddSubscription (request) {
-    var diff = [];
+    const diff = [];
 
     return createRoom.call(this, request.input.resource.index, request.input.resource.collection, request.input.body)
       .then(response => {
         if (response.diff) {
           diff.push(response.diff);
         }
+
         return subscribeToRoom.call(this, response.roomId, request);
       })
       .then(response => {
@@ -90,7 +93,7 @@ function HotelClerk (kuzzle) {
   this.addToChannels = function hotelClerkAddToChannels (channels, roomId, notification) {
     if (this.rooms[roomId]) {
       Object.keys(this.rooms[roomId].channels).forEach(channel => {
-        var
+        const
           c = this.rooms[roomId].channels[channel],
           stateMatch = c.state === 'all' || !notification.state || notification.action === 'publish' || c.state === notification.state,
           scopeMatch = c.scope === 'all' || !notification.scope || c.scope === notification.scope,
@@ -589,9 +592,9 @@ function removeRoomForAllCustomers (roomId) {
 function subscribeToRoom (roomId, request) {
   return createChannelConfiguration(request)
     .then(channel => {
-      var
-        changed = false,
-        channelName = roomId + '-' + crypto.createHash('md5').update(JSON.stringify(channel)).digest('hex'),
+      let changed = false;
+      const
+        channelName = roomId + '-' + highwayhash.asHexString(this.kuzzle.hashKey, Buffer.from(JSON.stringify(channel))),
         diff = {hcR: {
           i: request.input.resource.index,
           c: request.input.resource.collection,

--- a/lib/api/core/models/security/profile.js
+++ b/lib/api/core/models/security/profile.js
@@ -4,7 +4,7 @@ var
   Policies = require('./policies'),
   Promise = require('bluebird'),
   _ = require('lodash'),
-  md5 = require('crypto-md5'),
+  highwayhash = require('highwayhash'),
   async = require('async');
 
 function Profile () {
@@ -100,7 +100,7 @@ Profile.prototype.getRights = function profileGetRights (kuzzle) {
                     index: restriction.index,
                     collection: collection
                   },
-                  rightsKey = md5(JSON.stringify(rightsItem));
+                  rightsKey = highwayhash.asHexString(kuzzle.hashKey, Buffer.from(JSON.stringify(rightsItem)));
 
                 rightsItem.value = actionRights;
                 rightsObject[rightsKey] = rightsItem;

--- a/lib/api/dsl/index.js
+++ b/lib/api/dsl/index.js
@@ -1,16 +1,23 @@
 'use strict';
 
-var
+const
+  crypto = require('crypto'),
   Transformer = require('./transform'),
   Storage = require('./storage'),
   Matcher = require('./match');
 
 /**
+ * HashKey is optional: kuzzle instances must provide
+ * one, while plugins can instanciate DSL engines
+ * each one with its own hash key.
+ *
  * @constructor
+ * @param {string} [hashKey]
  */
-function RealtimeEngine () {
+function RealtimeEngine (hashKey) {
+  this.hashKey = hashKey || crypto.randomBytes(32);
   this.transformer = new Transformer();
-  this.storage = new Storage();
+  this.storage = new Storage(this.hashKey);
   this.matcher = new Matcher(this.storage);
 
   return this;
@@ -109,7 +116,7 @@ RealtimeEngine.prototype.remove = function remove (filterId) {
  * @returns {object} the flattened object
  */
 function flattenObject(target, id) {
-  var output = {};
+  let output = {};
 
   if (id) {
     output._id = id;

--- a/lib/api/dsl/storage/index.js
+++ b/lib/api/dsl/storage/index.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var
-  crypto = require('crypto'),
+const
   stringify = require('json-stable-stringify'),
   Promise = require('bluebird'),
+  highwayhash = require('highwayhash'),
   NotFoundError = require('kuzzle-common-objects').errors.NotFoundError,
   OperandsStorage = require('./storeOperands'),
   OperandsRemoval = require('./removeOperands'),
@@ -17,10 +17,12 @@ var
 /**
  * Real-time engine filters storage
  * @constructor
+ * @param {string} hashKey
  */
-function Storage () {
+function Storage (hashKey) {
   this.storeOperand = new OperandsStorage();
   this.removeOperand = new OperandsRemoval();
+  this.hashKey = hashKey;
 
   /**
    * Index/Collection => filters link table
@@ -148,7 +150,7 @@ function Storage () {
  * @return {object}
  */
 Storage.prototype.store = function store (index, collection, filters) {
-  let result = addFilter(this.filters, index, collection, filters);
+  let result = addFilter(this.hashKey, this.filters, index, collection, filters);
 
   if (!result.created) {
     return {diff: false, id: result.id};
@@ -158,12 +160,12 @@ Storage.prototype.store = function store (index, collection, filters) {
 
   filters.forEach(sf => {
     let
-      sfResult = addSubfilter(this.filters[result.id], this.subfilters, sf),
+      sfResult = addSubfilter(this.hashKey, this.filters[result.id], this.subfilters, sf),
       addedConditions,
       subfilter = this.subfilters[index][collection][sfResult.id];
 
     if (sfResult.created) {
-      addedConditions = addConditions(subfilter, this.conditions, index, collection, sf);
+      addedConditions = addConditions(this.hashKey, subfilter, this.conditions, index, collection, sf);
 
       addTestTables(this.testTables, subfilter, index, collection);
 
@@ -194,7 +196,7 @@ Storage.prototype.store = function store (index, collection, filters) {
  * @return {Promise<*>}
  */
 Storage.prototype.remove = function remove (filterId) {
-  var
+  let
     index,
     collection;
 
@@ -269,19 +271,20 @@ function addFiltersIndex(fIndexObj, index, collection, id) {
  * Returns a boolean indicating if the insertion was successful,
  * or, if false, indicating that the filter was already registered
  *
+ * @param {string} hashKey
  * @param {object} filtersObj - filters structure
  * @param {string} index
  * @param {string} collection
  * @param {object} filters
  * @return {object} containing a "created" boolean flag and the filter id
  */
-function addFilter(filtersObj, index, collection, filters) {
-  var
-    id = crypto.createHash('md5').update(stringify({
+function addFilter(hashKey, filtersObj, index, collection, filters) {
+  const
+    id = highwayhash.asHexString(hashKey, Buffer.from(stringify({
       index,
       collection,
       filters
-    })).digest('hex'),
+    }))),
     created = !filtersObj[id];
 
   if (created) {
@@ -299,15 +302,15 @@ function addFilter(filtersObj, index, collection, filters) {
  * if the subfilter has been created or updated.
  * If false, nothing changed.
  *
+ * @param {string} hashKey
  * @param {object} filtersObj
  * @param {object} subFiltersObj
  * @param {Array} subfilter
  * @return {object}
  */
-function addSubfilter(filtersObj, subFiltersObj, subfilter) {
-  var
-    sfId = crypto.createHash('md5').update(stringify(subfilter)).digest('hex'),
-    created = true;
+function addSubfilter(hashKey, filtersObj, subFiltersObj, subfilter) {
+  const sfId = highwayhash.asHexString(hashKey, Buffer.from(stringify(subfilter)));
+  let created = true;
 
   addIndexCollectionToObject(subFiltersObj, filtersObj.index, filtersObj.collection);
 
@@ -332,6 +335,7 @@ function addSubfilter(filtersObj, subFiltersObj, subfilter) {
  *
  * Returns the list of created conditions
  *
+ * @param {string} hashKey
  * @param {object} sfObj - link to the corresponding subfilter in the
  *                         subfilters structure
  * @param {object} condObj - conditions object structure
@@ -340,16 +344,16 @@ function addSubfilter(filtersObj, subFiltersObj, subfilter) {
  * @param {Array} subfilter - array of conditions
  * @return {Array}
  */
-function addConditions(sfObj, condObj, index, collection, subfilter) {
-  var diff = [];
+function addConditions(hashKey, sfObj, condObj, index, collection, subfilter) {
+  let diff = [];
 
   addIndexCollectionToObject(condObj, index, collection);
 
   subfilter.forEach(cond => {
-    var
-      cId = crypto.createHash('md5').update(stringify(cond)).digest('hex'),
-      condLink = condObj[index][collection][cId],
-      keyword;
+    const
+      cId = highwayhash.asHexString(hashKey, Buffer.from(stringify(cond))),
+      condLink = condObj[index][collection][cId];
+    let keyword;
 
     if (condLink) {
       if (condLink.subfilters.indexOf(sfObj) === -1) {

--- a/lib/api/dsl/storage/objects/testTable.js
+++ b/lib/api/dsl/storage/objects/testTable.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var SortedArray = require('sorted-array');
+const SortedArray = require('sorted-array');
 
 /**
  * Creates a test table entry. Mutates the provided subfilter object

--- a/lib/api/kuzzle.js
+++ b/lib/api/kuzzle.js
@@ -246,7 +246,7 @@ function getHashKey(cacheEngine) {
   return cacheEngine.setnx('hashKey', JSON.stringify(hashKey))
     .then(value => {
       if (value === 0) {
-        return cacheEngine.get('hashKey').then(value => Buffer.from(JSON.parse(value)));
+        return cacheEngine.get('hashKey').then(key => Buffer.from(JSON.parse(key)));
       }
 
       return hashKey;

--- a/lib/api/kuzzle.js
+++ b/lib/api/kuzzle.js
@@ -241,16 +241,12 @@ function registerErrorHandlers(kuzzle) {
  * @return {Promise<Buffer>}
  */
 function getHashKey(cacheEngine) {
-  let hashKey;
+  let hashKey = crypto.randomBytes(32);
 
-  return cacheEngine.get('hashKey')
+  return cacheEngine.setnx('hashKey', JSON.stringify(hashKey))
     .then(value => {
-      if (value === null) {
-        hashKey = crypto.randomBytes(32);
-        cacheEngine.set('hashKey', JSON.stringify(hashKey));
-      }
-      else {
-        hashKey = Buffer.from(JSON.parse(value));
+      if (value === 0) {
+        return cacheEngine.get('hashKey').then(value => Buffer.from(JSON.parse(value)));
       }
 
       return hashKey;

--- a/lib/api/kuzzle.js
+++ b/lib/api/kuzzle.js
@@ -7,6 +7,7 @@ const
   EventEmitter = require('eventemitter2').EventEmitter2,
   packageInfo = require('../../package.json'),
   path = require('path'),
+  crypto = require('crypto'),
   Dsl = require('./dsl'),
   EntryPoints = require('./core/entryPoints'),
   FunnelController = require('./controllers/funnelController'),
@@ -59,9 +60,6 @@ function Kuzzle () {
 
   // Room subscriptions core components
   this.hotelClerk = new HotelClerk(this);
-
-  /** @type {RealtimeEngine} */
-  this.dsl = new Dsl(this);
 
   // Notifications core component
   /** @type {Notifier} */
@@ -130,9 +128,16 @@ function Kuzzle () {
         this.notifier.init();
         this.statistics.init();
 
-        return Promise.resolve();
+        return getHashKey(this.services.list.internalCache);
       })
-      .then(() => this.repositories.init())
+      .then(hashKey => {
+        this.hashKey = hashKey;
+
+        /** @type {RealtimeEngine} */
+        this.dsl = new Dsl(hashKey);
+
+        return this.repositories.init();
+      })
       .then(() => this.validation.curateSpecification())
       .then(() => {
         this.cliController.init();
@@ -225,6 +230,31 @@ function registerErrorHandlers(kuzzle) {
     request.input.body.suffix = 'signal-sigtrap';
     kuzzle.cliController.actions.dump(request);
   });
+}
+
+/**
+ * Either gets the hash key from the cache service or,
+ * if unavailable, creates a hash key, stores it into
+ * the cache and returns it
+ *
+ * @param {object} cacheEngine
+ * @return {Promise<Buffer>}
+ */
+function getHashKey(cacheEngine) {
+  let hashKey;
+
+  return cacheEngine.get('hashKey')
+    .then(value => {
+      if (value === null) {
+        hashKey = crypto.randomBytes(32);
+        cacheEngine.set('hashKey', JSON.stringify(hashKey));
+      }
+      else {
+        hashKey = Buffer.from(JSON.parse(value));
+      }
+
+      return hashKey;
+    });
 }
 
 module.exports = Kuzzle;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "espresso-logic-minimizer": "^1.0.5",
     "eventemitter2": "^3.0.0",
     "fs-extra": "^1.0.0",
+    "highwayhash": "^2.1.0",
     "ioredis": "^2.5.0",
     "js-combinatorics": "^0.5.2",
     "json-stable-stringify": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "cli-color": "^1.1.0",
     "commander": "2.9.0",
     "compare-versions": "^3.0.0",
-    "crypto-md5": "^1.0.0",
     "debug": "^2.6.0",
     "denque": "^1.1.1",
     "dumpme": "^1.0.0",

--- a/test/api/core/hotelClerk/addSubscription.test.js
+++ b/test/api/core/hotelClerk/addSubscription.test.js
@@ -1,4 +1,6 @@
-var
+'use strict';
+
+const
   should = require('should'),
   Promise = require('bluebird'),
   Request = require('kuzzle-common-objects').Request,
@@ -8,7 +10,7 @@ var
   KuzzleMock = require('../../../mocks/kuzzle.mock');
 
 describe('Test: hotelClerk.addSubscription', () => {
-  var
+  let
     kuzzle,
     roomId,
     channel,
@@ -143,7 +145,7 @@ describe('Test: hotelClerk.addSubscription', () => {
   });
 
   it('should reject an error when a filter is unknown', () => {
-    var
+    let
       pAddSubscription,
       request = new Request({
         controller: 'realtime',

--- a/test/api/core/hotelClerk/addToChannels.test.js
+++ b/test/api/core/hotelClerk/addToChannels.test.js
@@ -1,4 +1,5 @@
-var
+require('reify');
+const
   should = require('should'),
   Request = require('kuzzle-common-objects').Request,
   Dsl = require('../../../../lib/api/dsl'),
@@ -7,7 +8,7 @@ var
   KuzzleMock = require('../../../mocks/kuzzle.mock');
 
 describe('Test: hotelClerk.addToChannels', () => {
-  var
+  let
     kuzzle,
     context = {
       connection: {id: 'connectionid'},
@@ -42,14 +43,14 @@ describe('Test: hotelClerk.addToChannels', () => {
   });
 
   it('should result in an empty array if the room does not exist', () => {
-    var result = [];
+    let result = [];
 
     kuzzle.hotelClerk.addToChannels(result, 'foo', {});
     should(result).be.an.Array().and.be.empty();
   });
 
   it('should push the right channels depending on the response state', done => {
-    var
+    let
       roomId,
       notification,
       channels = {};
@@ -69,7 +70,7 @@ describe('Test: hotelClerk.addToChannels', () => {
         return kuzzle.hotelClerk.addSubscription(new Request(request), context);
       })
       .then(response => {
-        var eligibleChannels = [];
+        let eligibleChannels = [];
 
         channels.pending = response.channel;
         notification.state = 'done';

--- a/test/api/core/hotelClerk/removeRooms.test.js
+++ b/test/api/core/hotelClerk/removeRooms.test.js
@@ -1,4 +1,4 @@
-var
+const
   should = require('should'),
   sinon = require('sinon'),
   sandbox = sinon.sandbox.create(),
@@ -10,7 +10,7 @@ var
   KuzzleMock = require('../../../mocks/kuzzle.mock');
 
 describe('Test: hotelClerk.removeRooms', () => {
-  var
+  let
     kuzzle,
     connectionId = 'connectionid',
     context,
@@ -43,7 +43,7 @@ describe('Test: hotelClerk.removeRooms', () => {
   });
 
   it('should reject an error if there is no subscription on this index', () => {
-    var request = new Request({
+    const request = new Request({
       controller: 'none',
       action: 'removeRooms',
       index: index,
@@ -55,7 +55,7 @@ describe('Test: hotelClerk.removeRooms', () => {
   });
 
   it('should reject an error if there is no subscription on this collection', () => {
-    var
+    const
       subscribeRequest = new Request({
         controller: 'realtime',
         action: 'subscribe',
@@ -78,7 +78,7 @@ describe('Test: hotelClerk.removeRooms', () => {
   });
 
   it('should remove room in global subscription for provided collection', () => {
-    var
+    const
       subscribeRequest = new Request({
         controller: 'realtime',
         action: 'subscribe',
@@ -105,7 +105,7 @@ describe('Test: hotelClerk.removeRooms', () => {
   });
 
   it('should remove room for subscription with filter for provided collection', () => {
-    var
+    const
       subscribeRequest = new Request({
         controller: 'realtime',
         action: 'subscribe',
@@ -132,7 +132,7 @@ describe('Test: hotelClerk.removeRooms', () => {
   });
 
   it('should remove room for global and filter subscription provided collection', () => {
-    var
+    const
       globalSubscribeRequest = new Request({
         controller: 'realtime',
         action: 'subscribe',
@@ -167,7 +167,7 @@ describe('Test: hotelClerk.removeRooms', () => {
   });
 
   it('should remove only room for provided collection', () => {
-    var
+    const
       subscribeCollection1 = new Request({
         controller: 'realtime',
         action: 'subscribe',
@@ -203,7 +203,7 @@ describe('Test: hotelClerk.removeRooms', () => {
   });
 
   it('should reject an error if room is provided but is not an array', () => {
-    var
+    const
       subscribeCollection1 = new Request({
         controller: 'realtime',
         action: 'subscribe',
@@ -226,8 +226,8 @@ describe('Test: hotelClerk.removeRooms', () => {
   });
 
   it('should remove only listed rooms for the collection', () => {
-    var
-      roomId,
+    let roomId;
+    const
       subscribeFilter1 = new Request({
         controller: 'realtime',
         action: 'subscribe',
@@ -264,8 +264,8 @@ describe('Test: hotelClerk.removeRooms', () => {
   });
 
   it('should return a response with partial error if a roomId doesn\'t correspond to the index', () => {
-    var
-      index2RoomName,
+    let index2RoomName;
+    const
       subscribe1 = new Request({
         controller: 'realtime',
         action: 'subscribe',
@@ -303,8 +303,8 @@ describe('Test: hotelClerk.removeRooms', () => {
   });
 
   it('should return a response with partial error if a roomId doesn\'t correspond to the collection', () => {
-    var
-      collection2RoomName,
+    let collection2RoomName;
+    const
       subscribe1 = new Request({
         controller: 'realtime',
         action: 'subscribe',
@@ -342,8 +342,8 @@ describe('Test: hotelClerk.removeRooms', () => {
   });
 
   it('should return a response with partial error if a roomId doesn\'t exist', () => {
-    var
-      badRoomName = 'badRoomId',
+    let badRoomName = 'badRoomId';
+    const
       subscribeRequest = new Request({
         controller: 'realtime',
         action: 'subscribe',

--- a/test/api/core/models/security/profile.test.js
+++ b/test/api/core/models/security/profile.test.js
@@ -1,26 +1,33 @@
-var
+'use strict';
+
+const
   should = require('should'),
   sinon = require('sinon'),
   sandbox = sinon.sandbox.create(),
   Promise = require('bluebird'),
-  Kuzzle = require('../../../../../lib/api/kuzzle'),
+  Kuzzle = require('../../../../mocks/kuzzle.mock'),
   Profile = require('../../../../../lib/api/core/models/security/profile'),
   Role = require('../../../../../lib/api/core/models/security/role'),
   Request = require('kuzzle-common-objects').Request;
 
 describe('Test: security/profileTest', () => {
-  var
+  const
     context = {connectionId: null, userId: null},
     request = new Request({
       index: 'index',
       collection: 'collection',
       controller: 'controller',
       action: 'action'
-    }, context),
+    }, context);
+  let
     kuzzle;
 
   before(() => {
     kuzzle = new Kuzzle();
+
+    // Replace the KuzzleMock stub by an empty function,
+    // as we need to stub this one in the following tests
+    kuzzle.repositories.role.loadRole = () => {};
   });
 
   afterEach(() => {
@@ -28,13 +35,13 @@ describe('Test: security/profileTest', () => {
   });
 
   it('should disallow any action when no role be found', () => {
-    var profile = new Profile();
+    const profile = new Profile();
 
     return should(profile.isActionAllowed(request)).be.fulfilledWith(false);
   });
 
   it('should allow the action if one of the roles allows it', () => {
-    var
+    const
       profile = new Profile(),
       roles = {
         disallowAllRole: new Role(),
@@ -91,7 +98,7 @@ describe('Test: security/profileTest', () => {
   });
 
   it('should retrieve the good rights list', () => {
-    var
+    const
       profile = new Profile(),
       role1 = new Role(),
       role2 = new Role(),
@@ -135,7 +142,7 @@ describe('Test: security/profileTest', () => {
 
     return profile.getRights(kuzzle)
       .then(rights => {
-        var filteredItem;
+        let filteredItem;
 
         should(rights).be.an.Object();
         rights = Object.keys(rights).reduce((array, item) => array.concat(rights[item]), []);
@@ -188,8 +195,6 @@ describe('Test: security/profileTest', () => {
           return item.controller === 'read' && item.action === 'listIndexes';
         });
         should(filteredItem).length(0);
-
       });
   });
-
 });

--- a/test/api/kuzzle.test.js
+++ b/test/api/kuzzle.test.js
@@ -1,4 +1,4 @@
-var
+const
   sinon = require('sinon'),
   Promise = require('bluebird'),
   should = require('should'),
@@ -7,10 +7,10 @@ var
   KuzzleMock = require('../mocks/kuzzle.mock');
 
 describe('/lib/api/kuzzle.js', () => {
-  var kuzzle;
+  let kuzzle;
 
   beforeEach(() => {
-    var mock = new KuzzleMock();
+    let mock = new KuzzleMock();
     kuzzle = new Kuzzle();
 
     [

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const
+  crypto = require('crypto'),
   _ = require('lodash'),
   sinon = require('sinon'),
   Kuzzle = require('../../lib/api/kuzzle'),
@@ -20,6 +21,8 @@ function KuzzleMock () {
     }
   }
 
+  this.hashKey = crypto.randomBytes(32);
+
   // we need a deep copy here
   this.config = _.merge({}, config);
 
@@ -36,6 +39,7 @@ function KuzzleMock () {
   };
 
   this.dsl = {
+    test: sinon.stub().returns([]),
     register: sinon.stub().returns(Promise.resolve()),
     remove: sinon.stub().returns(Promise.resolve())
   };
@@ -223,6 +227,7 @@ function KuzzleMock () {
         run: sinon.stub().returns(Promise.resolve({ids: []}))
       },
       internalCache: {
+        add: sinon.stub().returns(Promise.resolve()),
         expire: sinon.stub().returns(Promise.resolve()),
         flushdb: sinon.stub().returns(Promise.resolve()),
         get: sinon.stub().returns(Promise.resolve(null)),

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -233,6 +233,7 @@ function KuzzleMock () {
         get: sinon.stub().returns(Promise.resolve(null)),
         getInfos: sinon.stub().returns(Promise.resolve()),
         set: sinon.stub().returns(Promise.resolve()),
+        setnx: sinon.stub().returns(Promise.resolve()),
         volatileSet: sinon.stub().returns(Promise.resolve())
       },
       memoryStorage: {


### PR DESCRIPTION
# Description

Replace hash-generated values from MD5 to [HighwayHash](https://github.com/google/highwayhash), which has 2 advantages over MD5:

* protect Kuzzle from hash attacks, where crafted real-time filters might generate the same hashes than existing ones (very unlikely as provided filters are completely rewritten as minimized versions using Espresso)
* more than 10x faster than MD5

As HighwayHash requires a 256 bits key, a new `hashKey` property has been added to the kuzzle main object, and a new process has been added to the start sequence:

* generate a new random hash key, and set it in redis only if one does not already exist
* if redis answers with a "key already exists" return value, return the redis stored hash key
* otherwise, use the newly generated hash key

This allows Kuzzle cluster nodes to share the same hash values for their objects. 
(note: using redlock might be a good idea for this one, to make key sync more robust on a redis cluster)