### PR TITLE
DSL "bool" & "not" factorization fix

### DIFF
--- a/lib/api/dsl/transform/standardize.js
+++ b/lib/api/dsl/transform/standardize.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var
+const
   Promise = require('bluebird'),
   geohash = require('ngeohash'),
   BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
@@ -18,13 +18,8 @@ const RegexGeohash = /^[0-9a-z]{4,}$/;
  * so that every filters use the same syntax
  *
  * Does not mutate the input filters.
- *
- * @constructor
  */
-function Standardizer () {
-  var self = this;
-
-  this.dsl = {};
+class Standardizer {
 
   /**
    * Standardization entry point
@@ -32,10 +27,8 @@ function Standardizer () {
    * @param {object} filters
    * @returns {Promise} resolving to a standardized version of provided filters
    */
-  this.standardize = function standardize (filters) {
-    var keywords;
-
-    keywords = filters ? Object.keys(filters) : [];
+  standardize (filters) {
+    const keywords = filters ? Object.keys(filters) : [];
 
     if (keywords.length === 0) {
       return Promise.resolve({});
@@ -45,12 +38,12 @@ function Standardizer () {
       return Promise.reject(new BadRequestError('Invalid filter syntax'));
     }
 
-    if (!self.dsl[keywords[0]]) {
+    if (!this[keywords[0]]) {
       return Promise.reject(new BadRequestError(`Unknown DSL keyword: ${keywords[0]}`));
     }
 
-    return self.dsl[keywords[0]](filters);
-  };
+    return this[keywords[0]](filters);
+  }
 
   /**
    * Validate a "exists" keyword
@@ -59,7 +52,7 @@ function Standardizer () {
    * @param [name] - optional keyword name to use. Defaults to 'exists'
    * @returns {Promise} standardized filter
    */
-  this.dsl.exists = function exists (filter, name) {
+  exists (filter, name) {
     name = name || 'exists';
 
     return mustBeNonEmptyObject(filter[name], name)
@@ -72,7 +65,7 @@ function Standardizer () {
 
         return filter;
       });
-  };
+  }
 
   /**
    * Validate a "ids" keyword and converts it
@@ -81,7 +74,7 @@ function Standardizer () {
    * @param filter
    * @returns {Promise} standardized filter
    */
-  this.dsl.ids = function ids (filter) {
+  ids (filter) {
     return mustBeNonEmptyObject(filter.ids, 'ids')
       .then(field => onlyOneFieldAttribute(field, 'ids'))
       .then(() => requireAttribute(filter.ids, 'ids', 'values'))
@@ -93,25 +86,25 @@ function Standardizer () {
 
         return {or: filter.ids.values.map(v => ({equals: {_id: v}}))};
       });
-  };
+  }
 
   /**
    * Validate a "missing" keyword
    * @param filter
    * @returns {Promise} standardized filter
    */
-  this.dsl.missing = function missing (filter) {
-    return self.dsl.exists(filter, 'missing')
+  missing (filter) {
+    return this.exists(filter, 'missing')
       .then(f => ({not: {exists: {field: f.missing.field}}}));
-  };
+  }
 
   /**
    * Validate a "range" keyword
    * @param filter
    * @returns {Promise} standardized filter
    */
-  this.dsl.range = function range (filter) {
-    var rangeField;
+  range (filter) {
+    let rangeField;
 
     return mustBeNonEmptyObject(filter.range, 'range')
       .then(field => onlyOneFieldAttribute(field, 'range'))
@@ -120,7 +113,7 @@ function Standardizer () {
         return mustBeNonEmptyObject(filter.range[rangeField], `range.${rangeField}`);
       })
       .then(rangeValues => {
-        var
+        let
           index = rangeValues.findIndex(v => ['gt', 'lt', 'gte', 'lte'].indexOf(v) === -1),
           high = Infinity,
           low = -Infinity,
@@ -166,15 +159,15 @@ function Standardizer () {
 
         return filter;
       });
-  };
+  }
 
   /**
    * Validate a "regexp" keyword
    * @param filter
    * @returns {Promise} standardized filter
    */
-  this.dsl.regexp = function regexp (filter) {
-    var regexpField;
+  regexp (filter) {
+    let regexpField;
 
     return mustBeNonEmptyObject(filter.regexp, 'regexp')
       .then(field => onlyOneFieldAttribute(field, 'regexp'))
@@ -207,19 +200,19 @@ function Standardizer () {
 
         return filter;
       });
-  };
+  }
 
   /**
    * Validate a "equals" keyword
    * @param filter
    * @returns {Promise} standardized filter
    */
-  this.dsl.equals = function equals (filter) {
+  equals (filter) {
     return mustBeNonEmptyObject(filter.equals, 'equals')
       .then(field => onlyOneFieldAttribute(field, 'equals'))
       .then(field => mustBeString(filter.equals, 'equals', field[0]))
       .then(() => filter);
-  };
+  }
 
   /**
    * Validate a "in" keyword and converts it into a series
@@ -227,8 +220,8 @@ function Standardizer () {
    * @param filter
    * @returns {Promise} standardized filter
    */
-  this.dsl.in = function dslin (filter) {
-    var inValue;
+  in (filter) {
+    let inValue;
 
     return mustBeNonEmptyObject(filter.in, 'in')
       .then(field => onlyOneFieldAttribute(field, 'in'))
@@ -243,18 +236,18 @@ function Standardizer () {
 
         return {or: filter.in[inValue].map(v => ({equals: {[inValue]: v}}))};
       });
-  };
+  }
 
   /**
    * Validate a "geoBoundingBox" keyword
    * @param filter
    * @returns {Promise} standardized filter
    */
