### PR TITLE
remove debug for travis & use production mode

### DIFF
--- a/docker-compose/scripts/run-test.sh
+++ b/docker-compose/scripts/run-test.sh
@@ -6,6 +6,7 @@ ELASTIC_HOST=${kuzzle_services__db__host:-elasticsearch}
 ELASTIC_PORT=${kuzzle_services__db__port:-9200}
 
 npm install
+npm install --only=dev
 docker-compose/scripts/install-plugins.sh
 
 echo "[$(date --rfc-3339 seconds)] - Waiting for elasticsearch to be available"
@@ -28,5 +29,8 @@ fi
 echo "[$(date --rfc-3339 seconds)] - Starting Kuzzle..."
 
 pm2 start --silent /config/pm2.json
-npm test
+
+npm run --silent lint
+npm run unit-testing
 npm run codecov
+npm run functional-testing

--- a/docker-compose/test.yml
+++ b/docker-compose/test.yml
@@ -22,8 +22,8 @@ services:
       - kuzzle_services__internalCache__node__host=redis
       - kuzzle_services__memoryStorage__node__host=redis
       - kuzzle_services__proxyBroker__host=proxy
-      - NODE_ENV=development
-      - DEBUG=kuzzle:*
+      - NODE_ENV=production
+      - DEBUG=
       # Travis env var must be propagated into the container
       - TRAVIS
       - TRAVIS_COMMIT


### PR DESCRIPTION
* Debug outputs are too verbose and exceed the maximum size of travis logs.
* NODE_ENV=production
* Send coverage to codecov as soon as unit tests are done