### PR TITLE
Fix the server:info API route

### DIFF
--- a/features/step_definitions/serverController.js
+++ b/features/step_definitions/serverController.js
@@ -1,4 +1,4 @@
-var apiSteps = function () {
+function apiSteps () {
   this.When(/^I get server informations$/, function (callback) {
     this.api.getServerInfo()
       .then(body => {
@@ -8,6 +8,16 @@ var apiSteps = function () {
 
         if (!body.result) {
           return callback(new Error('No result provided'));
+        }
+
+        try {
+          const routeInfo = body.result.serverInfo.kuzzle.api.routes.server.info;
+          if (!routeInfo || routeInfo.controller !== 'server' || routeInfo.action !== 'info') {
+            return callback(new Error('Unexpected/incorrect serverInfo content'));
+          }
+        }
+        catch(e) {
+          callback(e);
         }
 
         this.result = body.result;
@@ -32,6 +42,6 @@ var apiSteps = function () {
       })
       .catch(error => callback(error));
   });
-};
+}
 
 module.exports = apiSteps;

--- a/lib/api/controllers/serverController.js
+++ b/lib/api/controllers/serverController.js
@@ -124,7 +124,18 @@ class ServerController {
       };
 
     ['controllers', 'pluginsControllers'].forEach(controllers => {
-      const httpRoutes = controllers === 'controllers' ? this.kuzzle.config.http.routes : this.kuzzle.pluginsManager.routes;
+      let
+        httpRoutes,
+        urlPrefix;
+
+      if (controllers === 'controllers') {
+        httpRoutes = this.kuzzle.config.http.routes;
+        urlPrefix = '';
+      }
+      else {
+        httpRoutes = this.kuzzle.pluginsManager.routes;
+        urlPrefix = '_plugin/';
+      }
 
       Object.keys(this.kuzzle.funnel[controllers]).forEach(controller => {
         const actionList = {};
@@ -155,7 +166,7 @@ class ServerController {
 
             if (routeDescription) {
               actionList[action].http = {
-                url: routeDescription.url,
+                url: (urlPrefix + routeDescription.url).replace(/\/\//g, '/'),
                 verb: routeDescription.verb.toUpperCase()
               };
             }

--- a/lib/api/controllers/serverController.js
+++ b/lib/api/controllers/serverController.js
@@ -123,35 +123,49 @@ class ServerController {
         services: {}
       };
 
-    Object.keys(this.kuzzle.funnel.controllers).forEach(controller => {
-      const actionList = {};
+    ['controllers', 'pluginsControllers'].forEach(controllers => {
+      const httpRoutes = controllers === 'controllers' ? this.kuzzle.config.http.routes : this.kuzzle.pluginsManager.routes;
 
-      Object.keys(this.kuzzle.funnel.controllers[controller]).forEach(action => {
-        let routeDescription = {};
+      Object.keys(this.kuzzle.funnel[controllers]).forEach(controller => {
+        const actionList = {};
+        const properties = [];
 
-        if (typeof this.kuzzle.funnel.controllers[controller][action] === 'function') {
-          actionList[action] = {name: action};
+        // Plugins controllers can never be ES6 classes
+        if (controllers === 'controllers') {
+          properties.push(...Object.getOwnPropertyNames(Object.getPrototypeOf(this.kuzzle.funnel[controllers][controller]))
+            .filter(p => p !== 'constructor'));
+        }
 
-          // resolve associated http route for each actions
-          Object.keys(this.kuzzle.config.http.routes).forEach(key => {
-            const route = this.kuzzle.config.http.routes[key];
+        properties.push(...Object.keys(this.kuzzle.funnel[controllers][controller])
+          .filter(p => this.kuzzle.funnel[controllers][controller].hasOwnProperty(p)));
 
-            if ((route.controller === controller || controller === 'memoryStorage' && route.controller === 'ms') && route.action === action) {
-              routeDescription = route;
-              return false;
+        properties.forEach(action => {
+          // we exclude action names starting with an underscore,
+          // as this is the usual way to name a private method
+          if (action[0] !== '_' && typeof this.kuzzle.funnel[controllers][controller][action] === 'function') {
+            actionList[action] = {controller, action};
+
+            // resolve associated http route for each actions
+            const routeDescription = httpRoutes.find(route => {
+              return (
+                (route.controller === controller || controller === 'memoryStorage' && route.controller === 'ms') &&
+                route.action === action
+              );
+            });
+
+            if (routeDescription) {
+              actionList[action].http = {
+                url: routeDescription.url,
+                verb: routeDescription.verb.toUpperCase()
+              };
             }
-          });
-
-          if (routeDescription.url) {
-            actionList[action].route = routeDescription.url;
-            actionList[action].method = routeDescription.verb;
           }
+        });
+
+        if (Object.keys(actionList).length > 0) {
+          response.kuzzle.api.routes[controller] = actionList;
         }
       });
-
-      if (Object.keys(actionList).length > 0) {
-        response.kuzzle.api.routes[controller] = actionList;
-      }
     });
 
     response.kuzzle.plugins = this.kuzzle.pluginsManager.getPluginsFeatures();

--- a/test/api/controllers/serverController.test.js
+++ b/test/api/controllers/serverController.test.js
@@ -1,4 +1,4 @@
-var
+const
   Promise = require('bluebird'),
   should = require('should'),
   sinon = require('sinon'),
@@ -8,7 +8,7 @@ var
   sandbox = sinon.sandbox.create();
 
 describe('Test: server controller', () => {
-  var
+  let
     serverController,
     kuzzle,
     foo = {foo: 'bar'},
@@ -17,7 +17,7 @@ describe('Test: server controller', () => {
     request;
 
   beforeEach(() => {
-    var data = {
+    const data = {
       controller: 'server',
       index,
       collection
@@ -107,6 +107,31 @@ describe('Test: server controller', () => {
 
   describe('#info', () => {
     it('should return a properly formatted server information object', () => {
+      class Foo {
+        constructor() {
+          this.qux = 'not a function';
+          this.baz = function () {};
+        }
+        _privateMethod() {}
+        publicMethod() {}
+      }
+
+      kuzzle.funnel.controllers = {
+        foo: new Foo()
+      };
+
+      kuzzle.funnel.pluginsControllers = {
+        foobar: {
+          _privateMethod: function () {},
+          publicMethod: function () {},
+          anotherMethod: function () {},
+          notAnAction: 3.14
+        }
+      };
+
+      kuzzle.config.http.routes.push({verb: 'foo', action: 'publicMethod', controller: 'foo', url: '/u/r/l'});
+      kuzzle.pluginsManager.routes = [{verb: 'bar', action: 'publicMethod', controller: 'foobar', url: '/foobar'}];
+
       return serverController.info()
         .then(response => {
           should(response).be.instanceof(Object);
@@ -115,7 +140,36 @@ describe('Test: server controller', () => {
           should(response.serverInfo.kuzzle).be.and.Object();
           should(response.serverInfo.kuzzle.version).be.a.String();
           should(response.serverInfo.kuzzle.api).be.an.Object();
-          should(response.serverInfo.kuzzle.api.routes).be.an.Object();
+          should(response.serverInfo.kuzzle.api.routes).match({
+            foo: {
+              publicMethod: {
+                action: 'publicMethod',
+                controller: 'foo',
+                http: {
+                  url: '/u/r/l',
+                  verb: 'FOO'
+                }
+              },
+              baz: {
+                action: 'baz',
+                controller: 'foo'
+              }
+            },
+            foobar: {
+              publicMethod: {
+                action: 'publicMethod',
+                controller: 'foobar',
+                http: {
+                  url: '/foobar',
+                  verb: 'BAR'
+                }
+              },
+              anotherMethod: {
+                action: 'anotherMethod',
+                controller: 'foobar'
+              }
+            }
+          });
           should(response.serverInfo.kuzzle.plugins).be.an.Object();
           should(response.serverInfo.kuzzle.system).be.an.Object();
           should(response.serverInfo.services).be.an.Object();

--- a/test/api/controllers/serverController.test.js
+++ b/test/api/controllers/serverController.test.js
@@ -160,7 +160,7 @@ describe('Test: server controller', () => {
                 action: 'publicMethod',
                 controller: 'foobar',
                 http: {
-                  url: '/foobar',
+                  url: '_plugin/foobar',
                   verb: 'BAR'
                 }
               },

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -72,6 +72,8 @@ function KuzzleMock () {
         createFirstAdmin: sinon.spy()
       }
     },
+    pluginsControllers: {
+    },
     init: sinon.spy(),
     getRequestSlot: sinon.stub().returns(true),
     handleErrorDump: sinon.spy(),


### PR DESCRIPTION
# Description

The `server:info` API route should return the list of controllers and actions exposed by Kuzzle's API. Since Kuzzle controllers have been migrated to ES6 classes, nothing was returned because an `Object.keys` was performed instead of an exposed classes methods retrieval.

# Other changes

* Also return routes exposed by controller plugins, with their corresponding HTTP endpoints
* Slightly modified the routes description to make it easier to understand
* Made the functional test on this route a bit stricter to prevent the lack of information to go unnoticed 

# Solved issue

#779 
