### PR TITLE
Improve Elasticsearch errors handling

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -350,6 +350,9 @@
       "port": 9200,
       "apiVersion": "5.0",
       "defaults": {
+        // Number of retries to attempt on an update conflict
+        // before throwing an error
+        "onUpdateConflictRetries": 0,
         // Time to live of a paginated search
         "scrollTTL": "15s"
       }

--- a/default.config.js
+++ b/default.config.js
@@ -167,6 +167,7 @@ module.exports = {
       port: 9200,
       apiVersion: '5.0',
       defaults: {
+        onUpdateConflictRetries: 0,
         scrollTTL: '15s'
       }
     },

--- a/lib/api/controllers/documentController.js
+++ b/lib/api/controllers/documentController.js
@@ -445,6 +445,10 @@ function doMultipleWriteActions (kuzzle, request, action) {
       modificationRequest.input.args.refresh = request.input.args.refresh;
     }
 
+    if (request.input.args.retryOnConflict) {
+      modificationRequest.input.args.retryOnConflict = request.input.args.retryOnConflict;
+    }
+
     promises.push(new Promise(resolve => {
       kuzzle.funnel.getRequestSlot(modificationRequest, overload => {
         if (overload) {

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -15,6 +15,69 @@ const
   es = require('elasticsearch'),
   compareVersions = require('compare-versions');
 
+const errorMessagesMapping = [
+  {
+    // [illegal_argument_exception] object mapping [titi] can't be changed from nested to non-nested
+    regex: /^\[illegal_argument_exception] object mapping \[(.*?)] can't be changed from nested to non-nested$/,
+    replacement: 'Can not change mapping for field "$1" from nested to another type'
+  },
+  {
+    // [illegal_argument_exception] object mapping [baz] can't be changed from non-nested to nested
+    regex: /^\[illegal_argument_exception] object mapping \[(.*?)] can't be changed from non-nested to nested$/,
+    replacement: 'Can not change mapping for field "$1" from object to another type'
+  },
+  {
+    // [illegal_argument_exception] Can't merge a non object mapping [aeaze] with an object mapping [aeaze]
+    regex: /^\[illegal_argument_exception] Can't merge a non object mapping \[(.*?)] with an object mapping \[(.*?)]$/,
+    replacement: 'Can not change mapping for field "$1" from object to a scalar type'
+  },
+  {
+    // [illegal_argument_exception] [tutu.tutu] is defined as an object in mapping [aze] but this name is already used for a field in other types
+    regex: /^\[illegal_argument_exception] \[(.*?)] is defined as an object in mapping \[(.*?)] but this name is already used for a field in other types$/,
+    replacement: 'Can not set mapping for field "$1" on collection "$2" because the field name is already used in another collection with a different type'
+  },
+  {
+    // [illegal_argument_exception] mapper [source.flags] of different type, current_type [string], merged_type [long]
+    regex: /^\[illegal_argument_exception] mapper \[(.*?)] of different type, current_type \[(.*?)], merged_type \[(.*?)]$/,
+    replacement: 'Can not change type of field "$1" from "$2" to "$3"'
+  },
+  {
+    // [mapper_parsing_exception] Mapping definition for [flags] has unsupported parameters:  [index : not_analyzed]
+    // eslint-disable-next-line no-regex-spaces
+    regex: /^\[mapper_parsing_exception] Mapping definition for \[(.*?)] has unsupported parameters:  \[(.*?)]$/,
+    replacement: 'Parameter "$2" is not supported for field "$1"'
+  },
+  {
+    // [mapper_parsing_exception] No handler for type [booleasn] declared on field [not]
+    regex: /^\[mapper_parsing_exception] No handler for type \[(.*?)] declared on field \[(.*?)]$/,
+    replacement: 'Can not set mapping for field "$2" because type "$1" does not exist'
+  },
+  {
+    // [mapper_parsing_exception] failed to parse [conditions.host.flags]
+    regex: /^\[mapper_parsing_exception] failed to parse \[(.*?)]$/,
+    replacement: 'Failed to validate value of field "$1". Are you trying to insert nested value in a non-nested field ?'
+  },
+  {
+    // [index_not_found_exception] no such index, with { resource.type=index_or_alias resource.id=foso index=foso }
+    regex: /^\[index_not_found_exception] no such index, with { resource\.type=([^\s]+) resource\.id=([^\s]+) (index_uuid=.* )?index=([^\s]+) }$/,
+    replacement: 'Index "$2" does not exist, please create it first'
+  },
+  {
+    // [mapper_parsing_exception] Expected map for property [fields] on field [foo] but got a class java.lang.String
+    regex: /^\[mapper_parsing_exception] Expected map for property \[fields] on field \[(.*?)] but got a class java\.lang\.String$/,
+    replacement: 'Mapping for field "$1" must be an object with a property "type"'
+  },
+  {
+    // [search_context_missing_exception] No search context found for id [154] (and) ...
+    regex: /^\[search_context_missing_exception] No search context found for id(.*)+/,
+    replacement: 'Unable to execute scroll request: scrollId seems to be outdated'
+  },
+  {
+    regex: /^\[version_conflict_engine_exception] \[data]\[(.*?)]: version conflict.*$/,
+    replacement: 'Unable to modify document "$1": cluster sync failed (too many simultaneous changes applied)'
+  }
+];
+
 /**
  * @property {Kuzzle} kuzzle
  * @property {object} settings
@@ -35,69 +98,6 @@ class ElasticSearch extends Service {
     };
     this.client = null;
     this.esVersion = null;
-
-    this.errorMessagesMapping = [
-      {
-        // [illegal_argument_exception] object mapping [titi] can't be changed from nested to non-nested
-        regex: /^\[illegal_argument_exception] object mapping \[(.*?)] can't be changed from nested to non-nested$/,
-        replacement: 'Can not change mapping for field "$1" from nested to another type'
-      },
-      {
-        // [illegal_argument_exception] object mapping [baz] can't be changed from non-nested to nested
-        regex: /^\[illegal_argument_exception] object mapping \[(.*?)] can't be changed from non-nested to nested$/,
-        replacement: 'Can not change mapping for field "$1" from object to another type'
-      },
-      {
-        // [illegal_argument_exception] Can't merge a non object mapping [aeaze] with an object mapping [aeaze]
-        regex: /^\[illegal_argument_exception] Can't merge a non object mapping \[(.*?)] with an object mapping \[(.*?)]$/,
-        replacement: 'Can not change mapping for field "$1" from object to a scalar type'
-      },
-      {
-        // [illegal_argument_exception] [tutu.tutu] is defined as an object in mapping [aze] but this name is already used for a field in other types
-        regex: /^\[illegal_argument_exception] \[(.*?)] is defined as an object in mapping \[(.*?)] but this name is already used for a field in other types$/,
-        replacement: 'Can not set mapping for field "$1" on collection "$2" because the field name is already used in another collection with a different type'
-      },
-      {
-        // [illegal_argument_exception] mapper [source.flags] of different type, current_type [string], merged_type [long]
-        regex: /^\[illegal_argument_exception] mapper \[(.*?)] of different type, current_type \[(.*?)], merged_type \[(.*?)]$/,
-        replacement: 'Can not change type of field "$1" from "$2" to "$3"'
-      },
-      {
-        // [mapper_parsing_exception] Mapping definition for [flags] has unsupported parameters:  [index : not_analyzed]
-        // eslint-disable-next-line no-regex-spaces
-        regex: /^\[mapper_parsing_exception] Mapping definition for \[(.*?)] has unsupported parameters:  \[(.*?)]$/,
-        replacement: 'Parameter "$2" is not supported for field "$1"'
-      },
-      {
-        // [mapper_parsing_exception] No handler for type [booleasn] declared on field [not]
-        regex: /^\[mapper_parsing_exception] No handler for type \[(.*?)] declared on field \[(.*?)]$/,
-        replacement: 'Can not set mapping for field "$2" because type "$1" does not exist'
-      },
-      {
-        // [mapper_parsing_exception] failed to parse [conditions.host.flags]
-        regex: /^\[mapper_parsing_exception] failed to parse \[(.*?)]$/,
-        replacement: 'Failed to validate value of field "$1". Are you trying to insert nested value in a non-nested field ?'
-      },
-      {
-        // [index_not_found_exception] no such index, with { resource.type=index_or_alias resource.id=foso index=foso }
-        regex: /^\[index_not_found_exception] no such index, with { resource\.type=([^\s]+) resource\.id=([^\s]+) (index_uuid=.* )?index=([^\s]+) }$/,
-        replacement: 'Index "$2" does not exist, please create it first'
-      },
-      {
-        // [mapper_parsing_exception] Expected map for property [fields] on field [foo] but got a class java.lang.String
-        regex: /^\[mapper_parsing_exception] Expected map for property \[fields] on field \[(.*?)] but got a class java\.lang\.String$/,
-        replacement: 'Mapping for field "$1" must be an object with a property "type"'
-      },
-      {
-        // [search_context_missing_exception] No search context found for id [154] (and) ...
-        regex: /^\[search_context_missing_exception] No search context found for id(.*)+/,
-        replacement: 'Unable to execute scroll request: scrollId seems to be outdated'
-      },
-      {
-        regex: /^\[version_conflict_engine_exception] \[data]\[(.*?)]: version conflict.*$/,
-        replacement: 'Unable to modify document "$1": cluster sync failed (too many simultaneous changes applied)'
-      }
-    ];
   }
 
   /**
@@ -902,7 +902,7 @@ class ElasticSearch extends Service {
       return new ServiceUnavailableError('Elasticsearch service is not connected');
     }
 
-    messageReplaced = this.errorMessagesMapping.some(mapping => {
+    messageReplaced = errorMessagesMapping.some(mapping => {
       message = message.replace(mapping.regex, mapping.replacement);
       return (message !== error.message);
     });

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -990,9 +990,8 @@ module.exports = ElasticSearch;
  *                            included in the Elasticsearch Request.
  * @return {object} data the data with cleaned attributes
  */
-function getElasticsearchRequest(request, kuzzle, extraParams) {
+function getElasticsearchRequest(request, kuzzle, extraParams = []) {
   const data = {};
-  extraParams = extraParams || [];
 
   if (request.input.resource.index) {
     if (request.input.resource.index === kuzzle.internalEngine.index) {

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -397,6 +397,11 @@ class ElasticSearch extends Service {
       }
     }
 
+    // retryOnConflict configuration
+    if (this.config.defaults.onUpdateConflictRetries > 0) {
+      esRequest.retryOnConflict = this.config.defaults.onUpdateConflictRetries;
+    }
+
     // Add metadata
     esRequest.body._kuzzle_info = {
       active: true,

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -1,14 +1,16 @@
-var
+'use strict';
+
+const
   debug = require('debug')('kuzzle:services:elasticsearch'),
   _ = require('lodash'),
   Promise = require('bluebird'),
-  util = require('util'),
   Service = require('./service'),
   BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
   InternalError = require('kuzzle-common-objects').errors.InternalError,
   ServiceUnavailableError = require('kuzzle-common-objects').errors.ServiceUnavailableError,
   NotFoundError = require('kuzzle-common-objects').errors.NotFoundError,
   KuzzleError = require('kuzzle-common-objects').errors.KuzzleError,
+  ExternalServiceError = require('kuzzle-common-objects').errors.ExternalServiceError,
   Request = require('kuzzle-common-objects').Request,
   es = require('elasticsearch'),
   compareVersions = require('compare-versions');
@@ -22,104 +24,95 @@ var
  * @param {object} config used to start the service
  * @constructor
  */
-function ElasticSearch (kuzzle, options, config) {
-  Object.defineProperties(this, {
-    kuzzle: {
-      value: kuzzle
-    },
-    settings: {
-      writable: true,
-      value: {
-        service: options.service,
-        autoRefresh: options.autoRefresh || {}
-      }
-    },
-    client: {
-      writable: true,
-      value: null
-    },
-    esVersion: {
-      writable: true,
-      value: null
-    }
-  });
+class ElasticSearch extends Service {
+  constructor(kuzzle, options, config) {
+    super();
+    this.kuzzle = kuzzle;
+    this.config = config;
+    this.settings = {
+      service: options.service,
+      autoRefresh: options.autoRefresh || {}
+    };
+    this.client = null;
+    this.esVersion = null;
 
-  this.errorMessagesMapping = [
-    {
-      // [illegal_argument_exception] object mapping [titi] can't be changed from nested to non-nested
-      regex: /^\[illegal_argument_exception] object mapping \[(.*?)] can't be changed from nested to non-nested$/,
-      replacement: 'Can not change mapping for field "$1" from nested to another type'
-    },
-    {
-      // [illegal_argument_exception] object mapping [baz] can't be changed from non-nested to nested
-      regex: /^\[illegal_argument_exception] object mapping \[(.*?)] can't be changed from non-nested to nested$/,
-      replacement: 'Can not change mapping for field "$1" from object to another type'
-    },
-    {
-      // [illegal_argument_exception] Can't merge a non object mapping [aeaze] with an object mapping [aeaze]
-      regex: /^\[illegal_argument_exception] Can't merge a non object mapping \[(.*?)] with an object mapping \[(.*?)]$/,
-      replacement: 'Can not change mapping for field "$1" from object to a scalar type'
-    },
-    {
-      // [illegal_argument_exception] [tutu.tutu] is defined as an object in mapping [aze] but this name is already used for a field in other types
-      regex: /^\[illegal_argument_exception] \[(.*?)] is defined as an object in mapping \[(.*?)] but this name is already used for a field in other types$/,
-      replacement: 'Can not set mapping for field "$1" on collection "$2" because the field name is already used in another collection with a different type'
-    },
-    {
-      // [illegal_argument_exception] mapper [source.flags] of different type, current_type [string], merged_type [long]
-      regex: /^\[illegal_argument_exception] mapper \[(.*?)] of different type, current_type \[(.*?)], merged_type \[(.*?)]$/,
-      replacement: 'Can not change type of field "$1" from "$2" to "$3"'
-    },
-    {
-      // [mapper_parsing_exception] Mapping definition for [flags] has unsupported parameters:  [index : not_analyzed]
-      // eslint-disable-next-line no-regex-spaces
-      regex: /^\[mapper_parsing_exception] Mapping definition for \[(.*?)] has unsupported parameters:  \[(.*?)]$/,
-      replacement: 'Parameter "$2" is not supported for field "$1"'
-    },
-    {
-      // [mapper_parsing_exception] No handler for type [booleasn] declared on field [not]
-      regex: /^\[mapper_parsing_exception] No handler for type \[(.*?)] declared on field \[(.*?)]$/,
-      replacement: 'Can not set mapping for field "$2" because type "$1" does not exist'
-    },
-    {
-      // [mapper_parsing_exception] failed to parse [conditions.host.flags]
-      regex: /^\[mapper_parsing_exception] failed to parse \[(.*?)]$/,
-      replacement: 'Failed to validate value of field "$1". Are you trying to insert nested value in a non-nested field ?'
-    },
-    {
-      // [index_not_found_exception] no such index, with { resource.type=index_or_alias resource.id=foso index=foso }
-      regex: /^\[index_not_found_exception] no such index, with { resource\.type=([^\s]+) resource\.id=([^\s]+) (index_uuid=.* )?index=([^\s]+) }$/,
-      replacement: 'Index "$2" does not exist, please create it first'
-    },
-    {
-      // [mapper_parsing_exception] Expected map for property [fields] on field [foo] but got a class java.lang.String
-      regex: /^\[mapper_parsing_exception] Expected map for property \[fields] on field \[(.*?)] but got a class java\.lang\.String$/,
-      replacement: 'Mapping for field "$1" must be an object with a property "type"'
-    },
-    {
-      // [search_context_missing_exception] No search context found for id [154] (and) ...
-      regex: /^\[search_context_missing_exception] No search context found for id(.*)+/,
-      replacement: 'Unable to execute scroll request: scrollId seems to be outdated'
-    },
-  ];
+    this.errorMessagesMapping = [
+      {
+        // [illegal_argument_exception] object mapping [titi] can't be changed from nested to non-nested
+        regex: /^\[illegal_argument_exception] object mapping \[(.*?)] can't be changed from nested to non-nested$/,
+        replacement: 'Can not change mapping for field "$1" from nested to another type'
+      },
+      {
+        // [illegal_argument_exception] object mapping [baz] can't be changed from non-nested to nested
+        regex: /^\[illegal_argument_exception] object mapping \[(.*?)] can't be changed from non-nested to nested$/,
+        replacement: 'Can not change mapping for field "$1" from object to another type'
+      },
+      {
+        // [illegal_argument_exception] Can't merge a non object mapping [aeaze] with an object mapping [aeaze]
+        regex: /^\[illegal_argument_exception] Can't merge a non object mapping \[(.*?)] with an object mapping \[(.*?)]$/,
+        replacement: 'Can not change mapping for field "$1" from object to a scalar type'
+      },
+      {
+        // [illegal_argument_exception] [tutu.tutu] is defined as an object in mapping [aze] but this name is already used for a field in other types
+        regex: /^\[illegal_argument_exception] \[(.*?)] is defined as an object in mapping \[(.*?)] but this name is already used for a field in other types$/,
+        replacement: 'Can not set mapping for field "$1" on collection "$2" because the field name is already used in another collection with a different type'
+      },
+      {
+        // [illegal_argument_exception] mapper [source.flags] of different type, current_type [string], merged_type [long]
+        regex: /^\[illegal_argument_exception] mapper \[(.*?)] of different type, current_type \[(.*?)], merged_type \[(.*?)]$/,
+        replacement: 'Can not change type of field "$1" from "$2" to "$3"'
+      },
+      {
+        // [mapper_parsing_exception] Mapping definition for [flags] has unsupported parameters:  [index : not_analyzed]
+        // eslint-disable-next-line no-regex-spaces
+        regex: /^\[mapper_parsing_exception] Mapping definition for \[(.*?)] has unsupported parameters:  \[(.*?)]$/,
+        replacement: 'Parameter "$2" is not supported for field "$1"'
+      },
+      {
+        // [mapper_parsing_exception] No handler for type [booleasn] declared on field [not]
+        regex: /^\[mapper_parsing_exception] No handler for type \[(.*?)] declared on field \[(.*?)]$/,
+        replacement: 'Can not set mapping for field "$2" because type "$1" does not exist'
+      },
+      {
+        // [mapper_parsing_exception] failed to parse [conditions.host.flags]
+        regex: /^\[mapper_parsing_exception] failed to parse \[(.*?)]$/,
+        replacement: 'Failed to validate value of field "$1". Are you trying to insert nested value in a non-nested field ?'
+      },
+      {
+        // [index_not_found_exception] no such index, with { resource.type=index_or_alias resource.id=foso index=foso }
+        regex: /^\[index_not_found_exception] no such index, with { resource\.type=([^\s]+) resource\.id=([^\s]+) (index_uuid=.* )?index=([^\s]+) }$/,
+        replacement: 'Index "$2" does not exist, please create it first'
+      },
+      {
+        // [mapper_parsing_exception] Expected map for property [fields] on field [foo] but got a class java.lang.String
+        regex: /^\[mapper_parsing_exception] Expected map for property \[fields] on field \[(.*?)] but got a class java\.lang\.String$/,
+        replacement: 'Mapping for field "$1" must be an object with a property "type"'
+      },
+      {
+        // [search_context_missing_exception] No search context found for id [154] (and) ...
+        regex: /^\[search_context_missing_exception] No search context found for id(.*)+/,
+        replacement: 'Unable to execute scroll request: scrollId seems to be outdated'
+      },
+      {
+        regex: /^\[version_conflict_engine_exception] \[data]\[(.*?)]: version conflict.*$/,
+        replacement: 'Unable to modify document "$1": cluster sync failed (too many simultaneous changes applied)'
+      }
+    ];
+  }
 
   /**
    * Initialize the elasticsearch client
    *
    * @returns {Promise}
    */
-  this.init = function elasticsearchInit () {
-    var
-      self = this,
-      host = config.host + ':' + config.port;
-
+  init() {
     if (this.client) {
       return Promise.resolve(this);
     }
 
     this.client = buildClient({
-      host,
-      apiVersion: config.apiVersion
+      host: this.config.host + ':' + this.config.port,
+      apiVersion: this.config.apiVersion
     });
 
     return Promise.resolve(this.client.info())
@@ -130,19 +123,19 @@ function ElasticSearch (kuzzle, options, config) {
           return Promise.reject(`Your elasticsearch version is ${this.esVersion.number}; Only elasticsearch version 5.0.0 and above are supported.`);
         }
 
-        return Promise.resolve(self);
+        return Promise.resolve(this);
       });
-  };
+  }
 
   /**
    * Return some basic information about this service
    *
    * @returns {Promise} service informations
    */
-  this.getInfos = function elasticsearchGetInfos () {
-    var response = {
+  getInfos() {
+    const response = {
       type: 'elasticsearch',
-      api: config.apiVersion
+      api: this.config.apiVersion
     };
 
     return this.client.info()
@@ -165,15 +158,14 @@ function ElasticSearch (kuzzle, options, config) {
         return response;
       })
       .catch(error => Promise.reject(this.formatESError(error)));
-  };
-
+  }
 
   /**
    * Scroll results from previous elasticsearch query
    * @param {Request} request
    * @returns {Promise} resolve documents matching the scroll id
    */
-  this.scroll = function elasticsearchScroll (request) {
+  scroll(request) {
     const esRequest = getElasticsearchRequest(request, this.kuzzle, ['scroll', 'scrollId']);
 
     if (!esRequest.scroll) {
@@ -183,14 +175,14 @@ function ElasticSearch (kuzzle, options, config) {
     return this.client.scroll(esRequest)
       .then(result => flattenSearchResults(result))
       .catch(error => Promise.reject(this.formatESError(error)));
-  };
+  }
 
   /**
    * Search documents from elasticsearch with a query
    * @param {Request} request
    * @returns {Promise} resolve documents matching the filter
    */
-  this.search = function elasticsearchSearch (request) {
+  search(request) {
     const esRequest = getElasticsearchRequest(request, this.kuzzle, ['from', 'size', 'scroll']);
 
     // todo add condition once the 'trash' feature has been implemented
@@ -199,15 +191,15 @@ function ElasticSearch (kuzzle, options, config) {
     return this.client.search(esRequest)
       .then(result => flattenSearchResults(result))
       .catch(error => Promise.reject(this.formatESError(error)));
-  };
+  }
 
   /**
    * Get the document with given ID
    * @param {Request} request
    * @returns {Promise} resolve the document
    */
-  this.get = function elasticsearchGet (request) {
-    var esRequest = getElasticsearchRequest(request, this.kuzzle);
+  get(request) {
+    const esRequest = getElasticsearchRequest(request, this.kuzzle);
 
     delete esRequest.body;
 
@@ -233,7 +225,7 @@ function ElasticSearch (kuzzle, options, config) {
         return result;
       })
       .catch(error => Promise.reject(this.formatESError(error)));
-  };
+  }
 
   /**
    * Return the list of documents matching the ids given in the body param
@@ -242,8 +234,8 @@ function ElasticSearch (kuzzle, options, config) {
    * @param {Request} request
    * @returns {Promise}
    */
-  this.mget = function elasticsearchMget (request) {
-    var esRequest = getElasticsearchRequest(request, this.kuzzle);
+  mget(request) {
+    const esRequest = getElasticsearchRequest(request, this.kuzzle);
 
     return this.client.mget(esRequest)
       .then(result => {
@@ -256,21 +248,21 @@ function ElasticSearch (kuzzle, options, config) {
         return result;
       })
       .catch(error => Promise.reject(this.formatESError(error)));
-  };
+  }
 
   /**
    * Count how many documents match the filter given in body
    * @param {Request} request
    * @returns {Promise} resolve the number of document
    */
-  this.count = function elasticsearchCount (request) {
-    var esRequest = getElasticsearchRequest(request, kuzzle);
+  count(request) {
+    const esRequest = getElasticsearchRequest(request, this.kuzzle);
 
     // todo add condition once the 'trash' feature has been implemented
     addActiveFilter(esRequest);
     return this.client.count(esRequest)
       .catch(error => Promise.reject(this.formatESError(error)));
-  };
+  }
 
   /**
    * Send to elasticsearch the new document
@@ -279,16 +271,16 @@ function ElasticSearch (kuzzle, options, config) {
    * @param {Request} request
    * @returns {Promise} resolve an object that contains _id
    */
-  this.create = function elasticsearchCreate (request) {
-    var esRequest = getElasticsearchRequest(request, kuzzle, ['refresh']);
+  create(request) {
+    const esRequest = getElasticsearchRequest(request, this.kuzzle, ['refresh']);
 
     if (esRequest.body._routing) {
       return Promise.reject(new BadRequestError('Kuzzle does not support "_routing" in create action.'));
     }
 
     if (esRequest.hasOwnProperty('refresh')) {
-      if (compareVersions(config.apiVersion, '5.0') < 0) {
-        return Promise.reject(new BadRequestError(`Refresh parameter is not supported by the version "${config.apiVersion}" of Elasticsearch API`));
+      if (compareVersions(this.config.apiVersion, '5.0') < 0) {
+        return Promise.reject(new BadRequestError(`Refresh parameter is not supported by the version "${this.config.apiVersion}" of Elasticsearch API`));
       }
       if (esRequest.refresh !== 'wait_for' && esRequest.refresh !== 'false' && esRequest.refresh !== false) {
         return Promise.reject(new BadRequestError('Refresh parameter only supports the value "wait_for" or false'));
@@ -316,7 +308,7 @@ function ElasticSearch (kuzzle, options, config) {
                 res.result = 'created';
                 res.created = true;
 
-                return refreshIndexIfNeeded.call(this, esRequest, _.extend(res, {_source: request.input.body}));
+                return this.refreshIndexIfNeeded(esRequest, _.extend(res, {_source: request.input.body}));
               })
               .catch(error => {
                 return Promise.reject(this.formatESError(error));
@@ -331,7 +323,7 @@ function ElasticSearch (kuzzle, options, config) {
           if (err.displayName === 'NotFound') {
             // The document doesn't exist, we create it
             return this.client.create(esRequest)
-              .then(result => refreshIndexIfNeeded.call(this, esRequest, _.extend(result, {_source: request.input.body})))
+              .then(result => this.refreshIndexIfNeeded(esRequest, _.extend(result, {_source: request.input.body})))
               .catch(error => Promise.reject(this.formatESError(error)));
           }
 
@@ -341,9 +333,9 @@ function ElasticSearch (kuzzle, options, config) {
     }
 
     return this.client.index(esRequest)
-      .then(result => refreshIndexIfNeeded.call(this, esRequest, _.extend(result, {_source: request.input.body})))
+      .then(result => this.refreshIndexIfNeeded(esRequest, _.extend(result, {_source: request.input.body})))
       .catch(error => Promise.reject(this.formatESError(error)));
-  };
+  }
 
   /**
    * Create a new document to ElasticSearch, or replace it if it already exist
@@ -351,16 +343,16 @@ function ElasticSearch (kuzzle, options, config) {
    * @param {Request} request
    * @returns {Promise} resolve an object that contains _id
    */
-  this.createOrReplace = function elasticsearchCreateOrReplace (request) {
-    var esRequest = getElasticsearchRequest(request, kuzzle, ['refresh']);
+  createOrReplace(request) {
+    const esRequest = getElasticsearchRequest(request, this.kuzzle, ['refresh']);
 
     if (esRequest.body._routing) {
       return Promise.reject(new BadRequestError('Kuzzle does not support "_routing" in createOrReplace action.'));
     }
 
     if (esRequest.hasOwnProperty('refresh')) {
-      if (compareVersions(config.apiVersion, '5.0') < 0) {
-        return Promise.reject(new BadRequestError(`Refresh parameter is not supported by the version "${config.apiVersion}" of Elasticsearch API`));
+      if (compareVersions(this.config.apiVersion, '5.0') < 0) {
+        return Promise.reject(new BadRequestError(`Refresh parameter is not supported by the version "${this.config.apiVersion}" of Elasticsearch API`));
       }
       if (esRequest.refresh !== 'wait_for' && esRequest.refresh !== 'false' && esRequest.refresh !== false) {
         return Promise.reject(new BadRequestError('Refresh parameter only supports the value "wait_for" or false'));
@@ -378,9 +370,9 @@ function ElasticSearch (kuzzle, options, config) {
     };
 
     return this.client.index(esRequest)
-      .then(result => refreshIndexIfNeeded.call(this, esRequest, _.extend(result, {_source: request.input.body})))
+      .then(result => this.refreshIndexIfNeeded(esRequest, _.extend(result, {_source: request.input.body})))
       .catch(error => Promise.reject(this.formatESError(error)));
-  };
+  }
 
   /**
    * Send to elasticsearch the partial document
@@ -389,16 +381,16 @@ function ElasticSearch (kuzzle, options, config) {
    * @param {Request} request
    * @returns {Promise} resolve an object that contains _id
    */
-  this.update = function elasticsearchUpdate (request) {
-    var esRequest = getElasticsearchRequest(request, kuzzle, ['refresh']);
+  update(request) {
+    const esRequest = getElasticsearchRequest(request, this.kuzzle, ['refresh']);
 
     if (esRequest.body._routing) {
       return Promise.reject(new BadRequestError('Kuzzle does not support "_routing" in update action.'));
     }
 
     if (esRequest.hasOwnProperty('refresh')) {
-      if (compareVersions(config.apiVersion, '5.0') < 0) {
-        return Promise.reject(new BadRequestError(`Refresh parameter is not supported by the version "${config.apiVersion}" of Elasticsearch API`));
+      if (compareVersions(this.config.apiVersion, '5.0') < 0) {
+        return Promise.reject(new BadRequestError(`Refresh parameter is not supported by the version "${this.config.apiVersion}" of Elasticsearch API`));
       }
       if (esRequest.refresh !== 'wait_for' && esRequest.refresh !== 'false' && esRequest.refresh !== false) {
         return Promise.reject(new BadRequestError('Refresh parameter only supports the value "wait_for" or false'));
@@ -415,9 +407,9 @@ function ElasticSearch (kuzzle, options, config) {
     esRequest.body = {doc: esRequest.body};
 
     return this.client.update(esRequest)
-      .then(result => refreshIndexIfNeeded.call(this, esRequest, result))
+      .then(result => this.refreshIndexIfNeeded(esRequest, result))
       .catch(error => Promise.reject(this.formatESError(error)));
-  };
+  }
 
   /**
    * Replace a document to ElasticSearch
@@ -425,9 +417,9 @@ function ElasticSearch (kuzzle, options, config) {
    * @param {Request} request
    * @returns {Promise} resolve an object that contains _id
    */
-  this.replace = function elasticsearchReplace (request) {
-    var
-      esRequest = getElasticsearchRequest(request, kuzzle, ['refresh']),
+  replace(request) {
+    const
+      esRequest = getElasticsearchRequest(request, this.kuzzle, ['refresh']),
       existQuery = {
         index: esRequest.index,
         type: esRequest.type,
@@ -439,8 +431,8 @@ function ElasticSearch (kuzzle, options, config) {
     }
 
     if (esRequest.hasOwnProperty('refresh')) {
-      if (compareVersions(config.apiVersion, '5.0') < 0) {
-        return Promise.reject(new BadRequestError(`Refresh parameter is not supported by the version "${config.apiVersion}" of Elasticsearch API`));
+      if (compareVersions(this.config.apiVersion, '5.0') < 0) {
+        return Promise.reject(new BadRequestError(`Refresh parameter is not supported by the version "${this.config.apiVersion}" of Elasticsearch API`));
       }
       if (esRequest.refresh !== 'wait_for' && esRequest.refresh !== 'false' && esRequest.refresh !== false) {
         return Promise.reject(new BadRequestError('Refresh parameter only supports the value "wait_for" or false'));
@@ -466,8 +458,8 @@ function ElasticSearch (kuzzle, options, config) {
 
         return Promise.reject(new NotFoundError('Document with id ' + esRequest.id + ' not found.'));
       })
-      .then(result => refreshIndexIfNeeded.call(this, esRequest, _.extend(result, {_source: request.input.body})));
-  };
+      .then(result => this.refreshIndexIfNeeded(esRequest, _.extend(result, {_source: request.input.body})));
+  }
 
   /**
    * Send to elasticsearch the document id to delete
@@ -475,12 +467,12 @@ function ElasticSearch (kuzzle, options, config) {
    * @param {Request} request
    * @returns {Promise} resolve an object that contains _id
    */
-  this.delete = function elasticsearchDelete (request) {
-    var esRequest = getElasticsearchRequest(request, kuzzle, ['refresh']);
+  delete(request) {
+    const esRequest = getElasticsearchRequest(request, this.kuzzle, ['refresh']);
 
     if (esRequest.hasOwnProperty('refresh')) {
-      if (compareVersions(config.apiVersion, '5.0') < 0) {
-        return Promise.reject(new BadRequestError(`Refresh parameter is not supported by the version "${config.apiVersion}" of Elasticsearch API`));
+      if (compareVersions(this.config.apiVersion, '5.0') < 0) {
+        return Promise.reject(new BadRequestError(`Refresh parameter is not supported by the version "${this.config.apiVersion}" of Elasticsearch API`));
       }
       if (esRequest.refresh !== 'wait_for' && esRequest.refresh !== 'false' && esRequest.refresh !== false) {
         return Promise.reject(new BadRequestError('Refresh parameter only supports the value "wait_for" or false'));
@@ -489,9 +481,9 @@ function ElasticSearch (kuzzle, options, config) {
 
     // todo do not delete the document but pass active to false
     return this.client.delete(esRequest)
-      .then(result => refreshIndexIfNeeded.call(this, esRequest, result))
+      .then(result => this.refreshIndexIfNeeded(esRequest, result))
       .catch(error => Promise.reject(this.formatESError(error)));
-  };
+  }
 
   /**
    * Delete all document that match the given filter
@@ -499,10 +491,10 @@ function ElasticSearch (kuzzle, options, config) {
    * @param {Request} request
    * @returns {Promise} resolve an object with ids
    */
-  this.deleteByQuery = function elasticsearchDeleteByQuery (request) {
-    var
-      esRequestSearch = getElasticsearchRequest(request, kuzzle, ['from', 'size', 'scroll']),
-      esRequestBulk = getElasticsearchRequest(request, kuzzle, ['refresh']);
+  deleteByQuery(request) {
+    const
+      esRequestSearch = getElasticsearchRequest(request, this.kuzzle, ['from', 'size', 'scroll']),
+      esRequestBulk = getElasticsearchRequest(request, this.kuzzle, ['refresh']);
 
     if (!esRequestSearch.body.query || !(esRequestSearch.body.query instanceof Object)) {
       return Promise.reject(new BadRequestError('Query cannot be empty'));
@@ -511,7 +503,7 @@ function ElasticSearch (kuzzle, options, config) {
     esRequestBulk.body = [];
     esRequestSearch.scroll = '30s';
 
-    return getAllIdsFromQuery.call(this, esRequestSearch)
+    return getAllIdsFromQuery(this.client, esRequestSearch)
       .then(ids => {
         ids.forEach(id => {
           esRequestBulk.body.push({update: {_index: esRequestBulk.index, _type: esRequestBulk.type, _id: id}});
@@ -523,19 +515,19 @@ function ElasticSearch (kuzzle, options, config) {
         }
 
         return this.client.bulk(esRequestBulk)
-          .then(() => refreshIndexIfNeeded.call(this, esRequestBulk, {ids: ids}))
+          .then(() => this.refreshIndexIfNeeded(esRequestBulk, {ids: ids}))
           .catch(error => Promise.reject(this.formatESError(error)));
       });
-  };
+  }
 
   /**
    * Delete all document that match the given filter from the trash
    * @param requestObject
    */
-  this.deleteByQueryFromTrash = function elasticsearchDeleteByQueryFromTrash (requestObject) {
-    var
-      esRequestSearch = getElasticsearchRequest(requestObject, kuzzle, ['from', 'size', 'scroll']),
-      esRequestBulk = getElasticsearchRequest(requestObject, kuzzle, ['refresh']);
+  deleteByQueryFromTrash(requestObject) {
+    const
+      esRequestSearch = getElasticsearchRequest(requestObject, this.kuzzle, ['from', 'size', 'scroll']),
+      esRequestBulk = getElasticsearchRequest(requestObject, this.kuzzle, ['refresh']);
 
     if (esRequestSearch.body.query === null) {
       return Promise.reject(new BadRequestError('null is not a valid document ID'));
@@ -544,7 +536,7 @@ function ElasticSearch (kuzzle, options, config) {
     esRequestBulk.body = [];
     esRequestSearch.scroll = '30s';
 
-    return getPaginatedIdsFromQuery.call(this, esRequestSearch)
+    return getPaginatedIdsFromQuery(this.client, esRequestSearch)
       .then(ids => {
         return new Promise((resolve, reject) => {
           ids.forEach(id => {
@@ -555,11 +547,11 @@ function ElasticSearch (kuzzle, options, config) {
             return resolve({ids: []});
           }
           return this.client.bulk(esRequestBulk)
-            .then(() => refreshIndexIfNeeded.call(this, esRequestBulk, {ids: ids}))
+            .then(() => this.refreshIndexIfNeeded(esRequestBulk, {ids: ids}))
             .catch(error => reject(this.formatESError(error)));
         });
       });
-  };
+  }
 
   /**
    * Create an empty collection with no mapping
@@ -567,15 +559,15 @@ function ElasticSearch (kuzzle, options, config) {
    * @param {Request} request
    * @returns {Promise}
    */
-  this.createCollection = function elasticsearchCreateCollection (request) {
-    var esRequest = getElasticsearchRequest(request, kuzzle);
+  createCollection(request) {
+    const esRequest = getElasticsearchRequest(request, this.kuzzle);
 
     esRequest.body = {};
     esRequest.body[esRequest.type] = {};
 
     return this.client.indices.putMapping(esRequest)
       .catch(error => Promise.reject(this.formatESError(error)));
-  };
+  }
 
   /**
    * Empty the content of a collection. Keep the existing mapping.
@@ -583,8 +575,8 @@ function ElasticSearch (kuzzle, options, config) {
    * @param {Request} request
    * @returns {Promise}
    */
-  this.truncateCollection = function elasticsearchTruncateCollection (request) {
-    var
+  truncateCollection(request) {
+    const
       deleteRequest = new Request({
         index: request.input.resource.index,
         collection: request.input.resource.collection,
@@ -597,7 +589,7 @@ function ElasticSearch (kuzzle, options, config) {
 
     return this.deleteByQuery(deleteRequest)
       .catch(error => Promise.reject(this.formatESError(error)));
-  };
+  }
 
   /**
    * Run several action and document
@@ -605,45 +597,44 @@ function ElasticSearch (kuzzle, options, config) {
    * @param {Request} request
    * @returns {Promise}
    */
-  this.import = function elasticsearchImport (request) {
-    var
+  import(request) {
+    const
       nameActions = ['index', 'create', 'update', 'delete'],
-      esRequest = getElasticsearchRequest(request, kuzzle, ['consistency', 'refresh', 'timeout', 'fields']),
-      bulkRequest,
-      error = null;
+      esRequest = getElasticsearchRequest(request, this.kuzzle, ['consistency', 'refresh', 'timeout', 'fields']);
+    let error = null;
 
     if (esRequest.hasOwnProperty('refresh')) {
-      if (compareVersions(config.apiVersion, '5.0') < 0) {
-        return Promise.reject(new BadRequestError(`Refresh parameter is not supported by the version "${config.apiVersion}" of Elasticsearch API`));
+      if (compareVersions(this.config.apiVersion, '5.0') < 0) {
+        return Promise.reject(new BadRequestError(`Refresh parameter is not supported by the version "${this.config.apiVersion}" of Elasticsearch API`));
       }
       if (esRequest.refresh !== 'wait_for' && esRequest.refresh !== 'false' && esRequest.refresh !== false) {
         return Promise.reject(new BadRequestError('Refresh parameter only supports the value "wait_for" or false'));
       }
     }
 
-    if (!(esRequest.body.bulkData instanceof Object)) {
+    if (!esRequest.body || !(esRequest.body.bulkData instanceof Object)) {
       return Promise.reject(new BadRequestError('import must specify a body attribute "bulkData" of type Object.'));
     }
 
-    bulkRequest = {
+    let bulkRequest = {
       body: esRequest.body.bulkData
     };
 
     Object.keys(esRequest)
-      .filter(key => {
-        return key !== 'body';
-      })
+      .filter(key => key !== 'body')
       .forEach(key => {
         bulkRequest[key] = esRequest[key];
       });
 
     // set missing index & type if possible
     bulkRequest.body.forEach(item => {
-      var action = Object.keys(item)[0];
+      const action = Object.keys(item)[0];
+
       if (nameActions.indexOf(action) !== -1) {
         if (!item[action]._type && esRequest.type) {
           item[action]._type = esRequest.type;
         }
+
         if (!item[action]._type) {
           error = new BadRequestError('Missing data collection argument');
         }
@@ -657,8 +648,8 @@ function ElasticSearch (kuzzle, options, config) {
           return false;
         }
 
-        if (item[action]._index === kuzzle.internalEngine.index) {
-          error = new BadRequestError(`Index "${kuzzle.internalEngine.index}" is protected, please use appropriated routes instead`);
+        if (item[action]._index === this.kuzzle.internalEngine.index) {
+          error = new BadRequestError(`Index "${this.kuzzle.internalEngine.index}" is protected, please use appropriated routes instead`);
           return false;
         }
       }
@@ -669,7 +660,7 @@ function ElasticSearch (kuzzle, options, config) {
     }
 
     return this.client.bulk(bulkRequest)
-      .then(response => refreshIndexIfNeeded.call(this, esRequest, response))
+      .then(response => this.refreshIndexIfNeeded(esRequest, response))
       .then(result => {
         // If some errors occured during the Bulk, we send a "Partial Error" response :
         if (result.errors) {
@@ -677,7 +668,8 @@ function ElasticSearch (kuzzle, options, config) {
 
           Object.keys(result.items).forEach(resultItem => {
             Object.keys(result.items[resultItem]).forEach(action => {
-              var item = result.items[resultItem][action];
+              const item = result.items[resultItem][action];
+
               if (item.error) {
                 item.action = action;
                 result.partialErrors.push(item);
@@ -689,7 +681,7 @@ function ElasticSearch (kuzzle, options, config) {
         return result;
       })
       .catch(err => Promise.reject(this.formatESError(err)));
-  };
+  }
 
   /**
    * Add a mapping definition to a specific type
@@ -697,12 +689,12 @@ function ElasticSearch (kuzzle, options, config) {
    * @param {Request} request
    * @return {Promise}
    */
-  this.updateMapping = function elasticsearchUpdateMapping (request) {
-    var esEequest = getElasticsearchRequest(request, kuzzle);
+  updateMapping(request) {
+    const esEequest = getElasticsearchRequest(request, this.kuzzle);
 
     return this.client.indices.putMapping(esEequest)
       .catch(error => Promise.reject(this.formatESError(error)));
-  };
+  }
 
   /**
    * Retrieve mapping definition for index/type
@@ -710,8 +702,8 @@ function ElasticSearch (kuzzle, options, config) {
    * @param {Request} request
    * @return {Promise}
    */
-  this.getMapping = function elasticsearchGetMapping (request) {
-    var esRequest = getElasticsearchRequest(request, kuzzle);
+  getMapping(request) {
+    const esRequest = getElasticsearchRequest(request, this.kuzzle);
 
     delete esRequest.body;
 
@@ -728,7 +720,7 @@ function ElasticSearch (kuzzle, options, config) {
         return Promise.reject(new NotFoundError('No mapping for index "' + request.input.resource.index + '"'));
       })
       .catch(error => Promise.reject(this.formatESError(error)));
-  };
+  }
 
   /**
    * Retrieve the complete list of existing data collections in the current index
@@ -736,14 +728,14 @@ function ElasticSearch (kuzzle, options, config) {
    * @param {Request} request
    * @return {Promise}
    */
-  this.listCollections = function elasticsearchListCollections (request) {
-    var esRequest = getElasticsearchRequest(request, kuzzle);
+  listCollections(request) {
+    const esRequest = getElasticsearchRequest(request, this.kuzzle);
 
     delete esRequest.body;
 
     return this.client.indices.getMapping(esRequest)
       .then(result => {
-        var collections = [];
+        let collections = [];
 
         if (result[request.input.resource.index]) {
           collections = Object.keys(result[request.input.resource.index].mappings);
@@ -752,7 +744,7 @@ function ElasticSearch (kuzzle, options, config) {
         return {collections: {stored: collections}};
       })
       .catch(error => Promise.reject(this.formatESError(error)));
-  };
+  }
 
   /**
    * Reset all indexes that the users is allowed to delete
@@ -760,8 +752,8 @@ function ElasticSearch (kuzzle, options, config) {
    * @param {Request} request
    * @return {Promise}
    */
-  this.deleteIndexes = function elasticsearchDeleteIndexes (request) {
-    var deletedIndexes = request.input.body.indexes;
+  deleteIndexes(request) {
+    const deletedIndexes = request.input.body.indexes;
 
     request.input.body = null;
 
@@ -772,29 +764,23 @@ function ElasticSearch (kuzzle, options, config) {
     return this.client.indices.delete({index: deletedIndexes})
       .then(() => ({deleted: deletedIndexes}))
       .catch(error => Promise.reject(this.formatESError(error)));
-  };
+  }
 
   /**
    * List all known indexes
    *
    * @returns {Promise}
    */
-  this.listIndexes = function elasticsearchListIndexes () {
-    var indexes = [];
-
+  listIndexes() {
     return this.client.indices.getMapping()
       .then(result => {
-        indexes = Object.keys(result);
-        indexes = indexes.filter(indexName => {
-          // @todo : manage internal index properly
-          // exclude empty results
-          return indexName !== '';
-        });
+        let indexes = Object.keys(result)
+          .filter(indexName => indexName !== ''); // @todo : manage internal index properly
 
         return {indexes};
       })
       .catch(error => Promise.reject(this.formatESError(error)));
-  };
+  }
 
   /**
    * Create a new index
@@ -802,12 +788,12 @@ function ElasticSearch (kuzzle, options, config) {
    * @param {Request} request
    * @returns {Promise}
    */
-  this.createIndex = function elasticsearchCreateIndex (request) {
-    var esRequest = getElasticsearchRequest(request, kuzzle);
+  createIndex(request) {
+    const esRequest = getElasticsearchRequest(request, this.kuzzle);
 
     return this.client.indices.create({index: esRequest.index})
       .catch(error => Promise.reject(this.formatESError(error)));
-  };
+  }
 
   /**
    * Delete an index
@@ -815,13 +801,13 @@ function ElasticSearch (kuzzle, options, config) {
    * @param {Request} request
    * @returns {Promise}
    */
-  this.deleteIndex = function elasticsearchDeleteIndex (request) {
-    var esRequest = getElasticsearchRequest(request, kuzzle);
+  deleteIndex(request) {
+    const esRequest = getElasticsearchRequest(request, this.kuzzle);
 
     delete this.settings.autoRefresh[esRequest.index];
     return this.client.indices.delete({index: esRequest.index})
       .catch(error => Promise.reject(this.formatESError(error)));
-  };
+  }
 
   /**
    * Forces a refresh on the index.
@@ -832,34 +818,34 @@ function ElasticSearch (kuzzle, options, config) {
    * @param {Request} request
    * @returns {Promise}
    */
-  this.refreshIndex = function elasticsearchRefreshIndex (request) {
-    var esRequest = getElasticsearchRequest(request, kuzzle);
+  refreshIndex(request) {
+    const esRequest = getElasticsearchRequest(request, this.kuzzle);
 
     return this.client.indices.refresh({index: esRequest.index})
       .catch(error => Promise.reject(this.formatESError(error)));
-  };
+  }
 
   /**
    * @param {Request} request
    * @returns {Promise}
    */
-  this.indexExists = function esIndexExists (request) {
-    var esRequest = getElasticsearchRequest(request, kuzzle);
+  indexExists(request) {
+    const esRequest = getElasticsearchRequest(request, this.kuzzle);
 
     return this.client.indices.exists(esRequest)
       .catch(error => Promise.reject(this.formatESError(error)));
-  };
+  }
 
   /**
    * @param {Request} request
    * @returns {Promise}
    */
-  this.collectionExists = function esCollectionExists (request) {
-    var esRequest = getElasticsearchRequest(request, kuzzle);
+  collectionExists(request) {
+    const esRequest = getElasticsearchRequest(request, this.kuzzle);
 
     return this.client.indices.existsType(esRequest)
       .catch(error => Promise.reject(this.formatESError(error)));
-  };
+  }
 
   /**
    * gets the autorefresh value currently set for the given index
@@ -867,9 +853,9 @@ function ElasticSearch (kuzzle, options, config) {
    * @param {Request} request
    * @returns {Promise}
    */
-  this.getAutoRefresh = function elasticsearchGetAutoRefresh (request) {
+  getAutoRefresh(request) {
     return Promise.resolve(this.settings.autoRefresh[request.input.resource.index] === true);
-  };
+  }
 
   /**
    * (dis|en)able the autorefresh for the index given in the request.
@@ -877,8 +863,8 @@ function ElasticSearch (kuzzle, options, config) {
    * @param {Request} request
    * @returns {Promise}
    */
-  this.setAutoRefresh = function elasticsearchSetAutoRefresh (request) {
-    var index = request.input.resource.index;
+  setAutoRefresh(request) {
+    const index = request.input.resource.index;
 
     if (request.input.body.autoRefresh === true) {
       this.settings.autoRefresh[index] = true;
@@ -889,18 +875,19 @@ function ElasticSearch (kuzzle, options, config) {
 
     return this.saveSettings()
       .then(() => this.getAutoRefresh(request));
-  };
+  }
 
-  this.formatESError = function elasticsearchFormatESError (error) {
-    var
+  /**
+   * Transforms raw ES errors into a normalized Kuzzle version
+   *
+   * @param {Error} error
+   * @returns {KuzzleError}
+   */
+  formatESError(error) {
+    let
       kuzzleError,
       messageReplaced,
       message = error.message || '';
-
-    messageReplaced = this.errorMessagesMapping.some(mapping => {
-      message = message.replace(mapping.regex, mapping.replacement);
-      return (message !== error.message);
-    });
 
     if (error instanceof KuzzleError) {
       return error;
@@ -909,6 +896,11 @@ function ElasticSearch (kuzzle, options, config) {
     if (error instanceof es.errors.NoConnections) {
       return new ServiceUnavailableError('Elasticsearch service is not connected');
     }
+
+    messageReplaced = this.errorMessagesMapping.some(mapping => {
+      message = message.replace(mapping.regex, mapping.replacement);
+      return (message !== error.message);
+    });
 
     switch (error.displayName) {
       case 'BadRequest':
@@ -933,8 +925,16 @@ function ElasticSearch (kuzzle, options, config) {
 
         kuzzleError = new NotFoundError(message);
         break;
+      case 'Conflict':
+        if (!messageReplaced) {
+          debug('unhandled "Conflict" elasticsearch error:');
+          debug(message);
+        }
+
+        kuzzleError = new ExternalServiceError(message);
+        break;
       default:
-        kuzzleError = new Error(message);
+        kuzzleError = new ExternalServiceError(message);
 
         debug('unhandled default elasticsearch error:');
         debug(message);
@@ -945,10 +945,32 @@ function ElasticSearch (kuzzle, options, config) {
     kuzzleError.service = 'elasticsearch';
 
     return kuzzleError;
-  };
-}
+  }
 
-util.inherits(ElasticSearch, Service);
+  /**
+   * Triggers an refresh call on the index set in the data request if the autoRefresh is on.
+   * Else, passes the response through.
+   *
+   * @this ElasticSearch
+   * @param {object} esRequest
+   * @param {object} response The response from elasticsearch
+   * @returns {Promise}
+   */
+  refreshIndexIfNeeded(esRequest, response) {
+    if (esRequest && esRequest.index && this.settings.autoRefresh[esRequest.index]) {
+      return this.refreshIndex(new Request({index: esRequest.index}))
+        .then(() => response)
+        .catch(error => {
+          // index refresh failures are non-blocking
+          this.kuzzle.pluginsManager.trigger('log:error', new InternalError('Error refreshing index ' + esRequest.index + ':\n' + error.message));
+
+          return Promise.resolve(response);
+        });
+    }
+
+    return Promise.resolve(response);
+  }
+}
 
 module.exports = ElasticSearch;
 
@@ -958,14 +980,14 @@ module.exports = ElasticSearch;
  *
  * @param {Request} request
  * @param {Kuzzle} kuzzle
- * @param {Array} extraParams [optional] An array of String values corresponding
+ * @param {Array} [extraParams] [optional] An array of String values corresponding
  *                            to the extra params from the Kuzzle Request to be
  *                            included in the Elasticsearch Request.
  * @return {object} data the data with cleaned attributes
  */
 function getElasticsearchRequest(request, kuzzle, extraParams) {
-  var data = {};
-  extraParams = extraParams || new Array();
+  const data = {};
+  extraParams = extraParams || [];
 
   if (request.input.resource.index) {
     if (request.input.resource.index === kuzzle.internalEngine.index) {
@@ -998,15 +1020,15 @@ function getElasticsearchRequest(request, kuzzle, extraParams) {
 /**
  * Scroll index in elasticsearch and return all document ids that match the filter
  *
- * @this ElasticSearch
+ * @param {object} client - elasticsearch client
  * @param {object} esRequest
  * @returns {Promise} resolve an array
  */
-function getAllIdsFromQuery(esRequest) {
-  var ids = [];
+function getAllIdsFromQuery(client, esRequest) {
+  const ids = [];
 
   return new Promise((resolve, reject) => {
-    this.client.search(esRequest, function getMoreUntilDone(error, response) {
+    client.search(esRequest, function getMoreUntilDone(error, response) {
       if (error) {
         return reject(error);
       }
@@ -1016,42 +1038,34 @@ function getAllIdsFromQuery(esRequest) {
       });
 
       if (response.hits.total !== ids.length) {
-        this.client.scroll({
+        client.scroll({
           scrollId: response._scroll_id,
           scroll: esRequest.scroll
-        }, getMoreUntilDone.bind(this));
+        }, getMoreUntilDone);
       }
       else {
         resolve(ids);
       }
-    }.bind(this));
+    });
   });
 }
 
 /**
  * Scroll index in elasticsearch and return all document ids that match the filter
  *
- * @this ElasticSearch
+ * @param {object} client - elasticseach client
  * @param {Object} data
  * @returns {Promise} resolve an array
  */
-function getPaginatedIdsFromQuery(data) {
-  var
-    ids = [];
-
+function getPaginatedIdsFromQuery(client, data) {
   return new Promise((resolve, reject) => {
-
-    this.client.search(data, function getMoreUntilDone(error, response) {
+    client.search(data, function getMoreUntilDone(error, response) {
       if (error) {
         return reject(error);
       }
 
-      response.hits.hits.forEach(hit => {
-        ids.push(hit._id);
-      });
-
       // todo: use real scroll here
-      resolve(ids);
+      resolve(response.hits.hits.map(hit => hit._id));
     });
   });
 }
@@ -1061,7 +1075,7 @@ function getPaginatedIdsFromQuery(data) {
  * @param {object} esRequest
  */
 function addActiveFilter(esRequest) {
-  var
+  const
     queryObject = {
       bool: {
         filter: {
@@ -1090,30 +1104,6 @@ function addActiveFilter(esRequest) {
   }
 
   return esRequest;
-}
-
-/**
- * Triggers an refresh call on the index set in the data request if the autoRefresh is on.
- * Else, passes the response through.
- *
- * @this ElasticSearch
- * @param {object} esRequest
- * @param {object} response The response from elasticsearch
- * @returns {Promise}
- */
-function refreshIndexIfNeeded(esRequest, response) {
-  if (esRequest && esRequest.index && this.settings.autoRefresh[esRequest.index]) {
-    return this.refreshIndex(new Request({index: esRequest.index}))
-      .then(() => response)
-      .catch(error => {
-        // index refresh failures are non-blocking
-        this.kuzzle.pluginsManager.trigger('log:error', new InternalError('Error refreshing index ' + esRequest.index + ':\n' + error.message));
-
-        return Promise.resolve(response);
-      });
-  }
-
-  return Promise.resolve(response);
 }
 
 /**

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -382,7 +382,7 @@ class ElasticSearch extends Service {
    * @returns {Promise} resolve an object that contains _id
    */
   update(request) {
-    const esRequest = getElasticsearchRequest(request, this.kuzzle, ['refresh']);
+    const esRequest = getElasticsearchRequest(request, this.kuzzle, ['refresh', 'retryOnConflict']);
 
     if (esRequest.body._routing) {
       return Promise.reject(new BadRequestError('Kuzzle does not support "_routing" in update action.'));
@@ -397,8 +397,8 @@ class ElasticSearch extends Service {
       }
     }
 
-    // retryOnConflict configuration
-    if (this.config.defaults.onUpdateConflictRetries > 0) {
+    // injecting retryOnConflict default configuration
+    if (!esRequest.hasOwnProperty('retryOnConflict') && this.config.defaults.onUpdateConflictRetries > 0) {
       esRequest.retryOnConflict = this.config.defaults.onUpdateConflictRetries;
     }
 


### PR DESCRIPTION
# Description

* Instead of returning a `KuzzleError` object on an unhandled Elasticsearch error, causing Kuzzle to dump itself when diagtools are activated, returns a `ExternalServiceError` 
* Add a new ES error mapper handling errors specific to document update conflicts
* Expose a new `onUpdateConflictRetries` option in Kuzzle configuration, taking an integer, and applying the `retryOnConflict` Elasticsearch option on update queries if no `retryOnConflict` argument is provided
* The document update route now accepts the `retryOnConflict` option, allowing clients to configure Elasticsearch's behavior on specific update queries (/cc @stafyniaksacha )

# Boy scout

* Bring the Elasticsearch service implementation in line with today's coding standards

# Solved issues

#730, #731 