### PR TITLE
Fix missing notifications

### DIFF
--- a/lib/api/dsl/storage/index.js
+++ b/lib/api/dsl/storage/index.js
@@ -228,7 +228,7 @@ class Storage {
 
     const {index, collection} = this.filters[filterId];
 
-    removeFromTestTables(this.filters, this.subfilters, this.testTables, index, collection, this.filters[filterId]);
+    this._removeFromTestTables(index, collection, this.filters[filterId]);
 
     this.filters[filterId].subfilters.forEach(subfilter => {
       if (subfilter.filters.length === 1) {
@@ -266,6 +266,146 @@ class Storage {
 
     return Bluebird.resolve();
   }
+
+  /**
+   * Removes a filter from test tables and rebuilds the structure if necessary
+   *
+   * @param {string} index
+   * @param {string} collection
+   * @param {object} filter - filter to be removed
+   * @private
+   */
+  _removeFromTestTables (index, collection, filter) {
+    const tt = this.testTables[index][collection];
+
+    if (tt.removedFilters[filter.id]) {
+      return;
+    }
+
+    tt.removedFilters[filter.id] = true;
+    tt.removedFiltersCount++;
+
+    if (tt.removedFiltersCount === tt.filtersCount) {
+      if (containsOne(this.testTables[index])) {
+        delete this.testTables[index];
+      }
+      else {
+        delete this.testTables[index][collection];
+      }
+
+      return;
+    }
+
+    // Declaring "i" inside the "for" statement downgrades
+    // performances by a factor of 3 to 4
+    // Should be fixed in later V8 versions
+    // (tested on Node 6.9.x)
+    let i; // NOSONAR
+
+    for(i = 0; i < filter.subfilters.length; i++) {
+      if (filter.subfilters[i].filters.length === 1) {
+        tt.removedConditions.insert(filter.subfilters[i].cidx);
+      }
+    }
+
+    /*
+     Perform a reindex only if the number of deleted conditions is greater
+     than 10% of the total number of registered conditions
+
+     In that case, we flag the reindex operation and launch it a few seconds
+     after that. This allows large unsubscriptions activity to finish.
+     Best case scenario: the test table is removed altogether, thus avoiding reindexation.
+     Worst case scenario: we still have a reindexation to perform, but luckily
+     including a lot more unsubscriptions to remove, greatly reducing the overall reindex cost
+     */
+    if (!tt.reindexing && tt.removedConditions.array.length > tt.clength / 10) {
+      tt.reindexing = true;
+      setTimeout(() => this._reindexTestTable(index, collection), 5000);
+    }
+  }
+
+  /**
+   * Performs a reindexation of a test table
+   *
+   * @param {string} index
+   * @param {string} collection
+   */
+  _reindexTestTable (index, collection) {
+    let
+      iCond = 0,
+      iRemoved = 0,
+      iTarget = 0;
+
+    /*
+     * Since the reindexation has been triggered, the test table might have been
+     * destroyed
+     */
+    if (!this.testTables[index] || !this.testTables[index][collection] || !this.testTables[index][collection].reindexing) {
+      return;
+    }
+
+    const tt = this.testTables[index][collection];
+
+    /*
+     * If there is a huge increase in new subscriptions, we should postpone the
+     * reindexation to a later time.
+     */
+    if (tt.removedConditions.array.length < tt.clength / 10) {
+      return;
+    }
+
+    // rebuild conditions index
+    const conditions = new Uint8Array(tt.conditions.length - tt.removedConditions.array.length);
+
+    while (iCond < tt.clength && iRemoved < tt.removedConditions.array.length) {
+      if (iCond !== tt.removedConditions.array[iRemoved]) {
+        conditions[iTarget] = tt.conditions[iCond];
+        iTarget++;
+      }
+      else {
+        iRemoved++;
+      }
+
+      iCond++;
+    }
+
+    if (iCond < tt.clength) {
+      conditions.set(tt.conditions.subarray(iCond), iTarget);
+    }
+
+    tt.conditions = conditions;
+
+    // refresh subfilters condition index pointers
+    const keys = Object.keys(this.subfilters[index][collection]);
+
+    for(let i = 0; i < keys.length; i++) {
+      const
+        sf = this.subfilters[index][collection][keys[i]],
+        cidx = tt.removedConditions.array.findIndex(idx => idx > sf.cidx);
+
+      sf.cidx -= cidx > -1 ? cidx : tt.removedConditions.array.length;
+    }
+
+    // rebuild filter index pointers
+    if (tt.removedFiltersCount) {
+      for (let i = 0; i < Object.keys(this.filtersIndex[index][collection]).length; i++) {
+        const
+          filterId = this.filtersIndex[index][collection][i],
+          filter = this.filters[filterId];
+
+        filter.fidx = i;
+      }
+    }
+
+    // updates the test table indicators
+    tt.filtersCount = Object.keys(this.filtersIndex[index][collection]).length;
+    tt.clength -= tt.removedConditions.array.length;
+    tt.removedFilters = {};
+    tt.removedFiltersCount = 0;
+    tt.removedConditions.array = [];
+    tt.reindexing = false;
+  }
+
 }
 
 /**
@@ -435,60 +575,6 @@ function addIndexCollectionToObject(obj, index, collection) {
 }
 
 /**
- * Removes a filter from test tables and rebuilds the structure if necessary
- *
- * @param {object} filters - filters reference object
- * @param {object} subfilters - subfilters reference object
- * @param {object} testTables - test tables object to mutate
- * @param {string} index
- * @param {string} collection
- * @param {object} filter - filter to be removed
- */
-function removeFromTestTables(filters, subfilters, testTables, index, collection, filter) {
-  const tt = testTables[index][collection];
-
-  tt.removedFilters.insert(filter.fidx);
-
-  if (tt.removedFilters.array.length === tt.filtersCount) {
-    if (containsOne(testTables[index])) {
-      delete testTables[index];
-    }
-    else {
-      delete testTables[index][collection];
-    }
-
-    return;
-  }
-
-  // Declaring "i" inside the "for" statement downgrades
-  // performances by a factor of 3 to 4
-  // Should be fixed in later V8 versions
-  // (tested on Node 6.9.x)
-  let i; // NOSONAR
-
-  for(i = 0; i < filter.subfilters.length; i++) {
-    if (filter.subfilters[i].filters.length === 1) {
-      tt.removedConditions.insert(filter.subfilters[i].cidx);
-    }
-  }
-
-  /*
-    Perform a reindex only if the number of deleted conditions is greater
-    than 10% of the total number of registered conditions
-
-    In that case, we flag the reindex operation and launch it a few seconds
-    after that. This allows large unsubscriptions activity to finish.
-    Best case scenario: the test table is removed altogether, thus avoiding reindexation.
-    Worst case scenario: we still have a reindexation to perform, but luckily
-    including a lot more unsubscriptions to remove, greatly recucing the overall reindex cost
-   */
-  if (!tt.reindexing && tt.removedConditions.array.length > tt.clength / 10) {
-    tt.reindexing = true;
-    setTimeout(() => reindexTestTable(filters, subfilters, testTables, index, collection), 5000);
-  }
-}
-
-/**
  * Removes a field from an object. If the collection containing it
  * is empty after the removal, this function deletes it too.
  * Same goes for the index.
@@ -510,91 +596,6 @@ function destroy(obj, index, collection, field) {
   else {
     delete obj[index][collection][field];
   }
-}
-
-/**
- * Performs a reindexation of a test table
- *
- * @param {object} filters - filters reference object
- * @param {object} subfilters - subfilters reference object
- * @param {object} testTables - test tables object to mutate
- * @param {string} index
- * @param {string} collection
- */
-function reindexTestTable(filters, subfilters, testTables, index, collection) {
-  let
-    i,
-    iCond = 0,
-    iRemoved = 0,
-    iTarget = 0;
-
-  /*
-   * Since the reindexation has been triggered, the test table might have been
-   * destroyed
-   */
-  if (!testTables[index] || !testTables[index][collection] || !testTables[index][collection].reindexing) {
-    return;
-  }
-
-  const tt = testTables[index][collection];
-
-  /*
-   * If there is a huge increase in new subscriptions, we should postpone the
-   * reindexation to a later time.
-   */
-  if (tt.removedConditions.array.length < tt.clength / 10) {
-    return;
-  }
-
-  // rebuild conditions index
-  const conditions = new Uint8Array(tt.conditions.length - tt.removedConditions.array.length);
-
-  while (iCond < tt.clength && iRemoved < tt.removedConditions.array.length) {
-    if (iCond !== tt.removedConditions.array[iRemoved]) {
-      conditions[iTarget] = tt.conditions[iCond];
-      iTarget++;
-    }
-    else {
-      iRemoved++;
-    }
-
-    iCond++;
-  }
-
-  if (iCond < tt.clength) {
-    conditions.set(tt.conditions.subarray(iCond), iTarget);
-  }
-
-  tt.conditions = conditions;
-
-  // refresh subfilters condition index pointers
-  let keys = Object.keys(subfilters[index][collection]);
-
-  for(i = 0; i < keys.length; i++) {
-    const
-      sf = subfilters[index][collection][keys[i]],
-      cidx = tt.removedConditions.array.findIndex(idx => idx > sf.cidx);
-
-    sf.cidx -= cidx > -1 ? cidx : tt.removedConditions.array.length;
-  }
-
-  // rebuild filter index pointers
-  keys = Object.keys(filters);
-
-  for (i = 0; i < keys.length; i++) {
-    const
-      key = keys[i],
-      fidx = tt.removedFilters.array.findIndex(idx => idx > filters[key].fidx);
-
-    filters[key].fidx -= fidx > -1 ? fidx : tt.removedFilters.array.length;
-  }
-
-  // updates the test table indicators
-  tt.filtersCount -= tt.removedFilters.array.length;
-  tt.clength -= tt.removedConditions.array.length;
-  tt.removedConditions.array = [];
-  tt.removedFilters.array = [];
-  tt.reindexing = false;
 }
 
 module.exports = Storage;

--- a/lib/api/dsl/storage/index.js
+++ b/lib/api/dsl/storage/index.js
@@ -331,11 +331,6 @@ class Storage {
    * @param {string} collection
    */
   _reindexTestTable (index, collection) {
-    let
-      iCond = 0,
-      iRemoved = 0,
-      iTarget = 0;
-
     /*
      * Since the reindexation has been triggered, the test table might have been
      * destroyed
@@ -355,40 +350,29 @@ class Storage {
     }
 
     // rebuild conditions index
-    const conditions = new Uint8Array(tt.conditions.length - tt.removedConditions.array.length);
-
-    while (iCond < tt.clength && iRemoved < tt.removedConditions.array.length) {
-      if (iCond !== tt.removedConditions.array[iRemoved]) {
-        conditions[iTarget] = tt.conditions[iCond];
-        iTarget++;
-      }
-      else {
-        iRemoved++;
-      }
-
-      iCond++;
-    }
-
-    if (iCond < tt.clength) {
-      conditions.set(tt.conditions.subarray(iCond), iTarget);
-    }
-
-    tt.conditions = conditions;
-
-    // refresh subfilters condition index pointers
-    const keys = Object.keys(this.subfilters[index][collection]);
-
-    for(let i = 0; i < keys.length; i++) {
+    {
       const
-        sf = this.subfilters[index][collection][keys[i]],
-        cidx = tt.removedConditions.array.findIndex(idx => idx > sf.cidx);
+        conditionKeys = Object.keys(this.subfilters[index][collection]),
+        conditions = new Uint8Array(tt.conditions.length);
 
-      sf.cidx -= cidx > -1 ? cidx : tt.removedConditions.array.length;
+      let i; // perf cf https://jsperf.com/bvidis-for-oddities - NOSONAR
+      for (i = 0; i < conditionKeys.length; i++) {
+        const
+          key = conditionKeys[i],
+          sf = this.subfilters[index][collection][key];
+
+        conditions[i] = sf.conditions.length;
+        sf.cidx = i;
+      }
+
+      tt.conditions = conditions;
+      tt.clength = conditionKeys.length;
     }
 
     // rebuild filter index pointers
     if (tt.removedFiltersCount) {
-      for (let i = 0; i < Object.keys(this.filtersIndex[index][collection]).length; i++) {
+      let i; // perf cf https://jsperf.com/bvidis-for-oddities - NOSONAR
+      for (i = 0; i < Object.keys(this.filtersIndex[index][collection]).length; i++) {
         const
           filterId = this.filtersIndex[index][collection][i],
           filter = this.filters[filterId];
@@ -399,7 +383,6 @@ class Storage {
 
     // updates the test table indicators
     tt.filtersCount = Object.keys(this.filtersIndex[index][collection]).length;
-    tt.clength -= tt.removedConditions.array.length;
     tt.removedFilters = {};
     tt.removedFiltersCount = 0;
     tt.removedConditions.array = [];

--- a/lib/api/dsl/storage/objects/testTable.js
+++ b/lib/api/dsl/storage/objects/testTable.js
@@ -41,7 +41,8 @@ class TestTable {
     this.clength = 0;
     this.conditions = new Uint8Array(10);
     this.removedConditions = new SortedArray([]);
-    this.removedFilters = new SortedArray([]);
+    this.removedFilters = {};
+    this.removedFiltersCount = 0;
     this.reindexing = false;
 
     this.conditions[this.clength] = subfilter.conditions.length;

--- a/test/api/dsl/testIndex.test.js
+++ b/test/api/dsl/testIndex.test.js
@@ -134,7 +134,10 @@ describe('#TestTables (== DSL filter indexes)', () => {
           should(filter.fidx).be.eql(1);
           should(filter.subfilters[0].cidx).be.eql(1);
           should(dsl.storage.testTables.i.c.clength).be.eql(2);
-          should(dsl.storage.testTables.i.c.removedFilters.array).match([0]);
+          should(dsl.storage.testTables.i.c.removedFilters)
+            .match({ [id1]: true });
+          should(dsl.storage.testTables.i.c.removedFiltersCount)
+            .be.eql(1);
           should(dsl.storage.testTables.i.c.removedConditions.array.length).be.eql(1);
           should(dsl.storage.testTables.i.c.reindexing).be.true();
 
@@ -143,7 +146,10 @@ describe('#TestTables (== DSL filter indexes)', () => {
           should(filter.fidx).be.eql(0);
           should(filter.subfilters[0].cidx).be.eql(0);
           should(dsl.storage.testTables.i.c.clength).be.eql(1);
-          should(dsl.storage.testTables.i.c.removedFilters.array).be.empty();
+          should(dsl.storage.testTables.i.c.removedFilters)
+            .be.empty();
+          should(dsl.storage.testTables.i.c.removedFiltersCount)
+            .be.eql(0);
           should(dsl.storage.testTables.i.c.removedConditions.array).be.empty();
           should(dsl.storage.testTables.i.c.reindexing).be.false();
 


### PR DESCRIPTION
# Description

Fixes some cases where Kuzzle DSL would send notifications to a subset of matching subscription rooms only.
In depth, the internal test table used by the DSL could assign the same index to different filters, making the notifier trigger only one notification for these.

The fix simplifies the way the test tables indices are computed upon a reinxing (following an unregistration).

# Related issue

* #822