### PR TITLE
Hotfix - concurrent requests can be executed multiple times

### DIFF
--- a/lib/api/controllers/documentController.js
+++ b/lib/api/controllers/documentController.js
@@ -320,18 +320,8 @@ function DocumentController (kuzzle) {
         deleteRequest.input.args.refresh = request.input.args.refresh;
       }
 
-      promises.push(new Promise(resolve => {
-        kuzzle.funnel.getRequestSlot(deleteRequest, overload => {
-          if (overload) {
-            deleteRequest.setError(overload);
-            return resolve(deleteRequest);
-          }
 
-          kuzzle.funnel.processRequest(deleteRequest)
-            .catch(error => deleteRequest.setError(error))
-            .finally(() => resolve(deleteRequest));
-        });
-      }));
+      promises.push(Promise.promisify(kuzzle.funnel.mExecute, {context: kuzzle.funnel})(deleteRequest));
     });
 
     return Promise.all(promises)
@@ -440,18 +430,7 @@ function doMultipleWriteActions (kuzzle, request, action) {
       modificationRequest.input.args.refresh = request.input.args.refresh;
     }
 
-    promises.push(new Promise(resolve => {
-      kuzzle.funnel.getRequestSlot(modificationRequest, overload => {
-        if (overload) {
-          modificationRequest.setError(overload);
-          return resolve(modificationRequest);
-        }
-
-        kuzzle.funnel.processRequest(modificationRequest)
-          .catch(error => modificationRequest.setError(error))
-          .finally(() => resolve(modificationRequest));
-      });
-    }));
+    promises.push(Promise.promisify(kuzzle.funnel.mExecute, {context: kuzzle.funnel})(modificationRequest));
   });
 
   return Promise.all(promises)

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -74,7 +74,7 @@ function FunnelController (kuzzle) {
    * Rejects it with a ServiceUnavailable error if Kuzzle is overloaded
    * and if the buffer limit has been reached
    *
-   * @param {Request} request
+   * @param {Request} request - can be mutated in case of overload error
    * @param {Function} callback
    */
   this.getRequestSlot = function funnelGetRequestSlot (request, callback) {
@@ -95,7 +95,7 @@ function FunnelController (kuzzle) {
 
     // resolves the callback immediately if a slot is available
     if (this.concurrentRequests < kuzzle.config.limits.concurrentRequests) {
-      return callback(null, request);
+      return true;
     }
 
     /*
@@ -114,7 +114,7 @@ function FunnelController (kuzzle) {
 
       kuzzle.pluginsManager.trigger('log:error', error);
       request.setError(error);
-      return callback(error, request);
+      return false;
     }
 
     this.cachedItems++;
@@ -135,6 +135,7 @@ function FunnelController (kuzzle) {
        */
       playCachedRequests(kuzzle, this);
     }
+    return true;
   };
 
   /**
@@ -147,32 +148,74 @@ function FunnelController (kuzzle) {
    * @param {Function} callback
    */
   this.execute = function funnelExecute (request, callback) {
-    this.getRequestSlot(request, overloadError => {
-      if (overloadError) {
-        // "handleErrorDump" shouldn't need to be called for 503 errors
-        return callback(overloadError, request);
-      }
+    const process = this.getRequestSlot(request, callback);
 
-      this.checkRights(request)
-        .then(modifiedRequest => this.processRequest(modifiedRequest))
-        .then(processResult => callback(null, processResult))
-        .catch(err => {
-          // JSON.stringify(new NativeError()) === '{}', i.e. Error, SyntaxError, TypeError, ReferenceError, etc.
-          kuzzle.pluginsManager.trigger('log:error', err instanceof Error && !(err instanceof KuzzleError)
-            ? err.message + '\n' + err.stack
-            : err
-          );
+    if (request.error) {
+      // "handleErrorDump" shouldn't need to be called for 503 errors
+      return callback(request.error, request);
+    }
 
-          request.setError(err);
-          callback(err, request);
+    // request has been put in cache. Do not process now
+    if (!process) {
+      return;
+    }
 
-          this.handleErrorDump(err);
+    this.checkRights(request)
+      .then(modifiedRequest => this.processRequest(modifiedRequest))
+      .then(processResult => callback(null, processResult))
+      .catch(err => this._executeError(err, request, true, callback));
+  };
 
-          return null;
-        });
+  /**
+   * Used by mXX actions - Same as execute but bypasses permissions checks
+   * @param {Request} request
+   * @param {Function} callback
+   */
+  this.mExecute = function mExecute (request, callback) {
+    const process = this.getRequestSlot(request, callback);
 
-      return null;
-    });
+    if (request.error) {
+      // overload error
+      callback(null, request);
+    }
+
+    // request has been cached. Do not process it now
+    if (!process) {
+      return;
+    }
+
+    return this.processRequest(request)
+      .then(response => callback(null, response))
+      .catch(e => this._executeError(e, request, false, callback));
+  };
+
+  /**
+   * Populates the given request with the error and calls the callback
+   *
+   * @param {Error} error
+   * @param {Request} request
+   * @param {boolean} asError - if set to true, calls the callback with its first argument as error
+   * @param {Function} callback
+   * @returns {null}
+   * @private
+   */
+  this._executeError = function _executeError (error, request, asError, callback) {
+    // JSON.stringify(new NativeError()) === '{}', i.e. Error, SyntaxError, TypeError, ReferenceError, etc.
+    kuzzle.pluginsManager.trigger('log:error', error instanceof Error && !(error instanceof KuzzleError)
+      ? error.message + '\n' + error.stack
+      : error
+    );
+
+    request.setError(error);
+    if (asError) {
+      callback(error, request);
+      this.handleErrorDump(error);
+    }
+    else {
+      callback(null, request);
+    }
+
+    return null;
   };
 
   /**

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -148,7 +148,7 @@ function FunnelController (kuzzle) {
    * @param {Function} callback
    */
   this.execute = function funnelExecute (request, callback) {
-    const process = this.getRequestSlot(request, callback);
+    const processNow = this.getRequestSlot(request, callback);
 
     if (request.error) {
       // "handleErrorDump" shouldn't need to be called for 503 errors
@@ -156,7 +156,7 @@ function FunnelController (kuzzle) {
     }
 
     // request has been put in cache. Do not process now
-    if (!process) {
+    if (!processNow) {
       return;
     }
 
@@ -172,7 +172,7 @@ function FunnelController (kuzzle) {
    * @param {Function} callback
    */
   this.mExecute = function mExecute (request, callback) {
-    const process = this.getRequestSlot(request, callback);
+    const processNow = this.getRequestSlot(request, callback);
 
     if (request.error) {
       // overload error
@@ -180,7 +180,7 @@ function FunnelController (kuzzle) {
     }
 
     // request has been cached. Do not process it now
-    if (!process) {
+    if (!processNow) {
       return;
     }
 

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -652,18 +652,7 @@ function mDelete (kuzzle, type, request) {
       _id: id
     }, request.context);
 
-    return new Promise(resolve => {
-      kuzzle.funnel.getRequestSlot(deleteRequest, overloadError => {
-        if (overloadError) {
-          deleteRequest.setError(overloadError);
-          return resolve(deleteRequest);
-        }
-
-        kuzzle.funnel.processRequest(deleteRequest)
-          .catch(error => deleteRequest.setError(error))
-          .finally(() => resolve(deleteRequest));
-      });
-    });
+    return Promise.promisify(kuzzle.funnel.mExecute, {context: kuzzle.funnel})(deleteRequest);
   }))
     .then(delRequests => {
       const

--- a/test/api/controllers/documentController.test.js
+++ b/test/api/controllers/documentController.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var
+const
   should = require('should'),
   sinon = require('sinon'),
   sandbox = sinon.sandbox.create(),
@@ -8,20 +8,23 @@ var
   KuzzleMock = require('../../mocks/kuzzle.mock'),
   Request = require('kuzzle-common-objects').Request,
   DocumentController = require('../../../lib/api/controllers/documentController'),
+  FunnelController = require('../../../lib/api/controllers/funnelController'),
   foo = {foo: 'bar'},
   InternalError = require('kuzzle-common-objects').errors.InternalError,
   ServiceUnavailableError = require('kuzzle-common-objects').errors.ServiceUnavailableError,
   PartialError = require('kuzzle-common-objects').errors.PartialError;
 
 describe('Test: document controller', () => {
-  var
+  let
     documentController,
+    funnelController,
     kuzzle,
     request,
     engine;
 
   beforeEach(() => {
     kuzzle = new KuzzleMock();
+    funnelController = new FunnelController(kuzzle);
     engine = kuzzle.services.list.storageEngine;
     documentController = new DocumentController(kuzzle);
     request = new Request({index: '%test', collection: 'unit-test-documentController'});
@@ -204,11 +207,7 @@ describe('Test: document controller', () => {
 
   describe('#doMultipleActions', () => {
     it('mCreate should fulfill with an object', () => {
-      kuzzle.funnel.processRequest = sandbox.spy(function () {
-        arguments[0].setResult({result: 'created'});
-
-        return Promise.resolve(arguments[0]);
-      });
+      kuzzle.funnel.mExecute.yields(null, {result: 'created'});
 
       request.input.body = {
         documents: [
@@ -219,22 +218,14 @@ describe('Test: document controller', () => {
 
       return documentController.mCreate(request)
         .then(result => {
-          should(result).match({hits: [{result: 'created'}, {result: 'created'}], total: 2});
+          should(result).match({hits: ['created', 'created'], total: 2});
         });
     });
 
     it('mCreate should set a partial error if one of the action fails', () => {
-      let callCount = 0;
-      kuzzle.funnel.processRequest = sandbox.spy(function () {
-        if (callCount > 0) {
-          return Promise.reject(new InternalError('some error'));
-        }
-
-        arguments[0].setResult({result: 'created'});
-        callCount++;
-
-        return Promise.resolve(arguments[0]);
-      });
+      kuzzle.funnel.mExecute.yields(null, {error: new InternalError('some error')});
+      kuzzle.funnel.mExecute
+        .onFirstCall().yields(null, {result: 'created'});
 
       request.input.body = {
         documents: [
@@ -245,7 +236,7 @@ describe('Test: document controller', () => {
 
       return documentController.mCreate(request)
         .then(result => {
-          should(result).match({hits: [{result: 'created'}], total: 1});
+          should(result).match({hits: ['created'], total: 1});
           should(request.error).be.instanceOf(PartialError);
           should(request.status).be.eql(206);
         });
@@ -277,13 +268,17 @@ describe('Test: document controller', () => {
     });
 
     it('mCreate should return a rejected promise if Kuzzle is overloaded', () => {
-      kuzzle.funnel.processRequest = sandbox.spy(function () {
-        arguments[0].setResult({result: 'updated'});
+      kuzzle.funnel.mExecute = funnelController.mExecute.bind(kuzzle.funnel);
+      kuzzle.funnel.processRequest.returns(Promise.resolve({result: 'updated'}));
 
-        return Promise.resolve(arguments[0]);
-      });
-
-      kuzzle.funnel.getRequestSlot.onSecondCall().yields(new ServiceUnavailableError('overloaded'));
+      let callCount = 0;
+      kuzzle.funnel.getRequestSlot = req => {
+        if (callCount++ > 0) {
+          req.setError(new ServiceUnavailableError('overloaded'));
+          return false;
+        }
+        return true;
+      };
 
       request.input.body = {
         documents: [
@@ -301,11 +296,7 @@ describe('Test: document controller', () => {
     });
 
     it('mCreateOrReplace should fulfill with an object', () => {
-      kuzzle.funnel.processRequest = sandbox.spy(function () {
-        arguments[0].setResult({result: 'updated'});
-
-        return Promise.resolve(arguments[0]);
-      });
+      kuzzle.funnel.mExecute.yields(null, {result: 'updated'});
 
       request.input.body = {
         documents: [
@@ -316,18 +307,22 @@ describe('Test: document controller', () => {
 
       return documentController.mCreateOrReplace(request)
         .then(result => {
-          should(result).match({hits: [{result: 'updated'}, {result: 'updated'}], total: 2});
+          should(result).match({hits: ['updated', 'updated'], total: 2});
         });
     });
 
     it('mCreateOrReplace should return a rejected promise if Kuzzle is overloaded', () => {
-      kuzzle.funnel.processRequest = sandbox.spy(function () {
-        arguments[0].setResult({result: 'updated'});
+      kuzzle.funnel.mExecute = funnelController.mExecute.bind(kuzzle.funnel);
+      kuzzle.funnel.processRequest.returns(Promise.resolve({result: 'updated'}));
 
-        return Promise.resolve(arguments[0]);
-      });
-
-      kuzzle.funnel.getRequestSlot.onSecondCall().yields(new ServiceUnavailableError('overloaded'));
+      let callCount = 0;
+      kuzzle.funnel.getRequestSlot = req => {
+        if (callCount++ > 0) {
+          req.setError(new ServiceUnavailableError('overloaded'));
+          return false;
+        }
+        return true;
+      };
 
       request.input.body = {
         documents: [
@@ -360,11 +355,7 @@ describe('Test: document controller', () => {
     });
 
     it('mUpdate should fulfill with an object', () => {
-      kuzzle.funnel.processRequest = sandbox.spy(function () {
-        arguments[0].setResult({result: 'updated'});
-
-        return Promise.resolve(arguments[0]);
-      });
+      kuzzle.funnel.mExecute.yields(null, {result: 'updated'});
 
       request.input.body = {
         documents: [
@@ -375,18 +366,23 @@ describe('Test: document controller', () => {
 
       return documentController.mUpdate(request)
         .then(result => {
-          should(result).match({hits: [{result: 'updated'}, {result: 'updated'}], total: 2});
+          should(result).match({hits: ['updated', 'updated'], total: 2});
         });
     });
 
     it('mUpdate should return a rejected promise if Kuzzle is overloaded', () => {
-      kuzzle.funnel.processRequest = sandbox.spy(function () {
-        arguments[0].setResult({result: 'updated'});
+      kuzzle.funnel.mExecute = funnelController.mExecute.bind(kuzzle.funnel);
+      kuzzle.funnel.processRequest.returns(Promise.resolve({result: 'updated'}));
 
-        return Promise.resolve(arguments[0]);
-      });
+      let callCount = 0;
+      kuzzle.funnel.getRequestSlot = req => {
+        if (callCount++ > 0) {
+          req.setError(new ServiceUnavailableError('overloaded'));
+          return false;
+        }
 
-      kuzzle.funnel.getRequestSlot.onSecondCall().yields(new ServiceUnavailableError('overloaded'));
+        return true;
+      };
 
       request.input.body = {
         documents: [
@@ -419,11 +415,7 @@ describe('Test: document controller', () => {
     });
 
     it('mReplace should fulfill with an object', () => {
-      kuzzle.funnel.processRequest = sandbox.spy(function () {
-        arguments[0].setResult({result: 'updated'});
-
-        return Promise.resolve(arguments[0]);
-      });
+      kuzzle.funnel.mExecute.yields(null, {result: 'updated'});
 
       request.input.body = {
         documents: [
@@ -434,18 +426,23 @@ describe('Test: document controller', () => {
 
       return documentController.mReplace(request)
         .then(result => {
-          should(result).match({hits: [{result: 'updated'}, {result: 'updated'}], total: 2});
+          should(result).match({hits: ['updated', 'updated'], total: 2});
         });
     });
 
     it('mReplace should return a rejected promise if Kuzzle is overloaded', () => {
-      kuzzle.funnel.processRequest = sandbox.spy(function () {
-        arguments[0].setResult({result: 'updated'});
+      kuzzle.funnel.mExecute = funnelController.mExecute.bind(kuzzle.funnel);
+      kuzzle.funnel.processRequest.returns(Promise.resolve({result: 'updated'}));
 
-        return Promise.resolve(arguments[0]);
-      });
+      let callCount = 0;
+      kuzzle.funnel.getRequestSlot = req => {
+        if (callCount++ > 0) {
+          req.setError(new ServiceUnavailableError('overloaded'));
+          return false;
+        }
 
-      kuzzle.funnel.getRequestSlot.onSecondCall().yields(new ServiceUnavailableError('overloaded'));
+        return true;
+      };
 
       request.input.body = {
         documents: [
@@ -664,11 +661,13 @@ describe('Test: document controller', () => {
 
   describe('#mDelete', () => {
     it('should fulfill with an object', () => {
-      kuzzle.funnel.processRequest = sandbox.spy(function () {
-        arguments[0].setResult({result: 'deleted'});
-
-        return Promise.resolve(arguments[0]);
-      });
+      kuzzle.funnel.mExecute
+        .onFirstCall().yields(null, new Request({
+          _id: 'documentId'
+        }))
+        .onSecondCall().yields(null, new Request({
+          _id: 'anotherDocumentId'
+        }));
 
       request.input.body = {ids: ['documentId', 'anotherDocumentId']};
 
@@ -679,17 +678,13 @@ describe('Test: document controller', () => {
     });
 
     it('should set a partial error if one of the action fails', () => {
-      let callCount = 0;
-      kuzzle.funnel.processRequest = sandbox.spy(function () {
-        if (callCount > 0) {
-          return Promise.reject(new InternalError('some error'));
-        }
-
-        arguments[0].setResult({result: 'deleted'});
-        callCount++;
-
-        return Promise.resolve(arguments[0]);
-      });
+      kuzzle.funnel.mExecute
+        .onFirstCall().yields(null, new Request({_id: 'documentId'}))
+        .onSecondCall().yields(null, (() => {
+          const req = new Request({_id: 'anotherDocumentId'});
+          req.setError(new InternalError('some error'));
+          return req;
+        })());
 
       request.input.body = {ids: ['documentId', 'anotherDocumentId']};
 
@@ -712,14 +707,20 @@ describe('Test: document controller', () => {
     });
 
     it('should return a rejected promise if Kuzzle is overloaded', () => {
-      kuzzle.funnel.processRequest = sandbox.spy(function () {
-        arguments[0].setResult({result: 'deleted'});
+      kuzzle.funnel.mExecute = funnelController.mExecute.bind(kuzzle.funnel);
+      kuzzle.funnel.processRequest = req => Promise.resolve(req);
 
-        return Promise.resolve(arguments[0]);
-      });
+      let callCount = 0;
+      kuzzle.funnel.getRequestSlot = req => {
+        if (callCount++ > 0) {
+          req.setError(new ServiceUnavailableError('overloaded'));
+          return false;
+        }
+
+        return true;
+      };
 
       request.input.body = {ids: ['documentId', 'anotherDocumentId']};
-      kuzzle.funnel.getRequestSlot.onSecondCall().yields(new ServiceUnavailableError('overloaded'));
 
       return documentController.mDelete(request)
         .then(result => {

--- a/test/api/controllers/securityController/index.js
+++ b/test/api/controllers/securityController/index.js
@@ -3,6 +3,7 @@ const
   should = require('should'),
   Promise = require('bluebird'),
   BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
+  FunnelController = require('../../../../lib/api/controllers/funnelController'),
   InternalError = require('kuzzle-common-objects').errors.InternalError,
   ServiceUnavailableError = require('kuzzle-common-objects').errors.ServiceUnavailableError,
   KuzzleMock = require('../../../mocks/kuzzle.mock'),
@@ -12,10 +13,12 @@ const
 
 describe('/api/controllers/security', () => {
   let
+    funnelController,
     kuzzle;
 
   beforeEach(() => {
     kuzzle = new KuzzleMock();
+    funnelController = new FunnelController(kuzzle);
   });
 
   describe('#mDelete', () => {
@@ -58,7 +61,18 @@ describe('/api/controllers/security', () => {
         }
       });
 
-      kuzzle.funnel.getRequestSlot.onThirdCall().yields(new ServiceUnavailableError('overloaded'));
+      kuzzle.funnel.mExecute = funnelController.mExecute.bind(kuzzle.funnel);
+      kuzzle.funnel.processRequest = req => Promise.resolve(req);
+
+      let callCount = 0;
+      kuzzle.funnel.getRequestSlot = req => {
+        if (callCount++ === 1) {
+          req.setError(new ServiceUnavailableError('overloaded'));
+          return false;
+        }
+
+        return true;
+      };
 
       return mDelete(kuzzle, 'type', request)
         .then(result => {
@@ -97,6 +111,8 @@ describe('/api/controllers/security', () => {
         }
       });
 
+      kuzzle.funnel.mExecute = (req, cb) => cb(null, req);
+
       return mDelete(kuzzle, 'type', request)
         .then(ids => {
           should(ids)
@@ -117,8 +133,13 @@ describe('/api/controllers/security', () => {
           }
         });
 
-      kuzzle.funnel.processRequest
-        .onCall(1).returns(Promise.reject(error));
+      kuzzle.funnel.mExecute.yields(null, new Request({_id: 'test'}));
+      kuzzle.funnel.mExecute
+        .onSecondCall().yields(null, (() => {
+          const req = new Request({_id: 'bar'});
+          req.setError(error);
+          return req;
+        })());
 
       return mDelete(kuzzle, 'type', request)
         .then(() => {

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -70,6 +70,7 @@ function KuzzleMock () {
     getRequestSlot: sinon.stub().yields(null),
     handleErrorDump: sinon.spy(),
     execute: sinon.spy(),
+    mExecute: sinon.stub(),
     processRequest: sinon.stub().returns(Promise.resolve()),
     checkRights: sinon.stub(),
     getEventName: sinon.spy()


### PR DESCRIPTION
# Description

This PR fixes the case when while running too many concurrent simultaneous requests, Kuzzle would try to execute them multiple times, leading for instance to some 404 errors in case of massive deletions.

# Related issue

* #785 

## Internal changes

3 issues fixed:

1. `funnel:execute` would still process the request if it had been put in cache
2. `funnel:getRequestSlot` would accept duplicates in its request cache
3. `funnel:_playCachedRequests` would call execute with the wrong callback, leading to case 1 again.