### PR TITLE
Fix dump exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ kuzzle-swagger.*
 #sonarqube
 .sonar
 .scannerwork
+.sonarlint
+/sonarlint.json
 
 #plugins
 plugins/available/*

--- a/default.config.js
+++ b/default.config.js
@@ -9,6 +9,29 @@
  * @class KuzzleConfiguration
  */
 module.exports = {
+
+  dump: {
+    enabled: true,
+    history: {
+      coredump: 3,
+      reports: 5
+    },
+    path: './dump/',
+    gcore: 'gcore',
+    dateFormat: 'YYYYMMDD-HHmmss',
+    handledErrors: {
+      enabled: true,
+      whitelist: [
+        // 'Error',
+        'RangeError',
+        'TypeError',
+        'KuzzleError',
+        'InternalError'
+      ],
+      minInterval: 10 * 60 * 1000
+    }
+  },
+
   /*
    routes: list of Kuzzle API exposed HTTP routes
    accessControlAllowOrigin: sets the Access-Control-Allow-Origin header used to
@@ -188,26 +211,6 @@ module.exports = {
 
   /** @type {DocumentSpecification} */
   validation: {
-  },
-
-  dump: {
-    enabled: true,
-    history: {
-      coredump: 3,
-      reports: 5
-    },
-    path: './dump/',
-    gcore: 'gcore',
-    dateFormat: 'YYYYMMDD-HHmm',
-    handledErrors: {
-      enabled: true,
-      whitelist: [
-        // 'Error',
-        'RangeError',
-        'TypeError',
-        'KuzzleError',
-        'InternalError'
-      ]
-    }
   }
+
 };

--- a/lib/api/controllers/cli/dump.js
+++ b/lib/api/controllers/cli/dump.js
@@ -34,7 +34,9 @@ const
   zlib = require('zlib'),
   glob = require('glob');
 
