### PR TITLE
Fix internal error on realtime:join

### DIFF
--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -237,7 +237,7 @@ function HotelClerk (kuzzle) {
     const roomId = request.input.body.roomId;
 
     if (!this.rooms[roomId]) {
-      return Bluebird.reject(new KuzzleInternalError('No room found for id ' + roomId));
+      return Bluebird.reject(new NotFoundError('No room found for id ' + roomId));
     }
 
     return Bluebird.resolve(subscribeToRoom.call(this, roomId, request))

--- a/test/api/controllers/realtimeController.test.js
+++ b/test/api/controllers/realtimeController.test.js
@@ -1,4 +1,4 @@
-var
+const
   should = require('should'),
   sinon = require('sinon'),
   sandbox = sinon.sandbox.create(),
@@ -8,7 +8,7 @@ var
   BadRequestError = require('kuzzle-common-objects').errors.BadRequestError;
 
 describe('Test: subscribe controller', () => {
-  var
+  let
     kuzzle,
     request,
     realtimeController,
@@ -64,15 +64,13 @@ describe('Test: subscribe controller', () => {
     it('should throw an error if body is not provided',() => {
       request.input.body = null;
 
-      should(() => {
-        realtimeController.join(request);
-      }).throw(BadRequestError);
+      return should(() => realtimeController.join(request))
+        .throw(BadRequestError);
     });
 
     it('should throw an error if roomId is not provided',() => {
-      should(() => {
-        realtimeController.join(request);
-      }).throw(BadRequestError);
+      return should(() => realtimeController.join(request))
+        .throw(BadRequestError);
     });
 
     it('should call the proper hotelClerk method',() => {

--- a/test/api/core/hotelClerk/addSubscription.test.js
+++ b/test/api/core/hotelClerk/addSubscription.test.js
@@ -5,8 +5,8 @@ const
   Promise = require('bluebird'),
   Request = require('kuzzle-common-objects').Request,
   HotelClerk = require('../../../../lib/api/core/hotelClerk'),
-  InternalError = require('kuzzle-common-objects').errors.InternalError,
   BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
+  NotFoundError = require('kuzzle-common-objects').errors.NotFoundError,
   KuzzleMock = require('../../../mocks/kuzzle.mock');
 
 describe('Test: hotelClerk.addSubscription', () => {
@@ -355,7 +355,7 @@ describe('Test: hotelClerk.addSubscription', () => {
   });
 
   it('#join should reject the promise if the room does not exist', () => {
-    var request = new Request({
+    const request = new Request({
       collection: collection,
       index: index,
       controller: 'realtime',
@@ -363,7 +363,8 @@ describe('Test: hotelClerk.addSubscription', () => {
       body: {roomId: 'no way I can exist'}
     }, context);
 
-    return should(kuzzle.hotelClerk.join(request)).be.rejectedWith(InternalError);
+    return should(kuzzle.hotelClerk.join(request))
+      .be.rejectedWith(NotFoundError);
   });
 
   it('should reject the subscription if the given state argument is incorrect', () => {


### PR DESCRIPTION
# Description

This PR fixes the case where a call to `realtime:join` action would issue an `Internal Error` if the room was not found, which, in turn would by default trigger a dump.

# Related issue

* #814 