### PR TITLE
Kuzzle fails to install on older Linux kernels

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "compare-versions": "^3.0.0",
     "debug": "^2.6.0",
     "denque": "^1.1.1",
-    "dumpme": "^1.0.0",
+    "dumpme": "^1.0.1",
     "easy-circular-list": "^1.0.13",
     "elasticsearch": "12.1.3",
     "espresso-logic-minimizer": "^2.0.1",


### PR DESCRIPTION
# Description

On Linux kernels < 3.4, Kuzzle fails to install, due to the `dumpme` module needing features appearing only in kernels >= 3.4

This PR forces Kuzzle to use the fixed version of the `dumpme` module, which do not use these kernel features anymore if they are not present.

# Fixed issue

#789