-  this.dsl.geoBoundingBox = function geoBoundingBox (filter) {
+  geoBoundingBox (filter) {
     return mustBeNonEmptyObject(filter.geoBoundingBox, 'geoBoundingBox')
       .then(field => onlyOneFieldAttribute(field, 'geoBoundingBox'))
       .then(field => {
-        var
+        let
           bBox = geoLocationToCamelCase(filter.geoBoundingBox[field[0]]),
           standardized = {};
 
@@ -324,15 +317,15 @@ function Standardizer () {
 
         return {geospatial: {geoBoundingBox: {[field[0]]: standardized}}};
       });
-  };
+  }
 
   /**
    * Validate a "geoDistance" keyword
    * @param filter
    * @returns {Promise} standardized filter
    */
-  this.dsl.geoDistance = function geoDistance (filter) {
-    var
+  geoDistance (filter) {
+    let
       docField,
       standardized = {geospatial: {geoDistance: {}}};
 
@@ -367,15 +360,15 @@ function Standardizer () {
 
         return standardized;
       });
-  };
+  }
 
   /**
    * Validate a "geoDistanceRange" keyword
    * @param filter
    * @returns {Promise} standardized filter
    */
-  this.dsl.geoDistanceRange = function geoDistanceRange (filter) {
-    var
+  geoDistanceRange (filter) {
+    let
       docField,
       standardized = {geospatial: {geoDistanceRange: {}}};
 
@@ -412,15 +405,15 @@ function Standardizer () {
 
         return standardized;
       });
-  };
+  }
 
   /**
    * Validate a "geoPolygon" keyword
    * @param filter
    * @returns {Promise} standardized filter
    */
-  this.dsl.geoPolygon = function geoPolygon (filter) {
-    var docField;
+  geoPolygon (filter) {
+    let docField;
 
     return mustBeNonEmptyObject(filter.geoPolygon, 'geoPolygon')
       .then(fields => onlyOneFieldAttribute(fields, 'geoBoundingBox'))
@@ -448,7 +441,7 @@ function Standardizer () {
 
         return {geospatial: {geoPolygon: {[docField]: points}}};
       });
-  };
+  }
 
   /**
    * Validates a AND-like operand
@@ -456,13 +449,13 @@ function Standardizer () {
    * @param {string} [operand] name - used by AND, MUST and MUST_NOT operands
    * @returns {Promise} standardized filter
    */
-  this.dsl.and = function and (filter, operand) {
+  and (filter, operand) {
     operand = operand || 'and';
 
     return mustBeNonEmptyArray(filter, operand, operand)
-      .then(() => standardizeFilterArray(self.standardize, filter[operand], operand))
+      .then(() => this._standardizeFilterArray(filter[operand], operand))
       .then(standardized => ({[operand]: standardized}));
-  };
+  }
 
   /**
    * Validates a OR-like operand
@@ -470,21 +463,21 @@ function Standardizer () {
    * @param {string} [operand] name - used by OR, SHOULD and SHOULD_NOT operands
    * @returns {Promise} standardized filter
    */
-  this.dsl.or = function or (filter, operand) {
+  or (filter, operand) {
     operand = operand || 'or';
 
     return mustBeNonEmptyArray(filter, operand, operand)
-      .then(() => standardizeFilterArray(self.standardize, filter[operand], operand))
+      .then(() => this._standardizeFilterArray(filter[operand], operand))
       .then(standardized => ({[operand]: standardized}));
-  };
+  }
 
   /**
    * Validates a NOT operand
    * @param filter
    * @returns {Promise} standardized filter
    */
