### PR TITLE
Diagtools - Preserve timestamp when copying log files from PM2

### DIFF
--- a/lib/api/controllers/cli/dump.js
+++ b/lib/api/controllers/cli/dump.js
@@ -92,13 +92,19 @@ function dump (request) {
     if (process.env.pm_err_log_path) {
       fs.copySync(
         path.dirname(process.env.pm_err_log_path),
-        path.join(dumpPath, 'logs')
+        path.join(dumpPath, 'logs'),
+        {
+          preserveTimestamps: true
+        }
       );
     }
     else if (process.env.pm_log_path) {
       fs.copySync(
         path.dirname(process.env.pm_log_path),
-        path.join(dumpPath, 'logs')
+        path.join(dumpPath, 'logs'),
+        {
+          preserveTimestamps: true
+        }
       );
     }
     else {


### PR DESCRIPTION
# Description

This PR keeps the timestamp when diagtools copy log files from PM2

# Related issue

* #713