### PR TITLE
Prevent crash reports on controller plugins bugs

### DIFF
--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -349,7 +349,7 @@ class FunnelController {
 
         // do not trigger global events on plugins' subrequests
         if (newRequest.origin === null) {
-          return triggerEvent(kuzzle, newRequest, 'request:onSuccess');
+          return triggerEvent(this.kuzzle, newRequest, 'request:onSuccess');
         }
 
         return newRequest;
@@ -365,7 +365,7 @@ class FunnelController {
 
         // do not trigger global events on plugins' subrequests
         if (modifiedRequest.origin === null) {
-          return triggerEvent(kuzzle, modifiedRequest, 'request:onError')
+          return triggerEvent(this.kuzzle, modifiedRequest, 'request:onError')
             .finally(() => Bluebird.reject(_error));
         }
 

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -336,7 +336,7 @@ class FunnelController {
       .then(newRequest => {
         modifiedRequest = newRequest;
 
-        return action(newRequest);
+        return controllers[request.input.controller][request.input.action](newRequest);
       })
       .then(responseData => {
         const afterEvent = this.getEventName(request.input.controller, 'after', request.input.action);

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -1,26 +1,53 @@
+/*
+ * Kuzzle, a backend software, self-hostable and ready to use
+ * to power modern apps
+ *
+ * Copyright 2017 Kuzzle
+ * mailto: support AT kuzzle.io
+ * website: http://kuzzle.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 'use strict';
 
-var
-  Promise = require('bluebird'),
+const
+  Bluebird = require('bluebird'),
   Deque = require('denque'),
   AuthController = require('./authController'),
   BulkController = require('./bulkController'),
   CollectionController = require('./collectionController'),
   DocumentController = require('./documentController'),
   IndexController = require('./indexController'),
-  KuzzleError = require('kuzzle-common-objects').errors.KuzzleError,
   MemoryStorageController = require('./memoryStorageController'),
   RealtimeController = require('./realtimeController'),
   SecurityController = require('./securityController'),
   ServerController = require('./serverController'),
-  BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
-  UnauthorizedError = require('kuzzle-common-objects').errors.UnauthorizedError,
-  ForbiddenError = require('kuzzle-common-objects').errors.ForbiddenError,
-  ServiceUnavailableError = require('kuzzle-common-objects').errors.ServiceUnavailableError,
-  Request = require('kuzzle-common-objects').Request;
+  Request = require('kuzzle-common-objects').Request,
+  {
+    BadRequestError,
+    ForbiddenError,
+    KuzzleError,
+    PluginImplementationError,
+    ServiceUnavailableError,
+    UnauthorizedError
+  } = require('kuzzle-common-objects').errors;
 
 const MIN_TIME_BEFORE_DUMP_PREV_ERROR = 60000;
 
+/**
+ * @class CacheItem
+ */
 class CacheItem {
   constructor(request, callback) {
     this.request = request;
@@ -29,41 +56,46 @@ class CacheItem {
 }
 
 /**
+ * @class FunnelController
  * @property {object} controllers
  * @param {Kuzzle} kuzzle
  */
-function FunnelController (kuzzle) {
-  this.overloaded = false;
-  this.concurrentRequests = 0;
-  this.controllers = {};
-  this.requestsCache = new Deque();
-  this.cachedItems = 0;
-  this.lastOverloadTime = 0;
-  this.overloadWarned = false;
-  this.lastWarningTime = 0;
+class FunnelController {
+  constructor(kuzzle) {
+    this.kuzzle = kuzzle;
+    this.overloaded = false;
+    this.concurrentRequests = 0;
+    this.controllers = {};
+    this.pluginsControllers = {};
+    this.requestsCache = new Deque();
+    this.cachedItems = 0;
+    this.lastOverloadTime = 0;
+    this.overloadWarned = false;
+    this.lastWarningTime = 0;
 
-  this.lastDumpedErrors = {};
+    this.lastDumpedErrors = {};
 
-  // used only for core-dump analysis
-  this.pendingRequests = {};
+    // used only for core-dump analysis
+    this.pendingRequests = {};
 
-  // used only for core-dump analysis
-  this.requestHistory = new Deque();
-  this.historized = 0;
+    // used only for core-dump analysis
+    this.requestHistory = new Deque();
+    this.historized = 0;
+  }
 
-  this.init = function funnelInit () {
-    this.controllers.auth = new AuthController(kuzzle);
-    this.controllers.bulk = new BulkController(kuzzle);
-    this.controllers.collection = new CollectionController(kuzzle);
-    this.controllers.document = new DocumentController(kuzzle);
-    this.controllers.index = new IndexController(kuzzle);
-    this.controllers.memoryStorage = this.controllers.ms = new MemoryStorageController(kuzzle);
-    this.controllers.realtime = new RealtimeController(kuzzle);
-    this.controllers.security = new SecurityController(kuzzle);
-    this.controllers.server = new ServerController(kuzzle);
+  init() {
+    this.controllers.auth = new AuthController(this.kuzzle);
+    this.controllers.bulk = new BulkController(this.kuzzle);
+    this.controllers.collection = new CollectionController(this.kuzzle);
+    this.controllers.document = new DocumentController(this.kuzzle);
+    this.controllers.index = new IndexController(this.kuzzle);
+    this.controllers.memoryStorage = this.controllers.ms = new MemoryStorageController(this.kuzzle);
+    this.controllers.realtime = new RealtimeController(this.kuzzle);
+    this.controllers.security = new SecurityController(this.kuzzle);
+    this.controllers.server = new ServerController(this.kuzzle);
 
-    kuzzle.pluginsManager.injectControllers();
-  };
+    this.pluginsControllers = this.kuzzle.pluginsManager.getPluginControllers();
+  }
 
   /**
    * Asks the overload-protection system for a request slot.
@@ -77,16 +109,16 @@ function FunnelController (kuzzle) {
    * @param {Request} request
    * @param {Function} callback
    */
-  this.getRequestSlot = function funnelGetRequestSlot (request, callback) {
+  getRequestSlot(request, callback) {
     this.pendingRequests[request.id] = request;
 
     if (this.overloaded) {
-      let now = Date.now();
+      const now = Date.now();
 
-      if ((this.cachedItems > kuzzle.config.limits.requestsBufferWarningThreshold) && (this.lastWarningTime === 0 || this.lastWarningTime < now - 500)) {
-        let overloadPercentage = Math.round(10000 * this.cachedItems / kuzzle.config.limits.requestsBufferSize) / 100;
-        kuzzle.pluginsManager.trigger('core:overload', overloadPercentage);
-        kuzzle.pluginsManager.trigger('log:warn', `[!WARNING!] Kuzzle overloaded: ${overloadPercentage}%. Delaying requests...`);
+      if ((this.cachedItems > this.kuzzle.config.limits.requestsBufferWarningThreshold) && (this.lastWarningTime === 0 || this.lastWarningTime < now - 500)) {
+        const overloadPercentage = Math.round(10000 * this.cachedItems / this.kuzzle.config.limits.requestsBufferSize) / 100;
+        this.kuzzle.pluginsManager.trigger('core:overload', overloadPercentage);
+        this.kuzzle.pluginsManager.trigger('log:warn', `[!WARNING!] Kuzzle overloaded: ${overloadPercentage}%. Delaying requests...`);
 
         this.overloadWarned = true;
         this.lastWarningTime = now;
@@ -94,8 +126,8 @@ function FunnelController (kuzzle) {
     }
 
     // resolves the callback immediately if a slot is available
-    if (this.concurrentRequests < kuzzle.config.limits.concurrentRequests) {
-      return callback(null, request);
+    if (this.concurrentRequests < this.kuzzle.config.limits.concurrentRequests) {
+      return callback(null);
     }
 
     /*
@@ -109,12 +141,12 @@ function FunnelController (kuzzle) {
      2- the number of cached requests is equal to the requestsBufferSize property.
      The request is then discarded and an error is returned to the sender
      */
-    if (this.cachedItems >= kuzzle.config.limits.requestsBufferSize) {
+    if (this.cachedItems >= this.kuzzle.config.limits.requestsBufferSize) {
       const error = new ServiceUnavailableError('Request discarded: Kuzzle Server is temporarily overloaded');
 
-      kuzzle.pluginsManager.trigger('log:error', error);
+      this.kuzzle.pluginsManager.trigger('log:error', error);
       request.setError(error);
-      return callback(error, request);
+      return callback(error);
     }
 
     this.cachedItems++;
@@ -133,9 +165,9 @@ function FunnelController (kuzzle) {
        even if this means executing this function once for nothing each
        time we start overload mode.
        */
-      playCachedRequests(kuzzle, this);
+      playCachedRequests(this.kuzzle, this);
     }
-  };
+  }
 
   /**
    * Execute the API request by 1/ asking for a request slot,
@@ -146,7 +178,7 @@ function FunnelController (kuzzle) {
    * @param {Request} request
    * @param {Function} callback
    */
-  this.execute = function funnelExecute (request, callback) {
+  execute(request, callback) {
     this.getRequestSlot(request, overloadError => {
       if (overloadError) {
         // "handleErrorDump" shouldn't need to be called for 503 errors
@@ -158,7 +190,7 @@ function FunnelController (kuzzle) {
         .then(processResult => callback(null, processResult))
         .catch(err => {
           // JSON.stringify(new NativeError()) === '{}', i.e. Error, SyntaxError, TypeError, ReferenceError, etc.
-          kuzzle.pluginsManager.trigger('log:error', err instanceof Error && !(err instanceof KuzzleError)
+          this.kuzzle.pluginsManager.trigger('log:error', err instanceof Error && !(err instanceof KuzzleError)
             ? err.message + '\n' + err.stack
             : err
           );
@@ -173,7 +205,7 @@ function FunnelController (kuzzle) {
 
       return null;
     });
-  };
+  }
 
   /**
    * Checks if an error is worth dumping Kuzzle. If so,
@@ -181,42 +213,40 @@ function FunnelController (kuzzle) {
    *
    * @param {KuzzleError|*} err
    */
-  this.handleErrorDump = function funnelHandleErrorDump (err) {
-    if (kuzzle.config.dump.enabled && kuzzle.config.dump.handledErrors.enabled) {
+  handleErrorDump(err) {
+    if (this.kuzzle.config.dump.enabled && this.kuzzle.config.dump.handledErrors.enabled) {
       setImmediate(() => {
-        var
+        const
           lastSeen = Date.now(),
-          request,
-          errorType,
-          errorMessage;
+          errorType = typeof err === 'object' && err.name ? err.name : typeof err;
 
-        errorType = typeof err === 'object' && err.name ? err.name : typeof err;
-
-        if (kuzzle.config.dump.handledErrors.whitelist.indexOf(errorType) > -1) {
-          request = new Request({
+        if (this.kuzzle.config.dump.handledErrors.whitelist.indexOf(errorType) > -1) {
+          const request = new Request({
             controller: 'actions',
             action: 'dump',
             body: {}
           });
 
           // simplify error message to use it in folder dump name
-          errorMessage = err.message;
+          let errorMessage = err.message;
+
           if (errorMessage.indexOf('\n') > -1) {
             errorMessage = errorMessage.split('\n')[0];
           }
+
           errorMessage = errorMessage.toLowerCase().replace(/[^a-zA-Z0-9-_]/g, '-').replace(/[-]+/g, '-').split('-');
           errorMessage = errorMessage.filter(value => value !== '').join('-');
 
           request.input.body.suffix = 'handled-'.concat(errorType.toLowerCase(), '-', errorMessage);
 
           if (!this.lastDumpedErrors[request.input.body.suffix] || this.lastDumpedErrors[request.input.body.suffix] < lastSeen - MIN_TIME_BEFORE_DUMP_PREV_ERROR) {
-            kuzzle.cliController.actions.dump(request);
+            this.kuzzle.cliController.actions.dump(request);
             this.lastDumpedErrors[request.input.body.suffix] = lastSeen;
           }
         }
       });
     }
-  };
+  }
 
   /**
    * Checks if a user has the necessary rights to execute the action
@@ -224,17 +254,17 @@ function FunnelController (kuzzle) {
    * @param {Request} request
    * @return {Promise<Request>}
    */
-  this.checkRights = function checkRights (request) {
-    return kuzzle.repositories.token.verifyToken(request.input.jwt)
+  checkRights(request) {
+    return this.kuzzle.repositories.token.verifyToken(request.input.jwt)
       .then(userToken => {
         request.context.token = userToken;
 
-        return kuzzle.repositories.user.load(request.context.token.userId);
+        return this.kuzzle.repositories.user.load(request.context.token.userId);
       })
       .then(user => {
         request.context.user = user;
 
-        return user.isActionAllowed(request, kuzzle);
+        return user.isActionAllowed(request, this.kuzzle);
       })
       .then(isAllowed => {
         if (!isAllowed) {
@@ -251,13 +281,13 @@ function FunnelController (kuzzle) {
 
           request.setError(error);
 
-          return triggerEvent(kuzzle, request, 'request:onUnauthorized')
-            .finally(() => Promise.reject(error));
+          return triggerEvent(this.kuzzle, request, 'request:onUnauthorized')
+            .finally(() => Bluebird.reject(error));
         }
 
-        return triggerEvent(kuzzle, request, 'request:onAuthorized');
+        return triggerEvent(this.kuzzle, request, 'request:onAuthorized');
       });
-  };
+  }
 
   /**
    * Executes the request immediately.
@@ -266,20 +296,31 @@ function FunnelController (kuzzle) {
    * @param {KuzzleRequest} request
    * @return {Promise}
    */
-  this.processRequest = function processRequest(request) {
-    if (
-      !this.controllers[request.input.controller]
-      || !this.controllers[request.input.controller][request.input.action]
-      || typeof this.controllers[request.input.controller][request.input.action] !== 'function'
-    ) {
+  processRequest(request) {
+    let controllers;
+
+    if (this.controllers[request.input.controller]) {
+      controllers = this.controllers;
+    }
+    else if (this.pluginsControllers[request.input.controller]) {
+      controllers = this.pluginsControllers;
+    }
+    else {
       delete this.pendingRequests[request.id];
-      return Promise.reject(new BadRequestError(`No corresponding action ${request.input.action} in controller ${request.input.controller}`));
+      throw new BadRequestError(`Unknown controller ${request.input.controller}`);
     }
 
-    kuzzle.statistics.startRequest(request);
+    const action = controllers[request.input.controller][request.input.action];
+
+    if (!action || typeof action !== 'function') {
+      delete this.pendingRequests[request.id];
+      throw new BadRequestError(`No corresponding action ${request.input.action} in controller ${request.input.controller}`);
+    }
+
+    this.kuzzle.statistics.startRequest(request);
     this.concurrentRequests++;
 
-    if (this.historized > kuzzle.config.limits.requestsHistorySize) {
+    if (this.historized > this.kuzzle.config.limits.requestsHistorySize) {
       this.requestHistory.shift();
     }
     else {
@@ -288,36 +329,42 @@ function FunnelController (kuzzle) {
 
     this.requestHistory.push(request);
 
-    let
-      beforeEvent = this.getEventName(request.input.controller, 'before', request.input.action),
-      modifiedRequest;
+    const beforeEvent = this.getEventName(request.input.controller, 'before', request.input.action);
+    let modifiedRequest;
 
-    return triggerEvent(kuzzle, request, beforeEvent)
+    return triggerEvent(this.kuzzle, request, beforeEvent)
       .then(newRequest => {
         modifiedRequest = newRequest;
 
-        return this.controllers[request.input.controller][request.input.action](newRequest);
+        return action(newRequest);
       })
       .then(responseData => {
-        let afterEvent = this.getEventName(request.input.controller, 'after', request.input.action);
+        const afterEvent = this.getEventName(request.input.controller, 'after', request.input.action);
         modifiedRequest.setResult(responseData, {status: request.status === 102 ? 200 : request.status});
 
-        return triggerEvent(kuzzle, modifiedRequest, afterEvent);
+        return triggerEvent(this.kuzzle, modifiedRequest, afterEvent);
       })
       .then(newRequest => {
-        kuzzle.statistics.completedRequest(request);
-        return triggerEvent(kuzzle, newRequest, 'request:onSuccess');
+        this.kuzzle.statistics.completedRequest(request);
+        return triggerEvent(this.kuzzle, newRequest, 'request:onSuccess');
       })
       .catch(error => {
-        kuzzle.statistics.failedRequest(request);
-        return triggerEvent(kuzzle, modifiedRequest, 'request:onError')
-          .finally(() => Promise.reject(error));
+        let _error = error;
+
+        this.kuzzle.statistics.failedRequest(request);
+
+        if (controllers === this.pluginsControllers && !(error instanceof KuzzleError)) {
+          _error = new PluginImplementationError(error);
+        }
+
+        return triggerEvent(this.kuzzle, modifiedRequest, 'request:onError')
+          .finally(() => Bluebird.reject(_error));
       })
       .finally(() => {
         this.concurrentRequests--;
         delete this.pendingRequests[request.id];
       });
-  };
+  }
 
   /**
    * Helper function meant to normalize event names
@@ -328,11 +375,11 @@ function FunnelController (kuzzle) {
    * @param {string} action - executed action
    * @returns {string} event name
    */
-  this.getEventName = function getEventName(controller, prefix, action) {
+  getEventName(controller, prefix, action) {
     const event = controller === 'memoryStorage' ? 'ms' : controller;
 
     return event + ':' + prefix + capitalizeFirstLetter(action);
-  };
+  }
 }
 
 /**
@@ -348,7 +395,7 @@ function playCachedRequests(kuzzle, funnel) {
 
   if (quantityToInject > 0) {
     for (let i = 0; i < quantityToInject; i++) {
-      let cachedItem = funnel.requestsCache.shift();
+      const cachedItem = funnel.requestsCache.shift();
       funnel.execute(cachedItem.request, cachedItem.callback);
     }
 
@@ -358,7 +405,7 @@ function playCachedRequests(kuzzle, funnel) {
   if (funnel.cachedItems > 0) {
     setTimeout(() => playCachedRequests(kuzzle, funnel), 0);
   } else {
-    let now = Date.now();
+    const now = Date.now();
     // No request remaining in cache => stop the background task and return to normal behavior
     funnel.overloaded = false;
 
@@ -389,7 +436,7 @@ function capitalizeFirstLetter(string) {
  */
 function triggerEvent(kuzzle, request, event) {
   if (request.hasTriggered(event)) {
-    return Promise.resolve(request);
+    return Bluebird.resolve(request);
   }
 
   request.triggers(event);

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -1,21 +1,38 @@
+/*
+ * Kuzzle, a backend software, self-hostable and ready to use
+ * to power modern apps
+ *
+ * Copyright 2017 Kuzzle
+ * mailto: support AT kuzzle.io
+ * website: http://kuzzle.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 'use strict';
 
 const
   debug = require('debug')('kuzzle:plugins'),
-  GatewayTimeoutError = require('kuzzle-common-objects').errors.GatewayTimeoutError,
-  PluginImplementationError = require('kuzzle-common-objects').errors.PluginImplementationError,
   PluginContext = require('./pluginContext'),
   PrivilegedPluginContext = require('./privilegedPluginContext'),
   async = require('async'),
   path = require('path'),
-  Promise = require('bluebird'),
+  Bluebird = require('bluebird'),
   _ = require('lodash'),
-  CircularList = require('easy-circular-list');
-
-// cannot be constant: stubbed in unit tests
-let
+  CircularList = require('easy-circular-list'),
   fs = require('fs'),
-  pm2 = require('pm2');
+  pm2 = require('pm2'),
+  {GatewayTimeoutError, PluginImplementationError} = require('kuzzle-common-objects').errors;
 
 let
   pm2Promise = null;
@@ -26,18 +43,20 @@ let
  */
 
 /**
+ * @class PluginsManager
  * @param kuzzle
- * @constructor
  */
-function PluginsManager (kuzzle) {
-  this.kuzzle = kuzzle;
-  this.plugins = {};
-  this.pipes = {};
-  this.controllers = {};
-  this.routes = [];
-  this.workers = {};
-  this.config = kuzzle.config.plugins;
-  this.silent = false;
+class PluginsManager {
+  constructor(kuzzle) {
+    this.kuzzle = kuzzle;
+    this.plugins = {};
+    this.pipes = {};
+    this.controllers = {};
+    this.routes = [];
+    this.workers = {};
+    this.config = kuzzle.config.plugins;
+    this.silent = false;
+  }
 
   /**
    * Initialize configured plugin in config/defaultPlugins.json and config/customPlugins.json
@@ -45,15 +64,16 @@ function PluginsManager (kuzzle) {
    * @param {object} [options]
    * @returns {Promise}
    */
-  this.init = function pluginInit (options) {
+  init(options) {
     this.silent = options && options.silent;
     this.plugins = loadPlugins(this.config, this.kuzzle.rootPath);
-  };
+  }
 
-  this.getPluginsFeatures = function plugingetPluginsFeatures () {
-    let pluginConfiguration = {};
+  getPluginsFeatures() {
+    const pluginConfiguration = {};
+
     Object.keys(this.plugins).forEach(plugin => {
-      let
+      const
         pluginInfo = this.plugins[plugin],
         p = {
           name: pluginInfo.name,
@@ -75,7 +95,7 @@ function PluginsManager (kuzzle) {
 
         if (pluginInfo.object.hasOwnProperty('controllers')) {
           p.controllers = _.uniq(Object.keys(pluginInfo.object.controllers));
-          p.controllers = p.controllers.map((item) => pluginInfo.name + '/' + item);
+          p.controllers = p.controllers.map(item => `${pluginInfo.name}/${item}`);
         }
 
         if (pluginInfo.object.hasOwnProperty('routes')) {
@@ -92,29 +112,30 @@ function PluginsManager (kuzzle) {
     });
 
     return pluginConfiguration;
-  };
+  }
 
   /**
    * Attach events hooks and pipes given by plugins
    */
-  this.run = function pluginRun () {
-    let promises;
-    let pluginsWorker = _.pickBy(this.plugins, plugin => plugin.config.threads);
+  run() {
+    const pluginsWorker = _.pickBy(this.plugins, plugin => plugin.config.threads);
 
     if (Object.keys(pluginsWorker).length > 0) {
       pm2Promise = pm2Init(this.workers, pluginsWorker, this.kuzzle.config);
     }
 
     if (Object.keys(this.plugins).length === 0) {
-      return Promise.resolve();
+      return Bluebird.resolve();
     }
 
-    promises = Object.keys(this.plugins).map((pluginName) => {
+    const promises = Object.keys(this.plugins).map(pluginName => {
       const
         plugin = this.plugins[pluginName],
-        pipeWarnTime = this.config.common.pipeWarnTime,
-        pipeTimeout = this.config.common.pipeTimeout,
-        initTimeout = this.config.common.initTimeout;
+        {
+          pipeWarnTime,
+          pipeTimeout,
+          initTimeout
+        } = this.config.common;
 
       if (plugin.config.threads) {
         debug('[%s] starting worker with %d threads', pluginName, plugin.config.threads);
@@ -123,27 +144,27 @@ function PluginsManager (kuzzle) {
           .timeout(initTimeout)
           .catch(err => {
             this.silent || console.log('Plugin', pluginName, ' errored with message: ', err.message, '. Skipping...'); // eslint-disable-line no-console
-            return Promise.resolve();
+            return Bluebird.resolve();
           });
       }
 
       debug('[%s] starting plugin in %s mode', pluginName, plugin.config.privileged ? 'privileged' : 'standard');
 
       // We sandbox the Promise.resolve into a Promise to be able to catch throwed errors if any
-      return new Promise((resolve) => {
+      return new Bluebird(resolve => {
         // Promise.resolve allows to convert any type of return into a bluebird Promise.
         // It allows to apply a timeout on it
-        return Promise.resolve(plugin.object.init(
+        return Bluebird.resolve(plugin.object.init(
           plugin.config,
-          plugin.config.privileged ? new PrivilegedPluginContext(kuzzle, pluginName) : new PluginContext(kuzzle, pluginName)
+          plugin.config.privileged ? new PrivilegedPluginContext(this.kuzzle, pluginName) : new PluginContext(this.kuzzle, pluginName)
         ))
           .timeout(initTimeout)
           .then(initStatus => {
             if (initStatus === false) {
-              return Promise.reject(new Error(`Something went wrong during the initialization of the plugin ${pluginName}.`));
+              return Bluebird.reject(new Error(`Something went wrong during the initialization of the plugin ${pluginName}.`));
             }
             if (plugin.object.hooks) {
-              initHooks(plugin, kuzzle);
+              initHooks(plugin, this.kuzzle);
             }
 
             if (plugin.object.pipes) {
@@ -155,7 +176,7 @@ function PluginsManager (kuzzle) {
             }
 
             if (plugin.object.scope) {
-              injectScope(plugin.object.scope, kuzzle.passport);
+              injectScope(plugin.object.scope, this.kuzzle.passport);
             }
 
             debug('[%s] plugin started', pluginName);
@@ -163,14 +184,14 @@ function PluginsManager (kuzzle) {
             resolve();
           });
       })
-      .catch(e => {
-        console.warn(`WARNING: Unable to init plugin ${pluginName}: ${e.message}`, e.stack); // eslint-disable-line no-console
-        return Promise.resolve();
-      });
+        .catch(e => {
+          console.warn(`WARNING: Unable to init plugin ${pluginName}: ${e.message}`, e.stack); // eslint-disable-line no-console
+          return Bluebird.resolve();
+        });
     });
 
-    return Promise.all(promises);
-  };
+    return Bluebird.all(promises);
+  }
 
   /**
    * Trigger an event for emit event and chain pipes
@@ -179,13 +200,13 @@ function PluginsManager (kuzzle) {
    * @param {*} data
    * @returns {Promise}
    */
-  this.trigger = function pluginTrigger (event, data) {
+  trigger(event, data) {
     debug('trigger "%s" event', event);
 
     return triggerPipes(this.pipes, event, data)
       .then(modifiedData => {
         // Execute in parallel Hook and Worker because we don't have to wait or execute in a particular order
-        return new Promise((resolve, reject) => {
+        return new Bluebird((resolve, reject) => {
           async.parallel([
             callback => triggerWorkers(this.workers, event, modifiedData).asCallback(callback),
             callback => triggerHooks(this.kuzzle, event, modifiedData).asCallback(callback)
@@ -198,18 +219,22 @@ function PluginsManager (kuzzle) {
           });
         });
       });
-  };
+  }
 
   /**
    * Inject plugin controllers within funnel Controller
+   * @returns {object}
    */
-  this.injectControllers = function pluginInjectControllers () {
-    _.forEach(this.controllers, (controller, name) => {
-      kuzzle.funnel.controllers[name] = controller;
-    });
-  };
-}
+  getPluginControllers() {
+    const controllers = {};
 
+    _.forEach(this.controllers, (controller, name) => {
+      controllers[name] = controller;
+    });
+
+    return controllers;
+  }
+}
 
 /**
  * Start the plugin worker with its configuration with PM2 when the connection is done
@@ -221,7 +246,7 @@ function PluginsManager (kuzzle) {
 function initWorkers (plugin, pluginName, kuzzleConfig) {
   return pm2Promise
     .then(() => {
-      const pm2StartPromise = Promise.promisify(pm2.start, {context: pm2});
+      const pm2StartPromise = Bluebird.promisify(pm2.start, {context: pm2});
 
       return pm2StartPromise({
         name: kuzzleConfig.plugins.common.workerPrefix + pluginName,
@@ -235,7 +260,7 @@ function initWorkers (plugin, pluginName, kuzzleConfig) {
     })
     .catch(err => {
       if (err) {
-        return Promise.reject(new PluginImplementationError('Error while starting worker plugin: '.concat(pluginName)));
+        return Bluebird.reject(new PluginImplementationError('Error while starting worker plugin: '.concat(pluginName)));
       }
     });
 }
@@ -255,18 +280,18 @@ function initWorkers (plugin, pluginName, kuzzleConfig) {
  * @returns {Promise}
  */
 function pm2Init (workers, pluginsWorker, kuzzleConfig) {
-  return Promise.fromNode(callback => pm2.connect(callback))
-    .then(() => Promise.fromNode(callback => pm2.list(callback)))
+  return Bluebird.fromNode(callback => pm2.connect(callback))
+    .then(() => Bluebird.fromNode(callback => pm2.list(callback)))
     .then(list => {
       const names = list
         .filter(process => process.name.indexOf(kuzzleConfig.plugins.common.workerPrefix) !== -1)
         .map(process => process.pm_id);
 
-      return Promise.fromNode(asyncCB => async.each(names, (name, callback) => {
+      return Bluebird.fromNode(asyncCB => async.each(names, (name, callback) => {
         pm2.delete(name, err => callback(err));
       }, err => asyncCB(err)));
     })
-    .then(() => Promise.fromNode(callback => pm2.launchBus(callback)))
+    .then(() => Bluebird.fromNode(callback => pm2.launchBus(callback)))
     .then(bus => {
       bus.on('ready', packet => {
         const
@@ -289,7 +314,7 @@ function pm2Init (workers, pluginsWorker, kuzzleConfig) {
             path: pluginsWorker[pluginName].path,
             kuzzleConfig: kuzConfig
           }
-        }, (err) => {
+        }, err => {
           if (err) {
             console.error(`ERROR: Unable to send data to plugin ${pluginName}: ${err.message}`, err.stack);  // eslint-disable-line no-console
           }
@@ -310,23 +335,19 @@ function pm2Init (workers, pluginsWorker, kuzzleConfig) {
       });
 
       bus.on('process:event', packet => {
-        if (packet.event) {
-          if (packet.event === 'exit') {
-            if (workers[packet.process.name]) {
-              workers[packet.process.name].pmIds.remove(packet.process.pm_id);
+        if (packet.event && packet.event === 'exit' && workers[packet.process.name]) {
+          workers[packet.process.name].pmIds.remove(packet.process.pm_id);
 
-              // /!\ We remove it only once from workers, exit event is received twice
-              if (workers[packet.process.name].pmIds && workers[packet.process.name].pmIds.getSize() === 0) {
-                delete workers[packet.process.name];
-              }
-            }
+          // /!\ We remove it only once from workers, exit event is received twice
+          if (workers[packet.process.name].pmIds && workers[packet.process.name].pmIds.getSize() === 0) {
+            delete workers[packet.process.name];
           }
         }
       });
 
-      return Promise.resolve();
+      return Bluebird.resolve();
     })
-    .catch(err => Promise.reject('Error with PM2', err));
+    .catch(err => Bluebird.reject('Error with PM2', err));
 }
 
 /**
@@ -336,21 +357,25 @@ function pm2Init (workers, pluginsWorker, kuzzleConfig) {
  * @param pipeTimeout
  */
 function initPipes (manager, plugin, pipeWarnTime, pipeTimeout) {
+  let
+    _warnTime = pipeWarnTime,
+    _timeout = pipeTimeout;
+
   if (plugin.config && plugin.config.pipeWarnTime !== undefined) {
-    pipeWarnTime = plugin.config.pipeWarnTime;
+    _warnTime = plugin.config.pipeWarnTime;
   }
   if (plugin.config && plugin.config.pipeTimeout !== undefined) {
-    pipeTimeout = plugin.config.pipeTimeout;
+    _timeout = plugin.config.pipeTimeout;
   }
 
   _.forEach(plugin.object.pipes, (fn, pipe) => {
     if (Array.isArray(fn)) {
       fn
         .filter(target => typeof plugin.object[target] === 'function')
-        .forEach(func => registerPipe(manager, plugin, pipeWarnTime, pipeTimeout, pipe, func));
+        .forEach(func => registerPipe(manager, plugin, _warnTime, _timeout, pipe, func));
     }
     else if (typeof plugin.object[fn] === 'function') {
-      registerPipe(manager, plugin, pipeWarnTime, pipeTimeout, pipe, fn);
+      registerPipe(manager, plugin, _warnTime, _timeout, pipe, fn);
     }
   });
 }
@@ -369,8 +394,8 @@ function initHooks (plugin, kuzzle) {
 }
 
 function initControllers (controllers, routes, plugin, pluginName) {
-  let controllerImported = Object.keys(plugin.object.controllers).every(controller => {
-    let description = plugin.object.controllers[controller];
+  const controllerImported = Object.keys(plugin.object.controllers).every(controller => {
+    const description = plugin.object.controllers[controller];
     debug('[%s][%s] starting controller registration', plugin.name, controller);
 
     if (typeof description !== 'object' || description === null || Array.isArray(description)) {
@@ -411,7 +436,7 @@ function initControllers (controllers, routes, plugin, pluginName) {
   }
   else if (plugin.object.routes) {
     plugin.object.routes.forEach(route => {
-      let valid = Object.keys(route).every(key => {
+      const valid = Object.keys(route).every(key => {
         if (['verb', 'url', 'controller', 'action'].indexOf(key) === -1) {
           // eslint-disable-next-line no-console
           console.error(`[Plugin Manager] Error initializing route ${route.url}: unknown route definition ${key}`);
@@ -468,7 +493,7 @@ function initControllers (controllers, routes, plugin, pluginName) {
 function triggerHooks(emitter, event, data) {
   emitter.emit(event, data);
 
-  return Promise.resolve(data);
+  return Bluebird.resolve(data);
 }
 
 /**
@@ -492,10 +517,10 @@ function triggerPipes(pipes, event, data) {
   }
 
   if (preparedPipes.length === 0) {
-    return Promise.resolve(data);
+    return Bluebird.resolve(data);
   }
 
-  return new Promise((resolve, reject) => {
+  return new Bluebird((resolve, reject) => {
     async.waterfall([callback => callback(null, data)].concat(preparedPipes), (error, result) => {
       if (error) {
         return reject(error);
@@ -511,7 +536,7 @@ function triggerPipes(pipes, event, data) {
  * @example
  *  getWildcardEvent('data:create') // return 'data:*'
  * @param {string} event
- * @returns {String|Boolean} wildcard event
+ * @returns {String} wildcard event
  */
 function getWildcardEvent (event) {
   const indexDelimiter = event.indexOf(':');
@@ -519,7 +544,7 @@ function getWildcardEvent (event) {
     return event.substring(0, indexDelimiter+1) + '*';
   }
 
-  return false;
+  return null;
 }
 
 /**
@@ -534,27 +559,27 @@ function triggerWorkers(workers, event, data) {
   const wildcardEvent = getWildcardEvent(event);
 
   if (Object.keys(workers).length === 0) {
-    return Promise.resolve(data);
+    return Bluebird.resolve(data);
   }
 
-  return new Promise((resolve, reject) => {
+  return new Bluebird((resolve, reject) => {
     async.forEachOf(workers, (worker, workerName, callback) => {
       if (worker.events.indexOf(event) === -1 && worker.events.indexOf(wildcardEvent) === -1) {
         return callback();
       }
 
-      let pmId = worker.pmIds.getNext();
+      const pmId = worker.pmIds.getNext();
       pm2.sendDataToProcessId(pmId, {
         topic: 'trigger',
         data: {
-          event: event,
+          event,
           message: data
         },
         id: pmId
       }, (err, res) => {
         callback(err, res);
       });
-    }, (err) => {
+    }, err => {
       if (err) {
         return reject(err);
       }
@@ -572,26 +597,33 @@ function triggerWorkers(workers, event, data) {
  */
 function loadPlugins(config, rootPath) {
   const pluginsDir = path.resolve(path.join(rootPath, 'plugins/enabled'));
-  let loadedPlugins = {};
+  const loadedPlugins = {};
 
   const pluginList = fs.readdirSync(pluginsDir)
-    .filter((element) => {
+    .filter(element => {
       const elStat = fs.statSync(path.join(pluginsDir, element));
       return elStat.isDirectory();
     });
 
   debug('loading plugins:\n%O', pluginList);
 
-  pluginList.forEach((pluginDirName) => {
+  pluginList.forEach(pluginDirName => {
     const pluginPath = path.resolve(pluginsDir, pluginDirName);
-    let plugin = null;
+    let
+      plugin = null,
+      packageExists = true;
 
     try {
-      if (fs.existsSync(path.resolve(pluginPath, 'package.json'))) {
-        plugin = loadPluginFromPackageJson(path.resolve(pluginsDir, pluginDirName), config);
-      } else {
-        plugin = loadPluginFromDirectory(path.resolve(pluginsDir, pluginDirName), config);
-      }
+      fs.accessSync(path.resolve(pluginPath, 'package.json'));
+    }
+    catch(e) {
+      packageExists = false;
+    }
+
+    try {
+      const loader = packageExists ? loadPluginFromPackageJson : loadPluginFromDirectory;
+
+      plugin = loader(path.resolve(pluginsDir, pluginDirName), config);
     } catch (e) {
       console.error(`Unable to load plugin ${pluginDirName}. ${e.message}\n${e.stack}`); // eslint-disable-line no-console
       return;
@@ -661,7 +693,7 @@ function registerPipe(manager, plugin, warnDelay, timeoutDelay, event, fn) {
 
     if (timeoutDelay) {
       pipeTimeoutTimer = setTimeout(() => {
-        let errorMsg = `Timeout error. Pipe plugin ${plugin.name} exceeded ${timeoutDelay}ms to execute. Aborting pipe`;
+        const errorMsg = `Timeout error. Pipe plugin ${plugin.name} exceeded ${timeoutDelay}ms to execute. Aborting pipe`;
         manager.trigger('log:error', errorMsg);
 
         timedOut = true;
@@ -700,7 +732,7 @@ function registerPipe(manager, plugin, warnDelay, timeoutDelay, event, fn) {
 function registerHook(kuzzle, plugin, event, fn) {
   debug('[%s] register hook on event "%s"', plugin.name, event);
 
-  kuzzle.on(event, (message) => {
+  kuzzle.on(event, message => {
     try {
       plugin.object[fn](message, event);
     }
@@ -727,4 +759,3 @@ function injectScope(scope, passport) {
 }
 
 module.exports = PluginsManager;
-

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -56,6 +56,7 @@ class PluginsManager {
     this.workers = {};
     this.config = kuzzle.config.plugins;
     this.silent = false;
+    this.registeredStrategies = [];
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "codecov": "1.0.1",
-    "cucumber": "1.3.1",
+    "cucumber": "^1.3.2",
     "eslint": "3.15.0",
     "mocha": "3.2.0",
     "mock-require": "^2.0.1",

--- a/test/api/controllers/funnelController/processRequest.test.js
+++ b/test/api/controllers/funnelController/processRequest.test.js
@@ -5,9 +5,9 @@ const
   sinon = require('sinon'),
   Promise = require('bluebird'),
   Request = require('kuzzle-common-objects').Request,
-  BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
   FunnelController = require('../../../../lib/api/controllers/funnelController'),
-  KuzzleMock = require('../../../mocks/kuzzle.mock');
+  KuzzleMock = require('../../../mocks/kuzzle.mock'),
+  {BadRequestError, PluginImplementationError} = require('kuzzle-common-objects').errors;
 
 describe('funnelController.processRequest', () => {
   let
@@ -25,66 +25,53 @@ describe('funnelController.processRequest', () => {
         fail: sinon.stub()
       }
     };
+
+    funnel.pluginsControllers = {
+      'fakePlugin/controller': {
+        ok: sinon.stub().returns(Promise.resolve()),
+        fail: sinon.stub()
+      }
+    };
   });
 
-  it('should reject the promise if no controller is specified', done => {
+  it('should throw if no controller is specified', () => {
     const request = new Request({action: 'create'});
 
-    funnel.processRequest(request)
-      .then(() => done('should have failed'))
-      .catch(e => {
-        should(e).be.instanceOf(BadRequestError);
-        should(funnel.requestHistory.isEmpty()).be.true();
-        should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
-        should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.false();
-        should(kuzzle.statistics.startRequest.called).be.false();
-        done();
-      });
+    should(() => funnel.processRequest(request)).throw(BadRequestError, {message: 'Unknown controller null'});
+    should(funnel.requestHistory.isEmpty()).be.true();
+    should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
+    should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.false();
+    should(kuzzle.statistics.startRequest.called).be.false();
   });
 
-  it('should reject the promise if no action is specified', done => {
-    const request = new Request({controller: 'document'});
+  it('should throw if no action is specified', () => {
+    const request = new Request({controller: 'fakeController'});
 
-    funnel.processRequest(request)
-      .then(() => done('should have failed'))
-      .catch(e => {
-        should(e).be.instanceOf(BadRequestError);
-        should(funnel.requestHistory.isEmpty()).be.true();
-        should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
-        should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.false();
-        should(kuzzle.statistics.startRequest.called).be.false();
-        done();
-      });
+    should(() => funnel.processRequest(request)).throw(BadRequestError, {message: 'No corresponding action null in controller fakeController'});
+    should(funnel.requestHistory.isEmpty()).be.true();
+    should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
+    should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.false();
+    should(kuzzle.statistics.startRequest.called).be.false();
   });
 
-  it('should reject the promise if the controller doesn\'t exist', done => {
-    const request = new Request({controller: 'foobar', action: 'create'});
+  it('should throw if the action doesn\'t exist', () => {
+    const request = new Request({controller: 'fakeController', action: 'create'});
 
-    funnel.processRequest(request)
-      .then(() => done('should have failed'))
-      .catch(e => {
-        should(e).be.instanceOf(BadRequestError);
-        should(funnel.requestHistory.isEmpty()).be.true();
-        should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
-        should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.false();
-        should(kuzzle.statistics.startRequest.called).be.false();
-        done();
-      });
+    should(() => funnel.processRequest(request)).throw(BadRequestError, {message: 'No corresponding action create in controller fakeController'});
+    should(funnel.requestHistory.isEmpty()).be.true();
+    should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
+    should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.false();
+    should(kuzzle.statistics.startRequest.called).be.false();
   });
 
-  it('should reject the promise if the action doesn\'t exist', done => {
-    const request = new Request({controller: 'foo', action: 'bar'});
+  it('should throw if a plugin action does not exist', () => {
+    const request = new Request({controller: 'fakePlugin/controller', action: 'create'});
 
-    funnel.processRequest(request)
-      .then(() => done('should have failed'))
-      .catch(e => {
-        should(e).be.instanceOf(BadRequestError);
-        should(funnel.requestHistory.isEmpty()).be.true();
-        should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
-        should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.false();
-        should(kuzzle.statistics.startRequest.called).be.false();
-        done();
-      });
+    should(() => funnel.processRequest(request)).throw(BadRequestError, {message: 'No corresponding action create in controller fakePlugin/controller'});
+    should(funnel.requestHistory.isEmpty()).be.true();
+    should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
+    should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.false();
+    should(kuzzle.statistics.startRequest.called).be.false();
   });
 
   it('should resolve the promise if everything is ok', () => {
@@ -123,6 +110,31 @@ describe('funnelController.processRequest', () => {
         should(funnel.requestHistory.toArray()).match([request]);
         should(kuzzle.pluginsManager.trigger).calledWith('fakeController:beforeFail');
         should(kuzzle.pluginsManager.trigger).not.be.calledWith('fakeController:afterFail');
+        should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
+        should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.true();
+        should(kuzzle.statistics.startRequest.called).be.true();
+        should(kuzzle.statistics.completedRequest.called).be.false();
+        should(kuzzle.statistics.failedRequest.called).be.true();
+        done();
+      });
+  });
+
+  it('should wrap a Node error on a plugin action failure', done => {
+    const request = new Request({
+      controller: 'fakePlugin/controller',
+      action: 'fail',
+    });
+
+    funnel.pluginsControllers['fakePlugin/controller'].fail.returns(Promise.reject(new Error('rejected')));
+
+    funnel.processRequest(request)
+      .then(() => done('should have failed'))
+      .catch(e => {
+        should(e).be.instanceOf(PluginImplementationError);
+        should(e.message).startWith('rejected');
+        should(funnel.requestHistory.toArray()).match([request]);
+        should(kuzzle.pluginsManager.trigger).calledWith('fakePlugin/controller:beforeFail');
+        should(kuzzle.pluginsManager.trigger).not.be.calledWith('fakePlugin/controller:afterFail');
         should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
         should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.true();
         should(kuzzle.statistics.startRequest.called).be.true();

--- a/test/api/controllers/funnelController/processRequest.test.js
+++ b/test/api/controllers/funnelController/processRequest.test.js
@@ -77,7 +77,7 @@ describe('funnelController.processRequest', () => {
   it('should resolve the promise if everything is ok', () => {
     const request = new Request({
       controller: 'fakeController',
-      action: 'ok',
+      action: 'ok'
     });
 
     return should(funnel.processRequest(request)
@@ -94,7 +94,7 @@ describe('funnelController.processRequest', () => {
       })).be.fulfilled();
   });
 
-  it('should reject the promise if a controller action fails', done => {
+  it('should reject the promise if a controller action fails', () => {
     const request = new Request({
       controller: 'fakeController',
       action: 'fail',
@@ -102,8 +102,10 @@ describe('funnelController.processRequest', () => {
 
     funnel.controllers.fakeController.fail.returns(Promise.reject(new Error('rejected')));
 
-    funnel.processRequest(request)
-      .then(() => done('should have failed'))
+    return funnel.processRequest(request)
+      .then(() => {
+        throw new Error('You shall not pass');
+      })
       .catch(e => {
         should(e).be.instanceOf(Error);
         should(e.message).be.eql('rejected');
@@ -115,11 +117,10 @@ describe('funnelController.processRequest', () => {
         should(kuzzle.statistics.startRequest.called).be.true();
         should(kuzzle.statistics.completedRequest.called).be.false();
         should(kuzzle.statistics.failedRequest.called).be.true();
-        done();
       });
   });
 
-  it('should wrap a Node error on a plugin action failure', done => {
+  it('should wrap a Node error on a plugin action failure', () => {
     const request = new Request({
       controller: 'fakePlugin/controller',
       action: 'fail',
@@ -127,8 +128,10 @@ describe('funnelController.processRequest', () => {
 
     funnel.pluginsControllers['fakePlugin/controller'].fail.returns(Promise.reject(new Error('rejected')));
 
-    funnel.processRequest(request)
-      .then(() => done('should have failed'))
+    return funnel.processRequest(request)
+      .then(() => {
+        throw new Error('You shall not pass');
+      })
       .catch(e => {
         should(e).be.instanceOf(PluginImplementationError);
         should(e.message).startWith('rejected');
@@ -140,7 +143,6 @@ describe('funnelController.processRequest', () => {
         should(kuzzle.statistics.startRequest.called).be.true();
         should(kuzzle.statistics.completedRequest.called).be.false();
         should(kuzzle.statistics.failedRequest.called).be.true();
-        done();
       });
   });
 

--- a/test/api/core/pluginsManager/init.test.js
+++ b/test/api/core/pluginsManager/init.test.js
@@ -2,184 +2,102 @@
 
 const
   should = require('should'),
-  rewire = require('rewire'),
+  mockrequire = require('mock-require'),
   sinon = require('sinon'),
-  KuzzleMock = require('../../../mocks/kuzzle.mock'),
-  path = require('path'),
-  PluginsManager = rewire('../../../../lib/api/core/plugins/pluginsManager');
+  KuzzleMock = require('../../../mocks/kuzzle.mock');
 
-describe('PluginsManager: init()', () => {
+describe('PluginsManager', () => {
   let
-    kuzzle,
-    pluginsManager;
+    PluginsManager,
+    pluginsManager,
+    fsStub,
+    kuzzle;
 
   beforeEach(() => {
+    fsStub = {
+      readdirSync: sinon.stub().returns([]),
+      accessSync: sinon.stub(),
+      statSync: sinon.stub()
+    };
+
+    mockrequire('fs', fsStub);
+    PluginsManager = mockrequire.reRequire('../../../../lib/api/core/plugins/pluginsManager');
+
     kuzzle = new KuzzleMock();
     pluginsManager = new PluginsManager(kuzzle);
   });
 
-  it('should load plugins at init', () => {
-    var spy = sinon.spy();
-
-    return PluginsManager.__with__({
-      loadPlugins: spy
-    })(() => {
+  describe('#init', () => {
+    it('should load plugins at init', () => {
       pluginsManager.init();
-      should(spy)
-        .be.calledOnce();
-    });
-  });
-});
-
-describe('PluginsManager: loadPlugins()', () => {
-  var
-    kuzzle,
-    pluginsManager;
-
-  beforeEach(() => {
-    kuzzle = new KuzzleMock();
-    pluginsManager = new PluginsManager(kuzzle);
-  });
-
-  it('should return an empty object if no plugins are enabled', () => {
-    return PluginsManager.__with__({
-      fs: {
-        readdirSync: () => {
-          return [];
-        }
-      }
-    })(() => {
-      pluginsManager.init();
-      should(pluginsManager.plugins)
-        .be.eql({});
+      should(fsStub.readdirSync.calledOnce).be.true();
+      should(pluginsManager.plugins).be.an.Object().and.be.empty();
     });
   });
 
-  it('should show a console error message if a malformed plugin is enabled', () => {
-    let consoleSpy = sinon.spy();
-    return PluginsManager.__with__({
-      fs: {
-        readdirSync: () => {
-          return ['kuzzle-plugin-test'];
-        },
-        existsSync: () => {
-          return true;
-        },
-        statSync: () => {
-          return {
-            isSymbolicLink: () => {
-              return true;
-            },
-            isDirectory: () => {
-              return true;
-            }
-          };
-        }
-      },
-      loadPluginFromPackageJson: () => {
-        throw new Error('oh crap!');
-      },
-      loadPluginFromDirectory: () => {
-        throw new Error('oh crap!');
-      },
-      console: {
-        error: consoleSpy
-      }
-    })(() => {
-      pluginsManager.init();
-      should(consoleSpy)
-        .be.calledOnce();
-    });
-  });
+  describe('#loadPlugins', () => {
+    it('should discard a plugin if loading it from package.json fails', () => {
+      fsStub.readdirSync.returns(['kuzzle-plugin-test']);
+      fsStub.statSync.returns({
+        isDirectory: () => true
+      });
 
-  it('should return a well-formed plugin instance if a valid node-module plugin is enabled', () => {
-    const pluginName = 'kuzzle-plugin-test';
-    return PluginsManager.__with__({
-      fs: {
-        readdirSync: () => {
-          return ['kuzzle-plugin-test'];
-        },
-        existsSync: () => {
-          return true;
-        },
-        statSync: () => {
-          return {
-            isSymbolicLink: () => {
-              return true;
-            },
-            isDirectory: () => {
-              return true;
-            }
-          };
-        }
-      },
-      require: (arg) => {
-        if (path.extname(arg) === '.json') {
-          return {
-            name: pluginName
-          };
-        }
-        return function () {
-          return {
-            kikou: 'LOL'
-          };
-        };
-      }
-    })(() => {
-      pluginsManager.init();
-      should(pluginsManager.plugins[pluginName])
-        .be.Object();
-      should(pluginsManager.plugins[pluginName])
-        .have.keys('name', 'object', 'config', 'path');
-      should(pluginsManager.plugins[pluginName].name)
-        .be.eql(pluginName);
-      should(pluginsManager.plugins[pluginName].object)
-        .be.ok();
-      should(pluginsManager.plugins[pluginName].path)
-        .be.ok();
+      should(() => pluginsManager.init()).not.throw();
+      should(pluginsManager.plugins).be.empty();
     });
-  });
 
-  it('should return a well-formed plugin instance if a valid requireable plugin is enabled', () => {
-    const pluginName = 'kuzzle-plugin-test';
-    return PluginsManager.__with__({
-      fs: {
-        readdirSync: () => {
-          return ['kuzzle-plugin-test'];
-        },
-        existsSync: () => {
-          return false;
-        },
-        statSync: () => {
-          return {
-            isSymbolicLink: () => {
-              return false;
-            },
-            isDirectory: () => {
-              return true;
-            }
-          };
-        }
-      },
-      require: () => {
-        return function () {
-          return {
-            kikou: 'LOL'
-          };
-        };
-      }
-    })(() => {
+    it('should discard a plugin if loading it from a directory fails', () => {
+      fsStub.accessSync.throws(new Error('package.json does not exist'));
+      fsStub.readdirSync.returns(['kuzzle-plugin-test']);
+      fsStub.statSync.returns({
+        isDirectory: () => true
+      });
+
+      should(() => pluginsManager.init()).not.throw();
+      should(pluginsManager.plugins).be.empty();
+    });
+
+    it('should return a well-formed plugin instance if a valid node-module plugin is enabled', () => {
+      fsStub.readdirSync.returns(['kuzzle-plugin-test']);
+      fsStub.statSync.returns({
+        isDirectory: () => true
+      });
+
+      const name = 'kuzzle-plugin-test';
+      mockrequire('/kuzzle/plugins/enabled/kuzzle-plugin-test', function () {});
+      mockrequire('/kuzzle/plugins/enabled/kuzzle-plugin-test/package.json', {name});
+      PluginsManager = mockrequire.reRequire('../../../../lib/api/core/plugins/pluginsManager');
+
+      pluginsManager = new PluginsManager(kuzzle);
+
       pluginsManager.init();
-      should(pluginsManager.plugins[pluginName])
-        .be.Object();
-      should(pluginsManager.plugins[pluginName])
-        .have.keys('name', 'object', 'config', 'path');
-      should(pluginsManager.plugins[pluginName].name)
-        .be.eql(pluginName);
-      should(pluginsManager.plugins[pluginName].object)
-        .be.ok();
-      should(pluginsManager.plugins[pluginName].path)
-        .be.ok();
+      should(pluginsManager.plugins[name]).be.Object();
+      should(pluginsManager.plugins[name]).have.keys('name', 'object', 'config', 'path');
+      should(pluginsManager.plugins[name].name).be.eql(name);
+      should(pluginsManager.plugins[name].object).be.ok();
+      should(pluginsManager.plugins[name].path).be.ok();
+    });
+
+    it('should return a well-formed plugin instance if a valid requireable plugin is enabled', () => {
+      const name = 'kuzzle-plugin-test';
+      fsStub.readdirSync.returns(['kuzzle-plugin-test']);
+      fsStub.accessSync.throws(new Error('package.json does not exist'));
+      fsStub.statSync.returns({
+        isDirectory: () => true
+      });
+
+      mockrequire('/kuzzle/plugins/enabled/kuzzle-plugin-test', function () {});
+      mockrequire('/kuzzle/plugins/enabled/kuzzle-plugin-test/package.json', {name});
+      PluginsManager = mockrequire.reRequire('../../../../lib/api/core/plugins/pluginsManager');
+
+      pluginsManager = new PluginsManager(kuzzle);
+
+      pluginsManager.init();
+      should(pluginsManager.plugins[name]).be.Object();
+      should(pluginsManager.plugins[name]).have.keys('name', 'object', 'config', 'path');
+      should(pluginsManager.plugins[name].name).be.eql(name);
+      should(pluginsManager.plugins[name].object).be.ok();
+      should(pluginsManager.plugins[name].path).be.ok();
     });
   });
 });

--- a/test/api/core/pluginsManager/run.test.js
+++ b/test/api/core/pluginsManager/run.test.js
@@ -2,16 +2,17 @@
 
 const
   should = require('should'),
+  mockrequire = require('mock-require'),
+  rewire = require('rewire'),
   /** @type {Params} */
   params = require('../../../../lib/config'),
-  rewire = require('rewire'),
   sinon = require('sinon'),
-  PluginsManager = rewire('../../../../lib/api/core/plugins/pluginsManager'),
   EventEmitter = require('eventemitter2').EventEmitter2,
   GatewayTimeoutError = require('kuzzle-common-objects').errors.GatewayTimeoutError;
 
 describe('Test plugins manager run', () => {
   let
+    PluginsManager,
     sandbox,
     plugin,
     pluginMock,
@@ -21,12 +22,12 @@ describe('Test plugins manager run', () => {
 
   before(() => {
     pm2Mock = function () {
-      var universalProcess = {
+      const universalProcess = {
         name: params.plugins.common.workerPrefix + 'testPlugin',
         pm_id: 42
       };
 
-      var busData = {
+      const busData = {
         'initialized': {
           process: universalProcess,
           data: {
@@ -43,7 +44,8 @@ describe('Test plugins manager run', () => {
           process: universalProcess
         }
       };
-      var
+
+      let
         busListeners,
         processList,
         uniqueness,
@@ -63,8 +65,7 @@ describe('Test plugins manager run', () => {
           callback(null);
         },
         start: function (processSpec, callback) {
-          var i;
-          for(i = 0; i < processSpec.instances; i++) {
+          for(let i = 0; i < processSpec.instances; i++) {
             processList.push({
               process: {
                 name: processSpec.name,
@@ -77,7 +78,7 @@ describe('Test plugins manager run', () => {
         launchBus: function (callback) {
           callback(null, {
             on: function (event, cb) {
-              var wrapper = function (data) {
+              const wrapper = function (data) {
                 cb(data);
               };
               if (!busListeners[event]) {
@@ -119,13 +120,8 @@ describe('Test plugins manager run', () => {
       };
     }();
 
-    PluginsManager.__set__('console', {
-      log: () => {},
-      error: () => {},
-      warn: () => {},
-    });
-
-    PluginsManager.__set__('pm2', pm2Mock);
+    mockrequire('pm2', pm2Mock);
+    PluginsManager = rewire('../../../../lib/api/core/plugins/pluginsManager');
   });
 
   beforeEach(() => {
@@ -500,7 +496,7 @@ describe('Test plugins manager run', () => {
   });
 
   it('should receive the triggered message', () => {
-    var triggerWorkers = PluginsManager.__get__('triggerWorkers');
+    const triggerWorkers = PluginsManager.__get__('triggerWorkers');
     plugin.config.threads = 1;
     plugin.config.hooks = {
       'foo:bar': 'foobar'
@@ -517,9 +513,7 @@ describe('Test plugins manager run', () => {
           should(pluginsManager.workers[params.plugins.common.workerPrefix + 'testPlugin'].pmIds).be.an.Object();
           should(pluginsManager.workers[params.plugins.common.workerPrefix + 'testPlugin'].pmIds.getSize()).be.equal(1);
 
-          triggerWorkers(pluginsManager.workers, 'foo:bar', {
-            'firstName': 'Ada'
-          });
+          triggerWorkers(pluginsManager.workers, 'foo:bar', {'firstName': 'Ada'});
 
           should(pm2Mock.getSentMessages()).be.an.Array().and.length(1);
           should(pm2Mock.getSentMessages()[0]).be.an.Object();


### PR DESCRIPTION
# Description

When a controller plugin throws an exception, it isn't wrapped in a `PluginImplementationError`, meaning that Kuzzle treats this exception as a possible core implementation problem and generates a crash reports.

This PR separates plugins controllers from core ones, and detects if an errors comes from a plugin. If so, it is encapsulated in a PluginImplementationError object.

# Other changes

- solve sonarqube issues
