### PR TITLE
Revoke associated JWTs on user deletion

### DIFF
--- a/features/HTTP.feature
+++ b/features/HTTP.feature
@@ -226,6 +226,17 @@ Feature: Test HTTP API
     And The token is invalid
 
   @usingHttp @cleanSecurity
+  Scenario: user token deletion
+    Given I create a user "useradmin" with id "user1-id"
+    When I log in as user1-id:testpwd expiring in 1h
+    Then I write the document
+    Then I check the JWT Token
+    And The token is valid
+    Then I delete the user "user1-id"
+    Then I check the JWT Token
+    And The token is invalid
+
+  @usingHttp @cleanSecurity
   Scenario: create restricted user
     Then I create a restricted user "restricteduser1" with id "restricteduser1-id"
 

--- a/features/Websocket.feature
+++ b/features/Websocket.feature
@@ -350,6 +350,17 @@ Feature: Test websocket API
     And The token is invalid
 
   @usingWebsocket @cleanSecurity
+  Scenario: user token deletion
+    Given I create a user "useradmin" with id "user1-id"
+    When I log in as user1-id:testpwd expiring in 1h
+    Then I write the document
+    Then I check the JWT Token
+    And The token is valid
+    Then I delete the user "user1-id"
+    Then I check the JWT Token
+    And The token is invalid
+
+  @usingWebsocket @cleanSecurity
   Scenario: create restricted user
     Then I create a restricted user "restricteduser1" with id "restricteduser1-id"
 

