### PR TITLE
Fix CLI unable to connect to Kuzzle

### DIFF
--- a/lib/api/controllers/cliController.js
+++ b/lib/api/controllers/cliController.js
@@ -45,7 +45,7 @@ class CliController {
       data: require('./cli/data')(this.kuzzle)
     };
 
-    this.kuzzle.services.list.broker.listen(this.kuzzle.config.queues.cliQueue, this.onListenCB);
+    this.kuzzle.services.list.broker.listen(this.kuzzle.config.queues.cliQueue, this.onListenCB.bind(this));
     this.kuzzle.pluginsManager.trigger('log:info', 'CLI controller initialized');
   }
 

--- a/test/api/controllers/cliController.test.js
+++ b/test/api/controllers/cliController.test.js
@@ -1,4 +1,4 @@
-var
+const
   rewire = require('rewire'),
   should = require('should'),
   sinon = require('sinon'),
@@ -8,7 +8,7 @@ var
   CliController = rewire('../../../lib/api/controllers/cliController');
 
 describe('lib/api/controllers/cliController', () => {
-  var
+  let
     kuzzle,
     cli,
     reset,
@@ -20,7 +20,7 @@ describe('lib/api/controllers/cliController', () => {
     dataStub;
 
   beforeEach(() => {
-    var requireMock = sinon.stub();
+    const requireMock = sinon.stub();
 
     adminExistsStub = sinon.stub();
     createFirstAdminStub = sinon.stub();
@@ -50,6 +50,7 @@ describe('lib/api/controllers/cliController', () => {
 
   describe('#init', () => {
     it('should set the actions and register itself to Kuzzle broker', () => {
+      cli.onListenCB = {bind: sinon.stub().returns('foobar')};
       cli.init();
 
       should(cli.actions.adminExists).be.exactly(adminExistsStub);
@@ -61,7 +62,8 @@ describe('lib/api/controllers/cliController', () => {
 
       should(kuzzle.services.list.broker.listen)
         .be.calledOnce()
-        .be.calledWith(kuzzle.config.queues.cliQueue, cli.onListenCB);
+        .be.calledWith(kuzzle.config.queues.cliQueue, 'foobar');
+      should(cli.onListenCB.bind).calledWith(cli);
 
       should(kuzzle.pluginsManager.trigger)
         .be.calledOnce()
@@ -71,7 +73,7 @@ describe('lib/api/controllers/cliController', () => {
 
   describe('#onListenCB', () => {
     it('should send an error if no action is provided', () => {
-      var rawRequest = {data: {requestId: 'test'}, options: {}};
+      const rawRequest = {data: {requestId: 'test'}, options: {}};
 
       cli.init();
 
@@ -84,7 +86,7 @@ describe('lib/api/controllers/cliController', () => {
     });
 
     it('should send an error if the provided action does not exist', () => {
-      var rawRequest = {data: {requestId: 'test', action: 'invalid'}, options: {}};
+      const rawRequest = {data: {requestId: 'test', action: 'invalid'}, options: {}};
 
       cli.init();
 
@@ -97,7 +99,7 @@ describe('lib/api/controllers/cliController', () => {
     });
 
     it('should send the response to the broker', () => {
-      var rawRequest = {data: {requestId: 'test', action: 'data'}, options: {}};
+      const rawRequest = {data: {requestId: 'test', action: 'data'}, options: {}};
 
       cli.init();
       cli.actions.data.returns(Promise.resolve('ok'));
@@ -112,7 +114,7 @@ describe('lib/api/controllers/cliController', () => {
     });
 
     it('should send the error gotten from the controller back to the broker', () => {
-      var
+      const
         rawRequest = {data: {requestId: 'test', action: 'data'}, options: {}},
         error = new BadRequestError('test');
 


### PR DESCRIPTION
# Description

Following the sonarqube issues fix, Kuzzle CLI was not working properly: the CLI controller attaches a listener to the websocket broker. But this listener now depends on the CLI Controller context, and it was detached from it.
