### PR TITLE
Remove the route security:createOrReplaceUser 

### DIFF
--- a/features/HTTP.feature
+++ b/features/HTTP.feature
@@ -173,7 +173,8 @@ Feature: Test HTTP API
 
   @usingHttp
   Scenario: Getting all statistics frame
-    When I get all statistics frames
+    When I get server informations
+    And I get all statistics frames
     Then I get at least 1 statistic frame
 
   @usingHttp
@@ -329,9 +330,9 @@ Feature: Test HTTP API
     When I create a new role "role1" with id "role1"
     And I create a new role "role2" with id "role2"
     And I create a new profile "profile2" with id "profile2"
-    And I create a new user "useradmin" with id "useradmin-id"
+    And I create a user "useradmin" with id "useradmin-id"
     And I create a user "user2" with id "user2-id"
-    And I can't create a new user "user2" with id "useradmin-id"
+    And I can't create a user "user2" with id "useradmin-id"
     Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profileIds":["admin"]}}
     Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profileIds":["#prefix#profile2"]}}
     Then I search for {"ids":{"type": "users", "values":["#prefix#useradmin-id", "#prefix#user2-id"]}} and find 2 users
@@ -346,7 +347,7 @@ Feature: Test HTTP API
 
   @usingHttp @cleanSecurity
   Scenario: user updateSelf
-    When I create a new user "useradmin" with id "useradmin-id"
+    When I create a user "useradmin" with id "useradmin-id"
     Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profileIds":["admin"]}}
     When I log in as useradmin-id:testpwd expiring in 1h
     Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profileIds":["admin"]}}
@@ -366,12 +367,12 @@ Feature: Test HTTP API
     And I create a new profile "profile4" with id "profile4"
     And I create a new profile "profile5" with id "profile5"
     And I create a new profile "profile6" with id "profile6"
-    And I create a new user "user1" with id "user1-id"
-    And I create a new user "user2" with id "user2-id"
-    And I create a new user "user3" with id "user3-id"
-    And I create a new user "user4" with id "user4-id"
-    And I create a new user "user5" with id "user5-id"
-    And I create a new user "user6" with id "user6-id"
+    And I create a user "user1" with id "user1-id"
+    And I create a user "user2" with id "user2-id"
+    And I create a user "user3" with id "user3-id"
+    And I create a user "user4" with id "user4-id"
+    And I create a user "user5" with id "user5-id"
+    And I create a user "user6" with id "user6-id"
     When I log in as user1-id:testpwd1 expiring in 1h
     Then I'm allowed to create a document in index "kuzzle-test-index" and collection "kuzzle-collection-test"
     And I'm allowed to create a document in index "kuzzle-test-index" and collection "kuzzle-collection-test-alt"

--- a/features/Websocket.feature
+++ b/features/Websocket.feature
@@ -283,7 +283,8 @@ Feature: Test websocket API
 
   @usingWebsocket
   Scenario: Getting all statistics frame
-    When I get all statistics frames
+    When I get server informations
+    And I get all statistics frames
     Then I get at least 1 statistic frame
 
   @usingWebsocket
@@ -453,9 +454,9 @@ Feature: Test websocket API
     When I create a new role "role1" with id "role1"
     And I create a new role "role2" with id "role2"
     And I create a new profile "profile2" with id "profile2"
-    And I create a new user "useradmin" with id "useradmin-id"
+    And I create a user "useradmin" with id "useradmin-id"
     And I create a user "user2" with id "user2-id"
-    And I can't create a new user "user2" with id "useradmin-id"
+    And I can't create a user "user2" with id "useradmin-id"
     Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profileIds":["admin"]}}
     Then I am able to get the user "user2-id" matching {"_id":"#prefix#user2-id","_source":{"profileIds":["#prefix#profile2"]}}
     Then I search for {"ids":{"type": "users", "values":["#prefix#useradmin-id", "#prefix#user2-id"]}} and find 2 users
@@ -470,7 +471,7 @@ Feature: Test websocket API
 
   @usingWebsocket @cleanSecurity
   Scenario: user updateSelf
