### PR TITLE
Emit UnauthorizedError when a valid token link to a removed user

### DIFF
--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -234,6 +234,12 @@ function FunnelController (kuzzle) {
       .then(user => {
         request.context.user = user;
 
+          if (!user) {
+              return Promise.reject(new UnauthorizedError(
+                  `Bad request [${request.input.resource.index}/${request.input.resource.collection}/${request.input.controller}/${request.input.action}] for user ${request.context.token.userId}: user not found`)
+              );
+          }
+
         return user.isActionAllowed(request, kuzzle);
       })
       .then(isAllowed => {


### PR DESCRIPTION
This fix issue #773 when user is deleted but the token linked to this user is still available