### PR TITLE
Keep track of previously run requests

### DIFF
--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -200,6 +200,7 @@ function instantiateRequest(request, data, options) {
   Object.assign(options, request.context.toJSON());
 
   target = new Request(data, options);
+  target.origin = target.previous = request;
 
   // forward informations from the provided request object
   ['_id', 'index', 'collection'].forEach(resource => {


### PR DESCRIPTION
# Description

Takes into account the latest changes made in the `kuzzle-common-objects` module, preventing infinite loops to occur when plugins generating request chains trigger events, and allowing plugin developers to keep track of request chains.

# See also

https://github.com/kuzzleio/kuzzle-common-objects/pull/25