-    When I create a new user "useradmin" with id "useradmin-id"
+    When I create a user "useradmin" with id "useradmin-id"
     Then I am able to get the user "useradmin-id" matching {"_id":"#prefix#useradmin-id","_source":{"profileIds":["admin"]}}
     When I log in as useradmin-id:testpwd expiring in 1h
     Then I am getting the current user, which matches {"_id":"#prefix#useradmin-id","_source":{"profileIds":["admin"]}}
@@ -498,12 +499,12 @@ Feature: Test websocket API
     And I create a new profile "profile4" with id "profile4"
     And I create a new profile "profile5" with id "profile5"
     And I create a new profile "profile6" with id "profile6"
-    And I create a new user "user1" with id "user1-id"
-    And I create a new user "user2" with id "user2-id"
-    And I create a new user "user3" with id "user3-id"
-    And I create a new user "user4" with id "user4-id"
-    And I create a new user "user5" with id "user5-id"
-    And I create a new user "user6" with id "user6-id"
+    And I create a user "user1" with id "user1-id"
+    And I create a user "user2" with id "user2-id"
+    And I create a user "user3" with id "user3-id"
+    And I create a user "user4" with id "user4-id"
+    And I create a user "user5" with id "user5-id"
+    And I create a user "user6" with id "user6-id"
     When I log in as user1-id:testpwd1 expiring in 1h
     Then I'm allowed to create a document in index "kuzzle-test-index" and collection "kuzzle-collection-test"
     And I'm allowed to create a document in index "kuzzle-test-index" and collection "kuzzle-collection-test-alt"

--- a/features/step_definitions/users.js
+++ b/features/step_definitions/users.js
@@ -33,18 +33,17 @@ module.exports = function () {
       });
   });
 
