### PR TITLE
DSL - Allow simple form for "regexp" operator

### DIFF
--- a/lib/api/dsl/transform/standardize.js
+++ b/lib/api/dsl/transform/standardize.js
@@ -20,6 +20,9 @@ const RegexGeohash = /^[0-9a-z]{4,}$/;
  * Does not mutate the input filters.
  */
 class Standardizer {
+  constructor () {
+    this._regexp = null;
+  }
 
   /**
    * Standardization entry point
@@ -162,44 +165,72 @@ class Standardizer {
   }
 
   /**
+   * Generator function used by "regexp"
    * Validate a "regexp" keyword
+   *
+   * @generator
    * @param filter
    * @returns {Promise} standardized filter
    */
-  regexp (filter) {
-    let regexpField;
+  static * _regexpGenerator (filter) {
+    const field = yield mustBeNonEmptyObject(filter.regexp, 'regexp');
+    yield onlyOneFieldAttribute(field, 'regexp');
 
-    return mustBeNonEmptyObject(filter.regexp, 'regexp')
-      .then(field => onlyOneFieldAttribute(field, 'regexp'))
-      .then(field => {
-        regexpField = field[0];
-        return mustBeNonEmptyObject(filter.regexp[regexpField], `regexp.${regexpField}`);
-      })
-      .then(regexpValues => {
-        if (regexpValues.findIndex(v => ['flags', 'value'].indexOf(v) === -1) !== -1) {
-          return Promise.reject(new BadRequestError('Keyword "regexp" can only contain the following attributes: flags, value'));
-        }
+    const regexpField = field[0];
 
-        return requireAttribute(filter.regexp[regexpField], 'regexp', 'value');
-      })
-      .then(() => {
-        if (filter.regexp[regexpField].flags) {
-          return mustBeString(filter.regexp[regexpField], 'regexp', 'flags');
-        }
+    let
+      isString,
+      isObject;
 
-        return Promise.resolve();
-      })
-      .then(() => {
-        try {
-          // eslint-disable-next-line no-new
-          new RegExp(filter.regexp[regexpField].value, filter.regexp[regexpField].flags);
-        }
-        catch (err) {
-          return Promise.reject(new BadRequestError(`Invalid regular expression "${filter.regexp[regexpField].value}": ${err.message}`));
-        }
+    try {
+      yield mustBeString(filter.regexp, `regexp${regexpField}`, regexpField);
+      isString = true;
+    }
+    catch (e) {
+      try {
+        yield mustBeNonEmptyObject(filter.regexp[regexpField], `regexp.${regexpField}`);
+        isObject = true;
+      }
+      catch (err) {
+        // do nothing
+      }
+    }
 
-        return filter;
-      });
+    if (!isObject && !isString) {
+      throw new BadRequestError(`regexp.${regexpField} must be either a string or a non-empty object`);
+    }
+
+    let
+      regexValue,
+      flags;
+
+    if (isString) {
+      regexValue = filter.regexp[regexpField];
+    }
+    else {
+      if (Object.keys(filter.regexp[regexpField]).findIndex(v => ['flags', 'value'].indexOf(v) === -1) > -1) {
+        throw new BadRequestError('Keyword "regexp" can only contain the following attributes: flags, value');
+      }
+
+      yield requireAttribute(filter.regexp[regexpField], 'regexp', 'value');
+      regexValue = filter.regexp[regexpField].value;
+
+      if (filter.regexp[regexpField].flags) {
+        yield mustBeString(filter.regexp[regexpField], 'regexp', 'flags');
+        flags = filter.regexp[regexpField].flags;
+      }
+    }
+
+
+    try {
+      // eslint-disable-next-line no-new
+      new RegExp(regexValue, flags);
+    }
+    catch (err) {
+      throw new BadRequestError(err.message);
+    }
+
+    return filter;
   }
 
   /**
@@ -562,6 +593,8 @@ class Standardizer {
   }
 
 }
+
+Standardizer.prototype.regexp = Promise.coroutine(Standardizer._regexpGenerator);
 
 module.exports = Standardizer;
 

--- a/test/api/dsl/keywords/regexp.test.js
+++ b/test/api/dsl/keywords/regexp.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var
+const
   should = require('should'),
   BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
   FieldOperand = require('../../../../lib/api/dsl/storage/objects/fieldOperand'),
@@ -8,7 +8,7 @@ var
   DSL = require('../../../../lib/api/dsl');
 
 describe('DSL.keyword.regexp', () => {
-  var dsl;
+  let dsl;
 
   beforeEach(() => {
     dsl = new DSL();
@@ -43,12 +43,42 @@ describe('DSL.keyword.regexp', () => {
       return should(dsl.validate({regexp: {foo: {value: 'foo(', flags: 'i'}}})).be.rejectedWith(BadRequestError);
     });
 
+    it('should reject filters with invalid flags', () => {
+      return should(dsl.validate({
+        regexp: {
+          foo: {
+            value: 'a',
+            flags: 'INVALID'
+          }
+        }
+      }))
+        .be.rejectedWith(BadRequestError);
+    });
+
     it('should validate a well-formed regular expression filter w/ flags', () => {
       return should(dsl.validate({regexp: {foo: {value: 'foo', flags: 'i'}}})).be.fulfilledWith(true);
     });
 
     it('should validate a well-formed regular expression filter without flags', () => {
       return should(dsl.validate({regexp: {foo: {value: 'foo'}}})).be.fulfilledWith(true);
+    });
+
+    it('should accept a simplified form', () => {
+      return dsl.validate({regexp: {
+        foo: '^bar'
+      }})
+        .then(response => {
+          should(response).be.true();
+        });
+    });
+
+    it('should reject an invalid simple form regex', () => {
+      return should(dsl.validate({
+        regexp: {
+          foo: '++'
+        }
+      }))
+        .be.rejectedWith(BadRequestError);
     });
   });
 


### PR DESCRIPTION
# Description

This PR adds the ability to use simple regular expression form in DSL filters, i.e.:

```js
{
  controller: 'realtime',
  action: 'subscribe',
  index: 'myindex',
  collection: 'mycollection',
  body: {
    regexp: {
      foo: '^some.*regex'
    }
  }
}
```

# Related issue

* #724