### PR TITLE
Do not trigger global request events on subrequests

### DIFF
--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -306,12 +306,24 @@ function FunnelController (kuzzle) {
       })
       .then(newRequest => {
         kuzzle.statistics.completedRequest(request);
-        return triggerEvent(kuzzle, newRequest, 'request:onSuccess');
+
+        // do not trigger global events on plugins' subrequests
+        if (newRequest.origin === null) {
+          return triggerEvent(kuzzle, newRequest, 'request:onSuccess');
+        }
+
+        return newRequest;
       })
       .catch(error => {
         kuzzle.statistics.failedRequest(request);
-        return triggerEvent(kuzzle, modifiedRequest, 'request:onError')
-          .finally(() => Promise.reject(error));
+
+        // do not trigger global events on plugins' subrequests
+        if (modifiedRequest.origin === null) {
+          return triggerEvent(kuzzle, modifiedRequest, 'request:onError')
+            .finally(() => Promise.reject(error));
+        }
+
+        return Promise.reject(error);
       })
       .finally(() => {
         this.concurrentRequests--;


### PR DESCRIPTION
# Description

When a plugin performs an API call, it creates automatically a requests chain, with the original client request as the first element.

On a requests chain, our current implementation behave like this:
* when the first subrequest succeeds, a `request:onSuccess` event is triggered with this subrequest provided to listening plugins
* no other subsequent subrequests can trigger this global event due to the infinite event loop protection
* the original client request does not trigger this event either, for the same reason

The last part is what is the most disturbing for plugin developers: global events are made to handle global rules. For instance, to add protocol headers on every outgoing responses.
But trying to do so, they only change a subrequest, with no impact on the response sent to the client.
Moreover, it seems incoherent if one log requests execution, to notice that a `request:onSuccess` event is triggered on the first subrequest, and not on any other subrequest, nor on the client request.

# Solved issue

https://github.com/kuzzleio/kuzzle-common-objects/issues/29

# Note

Excluding this pull request from the changelog, since it enhances a feature introduced in this development branch.