### PR TITLE
Delete now deactivate a document and notify by filters

### DIFF
--- a/lib/api/core/notifier.js
+++ b/lib/api/core/notifier.js
@@ -258,7 +258,7 @@ class NotifierController {
    * @param {Array} ids - list of deleted document IDs
    */
   notifyDocumentDelete(request, ids) {
-    return Bluebird.each(ids, (id, callback) => {
+    return Bluebird.all(ids.map(id => {
       const
         getRequest = new Request({
           action: 'delete',
@@ -267,10 +267,9 @@ class NotifierController {
           index: request.input.resource.index,
           _id: id,
           requestId: request.id,
-          volatile: request.input.volatile
+          volatile: request.input.volatile,
+          includeTrash: true
         });
-
-      getRequest.input.args.includeTrash = true;
 
       return this.kuzzle.services.list.storageEngine.get(getRequest)
         .then(result => {
@@ -293,8 +292,7 @@ class NotifierController {
             state: 'done'
           });
 
-          return this.kuzzle.services.list.internalCache.search(this.cacheKeyPrefix + deletedDocument._id)
-            .asCallback(callback);
+          return this.kuzzle.services.list.internalCache.search(this.cacheKeyPrefix + deletedDocument._id);
         })
         .then(cachedRooms => {
           const
@@ -307,14 +305,8 @@ class NotifierController {
 
           this.kuzzle.notifier.notify(cachedRooms, request, notification);
           return this.kuzzle.services.list.internalCache.remove(this.cacheKeyPrefix + id);
-        })
-        .asCallback(callback);
-    }, error => {
-      if (error) {
-        this.kuzzle.pluginsManager.trigger('log:error', error);
-        return false;
-      }
-    });
+        });
+    }));
   }
 }
 