-  this.dsl.not = function not (filter) {
-    var kwd;
+  not (filter) {
+    let kwd;
 
     return mustBeNonEmptyObject(filter.not, 'not')
       .then(fields => onlyOneFieldAttribute(fields, 'not'))
@@ -497,19 +490,19 @@ function Standardizer () {
 
         return mustBeNonEmptyObject(filter.not[kwd], `not.${kwd}`);
       })
-      .then(() => self.standardize(filter.not))
+      .then(() => this.standardize(filter.not))
       .then(result => {
         return {not: result};
       });
-  };
+  }
 
   /**
    * Validates a BOOL operand
    * @param filter
    * @returns {Promise} standardized filter
    */
-  this.dsl.bool = function bool (filter) {
-    var
+  bool (filter) {
+    const
       attributes = ['must', 'must_not', 'should', 'should_not'],
       standardized = {and: []};
 
@@ -520,56 +513,58 @@ function Standardizer () {
           return Promise.reject(new BadRequestError('"bool" operand accepts only the following attributes: ' + attributes.join(', ')));
         }
 
-        return filter.bool.must ? self.dsl.and(filter.bool, 'must') : Promise.resolve(null);
+        return filter.bool.must ? this.and(filter.bool, 'must') : Promise.resolve(null);
       })
       .then(f => {
         f && standardized.and.push({and: f.must});
-        return filter.bool.must_not ? self.dsl.and(filter.bool, 'must_not') : Promise.resolve(null);
+        return filter.bool.must_not ? this.and(filter.bool, 'must_not') : Promise.resolve(null);
       })
       .then(f => {
-        f && standardized.and.push({not: {and: f.must_not}});
-        return filter.bool.should ? self.dsl.or(filter.bool, 'should') : Promise.resolve(null);
+        f && standardized.and.push({not: {or: f.must_not}});
+        return filter.bool.should ? this.or(filter.bool, 'should') : Promise.resolve(null);
       })
       .then(f => {
         f && standardized.and.push({or: f.should});
-        return filter.bool.should_not ? self.dsl.or(filter.bool, 'should_not') : Promise.resolve(null);
+        return filter.bool.should_not ? this.or(filter.bool, 'should_not') : Promise.resolve(null);
       })
       .then(f => {
-        f && standardized.and.push({not: {or: f.should_not}});
+        f && standardized.and.push({not: {and: f.should_not}});
         return standardized;
       });
-  };
-
-  return this;
-}
-
-/**
- * Checks that a filters array is well-formed and standardized it
- *
- * @param {Function} standardize function
- * @param {Array} filters array
- * @param {string} keyword used to combine filters
- * @returns {Promise}
- */
-function standardizeFilterArray (standardize, filters, keyword) {
-  var idx;
-
-  // All registered items must be non-array, non-empty objects
-  idx = Object.keys(filters).findIndex(v => {
-    return typeof filters[v] !== 'object' ||
-      Array.isArray(filters[v]) ||
-      Object.keys(filters[v]).length === 0;
-  });
-
-  if (idx > -1) {
-    return Promise.reject(new BadRequestError(`"${keyword}" operand can only contain non-empty objects`));
   }
 
-  return Promise.reduce(filters.map(v => standardize(v)), (standardized, item) => {
-    standardized.push(item);
-    return standardized;
-  }, []);
+  /**
+   * Checks that a filters array is well-formed and standardized it
+   *
+   * @private
+   * @param {Array} filters array
+   * @param {string} keyword used to combine filters
+   * @returns {Promise}
+   */
+  _standardizeFilterArray (filters, keyword) {
+    let idx;
+
+    // All registered items must be non-array, non-empty objects
+    idx = Object.keys(filters).findIndex(v => {
+      return typeof filters[v] !== 'object' ||
+        Array.isArray(filters[v]) ||
+        Object.keys(filters[v]).length === 0;
+    });
+
+    if (idx > -1) {
+      return Promise.reject(new BadRequestError(`"${keyword}" operand can only contain non-empty objects`));
+    }
+
+    return Promise.reduce(filters.map(v => this.standardize(v)), (standardized, item) => {
+      standardized.push(item);
+      return standardized;
+    }, []);
+  }
+
 }
