### PR TITLE
fix elasticsearch error parser which crash when error got no body

### DIFF
--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -945,22 +945,26 @@ class ElasticSearch extends Service {
     switch (error.displayName) {
       case 'BadRequest':
         if (!messageReplaced) {
-          message = error.body.error.root_cause ? error.body.error.root_cause[0].reason : error.body.error.reason;
+          if (error.body && error.body.error) {
+            message = error.body.error.root_cause ? error.body.error.root_cause[0].reason : error.body.error.reason;
+          }
 
           debug('unhandled "BadRequest" elasticsearch error:');
-          debug(message);
+          debug(error);
         }
 
         kuzzleError = new BadRequestError(message);
         break;
       case 'NotFound':
         if (!messageReplaced) {
-          message = error.body.error
-            ? error.body.error.reason + ': ' + error.body.error['resource.id']
-            : error.message + ': ' + error.body._id;
+          if (error.body && error.body.error) {
+            message = error.body.error
+              ? error.body.error.reason + ': ' + error.body.error['resource.id']
+              : error.message + ': ' + error.body._id;
+          }
 
           debug('unhandled "NotFound" elasticsearch error:');
-          debug(message);
+          debug(error);
         }
 
         kuzzleError = new NotFoundError(message);
@@ -968,7 +972,7 @@ class ElasticSearch extends Service {
       case 'Conflict':
         if (!messageReplaced) {
           debug('unhandled "Conflict" elasticsearch error:');
-          debug(message);
+          debug(error);
         }
 
         kuzzleError = new ExternalServiceError(message);


### PR DESCRIPTION
Fix variable checking in elasticsearch error reporter function

Used kuzzle with latest version of elasticsearch 5.x, get from dump
```
error: 2017-04-12T13:39:33+00:00 [LOG:ERROR] Cannot read property 'root_cause' of undefined
TypeError: Cannot read property 'root_cause' of undefined
    at ElasticSearch.formatESError (/tmp/sandbox/app/lib/services/elasticsearch.js:948:37)
    at deleteByQuery.catch.error (/tmp/sandbox/app/lib/services/elasticsearch.js:643:43)
From previous event:
    at ElasticSearch.truncateCollection (/tmp/sandbox/app/lib/services/elasticsearch.js:643:13)
    at CollectionController.truncate (/tmp/sandbox/app/lib/api/controllers/collectionController.js:192:24)
    at triggerEvent.then.newRequest (/tmp/sandbox/app/lib/api/controllers/funnelController.js:299:80)
From previous event:
    at FunnelController.processRequest (/tmp/sandbox/app/lib/api/controllers/funnelController.js:296:8)
    at checkRights.then.modifiedRequest (/tmp/sandbox/app/lib/api/controllers/funnelController.js:157:39)
    at runCallback (timers.js:649:20)
    at tryOnImmediate (timers.js:622:5)
    at processImmediate [as _immediateCallback] (timers.js:594:5)
```