### PR TITLE
Harmonize ms.sort "limit" option

### DIFF
--- a/features/HTTP.feature
+++ b/features/HTTP.feature
@@ -1042,7 +1042,7 @@ Feature: Test HTTP API
     Then The ms result should match the json ["23", "54", "99"]
     When I call the sort method of the memory storage with arguments
       """
-      { "_id": "#prefix#set", "body": { "limit": {"offset": 1, "count": 2}, "direction": "DESC" }}
+      { "_id": "#prefix#set", "body": { "limit": [1, 2], "direction": "DESC" }}
       """
     Then The ms result should match the json ["54", "23"]
     When I call the srandmember method of the memory storage with arguments

--- a/features/Websocket.feature
+++ b/features/Websocket.feature
@@ -1172,7 +1172,7 @@ Feature: Test websocket API
     Then The ms result should match the json ["23", "54", "99"]
     When I call the sort method of the memory storage with arguments
       """
-      { "_id": "#prefix#set", "body": { "limit": {"offset": 1, "count": 2}, "direction": "DESC" }}
+      { "_id": "#prefix#set", "body": { "limit": [1, 2], "direction": "DESC" }}
       """
     Then The ms result should match the json ["54", "23"]
     When I call the srandmember method of the memory storage with arguments

--- a/lib/api/controllers/memoryStorageController.js
+++ b/lib/api/controllers/memoryStorageController.js
@@ -754,11 +754,11 @@ function extractArgumentsFromRequestForSort (request) {
     }
 
     if (request.input.body.limit !== undefined) {
-      kassert.assertBodyAttributeType(request, 'limit', 'object');
-      assertInt(request, 'limit.count', request.input.body.limit.count);
-      assertInt(request, 'limit.offset', request.input.body.limit.offset);
+      kassert.assertBodyAttributeType(request, 'limit', 'array');
+      assertInt(request, 'limit.offset', request.input.body.limit[0]);
+      assertInt(request, 'limit.count', request.input.body.limit[1]);
 
-      args.push('LIMIT', request.input.body.limit.offset, request.input.body.limit.count);
+      args.push('LIMIT', request.input.body.limit[0], request.input.body.limit[1]);
     }
 
     if (request.input.body.get !== undefined) {

--- a/test/api/controllers/memoryStorageController.test.js
+++ b/test/api/controllers/memoryStorageController.test.js
@@ -291,10 +291,7 @@ describe('Test: memoryStorage controller', () => {
             alpha: true,
             direction: 'DESC',
             by: 'pattern',
-            limit: {
-              offset: 10,
-              count: 20
-            },
+            limit: [10, 20],
             get: ['pattern1', 'pattern2'],
             store: 'storeParam'
           }
@@ -310,22 +307,22 @@ describe('Test: memoryStorage controller', () => {
       let req = new Request({
         _id: 'myKey',
         body: {
-          limit: [10, 20]
+          limit: {offset: 10, count: 20}
         }
       });
 
       should(() => extractArgumentsFromRequestForSort(req)).throw(BadRequestError);
 
-      req.input.body.limit = {count: 10};
+      req.input.body.limit = [10];
       should(() => extractArgumentsFromRequestForSort(req)).throw(BadRequestError);
 
-      req.input.body.limit = {offset: 20};
+      req.input.body.limit = [10, 'foo'];
       should(() => extractArgumentsFromRequestForSort(req)).throw(BadRequestError);
 
-      req.input.body.limit = {count: 'foobar', offset: 20};
+      req.input.body.limit = [null, 20];
       should(() => extractArgumentsFromRequestForSort(req)).throw(BadRequestError);
 
-      req.input.body.limit = {count: 10, offset: [20]};
+      req.input.body.limit = [10, [20]];
       should(() => extractArgumentsFromRequestForSort(req)).throw(BadRequestError);
     });
 


### PR DESCRIPTION
# Description

The new memory storage controller features multiple routes using a `limit` option, containing an offset and count values.

All actions take this option as an array `limit: [<offset>, <count>]` (e.g. `zrangebylex`), except the `sort` action, which uses an object (`limit: {offset: <offset>, count: <count>}`)

This difference poses a problem with the Android SDK (and all future strongly typed SDKs), as it prevents reusing the same option system just because of this route.

So this PR harmonizes the limit option for the `sort` action: it now takes an array with an offset and a count values, like any other routes.

This change has no impact on Javascript and PHP SDKs, and a documentation PR will soon be released with this change.