### PR TITLE
Inject the request in authentication verify callbacks

### DIFF
--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var
+const
   Promise = require('bluebird'),
   _ = require('lodash'),
   UnauthorizedError = require('kuzzle-common-objects').errors.UnauthorizedError,
@@ -12,26 +12,32 @@ var
   assertBodyHasAttribute = require('./util/requestAssertions').assertBodyHasAttribute;
 
 /**
+ * @class AuthController
  * @param {Kuzzle} kuzzle
  * @constructor
  */
-function AuthController (kuzzle) {
+class AuthController {
+  constructor(kuzzle) {
+    /** @type Kuzzle */
+    this.kuzzle = kuzzle;
+  }
+
   /**
    * Logs the current user out
    *
    * @param {Request} request
    * @returns {Promise<object>}
    */
-  this.logout = function authLogout (request) {
-    return kuzzle.repositories.token.expire(request.context.token)
+  logout(request) {
+    return this.kuzzle.repositories.token.expire(request.context.token)
       .then(() => Promise.resolve({}))
       .catch(err => {
-        var error = new InternalError('Error expiring token');
+        const error = new InternalError('Error while forcing token expiration');
         error.details = err;
 
         return Promise.reject(error);
       });
-  };
+  }
 
   /**
    * Attempts a login with request informations against the provided strategy; local is used if strategy is not provided.
@@ -39,20 +45,21 @@ function AuthController (kuzzle) {
    * @param {Request} request
    * @returns {Promise<Token>}
    */
-  this.login = function authLogin (request) {
-    var strategy;
-
+  login(request) {
     assertHasBody(request);
-    strategy = request.input.body.strategy || 'local';
 
-    return kuzzle.passport.authenticate({query: request.input.body}, strategy)
+    const strategy = request.input.body.strategy || 'local';
+
+    return this.kuzzle.passport.authenticate({query: request.input.body}, strategy)
       .then(userObject => {
-        var options = {};
+        const options = {};
+
         if (!userObject.headers) {
           if (request.input.body.expiresIn) {
             options.expiresIn = request.input.body.expiresIn;
           }
-          return kuzzle.repositories.token.generateToken(userObject, request, options);
+
+          return this.kuzzle.repositories.token.generateToken(userObject, request, options);
         }
 
         return Promise.resolve(userObject);
@@ -67,7 +74,7 @@ function AuthController (kuzzle) {
 
         return response;
       });
-  };
+  }
 
   /**
    * Returns the user identified by the given jwt token
@@ -75,9 +82,9 @@ function AuthController (kuzzle) {
    * @param {Request} request
    * @returns {Promise<object>}
    */
-  this.getCurrentUser = function authGetCurrentUser (request) {
-    return formatProcessing.formatUserForSerialization(kuzzle, request.context.user);
-  };
+  getCurrentUser(request) {
+    return formatProcessing.formatUserForSerialization(this.kuzzle, request.context.user);
+  }
 
   /**
    * Returns the rights of the user identified by the given jwt token
@@ -85,11 +92,11 @@ function AuthController (kuzzle) {
    * @param {Request} request
    * @returns {Promise<object>}
    */
-  this.getMyRights = function getMyRights (request) {
-    return request.context.user.getRights(kuzzle)
+  getMyRights(request) {
+    return request.context.user.getRights(this.kuzzle)
       .then(rights => Object.keys(rights).reduce((array, item) => array.concat(rights[item]), []))
       .then(rights => Promise.resolve({hits: rights, total: rights.length}));
-  };
+  }
 
   /**
    * Checks the validity of a token.
@@ -97,11 +104,11 @@ function AuthController (kuzzle) {
    * @param {Request} request
    * @returns {Promise<object>}
    */
-  this.checkToken = function authCheckToken (request) {
+  checkToken(request) {
     assertHasBody(request);
     assertBodyHasAttribute(request, 'token');
 
-    return kuzzle.repositories.token.verifyToken(request.input.body.token)
+    return this.kuzzle.repositories.token.verifyToken(request.input.body.token)
       .then(token => Promise.resolve({valid: true, expiresAt: token.expiresAt}))
       .catch(invalid => {
         if (invalid.status === 401) {
@@ -110,7 +117,7 @@ function AuthController (kuzzle) {
 
         return Promise.reject(invalid);
       });
-  };
+  }
 
   /**
    * Updates the current user if it is not anonymous
@@ -118,8 +125,8 @@ function AuthController (kuzzle) {
    * @param {Request} request
    * @returns {Promise<object>}
    */
-  this.updateSelf = function authUpdateSelf (request) {
-    if (request.context.user._id === kuzzle.repositories.user.anonymous()._id) {
+  updateSelf(request) {
+    if (request.context.user._id === this.kuzzle.repositories.user.anonymous()._id) {
       throw new UnauthorizedError('User must be connected in order to call auth:updateSelf');
     }
 
@@ -127,9 +134,9 @@ function AuthController (kuzzle) {
     assertBodyHasNotAttribute(request, '_id');
     assertBodyHasNotAttribute(request, 'profileIds');
 
-    return kuzzle.repositories.user.persist(_.extend(request.context.user, request.input.body), {database: {method: 'update'}})
-      .then(updatedUser => formatProcessing.formatUserForSerialization(kuzzle, updatedUser));
-  };
+    return this.kuzzle.repositories.user.persist(_.extend(request.context.user, request.input.body), {database: {method: 'update'}})
+      .then(updatedUser => formatProcessing.formatUserForSerialization(this.kuzzle, updatedUser));
+  }
 }
 
 module.exports = AuthController;

--- a/lib/api/core/auth/formatProcessing.js
+++ b/lib/api/core/auth/formatProcessing.js
@@ -38,7 +38,7 @@ module.exports = {
    * Serializes user and transforms it into a POJO
    *
    * @param {Kuzzle} kuzzle
-   * @param {User} user
+   * @param {User|object} user
    * @returns {Promise}
    */
   formatUserForSerialization: function formatUserForSerialization (kuzzle, user) {

--- a/lib/api/core/auth/passportResponse.js
+++ b/lib/api/core/auth/passportResponse.js
@@ -5,35 +5,35 @@ HTTP Response Mockup to emulate response objects for Passport Authentication
 */
 
 /**
- * @constructor
+ * @class PassportResponse
  */
-function PassportResponse () {
+class PassportResponse {
+  constructor() {
+    this.headers = {};
+    this.statusCode = 200;
+    this.onEndListener = null;
+  }
 
-  var onEndListener = null;
-
-  this.headers = {};
-  this.statusCode = 200;
-
-  this.setHeader = function passportSetHeader (field, value) {
+  setHeader(field, value) {
     this.headers[field] = value;
-  };
+  }
 
-  this.end = function passportEnd (statusCode) {
+  end(statusCode) {
     if (statusCode) {
       this.statusCode = statusCode;
     }
-    if(typeof onEndListener === 'function') {
-      onEndListener();
+    if(typeof this.onEndListener === 'function') {
+      this.onEndListener();
     }
-  };
+  }
 
-  this.getHeader = function passportGetHeader (key) {
+  getHeader(key) {
     return this.headers[key];
-  };
+  }
 
-  this.addEndListener = function passportAddEndListener (listener) {
-    onEndListener = listener;
-  };
+  addEndListener(listener) {
+    this.onEndListener = listener;
+  }
 }
 
 module.exports = PassportResponse;

--- a/lib/api/core/auth/passportWrapper.js
+++ b/lib/api/core/auth/passportWrapper.js
@@ -1,4 +1,4 @@
-var
+const
   Promise = require('bluebird'),
   passport = require('passport'),
   PassportResponse = require('./passportResponse'),
@@ -7,20 +7,20 @@ var
   InternalError = require('kuzzle-common-objects').errors.InternalError;
 
 /**
- * @constructor
+ * @class PassportWrapper
  */
-function PassportWrapper () {
-  this.scope = {};
+class PassportWrapper {
+  constructor() {
+    this.scope = {};
+  }
 
   /**
    * @param {{query: Object}}request
    * @param strategy
    * @returns {Promise.<*>}
    */
-  this.authenticate = function passportAuthenticate (request, strategy) {
-    var
-      response = new PassportResponse(),
-      error;
+  authenticate(request, strategy) {
+    const response = new PassportResponse();
 
     try {
       if (!passport._strategy(strategy)) {
@@ -35,7 +35,7 @@ function PassportWrapper () {
             reject(err);
           }
           else if (!user) {
-            error = new UnauthorizedError(info.message);
+            const error = new UnauthorizedError(info.message);
             error.details = {
               subCode: error.subCodes.AuthenticationError
             };
@@ -49,7 +49,7 @@ function PassportWrapper () {
     } catch (err) {
       return Promise.reject(new InternalError(err));
     }
-  };
+  }
 
   /**
    * Adds a scope for a strategy in this.scope
@@ -58,15 +58,20 @@ function PassportWrapper () {
    * @param {string} strategy name
    * @param {Array} scope - list of fields in the strategy's scope
    */
-  this.injectScope = (strategy, scope) => {
+  injectScope(strategy, scope) {
     this.scope[strategy] = scope;
-  };
+  }
 
   /**
    * Exposes passport.use function
    * Mainly used by the pluginContext
+   *
+   * @param {string} name - strategy name
+   * @param {object} strategy - instantiated strategy object
    */
-  this.use = passport.use.bind(passport);
+  use(name, strategy) {
+    passport.use(name, strategy);
+  }
 }
 
 module.exports = PassportWrapper;

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -58,20 +58,14 @@ class PluginContext {
         }
       });
 
-      Object.defineProperty(this.accessors, 'passport', {
+      Object.defineProperty(this.accessors, 'registerStrategy', {
         enumerable: true,
-        get: () => {
-          return {
-            use: kuzzle.passport.use
-          };
-        }
+        get: () => registerStrategy.bind(kuzzle)
       });
 
       Object.defineProperty(this.accessors, 'execute', {
         enumerable: true,
-        get: () => {
-          return execute.bind(kuzzle);
-        }
+        get: () => execute.bind(kuzzle)
       });
 
       /*
@@ -266,6 +260,29 @@ function instantiateRequest(request, data, options) {
   }
 
   return target;
+}
+
+/**
+ * Registers an authentication strategy
+ *
+ * @this kuzzle
+ * @param {function} Strategy - strategy constructor
+ * @param {string} name - strategy name
+ * @param {object} context - plugin context, used to bind the verify callback
+ * @param {function} verify - verification callback
+ * @param {object} [options] - strategy optional parameters
+ */
+function registerStrategy(Strategy, name, context, verify, options = {}) {
+  const opts = Object.assign(options, {passReqToCallback: true});
+
+  try {
+    this.passport.use(name, new Strategy(opts, verify.bind(context)));
+  }
+  catch (e) {
+    // There might not be any logger active when an authentication plugin registers its strategy
+    // eslint-disable-next-line no-console
+    console.error(new PluginImplementationError(`Unable to register authentication strategy: ${e.message}`));
+  }
 }
 
 module.exports = PluginContext;

--- a/test/api/core/pluginContext/pluginContext.test.js
+++ b/test/api/core/pluginContext/pluginContext.test.js
@@ -125,7 +125,7 @@ describe('Plugin Context', () => {
       });
 
       should(context.accessors).be.an.Object().and.not.be.empty();
-      should(context.accessors).have.properties(['passport', 'execute', 'users', 'validation', 'storage']);
+      should(context.accessors).have.properties(['registerStrategy', 'execute', 'users', 'validation', 'storage']);
     });
 
     it('should expose a correctly constructed validation accessor', () => {


### PR DESCRIPTION
# Description

Authentication `verify` callbacks may need to access the login request object, for instance to get information otherwise unavailable, or to execute API actions.
This pull requests injects the instantiated Request object that initiated an authentication process:

* replace the plugin context `accessors.passport.use` accessor method with `accessors.registerStrategy`. This method now takes the strategy *constructor* instead of an instantiated strategy object as an argument
* update the `local` default authentication plugin with the new API

# Documentation

https://github.com/kuzzleio/documentation/pull/180

# Solved issue

#746 