-  this.When(/^I (can't )?create a (new )?(restricted )?user "(.*?)" with id "(.*?)"$/, {timeout: 20000}, function (not, isNew, isRestricted, user, id, callback) {
-    const userObject = this.users[user];
-    let method;
+
+  this.When(/^I (can't )?create a (restricted )?user "(.*?)" with id "(.*?)"$/, {timeout: 20000}, function (not, isRestricted, user, id, callback) {
+    var
+      userObject = this.users[user],
+      method;
 
     if (isRestricted) {
       method = 'createRestrictedUser';
     }
-    else if (isNew) {
-      method = 'createUser';
-    }
     else {
-      method = 'createOrReplaceUser';
+      method = 'createUser';
     }
 
     id = this.idPrefix + id;

--- a/features/support/apiHttp.js
+++ b/features/support/apiHttp.js
@@ -151,6 +151,7 @@ ApiHttp.prototype.callApi = function (options) {
     }
     options.headers = _.extend(options.headers, {authorization: 'Bearer ' + this.world.currentUser.token});
   }
+
   options.json = true;
   options.forever = true;
 
@@ -647,13 +648,21 @@ ApiHttp.prototype.searchRoles = function (body, args) {
   return this.callApi(options);
 };
 
-ApiHttp.prototype.deleteRole = function (id) {
-  const options = {
-    url: this.apiPath('roles/' + id),
+ApiHttp.prototype.deleteRole = function (id, waitFor = false) {
+  return this.callApi({
+    url: this.apiPath('roles/' + id + (waitFor ? '?refresh=wait_for' : '')),
     method: 'DELETE'
-  };
+  });
+};
 
-  return this.callApi(options);
+ApiHttp.prototype.deleteRoles = function (ids, waitFor = false) {
+  return this.callApi({
+    url: this.apiPath('roles/_mDelete' + (waitFor ? '?refresh=wait_for' : '')),
+    method: 'POST',
+    body: {
+      ids
+    }
+  });
 };
 
 ApiHttp.prototype.createOrReplaceProfile = function (id, body) {
@@ -694,17 +703,20 @@ ApiHttp.prototype.mGetProfiles= function (body) {
   return this.callApi(options);
 };
 
-ApiHttp.prototype.searchProfiles = function (body, args) {
+ApiHttp.prototype.searchProfiles = function (query, args) {
   const options = {
     url: this.apiPath('profiles/_search'),
     method: 'POST',
-    body
+    body: {
+      query
+    }
   };
 
   if (args) {
     let first = true;
     Object.keys(args).forEach(arg => {
       options.url += (first ? '?' : '&') + `${arg}=${args[arg]}`;
+      first = false;
     });
   }
 
@@ -718,6 +730,25 @@ ApiHttp.prototype.scrollProfiles = function (scrollId) {
   };
 
   return this.callApi(options);
+};
+
+
+ApiHttp.prototype.deleteProfile = function (id, waitFor = false) {
+  return this.callApi({
+    url: this.apiPath('profiles/' + id + (waitFor ? '?refresh=wait_for' : '')),
+    method: 'DELETE'
+  });
+};
+
+
+ApiHttp.prototype.deleteProfiles = function (ids, waitFor = false) {
+  return this.callApi({
+    url: this.apiPath('profiles/_mDelete' + (waitFor ? '?refresh=wait_for' : '')),
+    method: 'POST',
+    body: {
+      ids
+    }
+  });
 };
 
 ApiHttp.prototype.deleteProfile = function (id) {
@@ -763,17 +794,20 @@ ApiHttp.prototype.getMyRights = function () {
   return this.callApi(options);
 };
 
-ApiHttp.prototype.searchUsers = function (body, args) {
+ApiHttp.prototype.searchUsers = function (query, args) {
   const options = {
     url: this.apiPath('users/_search'),
     method: 'POST',
-    body: { query: body }
+    body: {
+      query
+    }
   };
 
   if (args) {
     let first = true;
     Object.keys(args).forEach(arg => {
       options.url += (first ? '?' : '&') + `${arg}=${args[arg]}`;
+      first = false;
     });
   }
 
@@ -789,18 +823,20 @@ ApiHttp.prototype.scrollUsers = function (scrollId) {
   return this.callApi(options);
 };
 
-ApiHttp.prototype.deleteUser = function (id) {
+ApiHttp.prototype.deleteUser = function (id, waitFor = false) {
   return this.callApi({
-    url: this.apiPath('users/' + id),
+    url: this.apiPath('users/' + id + (waitFor ? '?refresh=wait_for' : '')),
     method: 'DELETE'
   });
 };
 
-ApiHttp.prototype.createOrReplaceUser = function (body, id) {
+ApiHttp.prototype.deleteUsers = function (ids, waitFor = false) {
   return this.callApi({
-    url: this.apiPath('users/' + id),
-    method: 'PUT',
-    body
+    url: this.apiPath('users/_mDelete' + (waitFor ? '?refresh=wait_for' : '')),
+    method: 'POST',
+    body: {
+      ids
+    }
   });
 };
 
@@ -845,6 +881,13 @@ ApiHttp.prototype.checkToken = function (token) {
 ApiHttp.prototype.refreshIndex = function (index) {
   return this.callApi({
     url: this.apiPath(index + '/_refresh'),
+    method: 'POST'
+  });
+};
+
+ApiHttp.prototype.refreshInternalIndex = function () {
+  return this.callApi({
+    url: this.apiPath('_refreshInternal'),
     method: 'POST'
   });
 };
@@ -909,6 +952,7 @@ ApiHttp.prototype.searchSpecifications = function (body, args) {
     let first = true;
     Object.keys(args).forEach(arg => {
       options.url += (first ? '?' : '&') + `${arg}=${args[arg]}`;
+      first = false;
     });
   }
 

--- a/features/support/apiRT.js
+++ b/features/support/apiRT.js
@@ -626,7 +626,7 @@ ApiRT.prototype.searchRoles = function (body, args) {
     msg = {
       controller: 'security',
       action: 'searchRoles',
-      body: body
+      body
     };
 
   _.forEach(args, (item, k) => {
@@ -636,13 +636,32 @@ ApiRT.prototype.searchRoles = function (body, args) {
   return this.send(msg);
 };
 
-ApiRT.prototype.deleteRole = function (id) {
-  const
-    msg = {
-      controller: 'security',
-      action: 'deleteRole',
-      _id: id
-    };
+ApiRT.prototype.deleteRole = function (id, waitFor = false) {
+  const msg = {
+    controller: 'security',
+    action: 'deleteRole',
+    _id: id
+  };
+
+  if (waitFor) {
+    msg.refresh = 'wait_for';
+  }
+
+  return this.send(msg);
+};
+
+ApiRT.prototype.deleteRoles = function (ids, waitFor = false) {
+  const msg = {
+    controller: 'security',
+    action: 'mDeleteRoles',
+    body: {
+      ids
+    }
+  };
+
+  if (waitFor) {
+    msg.refresh = 'wait_for';
+  }
 
   return this.send(msg);
 };
@@ -714,6 +733,35 @@ ApiRT.prototype.searchProfiles = function (body, args) {
   if (args) {
     Object.assign(msg, args);
   }
+};
+
+ApiRT.prototype.searchProfiles = function (query, args) {
+  const
+    msg = {
+      controller: 'security',
+      action: 'searchProfiles',
+      body: {
+        query
+      }
+    };
+
+  _.forEach(args, (item, k) => {
+    msg[k] = item;
+  });
+
+  return this.send(msg);
+};
+
+ApiRT.prototype.deleteProfile = function (id, waitFor = false) {
+  const msg = {
+    controller: 'security',
+    action: 'deleteProfile',
+    _id: id
+  };
+
+  if (waitFor) {
+    msg.refresh = 'wait_for';
+  }
 
   return this.send(msg);
 };
@@ -733,6 +781,22 @@ ApiRT.prototype.deleteProfile = function (id) {
       action: 'deleteProfile',
       _id: id
     };
+
+  return this.send(msg);
+};
+
+ApiRT.prototype.deleteProfiles = function (ids, waitFor = false) {
+  const msg = {
+    controller: 'security',
+    action: 'mDeleteProfiles',
+    body: {
+      ids
+    }
+  };
+
+  if (waitFor) {
+    msg.refresh = 'wait_for';
+  }
 
   return this.send(msg);
 };
@@ -768,12 +832,12 @@ ApiRT.prototype.getMyRights = function (id) {
   });
 };
 
-ApiRT.prototype.searchUsers = function (body, args) {
+ApiRT.prototype.searchUsers = function (query, args) {
   const msg = {
     controller: 'security',
     action: 'searchUsers',
     body: {
-      query: body
+      query
     }
   };
 
@@ -792,21 +856,34 @@ ApiRT.prototype.scrollUsers = function (scrollId) {
   });
 };
 
-ApiRT.prototype.deleteUser = function (id) {
-  return this.send({
+ApiRT.prototype.deleteUser = function (id, waitFor = false) {
+  const msg = {
     controller: 'security',
     action: 'deleteUser',
     _id: id
-  });
+  };
+
+  if (waitFor) {
+    msg.refresh = 'wait_for';
+  }
+
+  return this.send(msg);
 };
 
-ApiRT.prototype.createOrReplaceUser = function (body, id) {
-  return this.send({
+ApiRT.prototype.deleteUsers = function (ids, waitFor = false) {
+  const msg = {
     controller: 'security',
-    action: 'createOrReplaceUser',
-    body: body,
-    _id: id
-  });
+    action: 'mDeleteUsers',
+    body: {
+      ids
+    }
+  };
+
+  if (waitFor) {
+    msg.refresh = 'wait_for';
+  }
+
+  return this.send(msg);
 };
 
 ApiRT.prototype.updateSelf = function (body) {
@@ -823,6 +900,7 @@ ApiRT.prototype.createUser = function (body, id) {
     action: 'createUser',
     body: body
   };
+
   if (id !== undefined) {
     msg._id = id;
   }
@@ -856,6 +934,13 @@ ApiRT.prototype.refreshIndex = function (index) {
     index: index,
     controller: 'index',
     action: 'refresh'
+  });
+};
+
+ApiRT.prototype.refreshInternalIndex = function () {
+  return this.send({
+    controller: 'index',
+    action: 'refreshInternal'
   });
 };
 

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -62,13 +62,12 @@ module.exports = function () {
     this.mapping = {
       properties: {
         firstName: {
-          type: 'string',
+          type: 'text',
           copy_to: 'newFirstName'
         },
         newFirstName: {
-          type: 'string',
-          store: true,
-          index: 'not_analyzed'
+          type: 'keyword',
+          store: true
         }
       }
     };
@@ -76,13 +75,12 @@ module.exports = function () {
     this.securitymapping = {
       properties: {
         foo: {
-          type: 'string',
+          type: 'text',
           copy_to: 'bar'
         },
         bar: {
-          type: 'string',
-          store: true,
-          index: 'not_analyzed'
+          type: 'keyword',
+          store: true
         }
       }
     };

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -511,7 +511,7 @@ class SecurityController {
         request.input.body.profileIds = ['admin'];
         request.input.resource._id = request.input.resource._id || uuid.v4();
 
-        return this.kuzzle.funnel.controllers.security.createOrReplaceUser(request);
+        return this.kuzzle.funnel.controllers.security.createUser(request);
       })
       .then(response => {
         if (reset) {

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -194,7 +194,7 @@ class SecurityController {
 
     const role = this.kuzzle.repositories.role.getRoleFromRequest(request);
 
-    return this.kuzzle.repositories.role.deleteRole(role);
+    return this.kuzzle.repositories.role.deleteRole(role, request.input.args.refresh);
   }
 
   /**
@@ -278,7 +278,7 @@ class SecurityController {
     assertHasId(request);
 
     return this.kuzzle.repositories.profile.buildProfileFromRequest(request)
-      .then(profile => this.kuzzle.repositories.profile.deleteProfile(profile));
+      .then(profile => this.kuzzle.repositories.profile.deleteProfile(profile, request.input.args.refresh));
   }
 
   /**
@@ -388,8 +388,7 @@ class SecurityController {
   deleteUser(request) {
     assertHasId(request);
 
-    return this.kuzzle.repositories.user.delete(request.input.resource._id)
-      .then(() => ({ _id: request.input.resource._id}));
+    return this.kuzzle.repositories.user.delete(request.input.resource._id, {refresh: request.input.args.refresh});
   }
 
   /**
@@ -488,27 +487,6 @@ class SecurityController {
         return this.kuzzle.repositories.role.validateAndSaveRole(_.extend(role, request.input.body), {method: 'update'});
       })
       .then(updatedRole => formatProcessing.formatRoleForSerialization(updatedRole));
-  }
-
-  /**
-   * Creates or replaces a User in Kuzzle
-   *
-   * @param {Request} request
-   * @returns {Promise<Object>}
-   */
-  createOrReplaceUser(request) {
-    const user = new User();
-
-    assertHasBody(request);
-    assertBodyHasAttribute(request, 'profileIds');
-    assertHasId(request);
-    assertIdStartsNotUnderscore(request);
-
-    user._id = request.input.resource._id;
-
-    return this.kuzzle.repositories.user.hydrate(user, request.input.body)
-      .then(modifiedUser => this.kuzzle.repositories.user.persist(modifiedUser))
-      .then(modifiedUser => formatProcessing.formatUserForSerialization(this.kuzzle, modifiedUser));
   }
 
   /**
@@ -689,6 +667,10 @@ function mDelete (kuzzle, type, request) {
       action: `delete${action}`,
       _id: id
     }, request.context);
+
+    if (request.input.args.refresh) {
+      deleteRequest.input.args.refresh = request.input.args.refresh;
+    }
 
     return new Promise(resolve => {
       kuzzle.funnel.getRequestSlot(deleteRequest, overloadError => {

--- a/lib/api/core/models/repositories/profileRepository.js
+++ b/lib/api/core/models/repositories/profileRepository.js
@@ -180,10 +180,10 @@ class ProfileRepository extends Repository {
    * Given a Profile object, delete it from memory and database
    *
    * @param {Profile} profile
-   * @param {string} [refresh]
+   * @param {object} [options]
    * @returns {Promise}
    */
-  deleteProfile (profile, refresh = '') {
+  deleteProfile (profile, options = {}) {
     let query;
 
     if (!profile._id) {
@@ -207,7 +207,7 @@ class ProfileRepository extends Repository {
         }
 
         return this.deleteFromCache(profile._id)
-          .then(() => this.deleteFromDatabase(profile._id, refresh))
+          .then(() => this.deleteFromDatabase(profile._id, options))
           .then((deleteResponse) => {
             if (this.profiles[profile._id] !== undefined) {
               delete this.profiles[profile._id];

--- a/lib/api/core/models/repositories/profileRepository.js
+++ b/lib/api/core/models/repositories/profileRepository.js
@@ -127,6 +127,9 @@ class ProfileRepository extends Repository {
     if (roles && Array.isArray(roles) && roles.length) {
       query.query = {terms: {'policies.roleId': roles}};
     }
+    else {
+      query.query = {match_all: {}};
+    }
 
     return this.search(query, options);
   }
@@ -177,9 +180,10 @@ class ProfileRepository extends Repository {
    * Given a Profile object, delete it from memory and database
    *
    * @param {Profile} profile
+   * @param {string} [refresh]
    * @returns {Promise}
    */
-  deleteProfile (profile) {
+  deleteProfile (profile, refresh = '') {
     let query;
 
     if (!profile._id) {
@@ -190,7 +194,11 @@ class ProfileRepository extends Repository {
       return Promise.reject(new BadRequestError(profile._id + ' is one of the basic profiles of Kuzzle, you cannot delete it, but you can edit it.'));
     }
 
-    query = {terms: { 'profiles': [ profile._id ] }};
+    query = {
+      terms: {
+        'profiles': [ profile._id ]
+      }
+    };
 
     return this.kuzzle.repositories.user.search(query, {from: 0, size: 1})
       .then(response => {
@@ -199,7 +207,7 @@ class ProfileRepository extends Repository {
         }
 
         return this.deleteFromCache(profile._id)
-          .then(() => this.deleteFromDatabase(profile._id))
+          .then(() => this.deleteFromDatabase(profile._id, refresh))
           .then((deleteResponse) => {
             if (this.profiles[profile._id] !== undefined) {
               delete this.profiles[profile._id];

--- a/lib/api/core/models/repositories/repository.js
+++ b/lib/api/core/models/repositories/repository.js
@@ -251,10 +251,10 @@ class Repository {
    * Delete repository from database according to its id
    *
    * @param {string} id
-   * @param {string} [refresh]
+   * @param {object} [options]
    */
-  deleteFromDatabase (id, refresh) {
-    return this.databaseEngine.delete(this.collection, id, refresh);
+  deleteFromDatabase (id, options = {}) {
+    return this.databaseEngine.delete(this.collection, id, options);
   }
 
   /**

--- a/lib/api/core/models/repositories/repository.js
+++ b/lib/api/core/models/repositories/repository.js
@@ -240,7 +240,7 @@ class Repository {
     }
 
     if (this.databaseEngine) {
-      promises.push(this.deleteFromDatabase(id));
+      promises.push(this.deleteFromDatabase(id, options.refresh));
     }
 
     return Promise.all(promises);
@@ -250,10 +250,11 @@ class Repository {
   /**
    * Delete repository from database according to its id
    *
-   * @param id
+   * @param {string} id
+   * @param {string} [refresh]
    */
-  deleteFromDatabase (id) {
-    return this.databaseEngine.delete(this.collection, id);
+  deleteFromDatabase (id, refresh) {
+    return this.databaseEngine.delete(this.collection, id, refresh);
   }
 
   /**

--- a/lib/api/core/models/repositories/roleRepository.js
+++ b/lib/api/core/models/repositories/roleRepository.js
@@ -178,9 +178,10 @@ class RoleRepository extends Repository {
    * Given a Role object, delete it from memory and database
    *
    * @param {Role} role
+   * @param {string} [refresh]
    * @returns Promise
    */
-  deleteRole (role) {
+  deleteRole (role, refresh = '') {
     if (['admin', 'default', 'anonymous'].indexOf(role._id) > -1) {
       return Promise.reject(new BadRequestError(role._id + ' is one of the basic roles of Kuzzle, you cannot delete it, but you can edit it.'));
     }
@@ -191,7 +192,7 @@ class RoleRepository extends Repository {
           return Promise.reject(new BadRequestError('The role "' + role._id + '" cannot be deleted since it is used by some profile.'));
         }
 
-        return this.deleteFromDatabase(role._id)
+        return this.deleteFromDatabase(role._id, refresh)
           .then(deleteResponse => {
             if (this.roles[role._id]) {
               delete this.roles[role._id];

--- a/lib/api/core/models/repositories/roleRepository.js
+++ b/lib/api/core/models/repositories/roleRepository.js
@@ -161,15 +161,15 @@ class RoleRepository extends Repository {
    * Given a Role object, validates its definition and if OK, persist it to the database.
    *
    * @param {Role} role
-   * @param {object} [opts] The persistence options
+   * @param {object} [options] The persistence options
    * @returns Promise
    */
-  validateAndSaveRole (role, opts) {
+  validateAndSaveRole (role, options) {
     return role.validateDefinition()
       .then(() => {
         this.roles[role._id] = role;
         this.kuzzle.pluginsManager.trigger('core:roleRepository:save', {_id: role._id, controllers: role.controllers});
-        return this.persistToDatabase(role, opts);
+        return this.persistToDatabase(role, options);
       })
       .then(() => role);
   }
@@ -178,10 +178,10 @@ class RoleRepository extends Repository {
    * Given a Role object, delete it from memory and database
    *
    * @param {Role} role
-   * @param {string} [refresh]
+   * @param {object} [options]
    * @returns Promise
    */
-  deleteRole (role, refresh = '') {
+  deleteRole (role, options = {}) {
     if (['admin', 'default', 'anonymous'].indexOf(role._id) > -1) {
       return Promise.reject(new BadRequestError(role._id + ' is one of the basic roles of Kuzzle, you cannot delete it, but you can edit it.'));
     }
@@ -192,7 +192,7 @@ class RoleRepository extends Repository {
           return Promise.reject(new BadRequestError('The role "' + role._id + '" cannot be deleted since it is used by some profile.'));
         }
 
-        return this.deleteFromDatabase(role._id, refresh)
+        return this.deleteFromDatabase(role._id, options)
           .then(deleteResponse => {
             if (this.roles[role._id]) {
               delete this.roles[role._id];

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -241,7 +241,6 @@ module.exports = [
 
   {verb: 'put', url: '/profiles/:_id', controller: 'security', action: 'createOrReplaceProfile'},
   {verb: 'put', url: '/roles/:_id', controller: 'security', action: 'createOrReplaceRole'},
-  {verb: 'put', url: '/users/:_id', controller: 'security', action: 'createOrReplaceUser'},
   {verb: 'put', url: '/profiles/:_id/_update', controller: 'security', action: 'updateProfile'},
   {verb: 'put', url: '/roles/:_id/_update', controller: 'security', action: 'updateRole'},
   {verb: 'put', url: '/users/:_id/_update', controller: 'security', action: 'updateUser'},

--- a/lib/services/internalEngine/index.js
+++ b/lib/services/internalEngine/index.js
@@ -315,14 +315,19 @@ class InternalEngine {
    *
    * @param {string} type - data collection
    * @param {string} id - id of the document to delete
+   * @param {string} [refresh] - if equals refresh, will wait for the indexation before resolving
    * @returns {Promise} resolve an object that contains _id
    */
-  delete (type, id) {
+  delete (type, id, refresh) {
     const request = {
       index: this.index,
       type,
       id
     };
+
+    if (refresh === 'wait_for') {
+      request.refresh = 'wait_for';
+    }
 
     return this.client.delete(request)
       .catch(error => handleError(error));

--- a/lib/services/internalEngine/index.js
+++ b/lib/services/internalEngine/index.js
@@ -315,17 +315,17 @@ class InternalEngine {
    *
    * @param {string} type - data collection
    * @param {string} id - id of the document to delete
-   * @param {string} [refresh] - if equals refresh, will wait for the indexation before resolving
+   * @param {object} [options]
    * @returns {Promise} resolve an object that contains _id
    */
-  delete (type, id, refresh) {
+  delete (type, id, options = {}) {
     const request = {
       index: this.index,
       type,
       id
     };
 
-    if (refresh === 'wait_for') {
+    if (options.refresh === 'wait_for') {
       request.refresh = 'wait_for';
     }
 

--- a/test/api/controllers/securityController/createFirstAdmin.test.js
+++ b/test/api/controllers/securityController/createFirstAdmin.test.js
@@ -29,7 +29,7 @@ describe('Test: security controller - createFirstAdmin', () => {
       reset,
       resetRolesStub,
       resetProfilesStub,
-      createOrReplaceUser;
+      createUser;
 
     beforeEach(() => {
       reset = SecurityController.__set__({
@@ -38,9 +38,9 @@ describe('Test: security controller - createFirstAdmin', () => {
       });
       resetRolesStub = SecurityController.__get__('resetRoles');
       resetProfilesStub = SecurityController.__get__('resetProfiles');
-      createOrReplaceUser = sandbox.stub().returns(Promise.resolve());
+      createUser = sandbox.stub().returns(Promise.resolve());
 
-      kuzzle.funnel.controllers.security.createOrReplaceUser = createOrReplaceUser;
+      kuzzle.funnel.controllers.security.createUser = createUser;
     });
 
     afterEach(() => {
@@ -61,8 +61,8 @@ describe('Test: security controller - createFirstAdmin', () => {
 
       return adminController.createFirstAdmin(new Request({_id: 'toto', body: {password: 'pwd'}}))
         .then(() => {
-          should(createOrReplaceUser).be.calledOnce();
-          should(createOrReplaceUser.firstCall.args[0]).be.instanceOf(Request);
+          should(createUser).be.calledOnce();
+          should(createUser.firstCall.args[0]).be.instanceOf(Request);
           should(resetRolesStub).have.callCount(0);
           should(resetProfilesStub).have.callCount(0);
         });
@@ -76,8 +76,8 @@ describe('Test: security controller - createFirstAdmin', () => {
 
       return adminController.createFirstAdmin(new Request({_id: 'toto', body: {password: 'pwd'}, reset: true}))
         .then(() => {
-          should(createOrReplaceUser).be.calledOnce();
-          should(createOrReplaceUser.firstCall.args[0]).be.instanceOf(Request);
+          should(createUser).be.calledOnce();
+          should(createUser.firstCall.args[0]).be.instanceOf(Request);
           should(resetRolesStub).have.callCount(1);
           should(resetProfilesStub).have.callCount(1);
         });

--- a/test/api/controllers/securityController/users.test.js
+++ b/test/api/controllers/securityController/users.test.js
@@ -323,25 +323,6 @@ describe('Test: security controller - users', () => {
     });
   });
 
-  describe('#createOrReplaceUser', () => {
-    it('should return a valid responseObject', () => {
-      kuzzle.repositories.user.hydrate = sandbox.stub().returns(Promise.resolve());
-      kuzzle.repositories.user.persist = sandbox.stub().returns(Promise.resolve({_id: 'test'}));
-
-      return securityController.createOrReplaceUser(new Request({_id: 'test', body: {profileIds: ['admin']}}))
-        .then(response => {
-          should(response).be.instanceof(Object);
-          should(response).be.match({_id: 'test', _source: {}});
-        });
-    });
-
-    it('should reject the promise if no profile is given', () => {
-      return should(() => {
-        securityController.createOrReplaceUser(new Request({_id: 'test'}));
-      }).throw();
-    });
-  });
-
   describe('#getUserRights', () => {
     it('should resolve to an object on a getUserRights call', () => {
       kuzzle.repositories.user.load = userId => {

--- a/test/api/controllers/securityController/users.test.js
+++ b/test/api/controllers/securityController/users.test.js
@@ -185,8 +185,8 @@ describe('Test: security controller - users', () => {
   });
 
   describe('#deleteUser', () => {
-    it('should return a valid responseObject', () => {
-      kuzzle.repositories.user.delete = sandbox.stub().returns(Promise.resolve());
+    it('should return a valid response', () => {
+      kuzzle.repositories.user.delete = sandbox.stub().returns(Promise.resolve({_id: 'test'}));
 
       return securityController.deleteUser(new Request({_id: 'test'}))
         .then(response => {

--- a/test/api/core/models/repositories/profileRepository.test.js
+++ b/test/api/core/models/repositories/profileRepository.test.js
@@ -365,7 +365,7 @@ describe('Test: repositories/profileRepository', () => {
       profileRepository.searchProfiles(false, opts);
       should(profileRepository.search)
         .be.calledOnce()
-        .be.calledWith({query: {}}, opts);
+        .be.calledWith({query: {match_all: {}}}, opts);
 
       profileRepository.searchProfiles(['role1', 'role2']);
       should(profileRepository.search)


### PR DESCRIPTION
**Breaking change:**

* Remove the route security:createOrReplaceUser

**Boyscout:**

* Rewrite `cleanSecurity` to use the `wait_for`
* Adapt the repositories to accept a refresh option in the deletion chain
* Adapt the `security:delete*` to accept a refresh argument
* Adapt test mapping to be compliant with Elasticsearch 5

fixes #757