### PR TITLE
fix elasticsearch unhandled 404 error

### DIFF
--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -85,9 +85,9 @@ const errorMessagesMapping = [
     replacement: 'Failed to validate value of field "$1". Are you trying to insert nested value in a non-nested field ?'
   },
   {
-    // [index_not_found_exception] no such index, with { resource.type=index_or_alias resource.id=foso index=foso }
-    regex: /^\[index_not_found_exception] no such index, with { resource\.type=([^\s]+) resource\.id=([^\s]+) (index_uuid=.* )?index=([^\s]+) }$/,
-    replacement: 'Index "$2" does not exist, please create it first'
+    // [index_not_found_exception] no such index, with { resource.type=index_or_alias & resource.id=foso & index=foso }
+    regex: /^\[index_not_found_exception] no such index, with { resource\.type=([^\s]+) (& )?resource\.id=([^\s]+) (& )?(index_uuid=.* )?index=([^\s]+) }$/,
+    replacement: 'Index "$3" does not exist, please create it first'
   },
   {
     // [mapper_parsing_exception] Expected map for property [fields] on field [foo] but got a class java.lang.String


### PR DESCRIPTION
# Description

Fix elasticsearch error message parser on index not found exception

## Related debug message: 
`Wed, 03 May 2017 10:04:39 GMT kuzzle:services:elasticsearch unhandled "NotFound" elasticsearch error: { Error: [index_not_found_exception] no such index, with { resource.type="index_or_alias" & resource.id="kuzzle-test-index-new" & index_uuid="_na_" & index="kuzzle-test-index-new" } at [...] }
`