--- a/lib/api/core/notifier.js
+++ b/lib/api/core/notifier.js
@@ -273,7 +273,6 @@ function NotifierController (kuzzle) {
           this.notify(matchedRooms, request, {
             action: 'delete',
             _id: deletedDocument._id,
-            _source: deletedDocument._source,
             _meta,
             scope: 'out',
             state: 'done'

--- a/lib/api/core/notifier.js
+++ b/lib/api/core/notifier.js
@@ -259,51 +259,36 @@ class NotifierController {
    */
   notifyDocumentDelete(request, ids) {
     return Bluebird.all(ids.map(id => {
-      return this.kuzzle.services.list.internalCache.search(this.cacheKeyPrefix + id)
-        .then(cachedRooms => {
-          const
-            notification = {
-              action: 'delete',
-              scope: 'out',
-              state: 'done',
-              _id: id
-            };
+      const
+        getRequest = new Request({
+          collection: request.input.resource.collection,
+          index: request.input.resource.index,
+          _id: id,
+          includeTrash: true
+        });
 
-          this.kuzzle.notifier.notify(cachedRooms, request, notification);
-          return this.kuzzle.services.list.internalCache.remove(this.cacheKeyPrefix + id);
-        })
-        .then(()=> {
-          const
-            getRequest = new Request({
-              collection: request.input.resource.collection,
-              index: request.input.resource.index,
-              _id: id,
-              includeTrash: true
-            });
+      return this.kuzzle.services.list.storageEngine.get(getRequest)
+        .then(result => {
+          const deletedDocument = result;
 
-          return this.kuzzle.services.list.storageEngine.get(getRequest)
-            .then(result => {
-              const deletedDocument = result;
+          const matchedRooms = this.kuzzle.dsl.test(
+            request.input.resource.index,
+            request.input.resource.collection,
+            result._source,
+            result._id);
 
-              const matchedRooms = this.kuzzle.dsl.test(
-                request.input.resource.index,
-                request.input.resource.collection,
-                result._source,
-                result._id);
+          const _meta = deletedDocument._source._kuzzle_info;
+          delete deletedDocument._source._kuzzle_info;
 
-              const _meta = deletedDocument._source._kuzzle_info;
-              delete deletedDocument._source._kuzzle_info;
-
-              return this.notify(matchedRooms, request, {
-                _meta,
-                action: 'delete',
-                _id: deletedDocument._id,
-                scope: 'out',
-                state: 'done'
-              });
-            });
-        })
-        .then(() => Promise.resolve(id));
+          this.notify(matchedRooms, request, {
+            _meta,
+            action: 'delete',
+            _id: deletedDocument._id,
+            scope: 'out',
+            state: 'done'
+          });
+          return Promise.resolve(id);
+        });
     }));
   }
 }

--- a/lib/api/core/notifier.js
+++ b/lib/api/core/notifier.js
@@ -110,7 +110,7 @@ class NotifierController {
       this.notify(rooms, request, notificationContent);
     }
 
-    return { published: true };
+    return {published: true};
   }
 
 
@@ -259,41 +259,7 @@ class NotifierController {
    */
   notifyDocumentDelete(request, ids) {
     return Bluebird.all(ids.map(id => {
-      const
-        getRequest = new Request({
-          action: 'delete',
-          controller: 'document',
-          collection: request.input.resource.collection,
-          index: request.input.resource.index,
-          _id: id,
-          requestId: request.id,
-          volatile: request.input.volatile,
-          includeTrash: true
-        });
-
-      return this.kuzzle.services.list.storageEngine.get(getRequest)
-        .then(result => {
-          const deletedDocument = result;
-
-          const matchedRooms = this.kuzzle.dsl.test(
-            request.input.resource.index,
-            request.input.resource.collection,
-            result._source,
-            result._id);
-
-          const _meta = deletedDocument._source._kuzzle_info;
-          delete deletedDocument._source._kuzzle_info;
-
-          this.notify(matchedRooms, request, {
-            _meta,
-            action: 'delete',
-            _id: deletedDocument._id,
-            scope: 'out',
-            state: 'done'
-          });
-
-          return this.kuzzle.services.list.internalCache.search(this.cacheKeyPrefix + deletedDocument._id);
-        })
+      return this.kuzzle.services.list.internalCache.search(this.cacheKeyPrefix + id)
         .then(cachedRooms => {
           const
             notification = {
@@ -305,7 +271,39 @@ class NotifierController {
 
           this.kuzzle.notifier.notify(cachedRooms, request, notification);
           return this.kuzzle.services.list.internalCache.remove(this.cacheKeyPrefix + id);
-        });
+        })
+        .then(()=> {
+          const
+            getRequest = new Request({
+              collection: request.input.resource.collection,
+              index: request.input.resource.index,
+              _id: id,
+              includeTrash: true
+            });
+
+          return this.kuzzle.services.list.storageEngine.get(getRequest)
+            .then(result => {
+              const deletedDocument = result;
+
+              const matchedRooms = this.kuzzle.dsl.test(
+                request.input.resource.index,
+                request.input.resource.collection,
+                result._source,
+                result._id);
+
+              const _meta = deletedDocument._source._kuzzle_info;
+              delete deletedDocument._source._kuzzle_info;
+
+              return this.notify(matchedRooms, request, {
+                _meta,
+                action: 'delete',
+                _id: deletedDocument._id,
+                scope: 'out',
+                state: 'done'
+              });
+            });
+        })
+        .then(() => Promise.resolve(id));
     }));
   }
 }

--- a/lib/api/core/notifier.js
+++ b/lib/api/core/notifier.js
@@ -252,10 +252,10 @@ function NotifierController (kuzzle) {
           index: request.input.resource.index,
           _id: id,
           requestId: request.id,
-          volatile: request.input.volatile || {}
+          volatile: request.input.volatile
         });
 
-      getRequest.input.volatile.includeTrash = true;
+      getRequest.input.args.includeTrash = true;
 
       return kuzzle.services.list.storageEngine.get(getRequest)
         .then(result => {

--- a/lib/api/core/notifier.js
+++ b/lib/api/core/notifier.js
@@ -242,7 +242,46 @@ function NotifierController (kuzzle) {
    */
   this.notifyDocumentDelete = function notifierNotifyDocumentDelete (request, ids) {
     return Promise.each(ids, (id, callback) => {
-      return kuzzle.services.list.internalCache.search(this.cacheKeyPrefix + id)
+      var
+        matchedRooms,
+        deletedDocument,
+        getRequest = new Request({
+          action: 'delete',
+          controller: 'document',
+          collection: request.input.resource.collection,
+          index: request.input.resource.index,
+          _id: id,
+          requestId: request.id,
+          volatile: request.input.volatile || {}
+        });
+
+      getRequest.input.volatile.includeTrash = true;
+
+      return kuzzle.services.list.storageEngine.get(getRequest)
+        .then(result => {
+          deletedDocument = result;
+
+          matchedRooms = kuzzle.dsl.test(
+            request.input.resource.index,
+            request.input.resource.collection,
+            result._source,
+            result._id);
+
+          const _meta = deletedDocument._source._kuzzle_info;
+          delete deletedDocument._source._kuzzle_info;
+
+          this.notify(matchedRooms, request, {
+            action: 'delete',
+            _id: deletedDocument._id,
+            _source: deletedDocument._source,
+            _meta,
+            scope: 'out',
+            state: 'done'
+          });
+
+          return kuzzle.services.list.internalCache.search(this.cacheKeyPrefix + deletedDocument._id)
+            .asCallback(callback);
+        })
         .then(cachedRooms => {
           const
             notification = {
@@ -254,8 +293,7 @@ function NotifierController (kuzzle) {
 
           kuzzle.notifier.notify(cachedRooms, request, notification);
           return kuzzle.services.list.internalCache.remove(this.cacheKeyPrefix + id);
-        })
-        .asCallback(callback);
+        });
     }, (error) => {
       if (error) {
         kuzzle.pluginsManager.trigger('log:error', error);

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -196,8 +196,9 @@ class ElasticSearch extends Service {
 
     esRequest.body = request.input.body;
 
-    // todo add condition once the 'trash' feature has been implemented
-    addActiveFilter(esRequest);
+    if (!request.input.volatile || !request.input.volatile.includeTrash) {
+      addActiveFilter(esRequest);
+    }
 
     return this.client.search(esRequest)
       .then(result => {
@@ -237,9 +238,8 @@ class ElasticSearch extends Service {
     return this.client.get(esRequest)
       .then(result => {
         if (result._source) {
-          if (result._source._kuzzle_info && !result._source._kuzzle_info.active) {
-            // todo Feedback how to get it from the 'trash' once it is implemented
-            return Promise.reject(new NotFoundError(`Document ${result._id} was already deleted`));
+          if (result._source._kuzzle_info && (!result._source._kuzzle_info.active && (!request.input.volatile || !request.input.volatile.includeTrash))) {
+            return Promise.reject(new NotFoundError(`Document ${result._id} was already deleted. If you want to also get trashed documents set volatile argument includeTrash to true`));
           }
           if (result._source._kuzzle_info) {
             result._meta = result._source._kuzzle_info;
@@ -287,8 +287,9 @@ class ElasticSearch extends Service {
 
     esRequest.body = request.input.body;
 
-    // todo add condition once the 'trash' feature has been implemented
-    addActiveFilter(esRequest);
+    if (!request.input.volatile || !request.input.volatile.includeTrash) {
+      addActiveFilter(esRequest);
+    }
     return this.client.count(esRequest)
       .catch(error => Promise.reject(this.formatESError(error)));
   }
@@ -511,13 +512,13 @@ class ElasticSearch extends Service {
   }
 
   /**
-   * Send to elasticsearch the document id to delete
+   * Set the _kuzzle_info.active to false
    *
    * @param {Request} request
    * @returns {Promise} resolve an object that contains _id
    */
   delete(request) {
-    const esRequest = initESRequest(request, ['refresh']);
+    const esRequest = initESRequest(request, ['refresh', 'retryOnConflict']);
 
     esRequest.id = request.input.resource._id;
 
@@ -530,8 +531,23 @@ class ElasticSearch extends Service {
       }
     }
 
-    // todo do not delete the document but pass active to false
-    return this.client.delete(esRequest)
+    // injecting retryOnConflict default configuration
+    if (!esRequest.hasOwnProperty('retryOnConflict') && this.config.defaults.onUpdateConflictRetries > 0) {
+      esRequest.retryOnConflict = this.config.defaults.onUpdateConflictRetries;
+    }
+
+    // Add metadata
+    esRequest.body = {
+      _kuzzle_info: {
+        active: false,
+        deletedAt: Date.now(),
+        updater: request.context.user._id ? String(request.context.user._id) : null
+      }
+    };
+
+    esRequest.body = {doc: esRequest.body};
+
+    return this.client.update(esRequest)
       .then(result => this.refreshIndexIfNeeded(esRequest, result))
       .catch(error => Promise.reject(this.formatESError(error)));
   }
@@ -559,7 +575,7 @@ class ElasticSearch extends Service {
       .then(ids => {
         ids.forEach(id => {
           esRequestBulk.body.push({update: {_index: esRequestBulk.index, _type: esRequestBulk.type, _id: id}});
-          esRequestBulk.body.push({doc: {_kuzzle_info: { active: false, deletedAt: Date.now() }}});
+          esRequestBulk.body.push({doc: {_kuzzle_info: { active: false, deletedAt: Date.now(), updater: request.context.user._id ? String(request.context.user._id) : null }}});
         });
 
         if (esRequestBulk.body.length === 0) {

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -656,6 +656,8 @@ class ElasticSearch extends Service {
             match_all: {}
           }
         }
+      }, {
+        user: request.context.user
       });
 
     return this.deleteByQuery(deleteRequest)

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -196,7 +196,7 @@ class ElasticSearch extends Service {
 
     esRequest.body = request.input.body;
 
-    if (!request.input.volatile || !request.input.volatile.includeTrash) {
+    if (!request.input.args.includeTrash) {
       addActiveFilter(esRequest);
     }
 
@@ -238,7 +238,7 @@ class ElasticSearch extends Service {
     return this.client.get(esRequest)
       .then(result => {
         if (result._source) {
-          if (result._source._kuzzle_info && (!result._source._kuzzle_info.active && (!request.input.volatile || !request.input.volatile.includeTrash))) {
+          if (result._source._kuzzle_info && (!result._source._kuzzle_info.active && !request.input.args.includeTrash)) {
             return Promise.reject(new NotFoundError(`Document ${result._id} was already deleted. If you want to also get trashed documents set volatile argument includeTrash to true`));
           }
           if (result._source._kuzzle_info) {
@@ -287,7 +287,7 @@ class ElasticSearch extends Service {
 
     esRequest.body = request.input.body;
 
-    if (!request.input.volatile || !request.input.volatile.includeTrash) {
+    if (!request.input.args.includeTrash) {
       addActiveFilter(esRequest);
     }
     return this.client.count(esRequest)
@@ -575,7 +575,7 @@ class ElasticSearch extends Service {
       .then(ids => {
         ids.forEach(id => {
           esRequestBulk.body.push({update: {_index: esRequestBulk.index, _type: esRequestBulk.type, _id: id}});
-          esRequestBulk.body.push({doc: {_kuzzle_info: { active: false, deletedAt: Date.now(), updater: request.context.user._id ? String(request.context.user._id) : null }}});
+          esRequestBulk.body.push({doc: {_kuzzle_info: { active: false, deletedAt: Date.now(), updater: request.context.user._id ? String(request.context.user._id) : null}}});
         });
 
         if (esRequestBulk.body.length === 0) {

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -262,7 +262,7 @@ class ElasticSearch extends Service {
       .then(result => {
         if (result._source) {
           if (result._source._kuzzle_info && !result._source._kuzzle_info.active && !request.input.args.includeTrash) {
-            return Bluebird.reject(new NotFoundError(`Document ${result._id} was already deleted. If you want to also get trashed documents set includeTrash argument to true`));
+            return Bluebird.reject(new NotFoundError('Document not found'));
           }
           if (result._source._kuzzle_info) {
             result._meta = result._source._kuzzle_info;

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -219,10 +219,6 @@ class ElasticSearch extends Service {
 
     esRequest.body = request.input.body;
 
-    if (!request.input.args.includeTrash) {
-      addActiveFilter(esRequest);
-    }
-
     return this.client.search(esRequest)
       .then(result => {
         const flattened = flattenSearchResults(result);
@@ -286,6 +282,10 @@ class ElasticSearch extends Service {
     const esRequest = initESRequest(request);
 
     esRequest.body = request.input.body;
+
+    if (!request.input.args.includeTrash) {
+      addActiveFilter(esRequest);
+    }
 
     return this.client.mget(esRequest)
       .then(result => {

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -239,7 +239,7 @@ class ElasticSearch extends Service {
       .then(result => {
         if (result._source) {
           if (result._source._kuzzle_info && (!result._source._kuzzle_info.active && !request.input.args.includeTrash)) {
-            return Promise.reject(new NotFoundError(`Document ${result._id} was already deleted. If you want to also get trashed documents set volatile argument includeTrash to true`));
+            return Promise.reject(new NotFoundError(`Document ${result._id} was already deleted. If you want to also get trashed documents set includeTrash argument to true`));
           }
           if (result._source._kuzzle_info) {
             result._meta = result._source._kuzzle_info;

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -512,10 +512,12 @@ class ElasticSearch extends Service {
 
     // Add metadata
     esRequest.body = {
-      _kuzzle_info: {
-        active: false,
-        deletedAt: Date.now(),
-        updater: request.context.user._id ? String(request.context.user._id) : null
+      doc: {
+        _kuzzle_info: {
+          active: false,
+          deletedAt: Date.now(),
+          updater: request.context.user._id ? String(request.context.user._id) : null
+        }
       }
     };
 

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -219,6 +219,10 @@ class ElasticSearch extends Service {
 
     esRequest.body = request.input.body;
 
+    if (!request.input.args.includeTrash) {
+      addActiveFilter(esRequest);
+    }
+
     return this.client.search(esRequest)
       .then(result => {
         const flattened = flattenSearchResults(result);

--- a/test/api/core/notifier/notifyDocumentDelete.test.js
+++ b/test/api/core/notifier/notifyDocumentDelete.test.js
@@ -1,152 +1,4 @@
 'use strict';
-//
-// const
-//   should = require('should'),
-//   sinon = require('sinon'),
-//   sandbox = sinon.sandbox.create(),
-//   Promise = require('bluebird'),
-//   Request = require('kuzzle-common-objects').Request,
-//   Kuzzle = require('../../../mocks/kuzzle.mock'),
-//   Notifier = require.main.require('lib/api/core/notifier');
-//
-// describe('Test: notifier.notifyDocumentDelete', () => {
-//   let
-//     mockupCacheService = {
-//       id: undefined,
-//       addId: undefined,
-//
-//       init: function () {
-//         this.addId = this.removeId = this.room = undefined;
-//       },
-//
-//       remove: function (id) {
-//         this.id = id;
-//         return Promise.resolve({});
-//       },
-//
-//       search: function (id) {
-//         if (id === 'errorme') {
-//           return Promise.reject(new Error());
-//         }
-//
-//         return Promise.resolve(['']);
-//       }
-//     },
-//     // mockupCacheService = {
-//     //   addId: undefined,
-//     //   removeId: undefined,
-//     //   room: undefined,
-//     //
-//     //   init: function () {
-//     //     this.addId = this.removeId = this.room = undefined;
-//     //   },
-//     //
-//     //   add: function (id, room) {
-//     //     if (room.length > 0) {
-//     //       this.addId = id;
-//     //       this.room = room;
-//     //     }
-//     //     return Promise.resolve({});
-//     //   },
-//     //
-//     //   remove: function (id, room) {
-//     //     if (room.length > 0) {
-//     //       this.removeId = id;
-//     //     }
-//     //     return Promise.resolve({});
-//     //   },
-//     //
-//     //   search: function (id) {
-//     //     if (id === 'notif/removeme') {
-//     //       return Promise.resolve(['foobar']);
-//     //     }
-//     //
-//     //     return Promise.resolve([]);
-//     //   }
-//     // },
-//     kuzzle,
-//     notifier,
-//     request,
-//     notified = 0,
-//     notification;
-//
-//   before(() => {
-//     kuzzle = new Kuzzle();
-//     notifier = new Notifier(kuzzle);
-//   });
-//
-//   beforeEach(() => {
-//     kuzzle.internalEngine.get.returns(Promise.resolve({}));
-//     return kuzzle.services.init({whitelist: []})
-//       .then(() => {
-//         request = new Request({
-//           controller: 'document',
-//           action: 'delete',
-//           requestId: 'foo',
-//           collection: 'bar',
-//           body: { foo: 'bar' }
-//         });
-//
-//         kuzzle.services.list.internalCache = mockupCacheService;
-//         notifier.notify = function (rooms, r, n) {
-//           if (rooms.length > 0) {
-//             notified++;
-//             notification = n;
-//           }
-//         };
-//
-//         notified = 0;
-//         notification = null;
-//         mockupCacheService.init();
-//       });
-//   });
-//
-//   afterEach(() => {
-//     sandbox.restore();
-//   });
-//
-//   it('should do nothing if no id is provided', () => {
-//     return notifier.notifyDocumentDelete(request, [])
-//       .then(() => {
-//         should(notification).be.null();
-//       });
-//   });
-//
-//   it('should notify when a document has been deleted', () => {
-//     return notifier.notifyDocumentDelete(request, ['foobar'])
-//       .then(() => {
-//         should(mockupCacheService.id).be.exactly('notif/foobar');
-//
-//         should(notification.length).be.eql(1);
-//         should(notification[0].scope).be.exactly('out');
-//         should(notification[0].action).be.exactly('delete');
-//         should(notification[0]._id).be.exactly('foobar');
-//         should(notification[0].state).be.exactly('done');
-//       });
-//   });
-//
-//   it('should notify subscribers when a deleted document left their scope', () => {
-//     request.input.resource._id = 'removeme';
-//
-//     kuzzle.dsl.test.returns(Promise.resolve([]));
-//     kuzzle.services.list.storageEngine.get.returns(Promise.resolve({_id: 'removeme', _source: request.input.body}));
-//
-//     return notifier.notifyDocumentDelete(request, ['foobar'])
-//       .then(() => {
-//         should(notified).be.exactly(1);
-//         should(mockupCacheService.addId).be.undefined();
-//         should(mockupCacheService.room).be.undefined();
-//         should(mockupCacheService.removeId).be.exactly('notif/' + request.input.resource._id);
-//
-//         should(notification.scope).be.exactly('out');
-//         should(notification.action).be.exactly('delete');
-//         should(notification.state).be.eql('done');
-//         should(notification._id).be.eql(request.input.resource._id);
-//         should(notification._source).be.undefined();
-//       });
-//   });
-// });
-//
 
 var
   should = require('should'),
@@ -157,8 +9,7 @@ var
   Kuzzle = require('../../../mocks/kuzzle.mock'),
   Notifier = require.main.require('lib/api/core/notifier');
 
-
-  describe('Test: notifier.notifyDocumentDelete', () => {
+describe('Test: notifier.notifyDocumentDelete', () => {
   var
     kuzzle,
     request,
@@ -191,7 +42,7 @@ var
     return kuzzle.services.init({whitelist: []})
       .then(() => {
         kuzzle.services.list.internalCache = mockupCacheService;
-        kuzzle.notifier.notify = (rooms, r,n) => {
+        kuzzle.notifier.notify = (rooms, r, n) => {
           should(r).be.exactly(request);
           notification.push(n);
         };
@@ -201,10 +52,9 @@ var
           action: 'delete',
           requestId: 'foo',
           collection: 'bar',
-          body: { foo: 'bar' }
+          body: {foo: 'bar'}
         });
       });
-    kuzzle.services.list.storageEngine.get.returns(Promise.resolve({_id: 'addme', _source: request.input.body}));
   });
 
   afterEach(() => {

--- a/test/api/core/notifier/notifyDocumentDelete.test.js
+++ b/test/api/core/notifier/notifyDocumentDelete.test.js
@@ -1,12 +1,164 @@
+'use strict';
+//
+// const
+//   should = require('should'),
+//   sinon = require('sinon'),
+//   sandbox = sinon.sandbox.create(),
+//   Promise = require('bluebird'),
+//   Request = require('kuzzle-common-objects').Request,
+//   Kuzzle = require('../../../mocks/kuzzle.mock'),
+//   Notifier = require.main.require('lib/api/core/notifier');
+//
+// describe('Test: notifier.notifyDocumentDelete', () => {
+//   let
+//     mockupCacheService = {
+//       id: undefined,
+//       addId: undefined,
+//
+//       init: function () {
+//         this.addId = this.removeId = this.room = undefined;
+//       },
+//
+//       remove: function (id) {
+//         this.id = id;
+//         return Promise.resolve({});
+//       },
+//
+//       search: function (id) {
+//         if (id === 'errorme') {
+//           return Promise.reject(new Error());
+//         }
+//
+//         return Promise.resolve(['']);
+//       }
+//     },
+//     // mockupCacheService = {
+//     //   addId: undefined,
+//     //   removeId: undefined,
+//     //   room: undefined,
+//     //
+//     //   init: function () {
+//     //     this.addId = this.removeId = this.room = undefined;
+//     //   },
+//     //
+//     //   add: function (id, room) {
+//     //     if (room.length > 0) {
+//     //       this.addId = id;
+//     //       this.room = room;
+//     //     }
+//     //     return Promise.resolve({});
+//     //   },
+//     //
+//     //   remove: function (id, room) {
+//     //     if (room.length > 0) {
+//     //       this.removeId = id;
+//     //     }
+//     //     return Promise.resolve({});
+//     //   },
+//     //
+//     //   search: function (id) {
+//     //     if (id === 'notif/removeme') {
+//     //       return Promise.resolve(['foobar']);
+//     //     }
+//     //
+//     //     return Promise.resolve([]);
+//     //   }
+//     // },
+//     kuzzle,
+//     notifier,
+//     request,
+//     notified = 0,
+//     notification;
+//
+//   before(() => {
+//     kuzzle = new Kuzzle();
+//     notifier = new Notifier(kuzzle);
+//   });
+//
+//   beforeEach(() => {
+//     kuzzle.internalEngine.get.returns(Promise.resolve({}));
+//     return kuzzle.services.init({whitelist: []})
+//       .then(() => {
+//         request = new Request({
+//           controller: 'document',
+//           action: 'delete',
+//           requestId: 'foo',
+//           collection: 'bar',
+//           body: { foo: 'bar' }
+//         });
+//
+//         kuzzle.services.list.internalCache = mockupCacheService;
+//         notifier.notify = function (rooms, r, n) {
+//           if (rooms.length > 0) {
+//             notified++;
+//             notification = n;
+//           }
+//         };
+//
+//         notified = 0;
+//         notification = null;
+//         mockupCacheService.init();
+//       });
+//   });
+//
+//   afterEach(() => {
+//     sandbox.restore();
+//   });
+//
+//   it('should do nothing if no id is provided', () => {
+//     return notifier.notifyDocumentDelete(request, [])
+//       .then(() => {
+//         should(notification).be.null();
+//       });
+//   });
+//
+//   it('should notify when a document has been deleted', () => {
+//     return notifier.notifyDocumentDelete(request, ['foobar'])
+//       .then(() => {
+//         should(mockupCacheService.id).be.exactly('notif/foobar');
+//
+//         should(notification.length).be.eql(1);
+//         should(notification[0].scope).be.exactly('out');
+//         should(notification[0].action).be.exactly('delete');
+//         should(notification[0]._id).be.exactly('foobar');
+//         should(notification[0].state).be.exactly('done');
+//       });
+//   });
+//
+//   it('should notify subscribers when a deleted document left their scope', () => {
+//     request.input.resource._id = 'removeme';
+//
+//     kuzzle.dsl.test.returns(Promise.resolve([]));
+//     kuzzle.services.list.storageEngine.get.returns(Promise.resolve({_id: 'removeme', _source: request.input.body}));
+//
+//     return notifier.notifyDocumentDelete(request, ['foobar'])
+//       .then(() => {
+//         should(notified).be.exactly(1);
+//         should(mockupCacheService.addId).be.undefined();
+//         should(mockupCacheService.room).be.undefined();
+//         should(mockupCacheService.removeId).be.exactly('notif/' + request.input.resource._id);
+//
+//         should(notification.scope).be.exactly('out');
+//         should(notification.action).be.exactly('delete');
+//         should(notification.state).be.eql('done');
+//         should(notification._id).be.eql(request.input.resource._id);
+//         should(notification._source).be.undefined();
+//       });
+//   });
+// });
+//
+
 var
   should = require('should'),
   sinon = require('sinon'),
   sandbox = sinon.sandbox.create(),
   Promise = require('bluebird'),
   Request = require('kuzzle-common-objects').Request,
-  Kuzzle = require('../../../../lib/api/kuzzle');
+  Kuzzle = require('../../../mocks/kuzzle.mock'),
+  Notifier = require.main.require('lib/api/core/notifier');
 
-describe('Test: notifier.notifyDocumentDelete', () => {
+
+  describe('Test: notifier.notifyDocumentDelete', () => {
   var
     kuzzle,
     request,
@@ -26,14 +178,16 @@ describe('Test: notifier.notifyDocumentDelete', () => {
 
         return Promise.resolve(['']);
       }
-    };
+    },
+    notifier;
 
   before(() => {
     kuzzle = new Kuzzle();
+    notifier = new Notifier(kuzzle);
   });
 
   beforeEach(() => {
-    sandbox.stub(kuzzle.internalEngine, 'get').returns(Promise.resolve({}));
+    kuzzle.internalEngine.get.returns(Promise.resolve({}));
     return kuzzle.services.init({whitelist: []})
       .then(() => {
         kuzzle.services.list.internalCache = mockupCacheService;
@@ -43,13 +197,14 @@ describe('Test: notifier.notifyDocumentDelete', () => {
         };
         notification = [];
         request = new Request({
-          controller: 'write',
+          controller: 'document',
           action: 'delete',
           requestId: 'foo',
           collection: 'bar',
           body: { foo: 'bar' }
         });
       });
+    kuzzle.services.list.storageEngine.get.returns(Promise.resolve({_id: 'addme', _source: request.input.body}));
   });
 
   afterEach(() => {
@@ -57,15 +212,14 @@ describe('Test: notifier.notifyDocumentDelete', () => {
   });
 
   it('should do nothing if no id is provided', () => {
-    return kuzzle.notifier.notifyDocumentDelete(request, [])
+    return notifier.notifyDocumentDelete(request, [])
       .then(() => {
         should(notification.length).be.eql(0);
       });
   });
 
   it('should notify when a document has been deleted', () => {
-
-    return kuzzle.notifier.notifyDocumentDelete(request, ['foobar'])
+    return notifier.notifyDocumentDelete(request, ['foobar'])
       .then(() => {
         should(mockupCacheService.id).be.exactly('notif/foobar');
 
@@ -81,7 +235,7 @@ describe('Test: notifier.notifyDocumentDelete', () => {
   it('should notify for each document when multiple document have been deleted', () => {
     var ids = ['foo', 'bar'];
 
-    return kuzzle.notifier.notifyDocumentDelete(request, ids)
+    return notifier.notifyDocumentDelete(request, ids)
       .then(() => {
         should(notification.length).be.eql(ids.length);
         should(notification.map(n => n._id)).match(ids);

--- a/test/api/core/notifier/notifyDocumentDelete.test.js
+++ b/test/api/core/notifier/notifyDocumentDelete.test.js
@@ -1,16 +1,16 @@
 'use strict';
 
-var
+const
   should = require('should'),
   sinon = require('sinon'),
   sandbox = sinon.sandbox.create(),
-  Promise = require('bluebird'),
+  Bluebird = require('bluebird'),
   Request = require('kuzzle-common-objects').Request,
   Kuzzle = require('../../../mocks/kuzzle.mock'),
   Notifier = require.main.require('lib/api/core/notifier');
 
 describe('Test: notifier.notifyDocumentDelete', () => {
-  var
+  let
     kuzzle,
     request,
     notification,
@@ -19,15 +19,15 @@ describe('Test: notifier.notifyDocumentDelete', () => {
 
       remove: function (id) {
         this.id = id;
-        return Promise.resolve({});
+        return Bluebird.resolve({});
       },
 
       search: function (id) {
         if (id === 'errorme') {
-          return Promise.reject(new Error());
+          return Bluebird.reject(new Error());
         }
 
-        return Promise.resolve(['']);
+        return Bluebird.resolve(['']);
       }
     },
     notifier;
@@ -38,7 +38,7 @@ describe('Test: notifier.notifyDocumentDelete', () => {
   });
 
   beforeEach(() => {
-    kuzzle.internalEngine.get.returns(Promise.resolve({}));
+    kuzzle.internalEngine.get.returns(Bluebird.resolve({}));
     return kuzzle.services.init({whitelist: []})
       .then(() => {
         kuzzle.services.list.internalCache = mockupCacheService;

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -679,20 +679,20 @@ describe('Test: ElasticSearch service', () => {
     it('should allow to delete a document', () => {
       const refreshIndexSpy = sandbox.spy(elasticsearch, 'refreshIndexIfNeeded');
 
-      elasticsearch.client.delete.returns(Promise.resolve({}));
+      elasticsearch.client.update.returns(Promise.resolve({}));
 
       request.input.body = null;
       request.input.resource._id = createdDocumentId;
 
       return elasticsearch.delete(request)
         .then(() => {
-          should(elasticsearch.client.delete.firstCall.args[0].id).be.exactly(createdDocumentId);
+          should(elasticsearch.client.update.firstCall.args[0].id).be.exactly(createdDocumentId);
           should(refreshIndexSpy.calledOnce).be.true();
         });
     });
 
     it('should return a rejected promise if a delete fails', () => {
-      elasticsearch.client.delete.returns(Promise.reject(new Error('Mocked error')));
+      elasticsearch.client.update.returns(Promise.reject(new Error('Mocked error')));
 
       return should(elasticsearch.delete(request)).be.rejected();
     });
@@ -752,7 +752,7 @@ describe('Test: ElasticSearch service', () => {
               }
               if (cmd.doc) {
                 should(cmd.doc).not.be.undefined().and.be.an.Object();
-                should(cmd.doc).be.eql({_kuzzle_info: { active: false, deletedAt: 42 }});
+                should(cmd.doc).be.eql({_kuzzle_info: { active: false, deletedAt: 42, updater: 'test' }});
               }
             });
 


### PR DESCRIPTION
# Description

Delete now set the active attribute of _meta to false and then call the notifier.
We can now search and get documents which are also in the trash by setting a `includeTrash` attribute to `true` in the input.args attribute of the request.

# Related issue

* fix #699 #482 