### PR TITLE
Make ES actions responsible of retrieving their id and body attributes

### DIFF
--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -881,7 +881,7 @@ class ElasticSearch extends Service {
    * @returns {Promise}
    */
   setAutoRefresh(request) {
-    const index = request.input.resource.index;
+    const index = getIndex(request);
 
     if (request.input.body.autoRefresh === true) {
       this.settings.autoRefresh[index] = true;

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -166,10 +166,10 @@ class ElasticSearch extends Service {
    * @returns {Promise} resolve documents matching the scroll id
    */
   scroll(request) {
-    const esRequest = getElasticsearchRequest(request, this.kuzzle, ['scroll', 'scrollId']);
+    const esRequest = initESRequest(request, this.kuzzle, ['scroll', 'scrollId']);
 
     if (!esRequest.scroll) {
-      esRequest.scroll = this.kuzzle.config.services.db.defaults.scrollTTL;
+      esRequest.scroll = this.config.defaults.scrollTTL;
     }
 
     return this.client.scroll(esRequest)
@@ -183,7 +183,9 @@ class ElasticSearch extends Service {
    * @returns {Promise} resolve documents matching the filter
    */
   search(request) {
-    const esRequest = getElasticsearchRequest(request, this.kuzzle, ['from', 'size', 'scroll']);
+    const esRequest = initESRequest(request, this.kuzzle, ['from', 'size', 'scroll']);
+
+    esRequest.body = request.input.body;
 
     // todo add condition once the 'trash' feature has been implemented
     addActiveFilter(esRequest);
@@ -199,9 +201,9 @@ class ElasticSearch extends Service {
    * @returns {Promise} resolve the document
    */
   get(request) {
-    const esRequest = getElasticsearchRequest(request, this.kuzzle);
+    const esRequest = initESRequest(request, this.kuzzle);
 
-    delete esRequest.body;
+    esRequest.id = request.input.resource._id;
 
     // Just in case the user make a GET on url /mainindex/test/_search
     // Without this test we return something weird: a result.hits.hits with all document without filter because the body is empty in HTTP by default
@@ -235,7 +237,9 @@ class ElasticSearch extends Service {
    * @returns {Promise}
    */
   mget(request) {
-    const esRequest = getElasticsearchRequest(request, this.kuzzle);
+    const esRequest = initESRequest(request, this.kuzzle);
+
+    esRequest.body = request.input.body;
 
     return this.client.mget(esRequest)
       .then(result => {
@@ -256,7 +260,9 @@ class ElasticSearch extends Service {
    * @returns {Promise} resolve the number of document
    */
   count(request) {
-    const esRequest = getElasticsearchRequest(request, this.kuzzle);
+    const esRequest = initESRequest(request, this.kuzzle);
+
+    esRequest.body = request.input.body;
 
     // todo add condition once the 'trash' feature has been implemented
     addActiveFilter(esRequest);
@@ -272,7 +278,10 @@ class ElasticSearch extends Service {
    * @returns {Promise} resolve an object that contains _id
    */
   create(request) {
-    const esRequest = getElasticsearchRequest(request, this.kuzzle, ['refresh']);
+    const esRequest = initESRequest(request, this.kuzzle, ['refresh']);
+
+    esRequest.id = request.input.resource._id;
+    esRequest.body = request.input.body;
 
     if (esRequest.body._routing) {
       return Promise.reject(new BadRequestError('Kuzzle does not support "_routing" in create action.'));
@@ -344,7 +353,10 @@ class ElasticSearch extends Service {
    * @returns {Promise} resolve an object that contains _id
    */
   createOrReplace(request) {
-    const esRequest = getElasticsearchRequest(request, this.kuzzle, ['refresh']);
+    const esRequest = initESRequest(request, this.kuzzle, ['refresh']);
+
+    esRequest.id = request.input.resource._id;
+    esRequest.body = request.input.body;
 
     if (esRequest.body._routing) {
       return Promise.reject(new BadRequestError('Kuzzle does not support "_routing" in createOrReplace action.'));
@@ -382,7 +394,10 @@ class ElasticSearch extends Service {
    * @returns {Promise} resolve an object that contains _id
    */
   update(request) {
-    const esRequest = getElasticsearchRequest(request, this.kuzzle, ['refresh', 'retryOnConflict']);
+    const esRequest = initESRequest(request, this.kuzzle, ['refresh', 'retryOnConflict']);
+
+    esRequest.id = request.input.resource._id;
+    esRequest.body = request.input.body;
 
     if (esRequest.body._routing) {
       return Promise.reject(new BadRequestError('Kuzzle does not support "_routing" in update action.'));
@@ -424,12 +439,15 @@ class ElasticSearch extends Service {
    */
   replace(request) {
     const
-      esRequest = getElasticsearchRequest(request, this.kuzzle, ['refresh']),
+      esRequest = initESRequest(request, this.kuzzle, ['refresh']),
       existQuery = {
         index: esRequest.index,
         type: esRequest.type,
-        id: esRequest.id
+        id: request.input.resource._id
       };
+
+    esRequest.id = request.input.resource._id;
+    esRequest.body = request.input.body;
 
     if (esRequest.body._routing) {
       return Promise.reject(new BadRequestError('Kuzzle does not support "_routing" in replace action.'));
@@ -473,7 +491,9 @@ class ElasticSearch extends Service {
    * @returns {Promise} resolve an object that contains _id
    */
   delete(request) {
-    const esRequest = getElasticsearchRequest(request, this.kuzzle, ['refresh']);
+    const esRequest = initESRequest(request, this.kuzzle, ['refresh']);
+
+    esRequest.id = request.input.resource._id;
 
     if (esRequest.hasOwnProperty('refresh')) {
       if (compareVersions(this.config.apiVersion, '5.0') < 0) {
@@ -498,15 +518,16 @@ class ElasticSearch extends Service {
    */
   deleteByQuery(request) {
     const
-      esRequestSearch = getElasticsearchRequest(request, this.kuzzle, ['from', 'size', 'scroll']),
-      esRequestBulk = getElasticsearchRequest(request, this.kuzzle, ['refresh']);
+      esRequestSearch = initESRequest(request, this.kuzzle, ['from', 'size', 'scroll']),
+      esRequestBulk = initESRequest(request, this.kuzzle, ['refresh']);
+
+    esRequestSearch.body = request.input.body;
+    esRequestSearch.scroll = '30s';
+    esRequestBulk.body = [];
 
     if (!esRequestSearch.body.query || !(esRequestSearch.body.query instanceof Object)) {
       return Promise.reject(new BadRequestError('Query cannot be empty'));
     }
-
-    esRequestBulk.body = [];
-    esRequestSearch.scroll = '30s';
 
     return getAllIdsFromQuery(this.client, esRequestSearch)
       .then(ids => {
@@ -527,19 +548,21 @@ class ElasticSearch extends Service {
 
   /**
    * Delete all document that match the given filter from the trash
-   * @param requestObject
+   * @param {Request} request
+   * @returns {Promise}
    */
-  deleteByQueryFromTrash(requestObject) {
+  deleteByQueryFromTrash(request) {
     const
-      esRequestSearch = getElasticsearchRequest(requestObject, this.kuzzle, ['from', 'size', 'scroll']),
-      esRequestBulk = getElasticsearchRequest(requestObject, this.kuzzle, ['refresh']);
+      esRequestSearch = initESRequest(request, this.kuzzle, ['from', 'size', 'scroll']),
+      esRequestBulk = initESRequest(request, this.kuzzle, ['refresh']);
+
+    esRequestSearch.body = request.input.body;
+    esRequestSearch.scroll = '30s';
+    esRequestBulk.body = [];
 
     if (esRequestSearch.body.query === null) {
       return Promise.reject(new BadRequestError('null is not a valid document ID'));
     }
-
-    esRequestBulk.body = [];
-    esRequestSearch.scroll = '30s';
 
     return getPaginatedIdsFromQuery(this.client, esRequestSearch)
       .then(ids => {
@@ -565,10 +588,11 @@ class ElasticSearch extends Service {
    * @returns {Promise}
    */
   createCollection(request) {
-    const esRequest = getElasticsearchRequest(request, this.kuzzle);
+    const esRequest = initESRequest(request, this.kuzzle);
 
-    esRequest.body = {};
-    esRequest.body[esRequest.type] = {};
+    esRequest.body = {
+      [esRequest.type]: {}
+    };
 
     return this.client.indices.putMapping(esRequest)
       .catch(error => Promise.reject(this.formatESError(error)));
@@ -605,7 +629,7 @@ class ElasticSearch extends Service {
   import(request) {
     const
       nameActions = ['index', 'create', 'update', 'delete'],
-      esRequest = getElasticsearchRequest(request, this.kuzzle, ['consistency', 'refresh', 'timeout', 'fields']);
+      esRequest = initESRequest(request, this.kuzzle, ['consistency', 'refresh', 'timeout', 'fields']);
     let error = null;
 
     if (esRequest.hasOwnProperty('refresh')) {
@@ -617,22 +641,14 @@ class ElasticSearch extends Service {
       }
     }
 
-    if (!esRequest.body || !(esRequest.body.bulkData instanceof Object)) {
+    if (!request.input.body || !(request.input.body.bulkData instanceof Object)) {
       return Promise.reject(new BadRequestError('import must specify a body attribute "bulkData" of type Object.'));
     }
 
-    let bulkRequest = {
-      body: esRequest.body.bulkData
-    };
-
-    Object.keys(esRequest)
-      .filter(key => key !== 'body')
-      .forEach(key => {
-        bulkRequest[key] = esRequest[key];
-      });
+    esRequest.body = request.input.body.bulkData;
 
     // set missing index & type if possible
-    bulkRequest.body.forEach(item => {
+    esRequest.body.forEach(item => {
       const action = Object.keys(item)[0];
 
       if (nameActions.indexOf(action) !== -1) {
@@ -664,7 +680,7 @@ class ElasticSearch extends Service {
       return Promise.reject(error);
     }
 
-    return this.client.bulk(bulkRequest)
+    return this.client.bulk(esRequest)
       .then(response => this.refreshIndexIfNeeded(esRequest, response))
       .then(result => {
         // If some errors occured during the Bulk, we send a "Partial Error" response :
@@ -695,9 +711,11 @@ class ElasticSearch extends Service {
    * @return {Promise}
    */
   updateMapping(request) {
-    const esEequest = getElasticsearchRequest(request, this.kuzzle);
+    const esRequest = initESRequest(request, this.kuzzle);
 
-    return this.client.indices.putMapping(esEequest)
+    esRequest.body = request.input.body;
+
+    return this.client.indices.putMapping(esRequest)
       .catch(error => Promise.reject(this.formatESError(error)));
   }
 
@@ -708,9 +726,7 @@ class ElasticSearch extends Service {
    * @return {Promise}
    */
   getMapping(request) {
-    const esRequest = getElasticsearchRequest(request, this.kuzzle);
-
-    delete esRequest.body;
+    const esRequest = initESRequest(request, this.kuzzle);
 
     return this.client.indices.getMapping(esRequest)
       .then(result => {
@@ -734,9 +750,7 @@ class ElasticSearch extends Service {
    * @return {Promise}
    */
   listCollections(request) {
-    const esRequest = getElasticsearchRequest(request, this.kuzzle);
-
-    delete esRequest.body;
+    const esRequest = initESRequest(request, this.kuzzle);
 
     return this.client.indices.getMapping(esRequest)
       .then(result => {
@@ -759,8 +773,6 @@ class ElasticSearch extends Service {
    */
   deleteIndexes(request) {
     const deletedIndexes = request.input.body.indexes;
-
-    request.input.body = null;
 
     if (deletedIndexes === undefined || deletedIndexes.length === 0) {
       return Promise.resolve({deleted: []});
@@ -794,9 +806,7 @@ class ElasticSearch extends Service {
    * @returns {Promise}
    */
   createIndex(request) {
-    const esRequest = getElasticsearchRequest(request, this.kuzzle);
-
-    return this.client.indices.create({index: esRequest.index})
+    return this.client.indices.create({index: request.input.resource.index})
       .catch(error => Promise.reject(this.formatESError(error)));
   }
 
@@ -807,10 +817,8 @@ class ElasticSearch extends Service {
    * @returns {Promise}
    */
   deleteIndex(request) {
-    const esRequest = getElasticsearchRequest(request, this.kuzzle);
-
-    delete this.settings.autoRefresh[esRequest.index];
-    return this.client.indices.delete({index: esRequest.index})
+    delete this.settings.autoRefresh[request.input.resource.index];
+    return this.client.indices.delete({index: request.input.resource.index})
       .catch(error => Promise.reject(this.formatESError(error)));
   }
 
@@ -824,9 +832,7 @@ class ElasticSearch extends Service {
    * @returns {Promise}
    */
   refreshIndex(request) {
-    const esRequest = getElasticsearchRequest(request, this.kuzzle);
-
-    return this.client.indices.refresh({index: esRequest.index})
+    return this.client.indices.refresh({index: request.input.resource.index})
       .catch(error => Promise.reject(this.formatESError(error)));
   }
 
@@ -835,7 +841,7 @@ class ElasticSearch extends Service {
    * @returns {Promise}
    */
   indexExists(request) {
-    const esRequest = getElasticsearchRequest(request, this.kuzzle);
+    const esRequest = initESRequest(request, this.kuzzle);
 
     return this.client.indices.exists(esRequest)
       .catch(error => Promise.reject(this.formatESError(error)));
@@ -846,7 +852,7 @@ class ElasticSearch extends Service {
    * @returns {Promise}
    */
   collectionExists(request) {
-    const esRequest = getElasticsearchRequest(request, this.kuzzle);
+    const esRequest = initESRequest(request, this.kuzzle);
 
     return this.client.indices.existsType(esRequest)
       .catch(error => Promise.reject(this.formatESError(error)));
@@ -990,7 +996,7 @@ module.exports = ElasticSearch;
  *                            included in the Elasticsearch Request.
  * @return {object} data the data with cleaned attributes
  */
-function getElasticsearchRequest(request, kuzzle, extraParams = []) {
+function initESRequest(request, kuzzle, extraParams = []) {
   const data = {};
 
   if (request.input.resource.index) {
@@ -1004,19 +1010,11 @@ function getElasticsearchRequest(request, kuzzle, extraParams = []) {
     data.type = request.input.resource.collection;
   }
 
-  if (request.input.resource._id) {
-    data.id = request.input.resource._id;
-  }
-
   extraParams.forEach(argumentName => {
     if (typeof request.input.args[argumentName] !== 'undefined') {
       data[argumentName] = request.input.args[argumentName];
     }
   });
-
-  if (request.input.body) {
-    data.body = request.input.body;
-  }
 
   return data;
 }


### PR DESCRIPTION
# Description

Instead of letting the generic `getElasticsearchRequest` method setting the `id` and `body` attributes of ES requests, ES methods are now responsible for that part.

This allows plugin developers to pass on requests chain to various Kuzzle API method without having to worry about providing, say, an `id` to API methods not using one, especially considering the fact that when creating  a `Request` object, the plugin context copies every info it can from the previous one

# Other Changes

* rename `getElasticsearchRequest` to `initESRequest` and refactored code here and there to improve code clarity
* Unrelated bugfixes: `getAutoRefresh` and `setAutoRefresh` cannot be used on internal indexes anymore
