### PR TITLE
Fix dsl & canonization heap space exhaustion

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -15,6 +15,42 @@
     "accessControlAllowOrigin": "*"
   },
 
+  // Kuzzle configured limits
+  "limits": {
+    // * concurrentRequests:
+    //      Number of requests Kuzzle processes simultaneously.
+    //      Requests received above this limit are bufferized until a slot is freed
+    //      This value should be kept low to avoid overloading Kuzzle's event loop.
+    // * documentsFetchCount:
+    //      Maximum number of documents that can be fetched by a single API
+    //      request.This value cannot exceed 9999 and cannot be higher
+    //      than 80% of the requestsBufferSize value
+    // * documentsWriteCount:
+    //      Maximum number of documents that can be written by a single API
+    //      request.This value cannot exceed 9999 and cannot be higher
+    //      than 80% of the requestsBufferSize value
+    // * requestsBufferSize:
+    //      Maximum number of requests that can be bufferized.
+    //      Requests received above this limit are discarded with a 503 error
+    // * requestsBufferWarningThreshold:
+    //      Number of bufferized requests after
+    //      which Kuzzle will throw 'core:overload' events
+    //      (see http://docs.kuzzle.io/plugin-reference/#core)
+    // * requestHistorySize:
+    //      Completed API requests history. For debug and support purposes
+    // * subscriptionConditionsCount
+    //      Maximum number of conditions a subcription filter can contain
+    //      NB: A condition is either a "simple" operator (anything but and, or and bool)
+    //      or a boolean condition that contains only simple operators.
+    "concurrentRequests": 50,
+    "documentsFetchCount": 1000,
+    "documentsWriteCount": 200,
+    "requestsBufferSize": 50000,
+    "requestsBufferWarningThreshold": 5000,
+    "requestsHistorySize": 50,
+    "subscriptionConditionsCount": 16
+  },
+
   // The plugins section lets you define plugins behaviors
   // (see http://kuzzle.io/guide/#plugins)
   "plugins": {
@@ -166,37 +202,6 @@
         }
       }
     }
-  },
-
-  // Kuzzle configured limits
-  "limits": {
-    // * concurrentRequests:
-    //      Number of requests Kuzzle processes simultaneously.
-    //      Requests received above this limit are bufferized until a slot is freed
-    //      This value should be kept low to avoid overloading Kuzzle's event loop.
-    // * requestsBufferSize:
-    //      Maximum number of requests that can be bufferized.
-    //      Requests received above this limit are discarded with a 503 error
-    // * requestsBufferWarningThreshold:
-    //      Number of bufferized requests after
-    //      which Kuzzle will throw 'core:overload' events
-    //      (see http://docs.kuzzle.io/plugin-reference/#core)
-    // * requestHistorySize:
-    //      Completed API requests history. For debug and support purposes
-    // * documentsFetchCount:
-    //      Maximum number of documents that can be fetched by a single API
-    //      request.This value cannot exceed 9999 and cannot be higher
-    //      than 80% of the requestsBufferSize value
-    // * documentsWriteCount:
-    //      Maximum number of documents that can be written by a single API
-    //      request.This value cannot exceed 9999 and cannot be higher
-    //      than 80% of the requestsBufferSize value
-    "concurrentRequests": 50,
-    "requestsBufferSize": 50000,
-    "requestsBufferWarningThreshold": 5000,
-    "requestsHistorySize": 50,
-    "documentsFetchCount": 1000,
-    "documentsWriteCount": 200
   },
 
   // The services are the external components Kuzzle relies on.

--- a/default.config.js
+++ b/default.config.js
@@ -20,6 +20,16 @@ module.exports = {
     accessControlAllowOrigin: '*'
   },
 
+  limits: {
+    concurrentRequests: 50,
+    documentsFetchCount: 1000,
+    documentsWriteCount: 200,
+    requestsHistorySize: 50,
+    requestsBufferSize: 50000,
+    requestsBufferWarningThreshold: 5000,
+    subscriptionConditionsCount: 16
+  },
+
   plugins: {
     common: {
       workerPrefix: 'kpw:',
@@ -119,15 +129,6 @@ module.exports = {
         }
       }
     }