-let _kuzzle;
+let
+  _lock = false,
+  _kuzzle;
 
 /**
  * Create a dump
@@ -43,9 +45,17 @@ let _kuzzle;
  * @returns {Promise}
  */
 function dump (request) {
-  return new Bluebird(resolve => {
+  if (_lock) {
+    console.log('A dump is already being generated. Skipping.');
+    return Bluebird.resolve();
+  }
+
+  let dumpPath;
+  _lock = true;
+
+  return new Bluebird((resolve, reject) => {
     const suffix = request && request.input.args.suffix ? '-' + request.input.args.suffix : '';
-    const dumpPath = path.join(
+    dumpPath = path.join(
       path.normalize(_kuzzle.config.dump.path),
       moment().format(_kuzzle.config.dump.dateFormat).concat(suffix)
     );
@@ -54,7 +64,19 @@ function dump (request) {
     cleanUpHistory();
 
     console.log('Generating dump in '.concat(dumpPath));
-    fs.mkdirsSync(dumpPath);
+    try {
+      fs.mkdirsSync(dumpPath);
+    }
+    catch (e) {
+      if (e.message.startsWith('EEXIST')) {
+        console.log('Dump directory already exists. Skipping..');
+        return resolve();
+      }
+
+      console.log('ERROR: unknown error while trying to create dump folder');
+      console.error(e);
+      return reject();
+    }
 
     // dumping kuzzle configuration
     console.log('> dumping kuzzle configuration');
@@ -91,68 +113,112 @@ function dump (request) {
 
     // dumping std err/out
     console.log('> dumping std err/out');
-    if (process.env.pm_err_log_path) {
-      fs.copySync(
-        path.dirname(process.env.pm_err_log_path),
-        path.join(dumpPath, 'logs'),
-        {
-          preserveTimestamps: true
-        }
-      );
-    }
-    else if (process.env.pm_log_path) {
-      fs.copySync(
-        path.dirname(process.env.pm_log_path),
-        path.join(dumpPath, 'logs'),
-        {
-          preserveTimestamps: true
-        }
-      );
-    }
-    else {
+    if (!process.env.pm_err_log_path && !process.env.pm_log_path) {
       console.log('... no logs found');
+      return resolve();
     }
 
-    // core-dump
-    console.log('> generating core-dump');
-    dumpme(_kuzzle.config.dump.gcore || 'gcore', `${dumpPath}/core`);
-
-    // Gzip the core
-    glob(`${dumpPath}/core*`, (err, res) => {
+    const logDir = path.dirname(process.env.pm_err_log_path || process.env.pm_log_path);
+    fs.readdir(logDir, (err, files) => {
       if (err) {
-        console.error(err);
-        return;
+        console.log('... error reading log directory');
+        return resolve();
       }
 
-      const readStream = fs.createReadStream(res[0]);
-      const writeStream = fs.createWriteStream(`${dumpPath}/core.gz`);
+      Bluebird.all(files.map(file => Bluebird.promisify(fs.stat)(path.join(logDir, file))
+        .then(stats => {
+          return {
+            path: path.join(logDir, file),
+            stats
+          };
+        }))
+      )
+        .then(fileStats => {
+          const keep = {};
 
-      readStream
-        .pipe(zlib.createGzip())
-        .pipe(writeStream)
-        .on('finish', () => {
-          // rm the original core file
-          fs.unlink(res[0]);
+          for (const statFile of fileStats) {
+            const root = path.basename(statFile.path).replace(/(-\d+)?\.[^.]+$/, '');
+            if (!keep[root] || keep[root].stats.ctime < statFile.stats.ctime) {
+              keep[root] = statFile;
+            }
+          }
+
+          const promises = [];
+          for (const root of Object.keys(keep)) {
+            const statFile = keep[root];
+
+            fs.ensureDirSync(path.join(dumpPath, 'logs'));
+            // eslint-disable-next-line no-loop-func
+            promises.push(new Bluebird(res => {
+              fs.createReadStream(statFile.path)
+                .pipe(zlib.createGzip())
+                .pipe(fs.createWriteStream(path.join(dumpPath, 'logs', root + '.gz')))
+                .on('finish', () => {
+                  res();
+                });
+            }));
+          }
+          return Bluebird.all(promises);
+        })
+        .then(() => {
+          resolve();
+        })
+        .catch(e => {
+          console.error('fileStats', e);
+          resolve();
         });
     });
+  })
+    .then(() => new Bluebird((resolve, reject) => {
+      // core-dump
+      console.log('> generating core-dump');
+      dumpme(_kuzzle.config.dump.gcore || 'gcore', `${dumpPath}/core`);
 
-    // copy node binary
-    console.log('> copy node binary');
-    fs.copySync(process.argv[0], path.join(dumpPath, 'node'));
+      // Gzip the core
+      glob(`${dumpPath}/core*`, (err, res) => {
+        if (err) {
+          console.error(err);
+          return reject(err);
+        }
 
-    // dumping Kuzzle's stats
-    console.log('> dumping kuzzle\'s stats');
-    _kuzzle.statistics.getAllStats(new Request({action: 'getAllStats', controller: 'statistics'}))
-      .then(response => {
-        fs.writeFileSync(path.join(dumpPath, 'statistics.json'), JSON.stringify(response.hits, null, ' ').concat('\n'));
+        const readStream = fs.createReadStream(res[0]);
+        const writeStream = fs.createWriteStream(`${dumpPath}/core.gz`);
+
+        readStream
+          .pipe(zlib.createGzip())
+          .pipe(writeStream)
+          .on('finish', () => {
+            // rm the original core file
+            try {
+              fs.unlinkSync(res[0]);
+              resolve();
+            }
+            catch (e) {
+              resolve();
+            }
+          });
       });
+    }))
+    .then(() => {
+      // copy node binary
+      console.log('> copy node binary');
+      fs.copySync(process.execPath, path.join(dumpPath, 'node'));
 
-    console.log('Done.');
-    console.log('[ℹ] You can send the folder to the kuzzle core team at support@kuzzle.io');
-    console.log('===========================================================================');
+      // dumping Kuzzle's stats
+      console.log('> dumping kuzzle\'s stats');
+      return _kuzzle.statistics.getAllStats(new Request({action: 'getAllStats', controller: 'statistics'}));
+    })
+    .then(response => {
+      fs.writeFileSync(path.join(dumpPath, 'statistics.json'), JSON.stringify(response.hits, null, ' ').concat('\n'));
 
-    resolve(dumpPath);
-  });
+      console.log('Done.');
+      console.log('[ℹ] You can send the folder to the kuzzle core team at support@kuzzle.io');
+      console.log('===========================================================================');
+    })
+    .then(() => dumpPath)
+    .finally(() => {
+      _lock = false;
+    });
 }
 
 function cleanUpHistory() {
@@ -188,23 +254,11 @@ function cleanUpHistory() {
     fs.removeSync(dir);
   }
 
-  const corefiles = dumps
-    .filter(dir => {
-      try {
-        fs.accessSync(`${dir.path}/core`);
-        return true;
-      }
-      catch (e) {
-        return false;
-      }
-    })
-    .map(dir => `${dir.path}/core`);
-
-  while (corefiles.length >= config.history.coredump) {
-    const core = corefiles.shift();
-
-    console.log(`> removing coredump from history: ${core}`);
-    fs.removeSync(core);
+  for (let i = 0; i < dumps.length - config.history.coredump; i++) {
+    const corefiles = glob.sync(`${path.normalize(dumps[i].path)}/core*`);
+    if (corefiles[0]) {
+      fs.unlinkSync(corefiles[0]);
+    }
   }
 }
 

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -43,8 +43,6 @@ const
     UnauthorizedError
   } = require('kuzzle-common-objects').errors;
 
-const MIN_TIME_BEFORE_DUMP_PREV_ERROR = 60000;
-
 /**
  * @class CacheItem
  */
@@ -273,11 +271,11 @@ class FunnelController {
           errorMessage = errorMessage.toLowerCase().replace(/[^a-zA-Z0-9-_]/g, '-').replace(/[-]+/g, '-').split('-');
           errorMessage = errorMessage.filter(value => value !== '').join('-');
 
-          request.input.body.suffix = 'handled-'.concat(errorType.toLowerCase(), '-', errorMessage);
+          request.input.args.suffix = `handled-${errorType.toLocaleLowerCase()}-${errorMessage}`;
 
-          if (!this.lastDumpedErrors[request.input.body.suffix] || this.lastDumpedErrors[request.input.body.suffix] < lastSeen - MIN_TIME_BEFORE_DUMP_PREV_ERROR) {
+          if (!this.lastDumpedErrors[errorType] || this.lastDumpedErrors[errorType] < lastSeen - this.kuzzle.config.dump.handledErrors.minInterval) {
             this.kuzzle.cliController.actions.dump(request);
-            this.lastDumpedErrors[request.input.body.suffix] = lastSeen;
+            this.lastDumpedErrors[errorType] = lastSeen;
           }
         }
       });

--- a/lib/api/kuzzle.js
+++ b/lib/api/kuzzle.js
@@ -215,7 +215,7 @@ function registerErrorHandlers(kuzzle) {
   process.removeAllListeners('unhandledRejection');
   process.on('unhandledRejection', err => {
     console.error(`ERROR: unhandledRejection: ${err.message}`, err.stack); // eslint-disable-line no-console
-    request.input.body.suffix = 'unhandled-rejection';
+    request.input.args.suffix = 'unhandled-rejection';
     kuzzle.cliController.actions.dump(request)
       .finally(() => {
         process.exit(1);
@@ -225,7 +225,7 @@ function registerErrorHandlers(kuzzle) {
   process.removeAllListeners('uncaughtException');
   process.on('uncaughtException', err => {
     console.error(`ERROR: uncaughtException: ${err.message}`, err.stack); // eslint-disable-line no-console
-    request.input.body.suffix = 'uncaught-exception';
+    request.input.args.suffix = 'uncaught-exception';
     kuzzle.cliController.actions.dump(request)
       .finally(() => {
         process.exit(1);
@@ -236,7 +236,7 @@ function registerErrorHandlers(kuzzle) {
     process.removeAllListeners(signal);
     process.on(signal, () => {
       console.error(`ERROR: Caught signal: ${signal}`); // eslint-disable-line no-console
-      request.input.body.suffix = 'signal-'.concat(signal.toLowerCase());
+      request.input.args.suffix = 'signal-'.concat(signal.toLowerCase());
       kuzzle.cliController.actions.dump(request)
         .finally(() => {
           process.exit(coreDumpSigals[signal] + 128);
@@ -248,7 +248,7 @@ function registerErrorHandlers(kuzzle) {
   process.removeAllListeners('SIGTRAP');
   process.on('SIGTRAP', () => {
     console.error('ERROR: Caught signal: SIGTRAP'); // eslint-disable-line no-console
-    request.input.body.suffix = 'signal-sigtrap';
+    request.input.args.suffix = 'signal-sigtrap';
     kuzzle.cliController.actions.dump(request);
   });
 }


### PR DESCRIPTION
# Description 

This PR fixes several issues with the dump

1. Repair suffix handling + internal errors minimum interval
2. Dumps are not resolved only once they are actually processed (was not the case, notably regarding the core compression)
3. Dumps are locked. A requested dump will be discarded if one is already running
4. Tries to remove several cases where the dump itself would trigger an unhandled exception, leading to a dead loop for Kuzzle (cf for instance the check on the dump directory creation)

# Related issue 

* https://github.com/kuzzleio/kuzzle-private-backlog/issues/60 (private)