### PR TITLE
Autogenerate JWT salt

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -81,10 +81,12 @@
     //   * secret:
     //      String or buffer data containing either the secret for HMAC
     //      algorithms, or the PEM encoded private key for RSA and ECDSA.
+    //      If left to null (default), Kuzzle will autogenerate a random
+    //      seed (can only be used with HMAC algorithms).
     "jwt": {
       "algorithm": "HS256",
       "expiresIn": "1h",
-      "secret": "Change me"
+      "secret": null
     },
     // [default]
     // The default role defines permissions for all users,

--- a/default.config.js
+++ b/default.config.js
@@ -47,7 +47,7 @@ module.exports = {
     jwt: {
       algorithm: 'HS256',
       expiresIn: '1h',
-      secret: 'Kuzzle rocks'
+      secret: null
     },
     default: {
       role: {

--- a/lib/services/internalEngine/bootstrap.js
+++ b/lib/services/internalEngine/bootstrap.js
@@ -1,180 +1,250 @@
 'use strict';
 
-const Promise = require('bluebird');
-let _kuzzle;
+const
+  Bluebird = require('bluebird'),
+  crypto = require('crypto');
 
-/**
- *
- * @param kuzzle
- * @param engine {InternalEngine}
- * @constructor
- */
-function InternalEngineBootstrap (kuzzle, engine) {
-  _kuzzle = kuzzle;
-  this.db = engine || _kuzzle.internalEngine;
-}
+const
+  lockId = 'bootstrap-lock',
+  jwtSecretId = 'security.jwt.secret';
 
-/**
- * Bootstraps Kuzzle storage engine
- * Creates the internal index and collections if needed
- *
- * @returns {Promise.<T>}
- */
-InternalEngineBootstrap.prototype.all = function internalEngineBootstrapAll () {
-  return this.db.createInternalIndex()
-    .then(() => this.createCollections())
-    .then(() => this.db.refresh())
-    .then(() => Promise.resolve(_kuzzle.indexCache.add(this.db.index)))
-    .catch(error => {
-      // plugin manager is not initialized yet, cannot use the logger
-      console.error(error, error.stack);  // eslint-disable-line no-console
-      throw error;
-    });
-};
+class InternalEngineBootstrap {
 
-InternalEngineBootstrap.prototype.createCollections = function internalEngineBootstrapCreateCollections () {
-  return this.createPluginsCollection()
-    .then(() => this.createRolesCollection())
-    .then(() => this.createProfilesCollection())
-    .then(() => this.createUsersCollection())
-    .then(() => this.createValidationCollection(_kuzzle.config.validation));
-};
-
-InternalEngineBootstrap.prototype.createRolesCollection = function internalEngineBootstrapCreateRolesCollection () {
-  if (_kuzzle.indexCache.exists(this.db.index, 'roles')) {
-    return Promise.resolve();
+  /**
+   * @param kuzzle
+   * @param engine {InternalEngine}
+   * @constructor
+   */
+  constructor (kuzzle, engine) {
+    this.kuzzle = kuzzle;
+    this.db = engine || this.kuzzle.internalEngine;
   }
 
-  return this.db.updateMapping('roles', {
-    properties: {
-      controllers: {
-        enabled: false
-      }
+  /**
+   * Bootstraps Kuzzle storage engine
+   * Creates the internal index and collections if needed
+   */
+  * _allGen () {
+    const isLocked = yield this.lock();
+
+    if (isLocked) {
+      yield this.getJWTSecret();
+      return Bluebird.resolve();
     }
-  })
-    .then(() => {
-      const promises = ['anonymous', 'default', 'admin'].map(roleId => {
-        return this.db.createOrReplace('roles', roleId, _kuzzle.config.security.default.role);
+
+    yield this.db.createInternalIndex();
+    yield this.createCollections();
+    yield this.getJWTSecret();
+    yield this.db.refresh();
+
+    this.kuzzle.indexCache.add(this.db.index);
+
+    yield this.unLock();
+
+    return Bluebird.resolve();
+  }
+
+  createCollections () {
+    return this.createPluginsCollection()
+      .then(() => this.createRolesCollection())
+      .then(() => this.createProfilesCollection())
+      .then(() => this.createUsersCollection())
+      .then(() => this.createValidationCollection(this.kuzzle.config.validation));
+  }
+
+  createRolesCollection () {
+    if (this.kuzzle.indexCache.exists(this.db.index, 'roles')) {
+      return Bluebird.resolve();
+    }
+
+    return this.db.updateMapping('roles', {
+      properties: {
+        controllers: {
+          enabled: false
+        }
+      }
+    })
+      .then(() => {
+        const promises = ['anonymous', 'default', 'admin'].map(roleId => {
+          return this.db.createOrReplace('roles', roleId, this.kuzzle.config.security.default.role);
+        });
+
+        this.kuzzle.indexCache.add(this.db.index, 'roles');
+
+        return Bluebird.all(promises);
       });
-
-      _kuzzle.indexCache.add(this.db.index, 'roles');
-
-      return Promise.all(promises);
-    });
-};
-
-InternalEngineBootstrap.prototype.createPluginsCollection = function internalEngineBootstrapCreatePluginsCollection () {
-  if (_kuzzle.indexCache.exists(this.db.index, 'plugins')) {
-    return Promise.resolve();
   }
 
-  return this.db.updateMapping('plugins', {
-    properties: {
-      config: {
-        enabled: false
-      }
+  createPluginsCollection () {
+    if (this.kuzzle.indexCache.exists(this.db.index, 'plugins')) {
+      return Bluebird.resolve();
     }
-  });
-};
 
-InternalEngineBootstrap.prototype.createProfilesCollection = function internalEngineBootstrapCreateProfilesCollection () {
-  if (_kuzzle.indexCache.exists(this.db.index, 'profiles')) {
-    return Promise.resolve();
+    return this.db.updateMapping('plugins', {
+      properties: {
+        config: {
+          enabled: false
+        }
+      }
+    });
   }
 
-  return this.db.updateMapping('profiles', {
-    properties: {
-      policies: {
-        properties: {
-          roleId: {
-            type: 'keyword'
+  createProfilesCollection () {
+    if (this.kuzzle.indexCache.exists(this.db.index, 'profiles')) {
+      return Bluebird.resolve();
+    }
+
+    return this.db.updateMapping('profiles', {
+      properties: {
+        policies: {
+          properties: {
+            roleId: {
+              type: 'keyword'
+            }
           }
         }
       }
-    }
-  })
-    .then(() => {
-      _kuzzle.indexCache.add(this.db.index, 'profiles');
+    })
+      .then(() => {
+        this.kuzzle.indexCache.add(this.db.index, 'profiles');
 
-      const promises = ['default', 'anonymous', 'admin'].map(profileId => {
-        return this.db.createOrReplace('profiles', profileId, {
-          policies: [{roleId: profileId}]
+        const promises = ['default', 'anonymous', 'admin'].map(profileId => {
+          return this.db.createOrReplace('profiles', profileId, {
+            policies: [{roleId: profileId}]
+          });
         });
+
+        return Bluebird.all(promises);
       });
-
-      return Promise.all(promises);
-    });
-};
-
-InternalEngineBootstrap.prototype.createUsersCollection = function internalEngineBootstrapCreateUsersCollection () {
-  if (_kuzzle.indexCache.exists(this.db.index, 'users')) {
-    return Promise.resolve();
   }
 
-  return this.db.updateMapping('users', {
-    properties: {
-      profileIds: {
-        type: 'keyword'
-      },
-      password: {
-        index: false,
-        type: 'keyword'
-      }
+  createUsersCollection () {
+    if (this.kuzzle.indexCache.exists(this.db.index, 'users')) {
+      return Bluebird.resolve();
     }
-  })
-    .then(() => {
-      _kuzzle.indexCache.add(this.db.index, 'users');
-    });
-};
 
-InternalEngineBootstrap.prototype.createValidationCollection = function internalEngineBootstrapCreateValidationCollection (validationConfiguration) {
-  if (_kuzzle.indexCache.exists(this.db.index, 'validations')) {
-    return Promise.resolve();
+    return this.db.updateMapping('users', {
+      properties: {
+        profileIds: {
+          type: 'keyword'
+        },
+        password: {
+          index: false,
+          type: 'keyword'
+        }
+      }
+    })
+      .then(() => {
+        this.kuzzle.indexCache.add(this.db.index, 'users');
+      });
   }
 
-  _kuzzle.pluginsManager.trigger('log:info', '== Creating validation collection...');
+  createValidationCollection (validationConfiguration) {
+    if (this.kuzzle.indexCache.exists(this.db.index, 'validations')) {
+      return Bluebird.resolve();
+    }
 
-  return this.db.updateMapping('validations', {
-    properties: {
-      index: {
-        type: 'keyword'
-      },
-      collection: {
-        type: 'keyword'
-      },
-      validation: {
-        enabled: false
+    this.kuzzle.pluginsManager.trigger('log:info', '== Creating validation collection...');
+
+    return this.db.updateMapping('validations', {
+      properties: {
+        index: {
+          type: 'keyword'
+        },
+        collection: {
+          type: 'keyword'
+        },
+        validation: {
+          enabled: false
+        }
       }
-    }
-  }).then(() => {
-    if (validationConfiguration) {
-      const promises = [];
+    }).then(() => {
+      if (validationConfiguration) {
+        const promises = [];
 
-      Object.keys(validationConfiguration).forEach(indexName => {
-        Object.keys(validationConfiguration[indexName]).forEach(collectionName => {
-          // createOrReplace instead of create to avoid mess on concurency
-          // TODO fix with a lock instead
-          promises.push(_kuzzle.internalEngine.createOrReplace('validations', `${indexName}#${collectionName}`, {
-            index: indexName,
-            collection: collectionName,
-            validation: validationConfiguration[indexName][collectionName]
-          }));
+        Object.keys(validationConfiguration).forEach(indexName => {
+          Object.keys(validationConfiguration[indexName]).forEach(collectionName => {
+            // createOrReplace instead of create to avoid mess on concurency
+            // TODO fix with a lock instead
+            promises.push(this.kuzzle.internalEngine.createOrReplace('validations', `${indexName}#${collectionName}`, {
+              index: indexName,
+              collection: collectionName,
+              validation: validationConfiguration[indexName][collectionName]
+            }));
+          });
         });
-      });
 
-      return Promise.all(promises);
+        return Bluebird.all(promises);
+      }
+
+      return Bluebird.resolve();
+    })
+      .then(() => {
+        this.kuzzle.indexCache.add(this.db.index, 'validations');
+      });
+  }
+
+  * _getJWTSecretGen () {
+    if (this.kuzzle.config.security.jwt.secret !== null) {
+      return this.kuzzle.config.security.jwt.secret;
     }
 
-    return Promise.resolve();
-  })
-    .then(() => {
-      _kuzzle.indexCache.add(this.db.index, 'validations');
-    });
-};
+    // try to create first to avoid collisions
+    try {
+      const seed = crypto.randomBytes(512).toString('hex');
+      yield this.db.create('config', jwtSecretId, {seed});
+      this.kuzzle.config.security.jwt.secret = seed;
+    }
+    catch(e) {
+      const response = yield this.db.get('config', jwtSecretId);
+      this.kuzzle.config.security.jwt.secret = response._source.seed;
+    }
+  }
 
-InternalEngineBootstrap.prototype.adminExists = function internalEngineBootstrapAdminExists () {
-  return this.db.search('users', {query: {terms: {profileIds: ['admin']}}}, {from: 0, size: 0})
-    .then(response => (response.total > 0));
-};
+  adminExists () {
+    return this.db.search('users', {query: {terms: {profileIds: ['admin']}}}, {from: 0, size: 0})
+      .then(response => (response.total > 0));
+  }
+
+  /**
+   * Checks if Kuzzle is already being bootstraped.
+   * If not set a lock.
+   * Returns true if the bootstrap is locked, false otherwise.
+   *
+   * @generator
+   * @private
+   * @returns {boolean}
+   */
+  * _lockGen () {
+    let lock;
+
+    try {
+      yield this.db.create('config', lockId, {timestamp: Date.now()});
+      return false;
+    }
+    catch (e) {
+      // lock exists - try to get it and check if it is old enough to erase it
+    }
+
+    lock = yield this.db.get('config', lockId);
+    if (lock._source.timestamp < Date.now() - 30000) {
+      yield this.db.createOrReplace('config', lockId, {timestamp: Date.now()});
+      return false;
+    }
+
+    return true;
+  }
+
+  unLock () {
+    return this.db.delete('config', lockId);
+  }
+}
+
+InternalEngineBootstrap.prototype.all = Bluebird.coroutine(InternalEngineBootstrap.prototype._allGen);
+
+InternalEngineBootstrap.prototype.getJWTSecret = Bluebird.coroutine(InternalEngineBootstrap.prototype._getJWTSecretGen);
+
+InternalEngineBootstrap.prototype.lock = Bluebird.coroutine(InternalEngineBootstrap.prototype._lockGen);
+
 
 module.exports = InternalEngineBootstrap;

--- a/lib/services/internalEngine/index.js
+++ b/lib/services/internalEngine/index.js
@@ -67,7 +67,6 @@ class InternalEngine {
       .then(() => this);
   }
 
-
   /**
    * Search documents from elasticsearch with a query
    * @param {string} type - data collection

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -3,7 +3,6 @@ const
   jwt = require('jsonwebtoken'),
   Bluebird = require('bluebird'),
   /** @type KuzzleConfiguration */
-  params = require('../../../lib/config'),
   AuthController = require('../../../lib/api/controllers/authController'),
   Kuzzle = require('../../mocks/kuzzle.mock'),
   Request = require('kuzzle-common-objects').Request,
@@ -22,6 +21,7 @@ describe('Test the auth controller', () => {
 
   beforeEach(() => {
     kuzzle = new Kuzzle();
+    kuzzle.config.security.jwt.secret = 'test-secret';
 
     request = new Request({
       controller: 'auth',
@@ -98,7 +98,7 @@ describe('Test the auth controller', () => {
   describe('#logout', () => {
     beforeEach(() => {
       const
-        signedToken = jwt.sign({_id: 'admin'}, params.security.jwt.secret, {algorithm: params.security.jwt.algorithm}),
+        signedToken = jwt.sign({_id: 'admin'}, kuzzle.config.security.jwt.secret, {algorithm: kuzzle.config.security.jwt.algorithm}),
         t = new Token();
 
       t._id = signedToken;

--- a/test/api/core/models/repositories/tokenRepository.test.js
+++ b/test/api/core/models/repositories/tokenRepository.test.js
@@ -26,6 +26,7 @@ describe('Test: repositories/tokenRepository', () => {
 
   beforeEach(() => {
     kuzzle = new KuzzleMock();
+    kuzzle.config.security.jwt.secret = 'test-secret';
     tokenRepository = new TokenRepository(kuzzle);
 
     return tokenRepository.init();


### PR DESCRIPTION
# Description

For the time being, the secret used to generate JWT tokens solely relies on Kuzzle configuration. If the user does not customize this value, the seed used will be the default config one ('Kuzzle rocks'), which brings a security issue.
This PR set the default secret to null and make Kuzzle autogenerate a 512bytes random string.

# Related issue

* #737