### PR TITLE
Fix Kuzzle crash report on a beforeAction plugin error

### DIFF
--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -330,7 +330,7 @@ class FunnelController {
     this.requestHistory.push(request);
 
     const beforeEvent = this.getEventName(request.input.controller, 'before', request.input.action);
-    let modifiedRequest;
+    let modifiedRequest = request;
 
     return triggerEvent(this.kuzzle, request, beforeEvent)
       .then(newRequest => {


### PR DESCRIPTION
# Description

Whenever a plugin, plugged on a `<controller>:before<Action>` event, return an error, Kuzzle generates a crash reports because of a TypeError.
The reason is: the catched promise performs checks on the plugin's modified request, but at this point of time, it is not yet initialized.