--- a/features/support/apiHttp.js
+++ b/features/support/apiHttp.js
@@ -835,11 +835,33 @@ ApiHttp.prototype.updateSelf = function (body) {
 };
 
 ApiHttp.prototype.checkToken = function (token) {
-  return this.callApi({
+  let _token = null;
+  const request = {
     url: this.apiPath('_checkToken'),
     method: 'POST',
     body: {token}
-  });
+  };
+
+  if (this.world.currentUser && this.world.currentUser.token) {
+    _token = this.world.currentUser.token;
+    this.world.currentUser.token = null;
+  }
+
+  return this.callApi(request)
+    .then(response => {
+      if (token !== null) {
+        this.world.currentUser.token = _token;
+      }
+
+      return response;
+    })
+    .catch(error => {
+      if (token !== null) {
+        this.world.currentUser.token = _token;
+      }
+
+      return Promise.reject(error);
+    });
 };
 
 ApiHttp.prototype.refreshIndex = function (index) {

--- a/features/support/apiHttp.js
+++ b/features/support/apiHttp.js
@@ -849,14 +849,14 @@ ApiHttp.prototype.checkToken = function (token) {
 
   return this.callApi(request)
     .then(response => {
-      if (token !== null) {
+      if (_token !== null) {
         this.world.currentUser.token = _token;
       }
 
       return response;
     })
     .catch(error => {
-      if (token !== null) {
+      if (_token !== null) {
         this.world.currentUser.token = _token;
       }
 

--- a/features/support/apiRT.js
+++ b/features/support/apiRT.js
@@ -844,11 +844,28 @@ ApiRT.prototype.createRestrictedUser = function (body, id) {
 };
 
 ApiRT.prototype.checkToken = function (token) {
-  return this.send({
-    controller: 'auth',
-    action: 'checkToken',
-    body: {token}
-  });
+  let _token = null;
+
+  if (this.world.currentUser && this.world.currentUser.token) {
+    _token = this.world.currentUser.token;
+    this.world.currentUser.token = null;
+  }
+
+  return this.send({controller: 'auth', action: 'checkToken', body: {token}})
+    .then(response => {
+      if (_token !== null) {
+        this.world.currentUser.token = _token;
+      }
+
+      return response;
+    })
+    .catch(error => {
+      if (_token !== null) {
+        this.world.currentUser.token = _token;
+      }
+
+      return Promise.reject(error);
+    });
 };
 
 ApiRT.prototype.refreshIndex = function (index) {

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -1,23 +1,48 @@
+/*
+ * Kuzzle, a backend software, self-hostable and ready to use
+ * to power modern apps
+ *
+ * Copyright 2017 Kuzzle
+ * mailto: support AT kuzzle.io
+ * website: http://kuzzle.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 'use strict';
 
 const _ = require('lodash'),
   uuid = require('node-uuid'),
-  Promise = require('bluebird'),
+  Bluebird = require('bluebird'),
   formatProcessing = require('../core/auth/formatProcessing'),
-  NotFoundError = require('kuzzle-common-objects').errors.NotFoundError,
-  BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
-  PartialError = require('kuzzle-common-objects').errors.PartialError,
-  SizeLimitError = require('kuzzle-common-objects').errors.SizeLimitError,
   Request = require('kuzzle-common-objects').Request,
   User = require('../core/models/security/user'),
   Role = require('../core/models/security/role'),
   Profile = require('../core/models/security/profile'),
-  assertHasBody = require('./util/requestAssertions').assertHasBody,
-  assertBodyHasAttribute = require('./util/requestAssertions').assertBodyHasAttribute,
-  assertBodyHasNotAttribute = require('./util/requestAssertions').assertBodyHasNotAttribute,
-  assertBodyAttributeType = require('./util/requestAssertions').assertBodyAttributeType,
-  assertHasId = require('./util/requestAssertions').assertHasId,
-  assertIdStartsNotUnderscore = require('./util/requestAssertions').assertIdStartsNotUnderscore;
+  {
+    NotFoundError,
+    BadRequestError,
+    PartialError,
+    SizeLimitError
+  } = require('kuzzle-common-objects').errors,
+  {
+    assertHasBody,
+    assertBodyHasAttribute,
+    assertBodyHasNotAttribute,
+    assertBodyAttributeType,
+    assertHasId,
+    assertIdStartsNotUnderscore
+  } = require('./util/requestAssertions');
 
 /**
  * @param {Kuzzle} kuzzle
@@ -29,7 +54,7 @@ class SecurityController {
     /** @type Kuzzle */
     this.kuzzle = kuzzle;
   }
-  
+
   /**
    * Get the role mapping
    *
@@ -105,7 +130,7 @@ class SecurityController {
     return this.kuzzle.repositories.role.loadRole(request.input.resource._id)
       .then(role => {
         if (!role) {
-          return Promise.reject(new NotFoundError(`Role with id ${request.input.resource._id} not found`));
+          return Bluebird.reject(new NotFoundError(`Role with id ${request.input.resource._id} not found`));
         }
 
         return formatProcessing.formatRoleForSerialization(role);
@@ -125,8 +150,8 @@ class SecurityController {
 
     return this.kuzzle.repositories.role.loadMultiFromDatabase(request.input.body.ids)
       .then(roles => {
-        roles = roles.map(role => formatProcessing.formatRoleForSerialization(role));
-        return {hits: roles, total: roles.length};
+        const formatted = roles.map(role => formatProcessing.formatRoleForSerialization(role));
+        return {hits: formatted, total: formatted.length};
       });
   }
 
@@ -139,16 +164,14 @@ class SecurityController {
   searchRoles(request) {
     checkSearchPageLimit(request, this.kuzzle.config.limits.documentsFetchCount);
 
-    let
+    const
       controllers = request.input.body && request.input.body.controllers,
       from = request.input.args && request.input.args.from && Number(request.input.args.from),
       size = request.input.args && request.input.args.size && Number(request.input.args.size);
 
     return this.kuzzle.repositories.role.searchRole(controllers, from, size)
       .then(response => {
-        response.hits = response.hits.map((role => {
-          return formatProcessing.formatRoleForSerialization(role);
-        }));
+        response.hits = response.hits.map((role => formatProcessing.formatRoleForSerialization(role)));
 
         return response;
       });
@@ -209,7 +232,7 @@ class SecurityController {
     return this.kuzzle.repositories.profile.loadProfile(request.input.resource._id)
       .then(profile => {
         if (!profile) {
-          return Promise.reject(new NotFoundError(`Profile with id ${request.input.resource._id} not found`));
+          return Bluebird.reject(new NotFoundError(`Profile with id ${request.input.resource._id} not found`));
         }
 
         return formatProcessing.formatProfileForSerialization(profile);
@@ -229,8 +252,8 @@ class SecurityController {
 
     return this.kuzzle.repositories.profile.loadMultiFromDatabase(request.input.body.ids)
       .then(profiles => {
-        profiles = profiles.map(profile => formatProcessing.formatProfileForSerialization(profile));
-        return {hits: profiles, total: profiles.length};
+        const formatted = profiles.map(profile => formatProcessing.formatProfileForSerialization(profile));
+        return {hits: formatted, total: formatted.length};
       });
   }
 
@@ -315,7 +338,7 @@ class SecurityController {
     return this.kuzzle.repositories.user.load(request.input.resource._id)
       .then(user => {
         if (!user) {
-          return Promise.reject(new NotFoundError(`User with id ${request.input.resource._id} not found`));
+          return Bluebird.reject(new NotFoundError(`User with id ${request.input.resource._id} not found`));
         }
 
         return formatProcessing.formatUserForSerialization(this.kuzzle, user);
@@ -334,7 +357,7 @@ class SecurityController {
     return this.kuzzle.repositories.profile.loadProfile(request.input.resource._id)
       .then(profile => {
         if (!profile) {
-          return Promise.reject(new NotFoundError(`Profile with id ${request.input.resource._id} not found`));
+          return Bluebird.reject(new NotFoundError(`Profile with id ${request.input.resource._id} not found`));
         }
 
         return profile.getRights(this.kuzzle);
@@ -389,6 +412,7 @@ class SecurityController {
     assertHasId(request);
 
     return this.kuzzle.repositories.user.delete(request.input.resource._id)
+      .then(() => this.kuzzle.repositories.token.deleteByUserId(request.input.resource._id))
       .then(() => ({ _id: request.input.resource._id}));
   }
 
@@ -422,17 +446,15 @@ class SecurityController {
    * @returns {Promise<Object>}
    */
   createRestrictedUser(request) {
-    let
-      user = new User(),
-      pojoUser;
-
     assertHasBody(request);
     assertBodyHasNotAttribute(request, 'profileIds');
     assertIdStartsNotUnderscore(request);
 
-    pojoUser = request.input.body;
+    const pojoUser = request.input.body;
     pojoUser._id = request.input.resource._id || uuid.v4();
     pojoUser.profileIds = this.kuzzle.config.security.restrictedProfileIds;
+
+    const user = new User();
 
     return this.kuzzle.repositories.user.hydrate(user, pojoUser)
       .then(modifiedUser => this.kuzzle.repositories.user.persist(modifiedUser, {database: {method: 'create'}}))
@@ -482,7 +504,7 @@ class SecurityController {
     return this.kuzzle.repositories.role.loadRole(request.input.resource._id)
       .then(role => {
         if (!role) {
-          return Promise.reject(new NotFoundError('Cannot update role "' + request.input.resource._id + '": role not found'));
+          return Bluebird.reject(new NotFoundError(`Cannot update role ${request.input.resource._id}: role not found`));
         }
 
         return this.kuzzle.repositories.role.validateAndSaveRole(_.extend(role, request.input.body), {method: 'update'});
@@ -521,12 +543,12 @@ class SecurityController {
     assertHasBody(request);
     assertIdStartsNotUnderscore(request);
 
-    let reset = request.input.args.reset || false;
+    const reset = request.input.args.reset || false;
 
     return this.kuzzle.funnel.controllers.server.adminExists()
       .then(adminExists => {
         if (adminExists.exists) {
-          return Promise.reject(new Error('admin user is already set'));
+          return Bluebird.reject(new Error('admin user is already set'));
         }
 
         delete request.input.args.reset;
@@ -643,12 +665,12 @@ function createOrReplaceProfile (profileRepository, request, opts) {
  * @returns {Promise.<*>}
  */
 function resetRoles (defaults, roleRepository) {
-  let promises = ['admin', 'default', 'anonymous'].map(id => {
-    let role = Object.assign(new Role(), {_id: id}, defaults[id]);
+  const promises = ['admin', 'default', 'anonymous'].map(id => {
+    const role = Object.assign(new Role(), {_id: id}, defaults[id]);
     return roleRepository.validateAndSaveRole(role);
   });
 
-  return Promise.all(promises);
+  return Bluebird.all(promises);
 }
 
 /**
@@ -656,12 +678,12 @@ function resetRoles (defaults, roleRepository) {
  * @returns {Promise.<*>}
  */
 function resetProfiles (profileRepository) {
-  let promises = ['admin', 'default', 'anonymous'].map(id => {
-    let profile = Object.assign(new Profile(), {_id: id, policies: [{roleId: id}]});
+  const promises = ['admin', 'default', 'anonymous'].map(id => {
+    const profile = Object.assign(new Profile(), {_id: id, policies: [{roleId: id}]});
     return profileRepository.validateAndSaveProfile(profile);
   });
 
-  return Promise.all(promises);
+  return Bluebird.all(promises);
 }
 
 /**
@@ -672,8 +694,7 @@ function resetProfiles (profileRepository) {
  * @returns {Promise.<*>}
  */
 function mDelete (kuzzle, type, request) {
-  const
-    action = _.upperFirst(type);
+  const action = _.upperFirst(type);
 
   assertHasBody(request);
   assertBodyHasAttribute(request, 'ids');
@@ -683,14 +704,14 @@ function mDelete (kuzzle, type, request) {
     throw new BadRequestError(`Number of delete to perform exceeds the server configured value (${kuzzle.config.limits.documentsWriteCount})`);
   }
 
-  return Promise.all(request.input.body.ids.map(id => {
+  return Bluebird.all(request.input.body.ids.map(id => {
     const deleteRequest = new Request({
       controller: 'security',
       action: `delete${action}`,
       _id: id
     }, request.context);
 
-    return new Promise(resolve => {
+    return new Bluebird(resolve => {
       kuzzle.funnel.getRequestSlot(deleteRequest, overloadError => {
         if (overloadError) {
           deleteRequest.setError(overloadError);
@@ -733,7 +754,7 @@ function mDelete (kuzzle, type, request) {
  */
 function checkSearchPageLimit(request, limit) {
   if (request.input.args.size) {
-    let size = request.input.args.size - (request.input.args.from || 0);
+    const size = request.input.args.size - (request.input.args.from || 0);
 
     if (size > limit) {
       throw new SizeLimitError(`Search page size exceeds server configured documents limit (${limit})`);
@@ -749,11 +770,11 @@ function checkSearchPageLimit(request, limit) {
  * @returns {Promise<object>}
  */
 function formatUserSearchResult(kuzzle, formatter, raw) {
-  let
+  const
     promises = raw.hits.map(user => formatter(kuzzle, user)),
     users = raw;
 
-  return Promise.all(promises)
+  return Bluebird.all(promises)
     .then(formattedUsers => {
       users.hits = formattedUsers;
       return users;

--- a/lib/api/core/auth/tokenManager.js
+++ b/lib/api/core/auth/tokenManager.js
@@ -77,7 +77,7 @@ class TokenManager {
         clearTimeout(this.timer);
       }
 
-      this.timer = setTimeout(this.checkTokensValidity, delay);
+      this.timer = setTimeout(this.checkTokensValidity.bind(this), delay);
     }
   }
 

--- a/lib/api/core/auth/tokenManager.js
+++ b/lib/api/core/auth/tokenManager.js
@@ -1,3 +1,24 @@
+/*
+ * Kuzzle, a backend software, self-hostable and ready to use
+ * to power modern apps
+ *
+ * Copyright 2017 Kuzzle
+ * mailto: support AT kuzzle.io
+ * website: http://kuzzle.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 'use strict';
 
 const
@@ -22,30 +43,35 @@ const TIMEOUT_MAX = Math.pow(2, 31) - 1;
  * When a token is invalidated, it cleans up the corresponding connection's subscriptions, and notify the
  * user that the token has expired
  *
+ * @class TokenManager
  * @param {Kuzzle} kuzzle
- * @constructor
  */
-function TokenManager (kuzzle) {
-  /*
-   * Tokens are sorted by their expiration date
-   *
-   * The token id is added to the key to handle
-   * equality between different tokens sharing
-   * the exact same expiration date
-   */
-  this.tokens = new SortedArray([], (a, b) => {
-    if (a.idx === b.idx) {
-      return 0;
-    }
+class TokenManager {
+  constructor(kuzzle) {
+    /** @type Kuzzle */
+    this.kuzzle = kuzzle;
 
-    return a.idx < b.idx ? -1 : 1;
-  });
+    /*
+     * Tokens are sorted by their expiration date
+     *
+     * The token id is added to the key to handle
+     * equality between different tokens sharing
+     * the exact same expiration date
+     */
+    this.tokens = new SortedArray([], (a, b) => {
+      if (a.idx === b.idx) {
+        return 0;
+      }
 
-  this.timer = null;
+      return a.idx < b.idx ? -1 : 1;
+    });
 
-  this.runTimer = () => {
+    this.timer = null;
+  }
+
+  runTimer() {
     if (this.tokens.array.length > 0) {
-      let delay = Math.min(this.tokens.array[0].expiresAt - Date.now(), TIMEOUT_MAX);
+      const delay = Math.min(this.tokens.array[0].expiresAt - Date.now(), TIMEOUT_MAX);
 
       if (this.timer) {
         clearTimeout(this.timer);
@@ -53,7 +79,7 @@ function TokenManager (kuzzle) {
 
       this.timer = setTimeout(this.checkTokensValidity, delay);
     }
-  };
+  }
 
   /**
    * Adds a token to the repository
@@ -62,14 +88,14 @@ function TokenManager (kuzzle) {
    * @param {RequestContext} requestContext
    * @return {boolean}
    */
-  this.add = (token, requestContext) => {
-    if (requestContext.connectionId && token._id && token !== kuzzle.repositories.token.anonymous()._id) {
-      let idx = getTokenIndex(token);
+  add(token, requestContext) {
+    if (requestContext.connectionId && token._id && token !== this.kuzzle.repositories.token.anonymous()._id) {
+      const idx = getTokenIndex(token);
 
       this.tokens.insert({
+        idx,
         _id: token._id,
         expiresAt: token.expiresAt,
-        idx,
         userId: token.userId,
         connectionId: requestContext.connectionId
       });
@@ -82,16 +108,16 @@ function TokenManager (kuzzle) {
     }
 
     return false;
-  };
+  }
 
   /**
    * Force a token to expire before its expected time
    * @param token
    * @return {boolean}
    */
-  this.expire = (token) => {
-    if (token._id && token._id !== kuzzle.repositories.token.anonymous()._id && token.expiresAt) {
-      let
+  expire(token) {
+    if (token._id && token._id !== this.kuzzle.repositories.token.anonymous()._id && token.expiresAt) {
+      const
         idx = getTokenIndex(token),
         searchResult = this.tokens.search({idx});
 
@@ -102,27 +128,26 @@ function TokenManager (kuzzle) {
     }
 
     return false;
-  };
+  }
 
-  this.checkTokensValidity = () => {
-    let
-      now = Date.now();
+  checkTokensValidity() {
+    const now = Date.now();
 
     while (this.tokens.array.length > 0 && this.tokens.array[0].expiresAt < now) {
-      let connectionId = this.tokens.array[0].connectionId;
+      const connectionId = this.tokens.array[0].connectionId;
 
       // Send a token expiration notification to the user
-      if (kuzzle.hotelClerk.customers[connectionId]) {
-        let
-          rooms = Object.keys(kuzzle.hotelClerk.customers[connectionId]),
+      if (this.kuzzle.hotelClerk.customers[connectionId]) {
+        const
+          rooms = Object.keys(this.kuzzle.hotelClerk.customers[connectionId]),
           request = new Request({
             controller: 'auth',
             action: 'jwtTokenExpired',
             id: 'server notification'
           });
 
-        kuzzle.notifier.notify(rooms, request, {}, connectionId);
-        kuzzle.hotelClerk.removeCustomerFromAllRooms(new RequestContext({connectionId}));
+        this.kuzzle.notifier.notify(rooms, request, {}, connectionId);
+        this.kuzzle.hotelClerk.removeCustomerFromAllRooms(new RequestContext({connectionId}));
       }
 
       this.tokens.array.shift();
@@ -131,7 +156,7 @@ function TokenManager (kuzzle) {
     if (this.tokens.array.length > 0) {
       this.runTimer();
     }
-  };
+  }
 }
 
 /**

--- a/lib/api/core/models/repositories/tokenRepository.js
+++ b/lib/api/core/models/repositories/tokenRepository.js
@@ -62,7 +62,7 @@ class TokenRepository extends Repository {
    */
   expire(requestToken) {
     return super.expireFromCache(requestToken)
-      .then(() => super.delete(requestToken.userId + '#' + requestToken._id))
+      .then(() => super.delete(super.getCacheKey(requestToken.userId + '#' + requestToken._id)))
       .then(() => this.kuzzle.tokenManager.expire(requestToken));
   }
 
@@ -121,7 +121,10 @@ class TokenRepository extends Repository {
       .then(() => {
         this.kuzzle.tokenManager.add(token, request.context);
 
-        return this.persistToCache({_id: user._id + '#' + token._id}, expiresIn / 1000);
+        return this.persistToCache({
+          _id: user._id + '#' + token._id,
+          expiresAt: token.expiresAt
+        }, expiresIn / 1000);
       })
       .then(() => token)
       .catch(err => {
@@ -244,7 +247,7 @@ class TokenRepository extends Repository {
           .map(key => key.indexOf('#', userKey.length - 1) === -1 ? key.slice(userKey.length - 1) : null)
           .filter(key => key !== null);
 
-        const promises = jwts.map(token => super.delete(token));
+        const promises = jwts.map(token => this.load(token).then(cacheToken => this.expire(cacheToken)));
 
         return Bluebird.all(promises);
       });

--- a/lib/api/core/models/repositories/tokenRepository.js
+++ b/lib/api/core/models/repositories/tokenRepository.js
@@ -39,6 +39,7 @@ const
 class TokenRepository extends Repository {
   constructor (kuzzle, opts = {}) {
     super(kuzzle);
+    this.kuzzle = kuzzle;
     this.collection = 'token';
     this.ObjectConstructor = Token;
     if (opts.ttl !== undefined) {
@@ -48,7 +49,10 @@ class TokenRepository extends Repository {
 
   init() {
     super.init({
-      databaseEngine: null
+      databaseEngine: null,
+      // do not rely on the default value and explicitly
+      // use Redis for this repository
+      cacheEngine: this.kuzzle.services.list.internalCache
     });
   }
 
@@ -58,6 +62,7 @@ class TokenRepository extends Repository {
    */
   expire(requestToken) {
     return super.expireFromCache(requestToken)
+      .then(() => super.delete(requestToken.userId + '#' + requestToken._id))
       .then(() => this.kuzzle.tokenManager.expire(requestToken));
   }
 
@@ -116,8 +121,9 @@ class TokenRepository extends Repository {
       .then(() => {
         this.kuzzle.tokenManager.add(token, request.context);
 
-        return token;
+        return this.persistToCache({_id: user._id + '#' + token._id}, expiresIn / 1000);
       })
+      .then(() => token)
       .catch(err => {
         error = new KuzzleInternalError('Unable to generate token for unknown user');
         error.details = err.message;
@@ -204,6 +210,44 @@ class TokenRepository extends Repository {
 
   serializeToDatabase (token) {
     return this.serializeToCache (token);
+  }
+
+  /**
+   * Deletes tokens affiliated to the provided user identifier
+   *
+   * @param {string} userId
+   * @return {Promise}
+   */
+  deleteByUserId(userId) {
+    const userKey = super.getCacheKey(userId + '#*');
+
+    return this.cacheEngine.searchKeys(userKey)
+      .then(keys => {
+        /*
+         Given the fact that user ids have no restriction,
+         and that Redis pattern matching is lacking the
+         kind of features we need to safeguard against
+         matching unwanted keys,
+         we need to prevent to accidentally remove tokens
+         from other users.
+         For instance, given these two users:
+           foo
+           foo#bar
+
+         If we remove foo, "foo#bar"'s JWT will match the
+         pattern "foo#*".
+
+         This test is possible because '#' is not a valid
+         JWT character
+         */
+        const jwts = keys
+          .map(key => key.indexOf('#', userKey.length - 1) === -1 ? key.slice(userKey.length - 1) : null)
+          .filter(key => key !== null);
+
+        const promises = jwts.map(token => super.delete(token));
+
+        return Bluebird.all(promises);
+      });
   }
 }
 

--- a/lib/api/core/models/repositories/tokenRepository.js
+++ b/lib/api/core/models/repositories/tokenRepository.js
@@ -1,26 +1,42 @@
+/*
+ * Kuzzle, a backend software, self-hostable and ready to use
+ * to power modern apps
+ *
+ * Copyright 2017 Kuzzle
+ * mailto: support AT kuzzle.io
+ * website: http://kuzzle.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 'use strict';
 
 const
   _ = require('lodash'),
   jwt = require('jsonwebtoken'),
   ms = require('ms'),
-  Promise = require('bluebird'),
+  Bluebird = require('bluebird'),
   Token = require('../security/token'),
   Repository = require('./repository'),
-  InternalError = require('kuzzle-common-objects').errors.InternalError,
-  UnauthorizedError = require('kuzzle-common-objects').errors.UnauthorizedError;
+  { InternalError: KuzzleInternalError, UnauthorizedError } = require('kuzzle-common-objects').errors;
 
 /**
  * @class TokenRepository
  * @extends Repository
- * @constructor
+ * @param {Kuzzle} kuzzle
+ * @param {object} [opts]
  */
 class TokenRepository extends Repository {
-  /**
-   * @param {Kuzzle} kuzzle
-   * @param opts
-   * @constructor
-   */
   constructor (kuzzle, opts = {}) {
     super(kuzzle);
     this.collection = 'token';
@@ -30,7 +46,7 @@ class TokenRepository extends Repository {
     }
   }
 
-  init () {
+  init() {
     super.init({
       databaseEngine: null
     });
@@ -40,7 +56,7 @@ class TokenRepository extends Repository {
    * @param {Token} requestToken
    * @returns {Promise<Object>}
    */
-  expire (requestToken) {
+  expire(requestToken) {
     return super.expireFromCache(requestToken)
       .then(() => this.kuzzle.tokenManager.expire(requestToken));
   }
@@ -51,7 +67,7 @@ class TokenRepository extends Repository {
    * @param {object} opts
    * @returns {*}
    */
-  generateToken (user, request, opts) {
+  generateToken(user, request, opts) {
     const
       token = new Token(),
       options = opts || {};
@@ -61,13 +77,13 @@ class TokenRepository extends Repository {
       error;
 
     if (!user || user._id === null) {
-      error = new InternalError('Unknown User : cannot generate token');
-      return Promise.reject(error);
+      error = new KuzzleInternalError('Unknown User : cannot generate token');
+      return Bluebird.reject(error);
     }
 
     if (!request.context.connectionId) {
-      error = new InternalError('Unknown context : cannot generate token');
-      return Promise.reject(error);
+      error = new KuzzleInternalError('Unknown context : cannot generate token');
+      return Bluebird.reject(error);
     }
 
     if (!options.algorithm) {
@@ -83,10 +99,10 @@ class TokenRepository extends Repository {
       encodedToken = jwt.sign({_id: user._id}, this.kuzzle.config.security.jwt.secret, options);
     }
     catch (err) {
-      error = new InternalError('Error while generating token');
+      error = new KuzzleInternalError('Error while generating token');
       error.details = err.message;
       error.stack = err.stack;
-      return Promise.reject(error);
+      return Bluebird.reject(error);
     }
 
     _.assignIn(token, {
@@ -103,18 +119,18 @@ class TokenRepository extends Repository {
         return token;
       })
       .catch(err => {
-        error = new InternalError('Unable to generate token for unknown user');
+        error = new KuzzleInternalError('Unable to generate token for unknown user');
         error.details = err.message;
         error.stack = err.stack;
-        return Promise.reject(error);
+        return Bluebird.reject(error);
       });
   }
 
-  verifyToken (token) {
+  verifyToken(token) {
     let error;
 
     if (token === null) {
-      return Promise.resolve(this.anonymous());
+      return Bluebird.resolve(this.anonymous());
     }
 
     try {
@@ -136,51 +152,51 @@ class TokenRepository extends Repository {
         };
       }
       else {
-        error = new InternalError('Error verifying token');
+        error = new KuzzleInternalError('Error verifying token');
         error.details = err;
       }
 
-      return Promise.reject(error);
+      return Bluebird.reject(error);
     }
 
     return this.load(token)
       .then(userToken => {
         if (userToken === null) {
-          return Promise.reject(new UnauthorizedError('Invalid token', 401));
+          return Bluebird.reject(new UnauthorizedError('Invalid token', 401));
         }
 
         return userToken;
       })
       .catch(err => {
         if (err instanceof UnauthorizedError) {
-          return Promise.reject(err);
+          return Bluebird.reject(err);
         }
 
-        error = new InternalError('Unknown user');
+        error = new KuzzleInternalError('Unknown user');
         error.details = err;
 
-        return Promise.reject(error);
+        return Bluebird.reject(error);
       });
   }
 
   hydrate (userToken, data) {
     if (!_.isObject(data)) {
-      return Promise.resolve(userToken);
+      return Bluebird.resolve(userToken);
     }
 
     _.assignIn(userToken, data);
 
     if (!userToken.userId || userToken.userId === undefined || userToken.userId === null) {
-      return Promise.resolve(this.anonymous());
+      return Bluebird.resolve(this.anonymous());
     }
 
-    return Promise.resolve(userToken);
+    return Bluebird.resolve(userToken);
   }
 
   anonymous () {
     const token = new Token();
 
-    token._id = undefined;
+    token._id = null;
     token.userId = '-1';
 
     return token;
@@ -194,10 +210,8 @@ class TokenRepository extends Repository {
 module.exports = TokenRepository;
 
 function parseTimespan(time) {
-  let milliseconds;
-
   if (typeof time === 'string') {
-    milliseconds = ms(time);
+    const milliseconds = ms(time);
 
     if (typeof milliseconds === 'undefined') {
       return -1;
@@ -205,7 +219,8 @@ function parseTimespan(time) {
 
     return milliseconds;
   }
-  else if (typeof time === 'number') {
+
+  if (typeof time === 'number') {
     return time;
   }
 

--- a/lib/api/core/models/repositories/tokenRepository.js
+++ b/lib/api/core/models/repositories/tokenRepository.js
@@ -247,7 +247,13 @@ class TokenRepository extends Repository {
           .map(key => key.indexOf('#', userKey.length - 1) === -1 ? key.slice(userKey.length - 1) : null)
           .filter(key => key !== null);
 
-        const promises = jwts.map(token => this.load(token).then(cacheToken => this.expire(cacheToken)));
+        const promises = jwts.map(token => this.load(token).then(cacheToken => {
+          if (cacheToken !== null) {
+            return this.expire(cacheToken);
+          }
+
+          return null;
+        }));
 
         return Bluebird.all(promises);
       });

--- a/lib/services/redis.js
+++ b/lib/services/redis.js
@@ -173,7 +173,7 @@ function Redis (kuzzle, options, config) {
    *
    * @param {string} key
    * @param {string} value
-   * @param {string} ttl - in seconds
+   * @param {number} ttl - in seconds
    * @returns {Promise}
    */
   this.volatileSet = function redisVolatileSet (key, value, ttl) {

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -1,206 +1,103 @@
-var
+const
   should = require('should'),
-  _ = require('lodash'),
   jwt = require('jsonwebtoken'),
-  ms = require('ms'),
-  Promise = require('bluebird'),
+  Bluebird = require('bluebird'),
   /** @type KuzzleConfiguration */
   params = require('../../../lib/config'),
-  passport = require('passport'),
-  sinon = require('sinon'),
-  sandbox = sinon.sandbox.create(),
-  util = require('util'),
-  Kuzzle = require('../../../lib/api/kuzzle'),
+  AuthController = require('../../../lib/api/controllers/authController'),
+  Kuzzle = require('../../mocks/kuzzle.mock'),
   Request = require('kuzzle-common-objects').Request,
-  UnauthorizedError = require('kuzzle-common-objects').errors.UnauthorizedError,
-  BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
-  InternalError = require('kuzzle-common-objects').errors.InternalError,
   Token = require('../../../lib/api/core/models/security/token'),
-  request,
-  MockupStrategy;
-
-/**
- * @param name
- * @param verify
- * @constructor
- */
-MockupStrategy = function(name, verify) {
-  passport.Strategy.call(this);
-  this.name = name;
-  this._verify = verify;
-
-};
-
-util.inherits(MockupStrategy, passport.Strategy);
-
-MockupStrategy.prototype.authenticate = function(req) {
-  var
-    self = this,
-    username;
-
-  if (req.body && req.body.username) {
-    username = req.body.username;
-  }
-
-  function verified(err, user, info) {
-    if (err) { return self.error(err); }
-    if (!user) { return self.fail(info); }
-    self.success(user, info);
-  }
-
-  try {
-    this._verify(username, verified);
-  } catch (ex) {
-    return self.error(ex);
-  }
-};
+  {
+    UnauthorizedError,
+    BadRequestError,
+    InternalError: KuzzleInternalError
+  } = require('kuzzle-common-objects').errors;
 
 describe('Test the auth controller', () => {
-  var
-    kuzzle;
-
-  before(() => {
-    kuzzle = new Kuzzle();
-  });
+  let
+    request,
+    kuzzle,
+    authController;
 
   beforeEach(() => {
-    request = new Request({controller: 'auth', action: 'login', body: {strategy: 'mockup', username: 'jdoe'}});
-    sandbox.stub(kuzzle.internalEngine, 'get').returns(Promise.resolve({}));
+    kuzzle = new Kuzzle();
 
-    return kuzzle.services.init({whitelist: []})
-      .then(() => kuzzle.funnel.init())
-      .then(() => {
-        sandbox.stub(kuzzle.repositories.token, 'generateToken', (user, gtcontext, opts) => {
-          var
-            token = new Token(),
-            expiresIn,
-            encodedToken = jwt.sign({_id: user._id}, kuzzle.config.security.jwt.secret, opts);
+    request = new Request({
+      controller: 'auth',
+      action: 'login',
+      body: {
+        strategy: 'mockup',
+        username: 'jdoe'
+      }
+    });
 
-          if (!opts.expiresIn) {
-            opts.expiresIn = 0;
-          }
-          expiresIn = ms(opts.expiresIn);
-
-          _.assignIn(token, {
-            _id: encodedToken,
-            userId: user._id,
-            ttl: expiresIn,
-            expiresAt: Date.now() + expiresIn
-          });
-          return token;
-        });
-
-        sandbox.stub(kuzzle.repositories.token, 'persistToCache').returns(Promise.resolve());
-        sandbox.stub(kuzzle.repositories.user, 'load', t => {
-          if (t === 'unknown_user') {
-            return Promise.resolve(null);
-          }
-          return Promise.resolve({
-            _id: t,
-            profileIds: [t]
-          });
-        });
-
-        return null;
-      });
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    authController = new AuthController(kuzzle);
   });
 
   describe('#login', () => {
-    beforeEach(() => {
-      return passport.use(new MockupStrategy('mockup', function(username, callback) {
-        callback(null, {_id: username});
-      }));
-    });
-
     it('should resolve to a valid jwt token if authentication succeed', () => {
-      sandbox.stub(kuzzle.passport, 'authenticate', r => Promise.resolve({_id: r.query.username}));
-      return kuzzle.funnel.controllers.auth.login(request)
+      const token = new Token();
+
+      token._id = 'foo';
+      token.jwt = 'bar';
+      token.userId = 'foobar';
+
+      kuzzle.repositories.token.generateToken.returns(Bluebird.resolve(token));
+
+      return authController.login(request)
         .then(response => {
-          var decodedToken = jwt.verify(response.jwt, params.security.jwt.secret);
-          should(decodedToken._id).be.equal('jdoe');
+          should(response).match({_id: 'foobar', jwt: 'foo'});
+          should(kuzzle.repositories.token.generateToken).calledWith({}, request, {});
         });
     });
 
     it('should resolve to a redirect url', () => {
-      sandbox.stub(kuzzle.passport, 'authenticate').returns(Promise.resolve({headers: {Location: 'http://github.com'}}));
+      kuzzle.passport.authenticate.returns(Bluebird.resolve({headers: {Location: 'http://github.com'}}));
 
-      return kuzzle.funnel.controllers.auth.login(request)
+      return authController.login(request)
         .then(response => {
           should(response.headers.Location).be.equal('http://github.com');
         });
     });
 
     it('should use local strategy if no one is set', () => {
-
-      var spy = sandbox.stub(kuzzle.passport, 'authenticate', (data, strategy) => {
-        should(strategy).be.exactly('local');
-        return Promise.resolve('foo');
-      });
-
       delete request.input.body.strategy;
 
-      return kuzzle.funnel.controllers.auth.login(request)
+      return authController.login(request)
         .then(() => {
-          should(spy.calledOnce).be.true();
+          should(kuzzle.passport.authenticate).calledWith({query: request.input.body}, 'local');
         });
     });
 
-    it('should be able to set authentication expiration', function (done) {
-      this.timeout(1200);
+    it('should be able to set authentication expiration', () => {
+      const token = new Token();
+
+      token._id = 'foo';
+      token.jwt = 'bar';
+      token.userId = 'foobar';
+
+      kuzzle.repositories.token.generateToken.returns(Bluebird.resolve(token));
 
       request.input.body.expiresIn = '1s';
 
-      sandbox.stub(kuzzle.passport, 'authenticate', r => Promise.resolve({_id: r.query.username}));
-      kuzzle.funnel.controllers.auth.login(request, {connection: {id: 'banana'}})
+      return authController.login(request)
         .then(response => {
-          var decodedToken = jwt.verify(response.jwt, params.security.jwt.secret);
-          should(decodedToken._id).be.equal('jdoe');
-
-          setTimeout(() => {
-            try {
-              jwt.verify(response.jwt, params.security.jwt.secret);
-            }
-            catch (err) {
-              should(err).be.an.instanceOf(jwt.TokenExpiredError);
-              done();
-            }
-          }, 1000);
+          should(response).match({_id: 'foobar', jwt: 'foo'});
+          should(kuzzle.repositories.token.generateToken).calledWith({}, request, {expiresIn: '1s'});
         });
     });
 
-    it('should register token in the token manager when a connexion id is set', () => {
-      request.input.body.expiresIn = '1m';
-      request.context.connectionId = 'banana';
+    it('should reject if authentication fails', () => {
+      kuzzle.passport.authenticate.returns(Bluebird.reject(new Error('error')));
 
-      kuzzle.repositories.token.generateToken.restore();
-      sandbox.stub(kuzzle.tokenManager, 'add', token => {
-        should(token).be.an.instanceOf(Token);
-        should(token.ttl).be.exactly(60000);
-        should(token.expiresAt).be.approximately(Date.now() + token.ttl, 30);
-      });
-
-      sandbox.stub(kuzzle.passport, 'authenticate', r => Promise.resolve({_id: r.query.username}));
-      return kuzzle.funnel.controllers.auth.login(request);
-    });
-
-    it('should reject if authentication failure', () => {
-      sandbox.stub(kuzzle.passport, 'authenticate').returns(Promise.reject(new Error('Mockup Wrapper Error')));
-      return kuzzle.funnel.controllers.auth.login(request)
-        .then(() => should.fail('Authenticate should have reject'))
-        .catch((error) => {
-          should(error.message).be.exactly('Mockup Wrapper Error');
-        });
+      return should(authController.login(request)).be.rejected();
     });
   });
 
   describe('#logout', () => {
-
     beforeEach(() => {
-      var
+      const
         signedToken = jwt.sign({_id: 'admin'}, params.security.jwt.secret, {algorithm: params.security.jwt.algorithm}),
         t = new Token();
 
@@ -213,36 +110,30 @@ describe('Test the auth controller', () => {
         connectionId: 'papagaya',
         token: t
       });
-
-      sandbox.stub(kuzzle.repositories.token, 'expire').returns(Promise.resolve());
     });
 
     it('should expire token', () => {
-      kuzzle.repositories.token.expire.restore();
-      sandbox.stub(kuzzle.repositories.token, 'expire', token => {
-        should(token).be.exactly(request.context.token);
-        return Promise.resolve();
-      });
-
-      return kuzzle.funnel.controllers.auth.logout(request)
+      return authController.logout(request)
         .then(response => {
+          should(kuzzle.repositories.token.expire).calledWith(request.context.token);
           should(response.responseObject).be.instanceof(Object);
         });
     });
 
-    it('should emit an error if token cannot be expired', () => {
-      var error = new Error('Mocked error');
-      kuzzle.repositories.token.expire.restore();
-      sandbox.stub(kuzzle.repositories.token, 'expire').returns(Promise.reject(error));
-      return should(kuzzle.funnel.controllers.auth.logout(request)).be.rejectedWith(error);
+    it('should emit an error if the token cannot be expired', () => {
+      const error = new Error('Mocked error');
+
+      kuzzle.repositories.token.expire.returns(Bluebird.reject(error));
+
+      return should(authController.logout(request)).be.rejectedWith(KuzzleInternalError);
     });
   });
 
   describe('#getCurrentUser', () => {
     it('should return the user given in the context', () => {
-      var req = new Request({body: {}}, {token: {userId: 'admin'}, user: {_id: 'admin'}});
+      const req = new Request({body: {}}, {token: {userId: 'admin'}, user: {_id: 'admin'}});
 
-      return kuzzle.funnel.controllers.auth.getCurrentUser(req)
+      return authController.getCurrentUser(req)
         .then(response => {
           should(response).match(req.context.user);
         });
@@ -250,7 +141,7 @@ describe('Test the auth controller', () => {
   });
 
   describe('#checkToken', () => {
-    var testToken;
+    let testToken;
 
     beforeEach(() => {
       request = new Request({action: 'checkToken', controller: 'auth', body: {token: 'foobar'}}, {});
@@ -260,90 +151,61 @@ describe('Test the auth controller', () => {
 
     it('should throw an error if no token is provided', () => {
       return should(() => {
-        kuzzle.funnel.controllers.auth.checkToken(new Request({body: {}}));
+        authController.checkToken(new Request({body: {}}));
       }).throw(BadRequestError);
     });
 
     it('should return a valid response if the token is valid', () => {
-      sandbox.stub(kuzzle.repositories.token, 'verifyToken', arg => {
-        should(arg).be.eql(request.input.body.token);
-        return Promise.resolve(testToken);
-      });
+      kuzzle.repositories.token.verifyToken.returns(Bluebird.resolve(testToken));
 
-      return kuzzle.funnel.controllers.auth.checkToken(request)
+      return authController.checkToken(request)
         .then(response => {
           should(response).be.instanceof(Object);
           should(response.valid).be.true();
           should(response.state).be.undefined();
           should(response.expiresAt).be.eql(testToken.expiresAt);
+          should(kuzzle.repositories.token.verifyToken).calledWith(request.input.body.token);
         });
     });
 
     it('should return a valid response if the token is not valid', () => {
-      sandbox.stub(kuzzle.repositories.token, 'verifyToken', arg => {
-        should(arg).be.eql(request.input.body.token);
+      kuzzle.repositories.token.verifyToken.returns(Bluebird.reject(new UnauthorizedError('foobar')));
 
-        return Promise.reject(new UnauthorizedError('foobar'));
-      });
-
-      return kuzzle.funnel.controllers.auth.checkToken(request)
+      return authController.checkToken(request)
         .then(response => {
           should(response).be.instanceof(Object);
           should(response.valid).be.false();
           should(response.state).be.eql('foobar');
           should(response.expiresAt).be.undefined();
+          should(kuzzle.repositories.token.verifyToken).calledWith(request.input.body.token);
         });
     });
 
     it('should return a rejected promise if an error occurs', () => {
-      var error = new InternalError('Foobar');
-      sandbox.stub(kuzzle.repositories.token, 'verifyToken', arg => {
-        should(arg).be.eql(request.input.body.token);
-        return Promise.reject(error);
-      });
+      const error = new KuzzleInternalError('Foobar');
+      kuzzle.repositories.token.verifyToken.returns(Bluebird.reject(error));
 
-      return should(kuzzle.funnel.controllers.auth.checkToken(request)).be.rejectedWith(error);
+      return should(authController.checkToken(request)).be.rejectedWith(error);
     });
   });
 
   describe('#updateSelf', () => {
-    var
-      persistOptions;
-
-    beforeEach(() => {
-      persistOptions = {};
-      kuzzle.repositories.user.load.restore();
-      sandbox.stub(kuzzle.repositories.user, 'load', id => {
-        if (id === 'anonymous') {
-          return kuzzle.repositories.user.anonymous();
-        }
-        if (id === 'admin') {
-          return Promise.resolve({_id: 'admin', _source: {profilesId: ['admin']}});
-        }
-        return Promise.resolve(null);
-      });
-
-      sandbox.stub(kuzzle.repositories.user, 'persist', (user, opts) => {
-        persistOptions = opts;
-        return Promise.resolve(user);
-      });
-    });
+    const opts = {database: {method: 'update'}};
 
     it('should return a valid response', () => {
-      return kuzzle.funnel.controllers.auth.updateSelf(new Request(
+      return authController.updateSelf(new Request(
         {body: {foo: 'bar'}},
         {token: {userId: 'admin', _id: 'admin'}, user: {_id: 'admin'}}
       ))
         .then(response => {
           should(response).be.instanceof(Object);
-          should(persistOptions.database.method).be.exactly('update');
-          should(response._id).be.exactly('admin');
+          should(kuzzle.repositories.user.persist).calledWith({_id: 'admin', foo: 'bar'}, opts);
         });
     });
 
     it('should throw an error if profile is specified', () => {
       should(() => {
-        kuzzle.funnel.controllers.auth.updateSelf(new Request(
+        authController.updateSelf(new Request(
           {body: {foo: 'bar', profileIds: ['test']}},
           {token: {userId: 'admin', _id: 'admin'}, user: {_id: 'admin'}}
         ));
@@ -352,7 +214,7 @@ describe('Test the auth controller', () => {
 
     it('should throw an error if _id is specified in the body', () => {
       should(() => {
-        kuzzle.funnel.controllers.auth.updateSelf(new Request(
+        authController.updateSelf(new Request(
           {body: {foo: 'bar', _id: 'test'}},
           {token: {userId: 'admin', _id: 'admin'}, user: {_id: 'admin'}}
         ));
@@ -361,16 +223,16 @@ describe('Test the auth controller', () => {
 
     it('should throw an error if current user is anonymous', () => {
       should(() => {
-        kuzzle.funnel.controllers.auth.updateSelf(new Request({body: {foo: 'bar'}}, {token: {userId: '-1'}, user: {_id: '-1'}}));
+        authController.updateSelf(new Request({body: {foo: 'bar'}}, {token: {userId: '-1'}, user: {_id: '-1'}}));
       }).throw(UnauthorizedError);
     });
   });
 
   describe('#getMyRights', () => {
-    var req = new Request({body: {}}, {token: {userId: 'test'}, user: {
+    const req = new Request({body: {}}, {token: {userId: 'test'}, user: {
       _id: 'test',
       getRights: () => {
-        return Promise.resolve({
+        return Bluebird.resolve({
           rights1: {controller: 'read', action: 'get', index: 'foo', collection: 'bar', value: 'allowed'},
           rights2: {controller: 'write', action: 'delete', index: '*', collection: '*', value: 'conditional'}
         });
@@ -378,15 +240,13 @@ describe('Test the auth controller', () => {
     }});
 
     it('should be able to get current user\'s rights', () => {
-      return kuzzle.funnel.controllers.auth.getMyRights(req)
+      return authController.getMyRights(req)
         .then(response => {
-          var filteredItem;
-
           should(response).be.instanceof(Object);
           should(response.hits).be.an.Array();
           should(response.hits).length(2);
 
-          filteredItem = response.hits.filter(item => {
+          let filteredItem = response.hits.filter(item => {
             return item.controller === 'read' &&
               item.action === 'get' &&
               item.index === 'foo' &&

--- a/test/api/core/models/repositories/tokenRepository.test.js
+++ b/test/api/core/models/repositories/tokenRepository.test.js
@@ -220,7 +220,11 @@ describe('Test: repositories/tokenRepository', () => {
 
   describe('#deleteByUserId', () => {
     it('should delete the tokens associated to a user identifier', () => {
-      kuzzle.services.list.internalCache.searchKeys.returns(Promise.resolve(['foo#foo', 'foo#bar', 'foo#baz']));
+      kuzzle.services.list.internalCache.searchKeys.returns(Promise.resolve([
+        'repos/internalIndex/token/foo#foo',
+        'repos/internalIndex/token/foo#bar',
+        'repos/internalIndex/token/foo#baz'
+      ]));
 
       return tokenRepository.deleteByUserId('foo')
         .then(() => {
@@ -231,7 +235,11 @@ describe('Test: repositories/tokenRepository', () => {
     });
 
     it('should not delete tokens if the internal cache return a false positive', () => {
-      kuzzle.services.list.internalCache.searchKeys.returns(Promise.resolve(['foo#foo', 'foo#bar#bar', 'foo#baz']));
+      kuzzle.services.list.internalCache.searchKeys.returns(Promise.resolve([
+        'repos/internalIndex/token/foo#foo',
+        'repos/internalIndex/token/foo#bar#bar',
+        'repos/internalIndex/token/foo#baz'
+      ]));
 
       return tokenRepository.deleteByUserId('foo')
         .then(() => {

--- a/test/api/core/models/repositories/tokenRepository.test.js
+++ b/test/api/core/models/repositories/tokenRepository.test.js
@@ -1,24 +1,26 @@
-var
+const
   jwt = require('jsonwebtoken'),
-  Promise = require('bluebird'),
+  Bluebird = require('bluebird'),
   should = require('should'),
-  /** @type {Params} */
   KuzzleMock = require('../../../../mocks/kuzzle.mock'),
   sinon = require('sinon'),
   sandbox = sinon.sandbox.create(),
-  InternalError = require('kuzzle-common-objects').errors.InternalError,
-  UnauthorizedError = require('kuzzle-common-objects').errors.UnauthorizedError,
   Token = require('../../../../../lib/api/core/models/security/token'),
   User = require('../../../../../lib/api/core/models/security/user'),
   Request = require('kuzzle-common-objects').Request,
   RequestContext = require('kuzzle-common-objects').models.RequestContext,
-  TokenRepository = require('../../../../../lib/api/core/models/repositories/tokenRepository');
+  TokenRepository = require('../../../../../lib/api/core/models/repositories/tokenRepository'),
+  {
+    InternalError: KuzzleInternalError,
+    UnauthorizedError
+  } = require('kuzzle-common-objects').errors;
 
 describe('Test: repositories/tokenRepository', () => {
-  var
+  const
     context = new RequestContext({
       connectionId: 'papagayo'
-    }),
+    });
+  let
     kuzzle,
     tokenRepository;
 
@@ -35,7 +37,7 @@ describe('Test: repositories/tokenRepository', () => {
 
   describe('#constructor', () => {
     it('should take into account the options given', () => {
-      var repository = new TokenRepository(kuzzle, { ttl: 1000 });
+      const repository = new TokenRepository(kuzzle, { ttl: 1000 });
 
       should(repository.ttl).be.exactly(1000);
     });
@@ -43,7 +45,7 @@ describe('Test: repositories/tokenRepository', () => {
 
   describe('#anonymous', () => {
     it('should return a valid anonymous token', () => {
-      var anonymous = tokenRepository.anonymous();
+      const anonymous = tokenRepository.anonymous();
 
       assertIsAnonymous(anonymous);
     });
@@ -51,10 +53,9 @@ describe('Test: repositories/tokenRepository', () => {
 
   describe('#hydrate', () => {
     it('should return the given token if the given data is not a valid object', () => {
-      var
-        t = new Token();
+      const t = new Token();
 
-      return Promise.all([
+      return Bluebird.all([
         tokenRepository.hydrate(t, null),
         tokenRepository.hydrate(t),
         tokenRepository.hydrate(t, 'a scalar')
@@ -63,7 +64,7 @@ describe('Test: repositories/tokenRepository', () => {
     });
 
     it('should return the anonymous token if no _id is set', done => {
-      var token = new Token();
+      const token = new Token();
 
       tokenRepository.hydrate(token, {})
         .then(result => {
@@ -85,10 +86,7 @@ describe('Test: repositories/tokenRepository', () => {
     });
 
     it('should reject the token if the uuid is not known', () => {
-      var
-        token;
-
-      token = jwt.sign({_id: -99999}, kuzzle.config.security.jwt.secret, {algorithm: kuzzle.config.security.jwt.algorithm});
+      const token = jwt.sign({_id: -99999}, kuzzle.config.security.jwt.secret, {algorithm: kuzzle.config.security.jwt.algorithm});
 
       return should(tokenRepository.verifyToken(token)).be.rejectedWith(UnauthorizedError, {
         message: 'Invalid token'
@@ -96,7 +94,7 @@ describe('Test: repositories/tokenRepository', () => {
     });
 
     it('shoud reject the promise if the jwt is expired', () => {
-      var token = jwt.sign({_id: -1}, kuzzle.config.security.jwt.secret, {algorithm: kuzzle.config.security.jwt.algorithm, expiresIn: 0});
+      const token = jwt.sign({_id: -1}, kuzzle.config.security.jwt.secret, {algorithm: kuzzle.config.security.jwt.algorithm, expiresIn: 0});
 
       return should(tokenRepository.verifyToken(token)).be.rejectedWith(UnauthorizedError, {
         details: {
@@ -106,11 +104,11 @@ describe('Test: repositories/tokenRepository', () => {
     });
 
     it('should reject the promise if an error occurred while fetching the user from the cache', () => {
-      var token = jwt.sign({_id: 'auser'}, kuzzle.config.security.jwt.secret, {algorithm: kuzzle.config.security.jwt.algorithm});
+      const token = jwt.sign({_id: 'auser'}, kuzzle.config.security.jwt.secret, {algorithm: kuzzle.config.security.jwt.algorithm});
 
-      sandbox.stub(tokenRepository, 'loadFromCache').returns(Promise.reject(new InternalError('Error')));
+      sandbox.stub(tokenRepository, 'loadFromCache').returns(Bluebird.reject(new KuzzleInternalError('Error')));
 
-      return should(tokenRepository.verifyToken(token)).be.rejectedWith(InternalError);
+      return should(tokenRepository.verifyToken(token)).be.rejectedWith(KuzzleInternalError);
     });
 
     it('should load the anonymous user if the token is null', () => {
@@ -121,97 +119,88 @@ describe('Test: repositories/tokenRepository', () => {
 
   describe('#generateToken', () => {
     it('should reject the promise if the username is null', () => {
-      return should(tokenRepository.generateToken(null)).be.rejectedWith(InternalError);
+      return should(tokenRepository.generateToken(null)).be.rejectedWith(KuzzleInternalError);
     });
 
     it('should reject the promise if the context is null', () => {
-      return should(tokenRepository.generateToken(new User(), null)).be.rejectedWith(InternalError);
+      const user = new User();
+
+      user._id = 'foobar';
+
+      return should(tokenRepository.generateToken(user, new Request({}))).be.rejectedWith(KuzzleInternalError);
     });
 
     it('should reject the promise if an error occurred while generating the token', () => {
-      var algorithm = kuzzle.config.security.jwt.algorithm;
+      const
+        user = new User(),
+        request = new Request({}, context);
 
-      kuzzle.config.security.jwt.algorithm = 'fake JWT ALgorithm';
+      user._id = 'foobar';
 
-      return should(tokenRepository.generateToken(new User(), context)
-        .catch(err => {
-          kuzzle.config.security.jwt.algorithm = algorithm;
-
-          return Promise.reject(err);
-        })).be.rejectedWith(InternalError);
+      return should(tokenRepository.generateToken(user, request, {expiresIn: 'foo'}))
+        .be.rejectedWith(KuzzleInternalError, {message: 'Error while generating token'});
     });
 
-    it('should resolve to the good jwt token for a given username', done => {
-      var
+    it('should resolve to the good jwt token for a given username', () => {
+      const
         user = new User(),
         checkToken = jwt.sign({_id: 'userInCache'}, kuzzle.config.security.jwt.secret, {
           algorithm: kuzzle.config.security.jwt.algorithm,
           expiresIn: kuzzle.config.security.jwt.expiresIn
-        }),
-        request;
+        });
 
       user._id = 'userInCache';
-      request = new Request({}, {
-        connectionId: 'connectionId',
-        user
+
+      const request = new Request({}, {
+        user,
+        connectionId: 'connectionId'
       });
 
-      tokenRepository.generateToken(user, request)
+      return tokenRepository.generateToken(user, request)
         .then(token => {
           should(token).be.an.instanceOf(Token);
           should(token._id).be.exactly(checkToken);
-
-          done();
-        })
-        .catch(error => {
-          done(error);
         });
     });
 
     it('should return an internal error if an error occurs when generating token', () => {
-      var
-        user = new User(),
-        request;
+      const user = new User();
 
       user._id = 'userInCache';
-      request = new Request({}, {
+
+      const request = new Request({}, {
         connectionId: 'connectionId',
         user
       });
 
-      tokenRepository.generateToken(user, request, {expiresIn: 'toto'})
-        .catch(error => {
-          should(error).be.an.instanceOf(InternalError);
-          should(error.message).be.exactly('Error while generating token');
-        });
-    });
+      kuzzle.services.list.internalCache.volatileSet.returns(Promise.reject(new Error('error')));
 
+      return should(tokenRepository.generateToken(user, request))
+        .be.rejectedWith(KuzzleInternalError, {message: 'Unable to generate token for unknown user'});
+    });
   });
 
   describe('#serializeToCache', () => {
     it('should return a valid plain object', () => {
-      var
+      const
         token = tokenRepository.anonymous(),
-        result;
-
-      result = tokenRepository.serializeToCache(token);
+        result = tokenRepository.serializeToCache(token);
 
       should(result).not.be.an.instanceOf(Token);
       should(result).be.an.Object();
-      should(result._id).be.exactly(undefined);
+      should(result._id).be.exactly(null);
       should(result.userId).be.exactly('-1');
     });
   });
 
   describe('#expire', () => {
     it('should be able to expires a token', () => {
-      var
-        user = new User(),
-        request,
-        token;
+      const user = new User();
+      let token;
 
       user._id = 'userInCache';
-      request = new Request({}, {
+
+      const request = new Request({}, {
         connectionId: 'connectionId',
         user
       });
@@ -229,9 +218,32 @@ describe('Test: repositories/tokenRepository', () => {
     });
   });
 
+  describe('#deleteByUserId', () => {
+    it('should delete the tokens associated to a user identifier', () => {
+      kuzzle.services.list.internalCache.searchKeys.returns(Promise.resolve(['foo#foo', 'foo#bar', 'foo#baz']));
+
+      return tokenRepository.deleteByUserId('foo')
+        .then(() => {
+          should(kuzzle.services.list.internalCache.remove).calledWith('repos/internalIndex/token/foo');
+          should(kuzzle.services.list.internalCache.remove).calledWith('repos/internalIndex/token/bar');
+          should(kuzzle.services.list.internalCache.remove).calledWith('repos/internalIndex/token/baz');
+        });
+    });
+
+    it('should not delete tokens if the internal cache return a false positive', () => {
+      kuzzle.services.list.internalCache.searchKeys.returns(Promise.resolve(['foo#foo', 'foo#bar#bar', 'foo#baz']));
+
+      return tokenRepository.deleteByUserId('foo')
+        .then(() => {
+          should(kuzzle.services.list.internalCache.remove.callCount).be.eql(2);
+          should(kuzzle.services.list.internalCache.remove).calledWith('repos/internalIndex/token/foo');
+          should(kuzzle.services.list.internalCache.remove).calledWith('repos/internalIndex/token/baz');
+        });
+    });
+  });
 });
 
 function assertIsAnonymous (token) {
-  should(token._id).be.undefined();
+  should(token._id).be.null();
   should(token.userId).be.exactly('-1');
 }

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -149,7 +149,8 @@ function KuzzleMock () {
   };
 
   this.passport = {
-    use: sinon.spy()
+    use: sinon.stub(),
+    authenticate: sinon.stub().returns(Promise.resolve({}))
   };
 
   this.pluginsManager = {
@@ -178,11 +179,15 @@ function KuzzleMock () {
       search: sinon.stub().returns(Promise.resolve()),
       ObjectConstructor: sinon.stub().returns({}),
       hydrate: sinon.stub().returns(Promise.resolve()),
-      persist: sinon.stub().returns(Promise.resolve())
+      persist: sinon.stub().returns(Promise.resolve({})),
+      anonymous: sinon.stub().returns({_id: '-1'})
     },
     token: {
       anonymous: sinon.stub().returns({_id: 'anonymous'}),
-      verifyToken: sinon.stub().returns(Promise.resolve())
+      verifyToken: sinon.stub().returns(Promise.resolve()),
+      generateToken: sinon.stub().returns(Promise.resolve({})),
+      expire: sinon.stub().returns(Promise.resolve()),
+      deleteByUserId: sinon.stub().returns(Promise.resolve())
     }
   };
 
@@ -224,6 +229,7 @@ function KuzzleMock () {
       },
       internalCache: {
         add: sinon.stub().returns(Promise.resolve()),
+        del: sinon.stub().returns(Promise.resolve()),
         exists: sinon.stub().returns(Promise.resolve()),
         expire: sinon.stub().returns(Promise.resolve()),
         flushdb: sinon.stub().returns(Promise.resolve()),
@@ -233,6 +239,7 @@ function KuzzleMock () {
         pexpire: sinon.stub().returns(Promise.resolve()),
         psetex: sinon.stub().returns(Promise.resolve()),
         remove: sinon.stub().returns(Promise.resolve()),
+        searchKeys: sinon.stub().returns(Promise.resolve([])),
         set: sinon.stub().returns(Promise.resolve()),
         setnx: sinon.stub().returns(Promise.resolve()),
         volatileSet: sinon.stub().returns(Promise.resolve())


### PR DESCRIPTION
# Description

When deleting a user using `security:deleteUser`, the associated JWT were kept for their entire duration.
This lead to bugs when a deleted user tried to use one of these tokens, as Kuzzle tried to load a non-existing user, trusting the token to know if such a user exist.

This pull request maintain a list of JWT per user, and deletes all associated JWT when a user gets deleted.

Functional tests have been updated to reproduce the problem, ensuring it has been resolved.

# Other changes

* solve sonarqube issues on modified files
* rewrite most of the `authController` unit tests file, as it wasn't using mocks and because many tests  succeeded but not on the expected behavior
* fix unit tests on the `TokenRepository` class

# Solved issue

#773 
