### PR TITLE
Wrap authentication errors in PluginImplementationError object

### DIFF
--- a/lib/api/core/auth/passportWrapper.js
+++ b/lib/api/core/auth/passportWrapper.js
@@ -1,10 +1,34 @@
+/*
+ * Kuzzle, a backend software, self-hostable and ready to use
+ * to power modern apps
+ *
+ * Copyright 2017 Kuzzle
+ * mailto: support AT kuzzle.io
+ * website: http://kuzzle.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const
-  Promise = require('bluebird'),
+  Bluebird = require('bluebird'),
   passport = require('passport'),
   PassportResponse = require('./passportResponse'),
-  BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
-  UnauthorizedError = require('kuzzle-common-objects').errors.UnauthorizedError,
-  PluginImplementationError = require('kuzzle-common-objects').errors.PluginImplementationError;
+  {
+    KuzzleError,
+    BadRequestError,
+    UnauthorizedError,
+    PluginImplementationError
+  } = require('kuzzle-common-objects').errors;
 
 /**
  * @class PassportWrapper
@@ -23,17 +47,21 @@ class PassportWrapper {
     const response = new PassportResponse();
 
     if (!passport._strategy(strategy)) {
-      return Promise.reject(new BadRequestError('Unknown authentication strategy "' + strategy + '"'));
+      return Bluebird.reject(new BadRequestError(`Unknown authentication strategy "${strategy}"`));
     }
 
-    return new Promise((resolve, reject) => {
+    return new Bluebird((resolve, reject) => {
       response.addEndListener(() => resolve(response));
 
       passport.authenticate(strategy, {scope: this.scope[strategy]}, (err, user, info) => {
         if (err !== null) {
-          reject(new PluginImplementationError(err));
+          if (err instanceof KuzzleError) {
+            reject(err);
+          }
+          else {
+            reject(new PluginImplementationError(err));
+          }
         }
-
         else if (!user) {
           const error = new UnauthorizedError(info.message);
           error.details = {

--- a/lib/api/core/auth/passportWrapper.js
+++ b/lib/api/core/auth/passportWrapper.js
@@ -4,7 +4,7 @@ const
   PassportResponse = require('./passportResponse'),
   BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
   UnauthorizedError = require('kuzzle-common-objects').errors.UnauthorizedError,
-  InternalError = require('kuzzle-common-objects').errors.InternalError;
+  PluginImplementationError = require('kuzzle-common-objects').errors.PluginImplementationError;
 
 /**
  * @class PassportWrapper
@@ -22,33 +22,30 @@ class PassportWrapper {
   authenticate(request, strategy) {
     const response = new PassportResponse();
 
-    try {
-      if (!passport._strategy(strategy)) {
-        return Promise.reject(new BadRequestError('Unknown authentication strategy "' + strategy + '"'));
-      }
-
-      return new Promise((resolve, reject) => {
-        response.addEndListener(() => resolve(response));
-
-        passport.authenticate(strategy, {scope: this.scope[strategy]}, (err, user, info) => {
-          if (err !== null) {
-            reject(err);
-          }
-          else if (!user) {
-            const error = new UnauthorizedError(info.message);
-            error.details = {
-              subCode: error.subCodes.AuthenticationError
-            };
-            reject(error);
-          }
-          else {
-            resolve(user);
-          }
-        })(request, response);
-      });
-    } catch (err) {
-      return Promise.reject(new InternalError(err));
+    if (!passport._strategy(strategy)) {
+      return Promise.reject(new BadRequestError('Unknown authentication strategy "' + strategy + '"'));
     }
+
+    return new Promise((resolve, reject) => {
+      response.addEndListener(() => resolve(response));
+
+      passport.authenticate(strategy, {scope: this.scope[strategy]}, (err, user, info) => {
+        if (err !== null) {
+          reject(new PluginImplementationError(err));
+        }
+
+        else if (!user) {
+          const error = new UnauthorizedError(info.message);
+          error.details = {
+            subCode: error.subCodes.AuthenticationError
+          };
+          reject(error);
+        }
+        else {
+          resolve(user);
+        }
+      })(request, response);
+    });
   }
 
   /**

--- a/test/api/core/auth/passportWrapper.test.js
+++ b/test/api/core/auth/passportWrapper.test.js
@@ -85,7 +85,7 @@ describe('Test the passport Wrapper', () => {
   });
 
   it('should reject in case of authenticate error', () => {
-    return should(passportWrapper.authenticate({body: {username: 'jdoe'}}, 'error')).be.rejectedWith('Bad Credentials');
+    return should(passportWrapper.authenticate({body: {username: 'jdoe'}}, 'error')).be.rejectedWith(/^Bad Credentials/);
   });
 
   it('should return a PassportResponse if the strategy calls a HTTP redirection', () => {


### PR DESCRIPTION
# Description

To prevent unwanted coredumps caused by errors coming from authentication plugins, we need to wrap potential NodeJS errors in `PluginImplementationError` objects

# Other changes

Resolve Sonarqube issues
