### PR TITLE
Hotfix test that randomly break due to randomness introduced by highwayhash

### DIFF
--- a/test/api/dsl/dslApi.test.js
+++ b/test/api/dsl/dslApi.test.js
@@ -189,7 +189,7 @@ describe('DSL API', () => {
           should(sfs).be.an.Array();
           should(sfs.length).be.eql(1);
           should(sfs[0].filters.length).be.eql(2);
-          should(sfs[0].filters.map(f => f.id).sort()).match(ids.sort());
+          should(sfs[0].filters.map(f => f.id).sort()).match(Array.from(ids).sort());
 
           sf = sfs[0];
           return dsl.remove(subscription.id);


### PR DESCRIPTION
Explanation:

When `highwayhash` is seeded by default by a random seed (generated by `crypto`). As a result generated hashes don't have a predictable order anymore.
At the same time, we use `Array.sort()` in the test which returns a sorted Array, but also mutates the array it is called on.
This resulted in the test failing randomly due to the sort that inverted the 2 subscriptions randomly.