### PR TITLE
[HOTFIX] Remove customer subscriptions on disconnection

### DIFF
--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -520,7 +520,7 @@ function removeRoomForCustomer (requestContext, roomId, notify) {
     return Promise.reject(new NotFoundError(`The user with connection ${requestContext.connectionId} doesn't exist`));
   }
 
-  if (!this.customers[requestContext.connectionId][roomId]) {
+  if (this.customers[requestContext.connectionId][roomId] === undefined) {
     return Promise.reject(new NotFoundError(`The user with connectionId ${requestContext.connectionId} doesn't listen the room ${roomId}`));
   }
 
@@ -533,7 +533,7 @@ function removeRoomForCustomer (requestContext, roomId, notify) {
 
   return cleanUpRooms.call(this, roomId)
     .then(() => {
-      var
+      let
         count = this.rooms[roomId] ? this.rooms[roomId].customers.length : 0,
         request;
 

--- a/test/api/core/hotelClerk/removeRoomForCustomer.test.js
+++ b/test/api/core/hotelClerk/removeRoomForCustomer.test.js
@@ -1,0 +1,83 @@
+const
+  Promise = require('bluebird'),
+  rewire = require('rewire'),
+  sinon = require('sinon'),
+  should = require('should'),
+  HotelClerk = rewire('../../../../lib/api/core/hotelClerk'),
+  KuzzleMock = require('../../../mocks/kuzzle.mock'),
+  NotFoundError = require('kuzzle-common-objects').errors.NotFoundError,
+  RequestContext = require('kuzzle-common-objects').models.RequestContext;
+
+describe ('lib/core/hotelclerck:removeRoomForCustomer', () => {
+  let
+    context,
+    cleanupRooms,       // eslint-disable-line no-unused-vars
+    removeRoomForCustomers,
+    requestContext;
+
+  beforeEach(() => {
+    context = {
+      customers: {},
+      rooms: {
+        roomId: {
+          channels: {
+            ch1: true,
+            ch2: true
+          },
+          customers: ['connectionId']
+        }
+      },
+      kuzzle: new KuzzleMock()
+    };
+    cleanupRooms = sinon.stub().returns(Promise.resolve());
+
+    requestContext = new RequestContext({
+      connectionId: 'connectionId',
+      protocol: 'protocol'
+    });
+
+    removeRoomForCustomers = HotelClerk.__get__('removeRoomForCustomer').bind(context);
+  });
+
+  it('should reject if the connection cannot be found', () => {
+    return should(removeRoomForCustomers(requestContext, 'roomId'))
+      .be.rejectedWith(NotFoundError);
+  });
+
+  it('should reject if the customer did not subscribe to the room', () => {
+    context.customers.connectionId = {};
+
+    return should(removeRoomForCustomers(requestContext, 'roomId'))
+      .be.rejectedWith(NotFoundError);
+  });
+
+  it('should remove the room from the customer list and remove the connection entry if empty', () => {
+    context.customers.connectionId = {roomId: null};
+
+    return removeRoomForCustomers(requestContext, 'roomId', false)
+      .then(roomId => {
+        should(context.customers)
+          .be.empty();
+
+        should(roomId)
+          .be.eql('roomId');
+      });
+  });
+
+  it('should remove the room from the customer list and keep other existing rooms', () => {
+    context.customers.connectionId = {
+      roomId: null,
+      anotherRoom: null
+    };
+
+    return removeRoomForCustomers(requestContext, 'roomId', false)
+      .then(() => {
+        should(context.customers.connectionId)
+          .eql({
+            anotherRoom: null
+          });
+      });
+
+  });
+
+});


### PR DESCRIPTION
# Description

Fix issue where the subscriptions attached to a client were not removed when the client disconnects from Kuzzle.

# Related issue

* #733 