### PR TITLE
Add crash reports history limits

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -414,9 +414,8 @@
   //          Core dumps weight usually between 1 and 2GB,
   //          so make sure you have enough space to store
   //          the provided number of coredumps.
-  //      * traces:
-  //          Maximum number of traces dumped
-  //          (i.e. dump directories).
+  //      * reports:
+  //          Maximum number of reports directories
   //  * path:
   //      Directory path where the dumps are stored
   //  * gcore:
@@ -436,7 +435,7 @@
     "enabled": true,
     "history": {
       "coredump": 3,
-      "traces": 10
+      "reports": 10
     },
     "path": "./dump/",
     "gcore": "/usr/bin/gcore",

--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -408,6 +408,15 @@
   //  * enabled:
   //      Enable/disable informations dump on crash or on errors
   //      (see below)
+  //  * history:
+  //      * coredump:
+  //          Maximum number of core dumps to keep.
+  //          Core dumps weight usually between 1 and 2GB,
+  //          so make sure you have enough space to store
+  //          the provided number of coredumps.
+  //      * traces:
+  //          Maximum number of traces dumped
+  //          (i.e. dump directories).
   //  * path:
   //      Directory path where the dumps are stored
   //  * gcore:
@@ -425,6 +434,10 @@
   //          List of error types triggering a dump
   "dump": {
     "enabled": true,
+    "history": {
+      "coredump": 3,
+      "traces": 10
+    },
     "path": "./dump/",
     "gcore": "/usr/bin/gcore",
     "dateFormat": "YYYYMMDD-HHmm",

--- a/default.config.js
+++ b/default.config.js
@@ -193,7 +193,7 @@ module.exports = {
     enabled: true,
     history: {
       coredump: 3,
-      traces: 5
+      reports: 5
     },
     path: './dump/',
     gcore: 'gcore',

--- a/default.config.js
+++ b/default.config.js
@@ -190,7 +190,11 @@ module.exports = {
   },
 
   dump: {
-    enabled: false,
+    enabled: true,
+    history: {
+      coredump: 3,
+      traces: 5
+    },
     path: './dump/',
     gcore: 'gcore',
     dateFormat: 'YYYYMMDD-HHmm',

--- a/lib/api/controllers/cli/dump.js
+++ b/lib/api/controllers/cli/dump.js
@@ -1,17 +1,38 @@
+/*
+ * Kuzzle, a backend software, self-hostable and ready to use
+ * to power modern apps
+ *
+ * Copyright 2017 Kuzzle
+ * mailto: support AT kuzzle.io
+ * website: http://kuzzle.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 'use strict';
 
 /* eslint-disable no-console */
 
-var
-  Promise = require('bluebird'),
+const
+  Bluebird = require('bluebird'),
   path = require('path'),
   fs = require('fs-extra'),
   os = require('os'),
-  mkdirp = require('mkdirp'),
   Request = require('kuzzle-common-objects').Request,
   moment = require('moment'),
-  dumpme = require('dumpme'),
-  _kuzzle;
+  dumpme = require('dumpme');
+
+let _kuzzle;
 
 /**
  * Create a dump
@@ -20,83 +41,144 @@ var
  * @returns {Promise}
  */
 function dump (request) {
-  const suffix = request && request.input.args.suffix ? '-' + request.input.args.suffix : '';
-  const dumpPath = path.join(
-    path.normalize(_kuzzle.config.dump.path),
-    moment().format(_kuzzle.config.dump.dateFormat).concat(suffix)
-  );
-
-  console.log('===========================================================================');
-  console.log('Generating dump in '.concat(dumpPath));
-  mkdirp.sync(dumpPath);
-
-  // dumping kuzzle configuration
-  console.log('> dumping kuzzle configuration');
-  fs.writeFileSync(path.join(dumpPath, 'config.json'), JSON.stringify(_kuzzle.config, null, ' ').concat('\n'));
-
-  // dumping plugins configuration
-  console.log('> dumping plugins configuration');
-  fs.writeFileSync(path.join(dumpPath, 'plugins.json'), JSON.stringify(_kuzzle.pluginsManager.getPluginsFeatures(), null, ' ').concat('\n'));
-
-  // dumping nodejs configuration
-  console.log('> dumping nodejs configuration');
-  fs.writeFileSync(path.join(dumpPath, 'nodejs.json'), JSON.stringify({
-    env: process.env,
-    config: process.config,
-    argv: process.argv,
-    versions: process.versions,
-    release: process.release,
-    moduleLoadList: process.moduleLoadList
-  }, null, ' ').concat('\n'));
-
-  // dumping os configuration
-  console.log('> dumping os configuration');
-  fs.writeFileSync(path.join(dumpPath, 'os.json'), JSON.stringify({
-    platform: os.platform(),
-    loadavg: os.loadavg(),
-    uptime: os.uptime(),
-    cpus: os.cpus(),
-    mem: {
-      total: os.totalmem(),
-      free: os.freemem()
-    },
-    networkInterfaces: os.networkInterfaces()
-  }, null, ' ').concat('\n'));
-
-  // dumping std err/out
-  console.log('> dumping std err/out');
-  if (process.env.pm_err_log_path) {
-    fs.copySync(
-      path.dirname(process.env.pm_err_log_path),
-      path.join(dumpPath, 'logs')
+  return new Bluebird(resolve => {
+    const suffix = request && request.input.args.suffix ? '-' + request.input.args.suffix : '';
+    const dumpPath = path.join(
+      path.normalize(_kuzzle.config.dump.path),
+      moment().format(_kuzzle.config.dump.dateFormat).concat(suffix)
     );
-  } else if (process.env.pm_log_path) {
-    fs.copySync(
-      path.dirname(process.env.pm_log_path),
-      path.join(dumpPath, 'logs')
-    );
+
+    console.log('===========================================================================');
+    cleanUpHistory();
+
+    console.log('Generating dump in '.concat(dumpPath));
+    fs.mkdirsSync(dumpPath);
+
+    // dumping kuzzle configuration
+    console.log('> dumping kuzzle configuration');
+    fs.writeFileSync(path.join(dumpPath, 'config.json'), JSON.stringify(_kuzzle.config, null, ' ').concat('\n'));
+
+    // dumping plugins configuration
+    console.log('> dumping plugins configuration');
+    fs.writeFileSync(path.join(dumpPath, 'plugins.json'), JSON.stringify(_kuzzle.pluginsManager.getPluginsFeatures(), null, ' ').concat('\n'));
+
+    // dumping nodejs configuration
+    console.log('> dumping nodejs configuration');
+    fs.writeFileSync(path.join(dumpPath, 'nodejs.json'), JSON.stringify({
+      env: process.env,
+      config: process.config,
+      argv: process.argv,
+      versions: process.versions,
+      release: process.release,
+      moduleLoadList: process.moduleLoadList
+    }, null, ' ').concat('\n'));
+
+    // dumping os configuration
+    console.log('> dumping os configuration');
+    fs.writeFileSync(path.join(dumpPath, 'os.json'), JSON.stringify({
+      platform: os.platform(),
+      loadavg: os.loadavg(),
+      uptime: os.uptime(),
+      cpus: os.cpus(),
+      mem: {
+        total: os.totalmem(),
+        free: os.freemem()
+      },
+      networkInterfaces: os.networkInterfaces()
+    }, null, ' ').concat('\n'));
+
+    // dumping std err/out
+    console.log('> dumping std err/out');
+    if (process.env.pm_err_log_path) {
+      fs.copySync(
+        path.dirname(process.env.pm_err_log_path),
+        path.join(dumpPath, 'logs')
+      );
+    }
+    else if (process.env.pm_log_path) {
+      fs.copySync(
+        path.dirname(process.env.pm_log_path),
+        path.join(dumpPath, 'logs')
+      );
+    }
+    else {
+      console.log('... no logs found');
+    }
+
+    // core-dump
+    console.log('> generating core-dump');
+    dumpme(_kuzzle.config.dump.gcore || 'gcore', `${dumpPath}/core`);
+
+    // copy node binary
+    console.log('> copy node binary');
+    fs.copySync(process.argv[0], path.join(dumpPath, 'node'));
+
+    // dumping Kuzzle's stats
+    console.log('> dumping kuzzle\'s stats');
+    _kuzzle.statistics.getAllStats(new Request({action: 'getAllStats', controller: 'statistics'}))
+      .then(response => {
+        fs.writeFileSync(path.join(dumpPath, 'statistics.json'), JSON.stringify(response.hits, null, ' ').concat('\n'));
+      });
+
+    console.log('Done.');
+    console.log('[ℹ] You can send the folder to the kuzzle core team at support@kuzzle.io');
+    console.log('===========================================================================');
+
+    resolve(dumpPath);
+  });
+}
+
+function cleanUpHistory() {
+  const
+    config = _kuzzle.config.dump,
+    dumpPath = path.normalize(_kuzzle.config.dump.path);
+
+  try {
+    fs.accessSync(dumpPath, fs.constants.R_OK | fs.constants.W_OK | fs.constants.X_OK);
+  }
+  catch(e) {
+    return;
   }
 
-  // core-dump
-  console.log('> generating core-dump');
-  dumpme(_kuzzle.config.dump.gcore || 'gcore', `${dumpPath}/core`);
+  const dumps = fs.readdirSync(dumpPath)
+    .map(file => {
+      const filepath = `${dumpPath}/${file}`;
+      return {path: filepath, stat: fs.statSync(filepath)};
+    })
+    .filter(prop => prop.stat.isDirectory())
+    .sort((a, b) => {
+      if (a.stat.birthtime.getTime() === b.stat.birthtime.getTime()) {
+        return 0;
+      }
 
-  // copy node binary
-  console.log('> copy node binary');
-  fs.copySync(process.argv[0], path.join(dumpPath, 'node'));
-
-  // dumping Kuzzle's stats
-  console.log('> dumping kuzzle\'s stats');
-  _kuzzle.statistics.getAllStats(new Request({action: 'getAllStats', controller: 'statistics'}))
-    .then(response => {
-      fs.writeFileSync(path.join(dumpPath, 'statistics.json'), JSON.stringify(response.hits, null, ' ').concat('\n'));
+      return a.stat.birthtime < b.stat.birthtime ? -1 : 1;
     });
 
-  console.log('Done.');
-  console.log('[ℹ] You can send the folder to the kuzzle core team at support@kuzzle.io');
-  console.log('===========================================================================');
+  while (dumps.length >= config.history.traces) {
+    const dir = dumps.shift().path;
 
-  return Promise.resolve(dumpPath);
+    console.log(`> removing dump directory from history: ${dir}`);
+    fs.removeSync(dir);
+  }
+
+  const corefiles = dumps
+    .filter(dir => {
+      try {
+        fs.accessSync(`${dir.path}/core`);
+        return true;
+      }
+      catch (e) {
+        return false;
+      }
+    })
+    .map(dir => `${dir.path}/core`);
+
+  while (corefiles.length >= config.history.coredump) {
+    const core = corefiles.shift();
+
+    console.log(`> removing coredump from history: ${core}`);
+    fs.removeSync(core);
+  }
 }
 
 /**

--- a/lib/api/controllers/cli/dump.js
+++ b/lib/api/controllers/cli/dump.js
@@ -154,7 +154,7 @@ function cleanUpHistory() {
       return a.stat.birthtime < b.stat.birthtime ? -1 : 1;
     });
 
-  while (dumps.length >= config.history.traces) {
+  while (dumps.length >= config.history.reports) {
     const dir = dumps.shift().path;
 
     console.log(`> removing dump directory from history: ${dir}`);

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "jsonwebtoken": "^7.2.1",
     "kuzzle-common-objects": "git://github.com/kuzzleio/kuzzle-common-objects.git#2.x",
     "lodash": "4.17.4",
-    "mkdirp": "0.5.1",
     "moment": "2.17.1",
     "ms": "^1.0.0",
     "ngeohash": "0.6.0",

--- a/test/api/controllers/cli/dump.test.js
+++ b/test/api/controllers/cli/dump.test.js
@@ -36,7 +36,7 @@ describe('Test: dump', () => {
         dump: {
           history: {
             coredump: 3,
-            traces: 5
+            reports: 5
           },
           path: '/tmp',
           dateFormat: 'YYYY'
@@ -147,14 +147,14 @@ describe('Test: dump', () => {
         .then(() => should(fsStub.readdirSync).not.be.called());
     });
 
-    it('should not delete traces nor coredumps if limits are not reached', () => {
+    it('should not delete reports nor coredumps if limits are not reached', () => {
       fsStub.readdirSync.returns(['foo', 'bar']);
 
       return dump()
         .then(() => should(fsStub.removeSync).not.be.called());
     });
 
-    it('should delete traces directories if over the limit', () => {
+    it('should delete reports directories if over the limit', () => {
       fsStub.statSync.onSecondCall().returns({
         isDirectory: () => false,
         birthtime: new Date('1979-11-13 01:13')
@@ -175,9 +175,9 @@ describe('Test: dump', () => {
         });
     });
 
-    it('should delete coredumps in traces directories, if over the limit', () => {
+    it('should delete coredumps in reports directories, if over the limit', () => {
       // do not let directory removals interfers with coredump removals
-      kuzzle.config.dump.history.traces = 100;
+      kuzzle.config.dump.history.reports = 100;
 
       fsStub.readdirSync.returns([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 


### PR DESCRIPTION
# Description

Crash reports can be generated by Kuzzle when a problem is detected (without service downtime), or in case of a crash.

These reports generate a memory dump of Kuzzle for debugging purposes by the Kuzzle support team. These memory dumps weight usually about 1~2GB depending on Kuzzle activity at the time of the dump process.

These space-consuming reports are a problem in case of repeated errors: they can (and will) quickly saturate the filesystem.

The aim of this PR is to prevent this FS saturation by making the diagtools module handle its reports history, using configurable limits.

By defaults, these limits have been set to a maximum of 3 coredumps and 10 reports at any given time.
(coredumps will be erased from crash reports if the core limit is inferior to the reports one)

# Other changes

* remove the `mkdirp` dependency, redundant with `fs-extra.mkdirp` method
* solve sonarqube issues on modified files