-  },
-
-  limits: {
-    requestsHistorySize: 50,
-    concurrentRequests: 50,
-    requestsBufferSize: 50000,
-    requestsBufferWarningThreshold: 5000,
-    documentsFetchCount: 1000,
-    documentsWriteCount: 200
   },
 
   services: {

--- a/lib/api/dsl/transform/canonical.js
+++ b/lib/api/dsl/transform/canonical.js
@@ -1,9 +1,10 @@
 'use strict';
 
-var
-  _ = require('lodash'),
-  combinatorics = require('js-combinatorics'),
-  espresso = require('espresso-logic-minimizer'),
+const
+  BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
+  config = require('../../../config'),
+  Combinatorics = require('js-combinatorics'),
+  Espresso = require('espresso-logic-minimizer').Espresso,
   strcmp = require('../util/stringCompare');
 
 /**
@@ -11,7 +12,7 @@ var
  *
  * @constructor
  */
-function Canonical () {
+class Canonical {
   /**
    * Entry point of the normalizer: takes a filter in, and reduces it
    * into a simplified version
@@ -32,59 +33,191 @@ function Canonical () {
    * @return {Array} resolving to a simplified filters array
    * @throws if espresso is unable to normalize the provided filters
    */
-  this.convert = function convert (filters) {
-    var
-      conditions,
-      pla,
-      normalized,
-      result = [],
-      clone = _.cloneDeep(filters);
+  convert (filters) {
+    let
+      result = [];
 
     if (Object.keys(filters).length === 0) {
       return [[{'everything': true}]];
     }
 
-    conditions = extractConditions(clone);
-    pla = buildPLA(clone, conditions.length);
-    normalized = espresso(pla);
+    const conditions = extractConditions(this._cloneFilters(filters));
+    if (conditions.length > config.limits.subscriptionConditionsCount) {
+      throw new BadRequestError('Maximum number of sub conditions reached.');
+    }
+
+    let normalized = this._normalize(filters, conditions);
 
     normalized.forEach(entry => {
-      var
+      let
         i,
-        n,
-        subresult = [],
-        length = entry.length;
+        ors = [],
+        subresult = [];
 
-      for (i = 0; entry.charAt(i) !== ' ' && i < length; i++) {
+      for (i = 0; entry.charAt(i) !== ' ' && i < entry.length; i++) {
         // espresso output character can have the following values: '0', '1' or '-'
-        n = parseInt(entry.charAt(i), 2);
+        const
+          n = parseInt(entry.charAt(i), 2),
+          sub = conditions[i];
 
         if (!isNaN(n)) {
           // eslint-disable-next-line no-extra-boolean-cast
-          conditions[i].not = !(Boolean(n));
+          sub.not = !(Boolean(n));
 
-          subresult.push(conditions[i]);
+          if (sub.or || sub.and) {
+            const conds = sub.not
+              ? this._notAndOr(sub.or || sub.and)
+              : this._andOr(sub.or || sub.and);
+
+            if (sub.and && !sub.not || sub.or && sub.not) {
+              // and case
+              subresult = subresult.concat(conds);
+            }
+            else {
+              ors.push(conds);
+            }
+          }
+          else {
+            subresult.push(sub);
+          }
         }
       }
 
-      /*
-       sort the conditions to ensure we get the same room ID
-       from equivalent filters
-       */
-      result.push(subresult.sort((a, b) => {
+      if (ors.length === 0 && subresult.length > 0) {
+        result.push(subresult);
+      }
+      else if (ors.length > 0) {
+        const combinations = Combinatorics.cartesianProduct(...ors);
+        let n = combinations.length;
+
+        while (n--) {
+          result.push(subresult.concat(combinations.next()));
+        }
+      }
+
+    });
+
+    for (const sub of result) {
+      sub.sort((a, b) => {
         let
           k1 = Object.keys(a).find(k => k !== 'not'),
           k2 = Object.keys(b).find(k => k !== 'not');
 
         return strcmp(k1, k2);
-      }));
-    });
+      });
+    }
 
     return result;
-  };
+  }
 
-  return this;
+  /**
+   * Transforms an array of conditions into the format expected by the store
+   * @param {Object[]} conds
+   * @private
+   */
+  _andOr (conds) {
+    return conds.map(c => {
+      if (c.not) {
+        return Object.assign(c.not, {
+          not: true
+        });
+      }
+      return Object.assign(c, {not: false});
+    });
+  }
+
+  /**
+   * Custom _.cloneDeep equivalent, which keeps the _isLeaf non-enumerable property of the filters
+   * @param filters
+   * @returns {*}
+   * @private
+   */
+  _cloneFilters (filters) {
+    if (Array.isArray(filters)) {
+      return filters.map(v => this._cloneFilters(v));
+    }
+    if (!(filters instanceof Object)) {
+      return filters;
+    }
+
+    const clone = {};
+
+    for (let k of Object.keys(filters)) {
+      if (Array.isArray(filters[k])) {
+        clone[k] = filters[k].map(v => this._cloneFilters(v));
+      }
+      else if (filters[k] instanceof Object) {
+        clone[k] = this._cloneFilters(filters[k]);
+      }
+      else {
+        clone[k] = filters[k];
+      }
+    }
+    if (filters._isLeaf !== undefined) {
+      clone._isLeaf = filters._isLeaf;
+    }
+
+    return clone;
+  }
+
+  /**
+   * Given some standardized filters, returns the DNF form in espresso format
+   * @param filters
+   * @param conditions
+   * @returns {String[]}
+   * @private
+   */
+  _normalize (filters, conditions) {
+    if (conditions.length === 1) {
+      const
+        zero = evalFilter(filters, [0]),
+        one = evalFilter(filters, [1]),
+        combined = `${zero >>> 0}${one >>> 0}`;   // string binary representation of the truth table output
+
+      if (combined === '00') {
+        return [];
+      }
+      else if (combined === '01') {
+        return ['1 1'];
+      }
+      else if (combined === '10') {
+        return ['0 1'];
+      }
+      else if (combined === '11') {
+        return ['- 1'];
+      }
+    }
+
+    const
+      baseN = Combinatorics.baseN([0, 1], conditions.length),
+      espresso = new Espresso(conditions.length, 1);
+
+    let row;
+    while ((row = baseN.next())) {
+      espresso.push(row, [evalFilter(filters, row)]);
+    }
+
+    return espresso.minimize();
+  }
+
+  /**
+   * Negates an array of filters in the format expected by the storage
+   * @param conds
+   * @private
+   */
+  _notAndOr (conds) {
+    return conds.map(c => {
+      if (c.not) {
+        return Object.assign(c.not, {not: false});
+      }
+
+      return Object.assign(c, {
+        not: true
+      });
+    });
+  }
 }
+
 
 /**
  * Extracts the conditions from a filter set
@@ -94,7 +227,7 @@ function Canonical () {
  * @return {Array}
  */
 function extractConditions (filters, conditions) {
-  var key = Object.keys(filters)[0];
+  const key = Object.keys(filters)[0];
 
   conditions = conditions || [];
 
@@ -107,33 +240,12 @@ function extractConditions (filters, conditions) {
     return extractConditions(filters[key], conditions);
   }
 
+  if (filters._isLeaf) {
+    conditions.push(filters);
+    return conditions;
+  }
+
   return filters[key].reduce((p, c) => extractConditions(c, p), conditions);
-}
-
-/**
- * Builds a truth table calculating all combinatorics
- * of the provided filters, and returns it in PLA format
- *
- * @param {object} filters
- * @param {number} count - number of conditions
- * @return {Array} truth table in PLA format
- */
-function buildPLA (filters, count) {
-  var
-    baseTable = combinatorics.baseN([true, false], count).toArray(),
-    result = [`.i ${count}`, '.o 1'];
-
-  baseTable.forEach(t => {
-    var
-      output = evalFilter(filters, t) ? '1' : '0',
-      input = t.reduce((p, c) => p + (c ? '1' : '0'), '');
-
-    result.push(`${input} ${output}`);
-  });
-
-  result.push('.e');
-
-  return result;
 }
 
 /**
@@ -143,10 +255,10 @@ function buildPLA (filters, count) {
  * @param {object} filters
  * @param {Array} results - condition results, contains booleans
  * @param {object} [pos] - current condition position
- * @returns {Boolean}
+ * @returns {boolean}
  */
 function evalFilter(filters, results, pos) {
-  var key = Object.keys(filters)[0];
+  const key = Object.keys(filters)[0];
 
   /*
    * We need to embed our position value, which is a scalar,
@@ -156,7 +268,7 @@ function evalFilter(filters, results, pos) {
    */
   pos = pos || {value: 0};
 
-  if (['and', 'or', 'not'].indexOf(key) === -1) {
+  if (['and', 'or', 'not'].indexOf(key) === -1 || filters._isLeaf) {
     return results[pos.value++];
   }
 
@@ -165,7 +277,7 @@ function evalFilter(filters, results, pos) {
   }
 
   return filters[key].reduce((p, c) => {
-    var r = evalFilter(c, results, pos);
+    const r = evalFilter(c, results, pos);
 
     if (p === null) {
       return r;

--- a/lib/api/dsl/transform/canonical.js
+++ b/lib/api/dsl/transform/canonical.js
@@ -41,7 +41,7 @@ class Canonical {
       return [[{'everything': true}]];
     }
 
-    const conditions = extractConditions(this._cloneFilters(filters));
+    const conditions = this._extractConditions(filters);
     if (conditions.length > config.limits.subscriptionConditionsCount) {
       throw new BadRequestError('Maximum number of sub conditions reached.');
     }
@@ -161,6 +161,35 @@ class Canonical {
   }
 
   /**
+   * Extracts the conditions from a filter set
+   *
+   * @param {object} filters
+   * @param {Array} [conditions]
+   * @return {Array}
+   */
+  _extractConditions (filters, conditions) {
+    const key = Object.keys(filters)[0];
+
+    conditions = conditions || [];
+
+    if (['and', 'or', 'not'].indexOf(key) === -1) {
+      conditions.push(this._cloneFilters(filters));
+      return conditions;
+    }
+
+    if (key === 'not') {
+      return this._extractConditions(filters[key], conditions);
+    }
+
+    if (filters._isLeaf) {
+      conditions.push(this._cloneFilters(filters));
+      return conditions;
+    }
+
+    return filters[key].reduce((p, c) => this._extractConditions(c, p), conditions);
+  }
+
+  /**
    * Given some standardized filters, returns the DNF form in espresso format
    * @param filters
    * @param conditions
@@ -216,37 +245,10 @@ class Canonical {
       });
     });
   }
+
+
 }
 
-
-/**
- * Extracts the conditions from a filter set
- *
- * @param {object} filters
- * @param {Array} [conditions]
- * @return {Array}
- */
-function extractConditions (filters, conditions) {
-  const key = Object.keys(filters)[0];
-
-  conditions = conditions || [];
-
-  if (['and', 'or', 'not'].indexOf(key) === -1) {
-    conditions.push(filters);
-    return conditions;
-  }
-
-  if (key === 'not') {
-    return extractConditions(filters[key], conditions);
-  }
-
-  if (filters._isLeaf) {
-    conditions.push(filters);
-    return conditions;
-  }
-
-  return filters[key].reduce((p, c) => extractConditions(c, p), conditions);
-}
 
 /**
  * Given a boolean array containing the conditions results, returns

--- a/lib/api/dsl/transform/index.js
+++ b/lib/api/dsl/transform/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var
+const
   Promise = require('bluebird'),
   Standardizer = require('./standardize'),
   Canonical = require('./canonical'),

--- a/lib/api/dsl/transform/standardize.js
+++ b/lib/api/dsl/transform/standardize.js
@@ -35,7 +35,7 @@ class Standardizer {
     }
 
     if (keywords.length > 1) {
-      return Promise.reject(new BadRequestError('Invalid filter syntax'));
+      return Promise.reject(new BadRequestError('Invalid filter syntax. Filters must have one keyword only'));
     }
 
     if (!this[keywords[0]]) {
@@ -84,7 +84,18 @@ class Standardizer {
           return Promise.reject(new BadRequestError('Array "values" in keyword "ids" can only contain strings'));
         }
 
-        return {or: filter.ids.values.map(v => ({equals: {_id: v}}))};
+        const result = {
+          or: filter.ids.values.map(v => ({equals: {_id: v}})),
+        };
+        Object.defineProperties(result, {
+          _isLeaf: {
+            value: true,
+            writable: true,
+            enumerable: false
+          }
+        });
+
+        return result;
       });
   }
 
@@ -234,7 +245,19 @@ class Standardizer {
           return Promise.reject(new BadRequestError(`Array "${inValue}" in keyword "in" can only contain strings`));
         }
 
-        return {or: filter.in[inValue].map(v => ({equals: {[inValue]: v}}))};
+        const result = {
+          or: filter.in[inValue].map(v => ({equals: {[inValue]: v}})),
+        };
+
+        Object.defineProperties(result, {
+          _isLeaf: {
+            value: true,
+            writable: true,
+            enumerable: false
+          }
+        });
+
+        return result;
       });
   }
 
@@ -446,29 +469,25 @@ class Standardizer {
   /**
    * Validates a AND-like operand
    * @param {object} filter
-   * @param {string} [operand] name - used by AND, MUST and MUST_NOT operands
+   * @param {string} [keyword] name - user keyword entry (and, must, should_not).. used to display errors if any
    * @returns {Promise} standardized filter
    */
-  and (filter, operand) {
-    operand = operand || 'and';
-
-    return mustBeNonEmptyArray(filter, operand, operand)
-      .then(() => this._standardizeFilterArray(filter[operand], operand))
-      .then(standardized => ({[operand]: standardized}));
+  and (filter, keyword) {
+    keyword = keyword || 'and';
+    return mustBeNonEmptyArray(filter, 'and', keyword)
+      .then(() => this._standardizeFilterArray(filter, 'and'));
   }
 
   /**
    * Validates a OR-like operand
    * @param {object} filter
-   * @param {string} [operand] name - used by OR, SHOULD and SHOULD_NOT operands
+   * @param {string} [keyword] name - user keyword entry (or, should, must_not).. used to display errors if any
    * @returns {Promise} standardized filter
    */
-  or (filter, operand) {
-    operand = operand || 'or';
-
-    return mustBeNonEmptyArray(filter, operand, operand)
-      .then(() => this._standardizeFilterArray(filter[operand], operand))
-      .then(standardized => ({[operand]: standardized}));
+  or (filter, keyword) {
+    keyword = keyword || 'or';
+    return mustBeNonEmptyArray(filter, 'or', keyword)
+      .then(() => this._standardizeFilterArray(filter, 'or'));
   }
 
   /**
@@ -477,7 +496,8 @@ class Standardizer {
    * @returns {Promise} standardized filter
    */
   not (filter) {
-    let kwd;
+    let
+      kwd;
 
     return mustBeNonEmptyObject(filter.not, 'not')
       .then(fields => onlyOneFieldAttribute(fields, 'not'))
@@ -490,9 +510,42 @@ class Standardizer {
 
         return mustBeNonEmptyObject(filter.not[kwd], `not.${kwd}`);
       })
-      .then(() => this.standardize(filter.not))
-      .then(result => {
-        return {not: result};
+      .then(() => {
+        return this.standardize(filter.not)
+          .then(result => {
+            const k = Object.keys(result)[0];
+
+            if (k === 'and' || k === 'or') {
+              let _isLeaf = true;
+              return Promise.all(result[k].map(f => this.standardize({not: f})
+                .then(sub => {
+                  if (sub.or || sub.and) {
+                    _isLeaf = false;
+                  }
+                  return sub;
+                })))
+                .then(subs => {
+                  const res = {
+                    [k === 'and' ? 'or' : 'and']: subs
+                  };
+
+                  Object.defineProperties(res, {
+                    _isLeaf: {
+                      value: _isLeaf,
+                      writable: true,
+                      enumerable: false
+                    }
+                  });
+
+                  return res;
+                });
+            }
+
+            if (result.not) {
+              return result.not;
+            }
+            return {not: result};
+          });
       });
   }
 
@@ -503,8 +556,8 @@ class Standardizer {
    */
   bool (filter) {
     const
-      attributes = ['must', 'must_not', 'should', 'should_not'],
-      standardized = {and: []};
+      attributes = ['must', 'must_not', 'should', 'should_not'];
+
 
     return mustBeNonEmptyObject(filter.bool, 'bool')
       .then(fields => {
@@ -513,23 +566,21 @@ class Standardizer {
           return Promise.reject(new BadRequestError('"bool" operand accepts only the following attributes: ' + attributes.join(', ')));
         }
 
-        return filter.bool.must ? this.and(filter.bool, 'must') : Promise.resolve(null);
-      })
-      .then(f => {
-        f && standardized.and.push({and: f.must});
-        return filter.bool.must_not ? this.and(filter.bool, 'must_not') : Promise.resolve(null);
-      })
-      .then(f => {
-        f && standardized.and.push({not: {or: f.must_not}});
-        return filter.bool.should ? this.or(filter.bool, 'should') : Promise.resolve(null);
-      })
-      .then(f => {
-        f && standardized.and.push({or: f.should});
-        return filter.bool.should_not ? this.or(filter.bool, 'should_not') : Promise.resolve(null);
-      })
-      .then(f => {
-        f && standardized.and.push({not: {and: f.should_not}});
-        return standardized;
+        const f = {and: []};
+        if (filter.bool.must) {
+          f.and = f.and.concat(filter.bool.must);
+        }
+        if (filter.bool.must_not) {
+          f.and.push({not: {or: filter.bool.must_not}});
+        }
+        if (filter.bool.should) {
+          f.and.push({or: filter.bool.should});
+        }
+        if (filter.bool.should_not) {
+          f.and.push({not: {and: filter.bool.should_not}});
+        }
+
+        return this.standardize(f);
       });
   }
 
@@ -537,28 +588,77 @@ class Standardizer {
    * Checks that a filters array is well-formed and standardized it
    *
    * @private
-   * @param {Array} filters array
-   * @param {string} keyword used to combine filters
+   * @param {{ string:  }} filter array
+   * @param {string} operand - "real" operand to test - "and" or "or"
    * @returns {Promise}
    */
-  _standardizeFilterArray (filters, keyword) {
+  _standardizeFilterArray (filter, operand) {
     let idx;
 
     // All registered items must be non-array, non-empty objects
-    idx = Object.keys(filters).findIndex(v => {
-      return typeof filters[v] !== 'object' ||
-        Array.isArray(filters[v]) ||
-        Object.keys(filters[v]).length === 0;
+    idx = Object.keys(filter[operand]).findIndex(v => {
+      return typeof filter[operand][v] !== 'object' ||
+        Array.isArray(filter[operand][v]) ||
+        Object.keys(filter[operand][v]).length === 0;
     });
 
     if (idx > -1) {
-      return Promise.reject(new BadRequestError(`"${keyword}" operand can only contain non-empty objects`));
+      return Promise.reject(new BadRequestError(`"${operand}" operand can only contain non-empty objects`));
     }
 
-    return Promise.reduce(filters.map(v => this.standardize(v)), (standardized, item) => {
-      standardized.push(item);
-      return standardized;
-    }, []);
+    let result = {
+      [operand]: [],
+      _isLeaf: true
+    };
+    Object.defineProperties(result, {
+      _isLeaf: {
+        value: true,
+        writable: true,
+        enumerable: false
+      }
+    });
+
+    let
+      leaves = [],
+      andOrs = [];
+
+    return Promise.reduce(filter[operand].map(f => this.standardize(f)), (acc, sub) => {
+      if (sub[operand]) {
+        // and in and || or in or
+        leaves = leaves.concat(sub[operand]);
+        if (!sub._isLeaf) {
+          result._isLeaf = false;
+        }
+      }
+      else if (sub.and || sub.or) {
+        result._isLeaf = false;
+        andOrs.push(sub);
+      }
+      else {
+        leaves.push(sub);
+      }
+    }, result)
+      .then(() => {
+        // transforms filters like {and: [ equals, equals, equals, or ]}
+        // { and: [ and: [ equals, equals, equals ], or} to allow the sub and/or condition
+        // to be processed as one condition by the canonicalization
+        if (!result._isLeaf && leaves.length > 1) {
+          return this.standardize({[operand]: leaves})
+            .then(sub => {
+              result[operand] = andOrs.concat(sub);
+              return result;
+            });
+        }
+
+        result[operand] = andOrs.concat(leaves);
+
+        if (result[operand].length === 1) {
+          return result[operand][0];
+        }
+
+        return result;
+      });
+
   }
 
 }

--- a/lib/api/dsl/transform/standardize.js
+++ b/lib/api/dsl/transform/standardize.js
@@ -585,10 +585,10 @@ class Standardizer {
   }
 
   /**
-   * Checks that a filters array is well-formed and standardized it
+   * Checks that a filters array is well-formed and standardizes it
    *
    * @private
-   * @param {{ string:  }} filter array
+   * @param {Object} filter - "and" or "or" filter, i.e. {and: [cond1, cond2, ...]}
    * @param {string} operand - "real" operand to test - "and" or "or"
    * @returns {Promise}
    */

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dumpme": "^1.0.0",
     "easy-circular-list": "^1.0.13",
     "elasticsearch": "12.1.3",
-    "espresso-logic-minimizer": "^1.0.5",
+    "espresso-logic-minimizer": "^2.0.1",
     "eventemitter2": "^3.0.0",
     "fs-extra": "^1.0.0",
     "highwayhash": "^2.1.0",

--- a/test/api/dsl/operands/bool.test.js
+++ b/test/api/dsl/operands/bool.test.js
@@ -77,37 +77,19 @@ describe('DSL.operands.bool', () => {
         .then(result => {
           should(result).match({
             and: [
-              {
-                and: [
-                  {
-                    or: [
-                      { equals: { firstName: 'Grace' } },
-                      { equals: { firstName: 'Ada' } }
-                    ]
-                  },
-                  { range: { age: { gte: 36, lt: 85 } } }
-                ]
-              },
-              {
-                not: {
-                  or: [
-                    { equals: { city: 'NYC' } }
-                  ]
-                }
-              },
-              {
-                or: [
-                  { equals: { hobby: 'computer' } },
-                  { exists: { field: 'lastName' } }
-                ]
-              },
-              {
-                not: {
-                  and: [
-                    { regexp: { hobby: { value: '^.*ball', flags: 'i' } } }
-                  ]
-                }
-              }
+              {or: [
+                {equals: {firstName: 'Grace'}},
+                {equals: {firstName: 'Ada'}}
+              ]},
+              {or: [
+                {equals: {hobby: 'computer'}},
+                {exists: {field: 'lastName'}}
+              ]},
+              {and: [
+                {range: {age: {gte: 36, lt: 85}}},
+                {not: {equals: {city: 'NYC'}}},
+                {not: {regexp: {hobby: {value: '^.*ball', flags: 'i'}}}}
+              ]}
             ]
           });
         });


### PR DESCRIPTION
# Description

This PR fixes the case where the canonization would extract too many conditions from the subscription filters and exhaust the Javascript memory heap.
The issue is coming from the canonization process, which computes a truth table with a size of 2^n elements, n being the number of conditions.

# Changes

* reduced the number of conditions by considering or and and filters that do not contain any `and` or `or` child clause as a condition (+ several small tricks in the standardizer)
* Introduced a configurable limit of possible conditions to submit to the canonization.

# Related issue:

* #770 
