### PR TITLE
[HOTFIX] Prevent crash from plugins unhandled exceptions

### DIFF
--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -104,11 +104,11 @@ function execute (request, callback) {
         }
         catch (e) {
           kuzzle.pluginsManager.trigger('log:error', new PluginImplementationError(`Uncatched error by a plugin callback: ${e}`));
-          kuzzle.pluginsManager.trigger('log:error', `Previous error: ${err}`);
         }
 
         return;
       }
+
       return Promise.resolve(response);
     })
     .catch(err => {

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -94,12 +94,19 @@ function PluginContext(kuzzle) {
  * @param {function} callback
  */
 function execute (request, callback) {
-  var kuzzle = this;
+  const kuzzle = this;
 
   return kuzzle.funnel.processRequest(request)
     .then(response => {
       if (callback) {
-        callback(null, response);
+        try {
+          callback(null, response);
+        }
+        catch (e) {
+          kuzzle.pluginsManager.trigger('log:error', new PluginImplementationError(`Uncatched error by a plugin callback: ${e}`));
+          kuzzle.pluginsManager.trigger('log:error', `Previous error: ${err}`);
+        }
+
         return;
       }
       return Promise.resolve(response);
@@ -109,7 +116,13 @@ function execute (request, callback) {
       kuzzle.funnel.handleErrorDump(err);
 
       if (callback) {
-        callback(err, request);
+        try {
+          callback(err, request);
+        }
+        catch (e) {
+          kuzzle.pluginsManager.trigger('log:error', new PluginImplementationError(`Uncatched error by a plugin callback: ${e}`));
+          kuzzle.pluginsManager.trigger('log:error', `Previous error: ${err}`);
+        }
         return;
       }
 
@@ -129,8 +142,6 @@ function execute (request, callback) {
  * @returns {Promise<T>}
  */
 function createUser(userRepository, name, profile, userInfo) {
-  var userConstructor = new userRepository.ObjectConstructor();
-
   if (!userInfo) {
     if (profile && typeof profile === 'object') {
       userInfo = profile;
@@ -155,7 +166,7 @@ function createUser(userRepository, name, profile, userInfo) {
     userInfo.profileIds = Array.isArray(profile) ? profile : [profile];
   }
 
-  return userRepository.hydrate(userConstructor, userInfo)
+  return userRepository.hydrate(new userRepository.ObjectConstructor(), userInfo)
     .then(user => userRepository.persist(user, {database: {method: 'create'}}))
     /*
      masking the resolved user object to avoid plugin developers having access

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.0.0-RC9.5",
+  "version": "1.0.0-RC9.6",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {


### PR DESCRIPTION
# Description

When a plugin invokes `pluginContext.execute` with a callback, and if that callback crashes, the exception is not catched, resulting in a Kuzzle crash + restart.

This PR solves this by encapsulating plugin callback calls in `try..catch` statements. If an error occurs, a `PluginImplementationError` is logged and, if appropriate, the API call error too.