+
+module.exports = Standardizer;
+
 
 /**
  * Verifies that "filter" contains only 1 field
@@ -607,7 +602,7 @@ function requireAttribute(filter, keyword, attribute) {
  * @returns {Promise} Promise resolving to the object's keys
  */
 function mustBeNonEmptyObject(filter, keyword) {
-  var field;
+  let field;
 
   if (!filter || typeof filter !== 'object' || Array.isArray(filter) || (field = Object.keys(filter)).length === 0) {
     return Promise.reject(new BadRequestError(`"${keyword}" must be a non-empty object`));

--- a/test/api/dsl/dslApi.test.js
+++ b/test/api/dsl/dslApi.test.js
@@ -74,7 +74,7 @@ describe('DSL API', () => {
         .then(result => {
           let bool = {
             bool: {
-              must_not: [
+              should_not: [
                 {exists: { field: 'bar' }},
                 {equals: { foo: 'bar' }}
               ]

--- a/test/api/dsl/keywords/geoBoundingBox.test.js
+++ b/test/api/dsl/keywords/geoBoundingBox.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var
+const
   should = require('should'),
   BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
   FieldOperand = require('../../../../lib/api/dsl/storage/objects/fieldOperand'),
@@ -29,7 +29,7 @@ describe('DSL.keyword.geoBoundingBox', () => {
 
   beforeEach(() => {
     dsl = new DSL();
-    standardize = dsl.transformer.standardizer.standardize;
+    standardize = dsl.transformer.standardizer.standardize.bind(dsl.transformer.standardizer);
   });
 
   describe('#validation/standardization', () => {

--- a/test/api/dsl/keywords/geoDistance.test.js
+++ b/test/api/dsl/keywords/geoDistance.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var
+const
   should = require('should'),
   BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
   FieldOperand = require('../../../../lib/api/dsl/storage/objects/fieldOperand'),
@@ -25,7 +25,7 @@ describe('DSL.keyword.geoDistance', () => {
 
   beforeEach(() => {
     dsl = new DSL();
-    standardize = dsl.transformer.standardizer.standardize;
+    standardize = dsl.transformer.standardizer.standardize.bind(dsl.transformer.standardizer);
   });
 
   describe('#validation/standardization', () => {

--- a/test/api/dsl/keywords/geoDistanceRange.test.js
+++ b/test/api/dsl/keywords/geoDistanceRange.test.js
@@ -26,7 +26,7 @@ describe('DSL.keyword.geoDistanceRange', () => {
 
   beforeEach(() => {
     dsl = new DSL();
-    standardize = dsl.transformer.standardizer.standardize;
+    standardize = dsl.transformer.standardizer.standardize.bind(dsl.transformer.standardizer);
   });
 
   describe('#validation/standardization', () => {

--- a/test/api/dsl/keywords/geoPolygon.test.js
+++ b/test/api/dsl/keywords/geoPolygon.test.js
@@ -43,7 +43,7 @@ describe('DSL.keyword.geoPolygon', () => {
 
   beforeEach(() => {
     dsl = new DSL();
-    standardize = dsl.transformer.standardizer.standardize;
+    standardize = dsl.transformer.standardizer.standardize.bind(dsl.transformer.standardizer);
   });
 
   describe('#validation/standardization', () => {

--- a/test/api/dsl/keywords/geospatial.test.js
+++ b/test/api/dsl/keywords/geospatial.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var
+const
   should = require('should'),
   DSL = require('../../../../lib/api/dsl');
 

--- a/test/api/dsl/keywords/missing.test.js
+++ b/test/api/dsl/keywords/missing.test.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var
+const
   should = require('should'),
   sinon = require('sinon'),
   DSL = require('../../../../lib/api/dsl');
 
 describe('DSL.keyword.missing', () => {
-  var dsl;
+  let dsl;
 
   beforeEach(() => {
     dsl = new DSL();
@@ -14,7 +14,7 @@ describe('DSL.keyword.missing', () => {
 
   describe('#standardization', () => {
     it('should return a "not exists" condition', () => {
-      let spy = sinon.spy(dsl.transformer.standardizer.dsl, 'exists');
+      let spy = sinon.spy(dsl.transformer.standardizer, 'exists');
 
       return dsl.transformer.standardizer.standardize({missing: {field: 'foo'}})
         .then(result => {

--- a/test/api/dsl/operands/bool.test.js
+++ b/test/api/dsl/operands/bool.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var
+const
   should = require('should'),
   BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
   DSL = require('../../../../lib/api/dsl');
@@ -90,7 +90,7 @@ describe('DSL.operands.bool', () => {
               },
               {
                 not: {
-                  and: [
+                  or: [
                     { equals: { city: 'NYC' } }
                   ]
                 }
@@ -103,7 +103,7 @@ describe('DSL.operands.bool', () => {
               },
               {
                 not: {
-                  or: [
+                  and: [
                     { regexp: { hobby: { value: '^.*ball', flags: 'i' } } }
                   ]
                 }


### PR DESCRIPTION
# Description

This PR fixes the case where, when submitting multiple clauses in the `*_not` properties of a `bool` filter, would lead to not be notified.

# Related issue

* #766