### PR TITLE
Fix unhandled errors on client disconnect

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -326,16 +326,19 @@
     //   * host:
     //       Host name/address of a Kuzzle proxy server.
     //       Can be a hostname, an IP address or an URI.
-    //   * port:
-    //       Network port opened by the Kuzzle proxy server
-    //   * retryInterval:
-    //       Time interval (in millisconds) between reconnections retries
-    //       when the connection to the broker server has been lost
     //   * pingTimeout:
     //       Timeout (in milliseconds) of a ping request. If reached, Kuzzle
     //       marks its connection to the distant host as lost.
     //   * pingInterval:
     //       Time (in milliseconds) between ping requests
+    //   * port:
+    //       Network port opened by the Kuzzle proxy server
+    //   * retryClientListDelay
+    //       Time after which (in milliseconds) Kuzzle should ask the proxy to
+    //       send the list of clients back after a disconnection (default 1s).
+    //   * retryInterval:
+    //       Time interval (in millisconds) between reconnections retries
+    //       when the connection to the broker server has been lost
     "proxyBroker": {
       "host": "localhost",
       "port": 7331,

--- a/default.config.js
+++ b/default.config.js
@@ -183,7 +183,8 @@ module.exports = {
     proxyBroker: {
       host: 'localhost',
       port: 7331,
-      retryInterval: 1000
+      retryInterval: 1000,
+      resendClientListDelay: 1000
     },
     db: {
       aliases: ['storageEngine'],

--- a/lib/api/controllers/collectionController.js
+++ b/lib/api/controllers/collectionController.js
@@ -227,34 +227,35 @@ class CollectionController {
       throw new BadRequestError(`must specify a valid type argument; Expected: "all", "stored" or "realtime"; Received: "${type}".`);
     }
 
-    if (type === 'stored') {
-      return this.engine.listCollections(request)
-        .then(response => {
-          response.type = type;
-          response.collections = formatCollections(response);
-          return Bluebird.resolve(response);
+    let collections = [];
+
+    if (type === 'realtime' || type === 'all') {
+      collections = this.kuzzle.hotelClerk.getRealtimeCollections(request.input.resource.index)
+        .map(name => ({name, type: 'realtime'}));
+    }
+
+    return Bluebird.resolve()
+      .then(() => {
+        if (type === 'stored' || type === 'all') {
+          return this.engine.listCollections(request)
+            .then(response => {
+              for (const name of response.collections.stored) {
+                collections.push({name, type: 'stored'});
+              }
+            });
+        }
+
+        return Bluebird.resolve();
+      })
+      .then(() => {
+        collections.sort((a, b) => {
+          if (a.name === b.name) {
+            return 0;
+          }
+          return a.name < b.name ? -1 : 1;
         });
-    }
 
-    const realtimeCollections = this.kuzzle.hotelClerk.getRealtimeCollections()
-      .filter(collection => collection.index === request.input.resource.index)
-      .map(collection => collection.name);
-
-    if (type === 'realtime') {
-      const realtimeResponse = {type, collections: {realtime: realtimeCollections}};
-
-      realtimeResponse.collections = formatCollections(realtimeResponse);
-
-      return Bluebird.resolve(realtimeResponse);
-    }
-
-    return this.engine.listCollections(request)
-      .then(response => {
-        response.type = type;
-        response.collections.realtime = realtimeCollections;
-        response.collections = formatCollections(response);
-
-        return Bluebird.resolve(paginateCollections(request, response));
+        return paginateCollections(request, {type, collections});
       });
   }
 
@@ -369,30 +370,3 @@ function paginateCollections (request, response) {
   return response;
 }
 
-/**
- * @param {object} response
- * @returns {Array.<{name: string, type: string}>}
- */
-function formatCollections (response) {
-  const collections = [];
-
-  if (response.collections.realtime) {
-    response.collections.realtime.forEach(item => {
-      collections.push({name: item, type: 'realtime'});
-    });
-  }
-
-  if (response.collections.stored) {
-    response.collections.stored.forEach(item => {
-      collections.push({name: item, type: 'stored'});
-    });
-  }
-
-  return collections.sort((a, b) => {
-    if (a.name === b.name) {
-      return 0;
-    }
-
-    return a.name < b.name ? -1 : 1;
-  });
-}

--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -62,17 +62,18 @@ class RouterController {
    */
   removeConnection(requestContext) {
     if (!requestContext.connectionId || !requestContext.protocol) {
-      this.kuzzle.pluginsManager.trigger('log:error', new PluginImplementationError('Unable to remove connection - invalid arguments:' + JSON.stringify(requestContext.context)));
+      return this.kuzzle.pluginsManager.trigger('log:error', new PluginImplementationError('Unable to remove connection - invalid arguments:' + JSON.stringify(requestContext.context)));
     }
-    else if (!this.connections[requestContext.connectionId]) {
-      this.kuzzle.pluginsManager.trigger('log:error', new PluginImplementationError('Unable to remove connection - unknown connectionId:' + JSON.stringify(requestContext.connectionId)));
-    }
-    else {
-      delete this.connections[requestContext.connectionId];
 
-      this.kuzzle.hotelClerk.removeCustomerFromAllRooms(requestContext);
-      this.kuzzle.statistics.dropConnection(requestContext);
+    if (!this.connections[requestContext.connectionId]) {
+      return this.kuzzle.pluginsManager.trigger('log:error', new PluginImplementationError('Unable to remove connection - unknown connectionId:' + JSON.stringify(requestContext.connectionId)));
     }
+
+    delete this.connections[requestContext.connectionId];
+
+    this.kuzzle.hotelClerk.removeCustomerFromAllRooms(requestContext);
+
+    this.kuzzle.statistics.dropConnection(requestContext);
   }
 
   /**

--- a/lib/api/core/entryPoints/kuzzleProxy.js
+++ b/lib/api/core/entryPoints/kuzzleProxy.js
@@ -41,11 +41,16 @@ class KuzzleProxy {
   init() {
     debug('initialize proxy communication');
 
-    this.kuzzle.services.list.proxyBroker.listen('request', onRequest.bind(this));
-    this.kuzzle.services.list.proxyBroker.listen('connection', onConnection.bind(this));
-    this.kuzzle.services.list.proxyBroker.listen('disconnect', onDisconnect.bind(this));
-    this.kuzzle.services.list.proxyBroker.listen('error', onDisconnect.bind(this));
-    this.kuzzle.services.list.proxyBroker.listen('httpRequest', onHttpRequest.bind(this));
+    const proxy = this.kuzzle.services.list.proxyBroker;
+
+    proxy.listen('request', onRequest.bind(this));
+    proxy.listen('connection', onConnection.bind(this));
+    proxy.listen('disconnect', onDisconnect.bind(this));
+    proxy.listen('error', onDisconnect.bind(this));
+    proxy.listen('httpRequest', onHttpRequest.bind(this));
+
+    proxy.send('ready', true);
+    proxy.onConnectHandlers.push(() => setTimeout(() => proxy.send('ready', true), this.kuzzle.config.services.proxyBroker.resendClientListDelay));
   }
 
   joinChannel(data) {

--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -22,56 +22,52 @@
 'use strict';
 
 const
-  _ = require('lodash'),
-  async = require('async'),
   Bluebird = require('bluebird'),
   Request = require('kuzzle-common-objects').Request,
   {
     BadRequestError,
-    NotFoundError,
-    InternalError: KuzzleInternalError
+    NotFoundError
   } = require('kuzzle-common-objects').errors;
 
-/**
- *
- * @global JSON
- * @param {Kuzzle} kuzzle
- * @constructor
- */
-function HotelClerk (kuzzle) {
-  this.kuzzle = kuzzle;
-  /**
-   * A simple list of rooms, containing their associated filter and how many users have subscribed to it
-   *
-   * Example: subscribing to a chat room where the subject is Kuzzle
-   *  rooms = {
-   *    'f45de4d8ef4f3ze4ffzer85d4fgkzm41' : { // -> the room unique ID (=== the filter unique ID)
-   *      customers: [ 'connectionId' ], // -> list of users subscribing to this room
-   *      channels: {                    // -> room channels
-   *        'roomId-<configurationHash>': {   // channel name
-   *          state: 'all|pending|done',      // request state filter, default: 'done'
-   *          scope: 'all|in|out|none',       // request scope filter, default: 'all'
-   *          users: 'all|in|out|none'        // filter users notifications, default: 'none'
-   *        }
-   *      },
-   *      index: 'index', // -> the index name
-   *      collection: 'message', // -> the collection name
-   *    }
-   *  }
-   */
-  this.rooms = {};
-  /**
-   * In addition to this.rooms, this.customers allows managing users and their rooms
-   * Example for a customer who subscribes to the room 'chat-room-kuzzle'
-   * customers = {
-   *  '87fd-gre7ggth544z' : { // -> connection id (like socket id)
-   *      'fr4fref4f8fre47fe': { // -> subscribed rooms id
-   *        // volatile data for this customer's subscription on that room
-   *      }
-   *   }
-   * }
-   */
-  this.customers = {};
+class HotelClerk {
+
+  constructor (kuzzle) {
+    this.kuzzle = kuzzle;
+
+    /**
+     * A simple list of rooms, containing their associated filter and how many users have subscribed to it
+     *
+     * Example: subscribing to a chat room where the subject is Kuzzle
+     *  rooms = {
+     *    'f45de4d8ef4f3ze4ffzer85d4fgkzm41' : { // -> the room unique ID (=== the filter unique ID)
+     *      customers: Set([ 'connectionId' ]), // -> list of users subscribing to this room
+     *      channels: {                    // -> room channels
+     *        'roomId-<configurationHash>': {   // channel name
+     *          state: 'all|pending|done',      // request state filter, default: 'done'
+     *          scope: 'all|in|out|none',       // request scope filter, default: 'all'
+     *          users: 'all|in|out|none'        // filter users notifications, default: 'none'
+     *        }
+     *      },
+     *      index: 'index', // -> the index name
+     *      collection: 'message', // -> the collection name
+     *    }
+     *  }
+     */
+    this.rooms = {};
+
+    /**
+     * In addition to this.rooms, this.customers allows managing users and their rooms
+     * Example for a customer who subscribes to the room 'chat-room-kuzzle'
+     * customers = {
+     *  '87fd-gre7ggth544z' : { // -> connection id (like socket id)
+     *      'fr4fref4f8fre47fe': { // -> subscribed rooms id
+     *        // volatile data for this customer's subscription on that room
+     *      }
+     *   }
+     * }
+     */
+    this.customers = {};
+  }
 
   /**
    * Link a user connection to a room.
@@ -84,26 +80,24 @@ function HotelClerk (kuzzle) {
    * user has already subscribed to this room name (just for rooms with same name, there is no error
    * if the room has a different name with same filter) or if there is an error during room creation
    */
-  this.addSubscription = function hotelClerkAddSubscription (request) {
+  addSubscription (request) {
     const diff = [];
 
-    return createRoom.call(this, request.input.resource.index, request.input.resource.collection, request.input.body)
+    return this._createRoom(request.input.resource.index, request.input.resource.collection, request.input.body)
       .then(response => {
         if (response.diff) {
           diff.push(response.diff);
         }
 
-        return subscribeToRoom.call(this, response.roomId, request);
-      })
-      .then(response => {
-        if (response.diff) {
-          diff.push(response.diff);
-          kuzzle.pluginsManager.trigger('core:hotelClerk:addSubscription', diff);
+        const subResponse = this._subscribeToRoom(response.roomId, request);
+        if (subResponse.diff) {
+          diff.push(subResponse.diff);
+          this.kuzzle.pluginsManager.trigger('core:hotelClerk:addSubscription', diff);
         }
 
-        return response.data;
+        return subResponse.data;
       });
-  };
+  }
 
   /**
    * Returns the list of existing channels on a given room, depending of the response object
@@ -112,77 +106,76 @@ function HotelClerk (kuzzle) {
    * @param {string} roomId
    * @param {object} notification object
    */
-  this.addToChannels = function hotelClerkAddToChannels (channels, roomId, notification) {
-    if (this.rooms[roomId]) {
-      Object.keys(this.rooms[roomId].channels).forEach(channel => {
-        const
-          c = this.rooms[roomId].channels[channel],
-          stateMatch = c.state === 'all' || !notification.state || notification.action === 'publish' || c.state === notification.state,
-          scopeMatch = c.scope === 'all' || !notification.scope || c.scope === notification.scope,
-          usersMatch = c.users === 'all' || notification.getUserFlag() === 'none' || c.users === notification.getUserFlag();
+  addToChannels (channels, roomId, notification) {
+    const room = this.rooms[roomId];
 
-        if (stateMatch && scopeMatch && usersMatch) {
-          channels.push(channel);
-        }
-      });
+    if (room === undefined) {
+      return;
     }
-  };
 
-  /**
-   * Remove the connection.id from the room and delete it if there is no subscriber left in it
-   *
-   * @param {Request} request
-   * @returns {Promise} promise
-   */
-  this.removeSubscription = function hotelClerkRemoveSubscription (request) {
-    // Remove the room for the customer, don't wait for deletion before continuing
-    return removeRoomForCustomer.call(this, request.context, request.input.body.roomId)
-      .then(roomId => ({roomId}));
-  };
+    for (const channel of Object.keys(room.channels)) {
+      const
+        c = room.channels[channel],
+        stateMatch = c.state === 'all' || !notification.state || notification.action === 'publish' || c.state === notification.state,
+        scopeMatch = c.scope === 'all' || !notification.scope || c.scope === notification.scope,
+        usersMatch = c.users === 'all' || notification.getUserFlag() === 'none' || c.users === notification.getUserFlag();
+
+      if (stateMatch && scopeMatch && usersMatch) {
+        channels.push(channel);
+      }
+    }
+  }
 
   /**
    * Return the subscribers count on a given room
    *
    * @param {Request} request
-   * @returns {Promise} promise
+   * @returns {Object}
    */
-  this.countSubscription = function hotelClerkCountSubscription (request) {
-    if (!this.rooms[request.input.body.roomId]) {
-      return Bluebird.reject(new NotFoundError(`The room Id "${request.input.body.roomId}" does not exist`));
+  countSubscription (request) {
+    const room = this.rooms[request.input.body.roomId];
+
+    if (room === undefined) {
+      throw new NotFoundError(`The room Id "${request.input.body.roomId}" does not exist`);
     }
 
-    return Bluebird.resolve({count: this.rooms[request.input.body.roomId].customers.length});
-  };
+    return {count: this.rooms[request.input.body.roomId].customers.size};
+  }
 
   /**
-   * This function will delete a user from this.customers, and
-   * decrement the subscribers count in all rooms where he has subscribed to
-   * Call the cleanUpRooms function to manage empty rooms
-   * Usually called on a user disconnection event
-   *
-   * @param {RequestContext} requestContext
-   * @returns {Promise}
+   * Given an index, returns an array of collections on which some filters are registered
+   * @param {string} index
+   * @returns {Array}
    */
-  this.removeCustomerFromAllRooms = function hotelClerkRemoveCustormerFromAllRooms (requestContext) {
-    if (!this.customers[requestContext.connectionId]) {
-      // No need to raise an error if the connection has already been cleaned up
-      return Bluebird.resolve();
+  getRealtimeCollections (index) {
+    const collections = [];
+
+    if (this.kuzzle.dsl.storage.filtersIndex[index]) {
+      for (const collection of Object.keys(this.kuzzle.dsl.storage.filtersIndex[index])) {
+        collections.push(collection);
+      }
     }
 
-    const rooms = Object.keys(this.customers[requestContext.connectionId]);
+    return collections;
+  }
 
-    return new Bluebird((resolve, reject) => {
-      async.each(rooms, (roomId, callback) => {
-        removeRoomForCustomer.call(this, requestContext, roomId).asCallback(callback);
-      }, err => {
-        if (err) {
-          return reject(err);
-        }
+  /**
+   * Joins an existing room.
+   *
+   * @param {Request} request
+   * @returns {Object}
+   */
+  join (request) {
+    const roomId = request.input.body.roomId;
 
-        resolve();
-      });
-    });
-  };
+    if (!this.rooms[roomId]) {
+      throw new NotFoundError('No room found for id ' + roomId);
+    }
+
+    const response = this._subscribeToRoom(roomId, request);
+    this.kuzzle.pluginsManager.trigger('core:hotelClerk:join', response);
+    return response.data;
+  }
 
   /**
    * Return all rooms for all filters for all collections
@@ -191,445 +184,415 @@ function HotelClerk (kuzzle) {
    * @param {Request} request
    * @returns {Promise} resolve an object with collection, rooms, subscribers
    */
-  this.listSubscriptions = function hotelClerkListSubscriptions (request) {
-    return new Bluebird(resolve => {
-      const list = {};
+  listSubscriptions (request) {
+    const
+      list = {},
+      promises = [],
+      dslIndex = this.kuzzle.dsl.storage.filtersIndex;
 
-      async.each(Object.keys(this.rooms), (roomId, callback) => {
-        const
-          room = this.rooms[roomId],
-          rightRequest = new Request({
-            action: 'search',
-            controller: 'document',
-            index: room.index,
-            collection: room.collection
-          }, request.context);
+    for (const index of Object.keys(dslIndex)) {
+      for (const collection of Object.keys(dslIndex[index])) {
+        const isAllowedRequest = new Request({
+          controller: 'document',
+          action: 'search',
+          index,
+          collection
+        }, request.context);
 
-        return request.context.user.isActionAllowed(rightRequest, kuzzle)
+        promises.push(request.context.user.isActionAllowed(isAllowedRequest, this.kuzzle)
           .then(isAllowed => {
             if (!isAllowed) {
-              return callback(null);
+              return;
             }
 
-            if (!list[room.index]) {
-              list[room.index] = {};
+            if (!list[index]) {
+              list[index] = {};
+            }
+            if (!list[index][collection]) {
+              list[index][collection] = {};
             }
 
-            if (!list[room.index][room.collection]) {
-              list[room.index][room.collection] = {};
+            for (const roomId of dslIndex[index][collection]) {
+              const room = this.rooms[roomId];
+              // the room may be currently registering in the dsl and not ready in the hotel clerk
+              // or already deleted in from the hotel clerk and still in the dsl
+              if (room) {
+                list[index][collection][roomId] = room.customers.size;
+              }
             }
-
-            list[room.index][room.collection][roomId] = room.customers.length;
-            callback(null);
-          });
-      }, () => resolve(list));
-    });
-  };
-
-  /**
-   * Joins an existing room.
-   *
-   * @param {Request} request
-   * @returns {Promise}
-   */
-  this.join = function hotelClerkJoin (request) {
-    const roomId = request.input.body.roomId;
-
-    if (!this.rooms[roomId]) {
-      return Bluebird.reject(new NotFoundError('No room found for id ' + roomId));
+          }));
+      }
     }
 
-    return Bluebird.resolve(subscribeToRoom.call(this, roomId, request))
-      .then(response => {
-        kuzzle.pluginsManager.trigger('core:hotelClerk:join', response);
-        return response.data;
-      });
-  };
+    return Bluebird.all(promises)
+      .then(() => list);
+  }
+
+  /**
+   * This function will delete a user from this.customers, and
+   * decrement the subscribers count in all rooms where he has subscribed to
+   * Call the cleanUpRooms function to manage empty rooms
+   * Usually called on a user disconnection event
+   *
+   * @param {RequestContext} requestContext
+   */
+  removeCustomerFromAllRooms (requestContext) {
+    if (!this.customers[requestContext.connectionId]) {
+      // No need to raise an error if the connection has already been cleaned up
+      return;
+    }
+
+    for (const roomId of Object.keys(this.customers[requestContext.connectionId])) {
+      try {
+        this._removeRoomForCustomer(requestContext, roomId);
+      }
+      catch (err) {
+        this.kuzzle.pluginsManager.trigger('log:error', err);
+      }
+    }
+  }
 
   /**
    * Remove rooms for a given collection
    * If rooms attribute is not provided, all rooms for the collection are removed
    * @param {Request} request
-   * @returns {Promise}
+   * @return {Promise<Object>}
    */
-  this.removeRooms = function hotelClerkRemoveRooms (request) {
-    if (!kuzzle.dsl.exists(request.input.resource.index, request.input.resource.collection)) {
-      return Bluebird.reject(new NotFoundError(`No subscription found on index ${request.input.resource.index} and collection ${request.input.resource.collection}`));
+  removeRooms (request) {
+    if (!this.kuzzle.dsl.exists(request.input.resource.index, request.input.resource.collection)) {
+      throw new NotFoundError(`No subscription found on index ${request.input.resource.index} and collection ${request.input.resource.collection}`);
     }
 
     if (request.input.body && request.input.body.rooms) {
       if (!Array.isArray(request.input.body.rooms)) {
-        return Bluebird.reject(new BadRequestError('The rooms attribute must be an array'));
+        throw new BadRequestError('The rooms attribute must be an array');
       }
 
-      return removeListRoomsInCollection.call(this, request.input.resource.index, request.input.resource.collection, request.input.body.rooms)
-        .then(partialErrors => ({acknowledge: true, partialErrors}));
+      const
+        {
+          index,
+          collection
+        } = request.input.resource,
+        rooms = request.input.body.rooms,
+        partialErrors = this._removeListRoomsInCollection(index, collection, rooms);
+
+      return {acknowledged: true, partialErrors};
     }
 
-    return removeAllRoomsInCollection.call(this, request.input.resource.index, request.input.resource.collection)
-      .then(() => ({acknowledge: true}));
-  };
-
-  /**
-   * Returns an unique list of subscribed collections
-   *
-   * @returns {Array}
-   */
-  this.getRealtimeCollections = function hotelClerkGetRealtimeCollections () {
-    const collections = [];
-
-    Object.keys(this.rooms).forEach(room => {
-      collections.push({name: this.rooms[room].collection, index: this.rooms[room].index});
-    });
-
-    return _.uniqWith(collections, _.isEqual);
-  };
-
-
-  // pseudo private methods.
-  Object.defineProperties(this, {
-    addRoomForCustomer: {
-      value: addRoomForCustomer.bind(this)
-    },
-    removeRoomForCustomer: {
-      value: removeRoomForCustomer.bind(this)
-    }
-  });
-
-}
-
-/** MANAGE ROOMS **/
-
-/**
- * Remove all rooms for provided collection
- * Will remove room from the DSL, from the rooms list and for each customers.
- *
- * @this HotelClerk
- * @param index
- * @param collection
- * @returns {Promise} resolve nothing
- */
-function removeAllRoomsInCollection (index, collection) {
-  const dslFilters = this.kuzzle.dsl.getFilterIds(index, collection);
-
-  return new Bluebird((resolve, reject) => {
-    async.each(dslFilters, (id, cb) => removeRoomEverywhere.call(this, id).asCallback(cb), err => {
-      if (err) {
-        return reject(err);
-      }
-      resolve();
-    });
-  });
-}
-
-/**
- * @this HotelClerk
- * @param {string} index
- * @param {string} collection
- * @param {String[]} rooms
- * @returns {Promise}
- */
-function removeListRoomsInCollection (index, collection, rooms) {
-  const partialErrors = [];
-
-  return new Bluebird(resolve => {
-    async.each(rooms, (roomId, callback) => {
-      if (!this.rooms[roomId]) {
-        // don't stop the loop if error occured but return a partial error to user
-        partialErrors.push(`No room with id ${roomId}`);
-        return callback();
-      }
-
-      if (this.rooms[roomId].index !== index) {
-        // don't stop the loop if error occured but return a partial error to user
-        partialErrors.push(`The room ${roomId} does not match index ${index}`);
-        return callback();
-      }
-
-      if (this.rooms[roomId].collection !== collection) {
-        // don't stop the loop if error occured but return a partial error to user
-        partialErrors.push(`The room ${roomId} does not match collection ${collection}`);
-        return callback();
-      }
-
-      removeRoomEverywhere.call(this, roomId).asCallback(callback);
-    }, () => resolve(partialErrors));
-  });
-}
-
-/**
- * Create new room if needed
- *
- * @this HotelClerk
- * @param {string} index
- * @param {string} collection
- * @param {object} filters
- * @returns {Promise} promise
- */
-function createRoom (index, collection, filters) {
-  let
-    diff,
-    formattedFilters,
-    roomId;
-
-  if (!index || !collection) {
-    return Bluebird.reject(new BadRequestError('Cannot subscribe without an index and a collection'));
+    this._removeAllRoomsInCollection(request.input.resource.index, request.input.resource.collection);
+    return {acknowledged: true};
   }
 
-  return this.kuzzle.dsl.register(index, collection, filters)
-    .then(response => {
-      roomId = response.id;
-      diff = response.diff;
-      formattedFilters = response.filter;
+  /**
+   * Remove the connection.id from the room and delete it if there is no subscriber left in it
+   *
+   * @param {Request} request
+   */
+  removeSubscription (request) {
+    // Remove the room for the customer, don't wait for deletion before continuing
+    this._removeRoomForCustomer(request.context, request.input.body.roomId);
+    return request.input.body.roomId;
+  }
 
-      if (!diff && this.rooms[roomId] && !this.rooms[roomId].destroyed) {
-        return {diff, roomId};
-      }
+  /**
+   * Associate the room to the connectionId in this.clients
+   * Allow to manage later disconnection and delete socket/rooms/...
+   *
+   * @param {Request} request
+   * @param {string} roomId
+   * @param {object} volatile
+   */
+  _addRoomForCustomer (request, roomId, volatile) {
+    if (!this.customers[request.context.connectionId]) {
+      this.customers[request.context.connectionId] = {};
+    }
 
-      return Bluebird.fromNode(asyncCB => async.retry(callback => {
-        // if the room is about to be destroyed, we have to delay its re-registration until its destruction has completed
-        if (this.rooms[roomId] && this.rooms[roomId].destroyed) {
-          return callback(new KuzzleInternalError(`Cannot create the room ${roomId} because it has been marked for destruction`));
+
+    this.rooms[roomId].customers.add(request.context.connectionId);
+    this.customers[request.context.connectionId][roomId] = volatile;
+  }
+
+  /**
+   * Create a channel object and resolve it
+   *
+   * @param {Request} request
+   * @return {Promise<NotificationObject>}
+   */
+  _createChannelConfiguration (request) {
+    const channel = {};
+
+    if (request.input.args.state && ['all', 'done', 'pending'].indexOf(request.input.args.state) === -1) {
+      throw new BadRequestError('Incorrect value for the "state" parameter. Expected: all, done or pending. Got: ' + request.input.args.state);
+    } else if (!request.input.args.state) {
+      channel.state = 'done';
+    } else {
+      channel.state = request.input.args.state;
+    }
+
+    if (request.input.args.scope && ['all', 'in', 'out', 'none'].indexOf(request.input.args.scope) === -1) {
+      throw new BadRequestError('Incorrect value for the "scope" parameter. Expected: all, in, out or none. Got: ' + request.input.args.scope);
+    } else if (!request.input.args.scope) {
+      channel.scope = 'all';
+    } else {
+      channel.scope = request.input.args.scope;
+    }
+
+    if (request.input.args.users && ['all', 'in', 'out', 'none'].indexOf(request.input.args.users) === -1) {
+      throw new BadRequestError('Incorrect value for the "users" parameter. Expected: all, in, out or none. Got: ' + request.input.args.users);
+    } else if (!request.input.args.users) {
+      channel.users = 'none';
+    } else {
+      channel.users = request.input.args.users;
+    }
+
+    return channel;
+  }
+
+  /**
+   * Create new room if needed
+   *
+   * @this HotelClerk
+   * @param {string} index
+   * @param {string} collection
+   * @param {object} filters
+   * @returns {Promise} promise
+   */
+  _createRoom (index, collection, filters) {
+    let
+      diff,
+      formattedFilters,
+      roomId;
+
+    if (!index || !collection) {
+      return Bluebird.reject(new BadRequestError('Cannot subscribe without an index and a collection'));
+    }
+
+    return this.kuzzle.dsl.register(index, collection, filters)
+      .then(response => {
+        roomId = response.id;
+        diff = response.diff;
+        formattedFilters = response.filter;
+
+        if (!diff && this.rooms[roomId]) {
+          return {diff, roomId};
         }
-        callback(null, {roomId});
-      }, asyncCB))
-        .then(() => {
-          return this.kuzzle.pluginsManager.trigger('room:new', {
-            roomId,
-            index,
-            collection,
-            formattedFilters
-          });
+
+        return this.kuzzle.pluginsManager.trigger('room:new', {
+          roomId,
+          index,
+          collection,
+          formattedFilters
         })
-        .then(modifiedData => {
-          this.rooms[modifiedData.roomId] = {
-            id: modifiedData.roomId,
-            customers: [],
-            index: modifiedData.index,
+        .then(modified => {
+          this.rooms[modified.roomId] = {
+            id: modified.roomId,
+            customers: new Set(),
+            index: modified.index,
             channels: {},
-            collection: modifiedData.collection
+            collection: modified.collection
           };
 
           return {diff, roomId};
         });
-    });
-}
-
-/**
- * Associate the room to the connectionId in this.clients
- * Allow to manage later disconnection and delete socket/rooms/...
- *
- * @this HotelClerk
- * @param {Request} request
- * @param {string} roomId
- * @param {object} volatile
- */
-function addRoomForCustomer (request, roomId, volatile) {
-  if (!this.customers[request.context.connectionId]) {
-    this.customers[request.context.connectionId] = {};
+      });
   }
 
-  this.rooms[roomId].customers.push(request.context.connectionId);
-  this.customers[request.context.connectionId][roomId] = volatile;
-}
+  /**
+   * Remove all rooms for provided collection
+   * Will remove room from the DSL, from the rooms list and for each customers.
+   *
+   * @this HotelClerk
+   * @param index
+   * @param collection
+   */
+  _removeAllRoomsInCollection (index, collection) {
+    // we need a copy of the array as it will be progressively be destroyed
+    const dslFilters = [].concat(this.kuzzle.dsl.getFilterIds(index, collection));
 
-/**
- * Create a channel object and resolve it
- *
- * @param {Request} request
- * @return {Promise<NotificationObject>}
- */
-function createChannelConfiguration (request) {
-  const channel = {};
-
-  if (request.input.args.state && ['all', 'done', 'pending'].indexOf(request.input.args.state) === -1) {
-    return Bluebird.reject(new BadRequestError('Incorrect value for the "state" parameter. Expected: all, done or pending. Got: ' + request.input.args.state));
-  } else if (!request.input.args.state) {
-    channel.state = 'done';
-  } else {
-    channel.state = request.input.args.state;
+    for (const roomId of dslFilters) {
+      this._removeRoomEverywhere(roomId);
+    }
   }
 
-  if (request.input.args.scope && ['all', 'in', 'out', 'none'].indexOf(request.input.args.scope) === -1) {
-    return Bluebird.reject(new BadRequestError('Incorrect value for the "scope" parameter. Expected: all, in, out or none. Got: ' + request.input.args.scope));
-  } else if (!request.input.args.scope) {
-    channel.scope = 'all';
-  } else {
-    channel.scope = request.input.args.scope;
+  /**
+   * @this HotelClerk
+   * @param {string} index
+   * @param {string} collection
+   * @param {String[]} rooms
+   */
+  _removeListRoomsInCollection (index, collection, rooms) {
+    const partialErrors = [];
+
+    for (const roomId of rooms) {
+      if (!this.rooms[roomId]) {
+        // don't stop the loop if error occurred but return a partial error to user
+        partialErrors.push(`No room with id ${roomId}`);
+      }
+      else if (this.rooms[roomId].index !== index) {
+        // don't stop the loop if error occurred but return a partial error to user
+        partialErrors.push(`The room ${roomId} does not match index ${index}`);
+      }
+      else if (this.rooms[roomId].collection !== collection) {
+        // don't stop the loop if error occurred but return a partial error to user
+        partialErrors.push(`The room ${roomId} does not match collection ${collection}`);
+      }
+      else {
+        this._removeRoomEverywhere(roomId);
+      }
+    }
+
+    return partialErrors;
   }
 
-  if (request.input.args.users && ['all', 'in', 'out', 'none'].indexOf(request.input.args.users) === -1) {
-    return Bluebird.reject(new BadRequestError('Incorrect value for the "users" parameter. Expected: all, in, out or none. Got: ' + request.input.args.users));
-  } else if (!request.input.args.users) {
-    channel.users = 'none';
-  } else {
-    channel.users = request.input.args.users;
+  /**
+   * Remove a roomId for all customers (allow to delete a room everywhere)
+   *
+   * @this HotelClerk
+   * @param roomId
+   */
+  _removeRoomForAllCustomers (roomId) {
+    for (const connectionId of Object.keys(this.customers)) {
+      for (const customerRoomId of Object.keys(this.customers[connectionId])) {
+        if (customerRoomId === roomId) {
+          delete this.customers[connectionId][customerRoomId];
+        }
+      }
+    }
   }
 
-  return Bluebird.resolve(channel);
-}
+  /**
+   * Remove a room everywhere: in customers, in the DSL and in this.rooms
+   * Allow to delete a room with action admin/removeRooms or admin/removeRooms
+   *
+   * @this HotelClerk
+   * @param roomId
+   */
+  _removeRoomEverywhere (roomId) {
+    this._removeRoomForAllCustomers(roomId);
 
-/**
- * Delete room if no user has subscribed to it, and remove it also from the DSL
- *
- * @this HotelClerk
- * @param roomId
- * @returns {Promise<string>}
- */
-function cleanUpRooms (roomId) {
-  if (this.rooms[roomId].customers.length === 0 && !this.rooms[roomId].destroyed) {
-    /*
-     This flag ensures that a room is destroyed only once.
-     Multiple room cleanup might happen when different users unsubscribe at the same time, and trying
-     to destroy the same room multiple times lead to unpredictable results
-     */
-    this.rooms[roomId].destroyed = true;
+    const room = this.rooms[roomId];
 
-    this.kuzzle.pluginsManager.trigger('room:remove', roomId);
-    return this.kuzzle.dsl.remove(roomId)
-      .then(() => roomId)
-      .catch(error => {
-        this.kuzzle.pluginsManager.trigger('log:error', error);
-        return Bluebird.reject(error);
-      })
-      .finally(() => delete this.rooms[roomId]);
+    if (!room) {
+      // room is not registered. Nothing to do but warn in case of
+      this.kuzzle.pluginsManager.trigger('log:warn', `hotelClerk._removeRoomEveryWhere could not find room ${roomId}`);
+      return;
+    }
+
+    delete this.rooms[roomId];
+    this._removeRoomFromDsl(roomId);
   }
 
-  return Bluebird.resolve(roomId);
-}
+  /**
+   * Remove the room from subscribed room from the user
+   * Return the roomId in user mapping
+   *
+   * @this HotelClerk
+   * @param {RequestContext} requestContext
+   * @param {string} roomId
+   * @param {Boolean} [notify]
+   * @return {String}
+   */
+  _removeRoomForCustomer (requestContext, roomId, notify = true) {
+    const room = this.rooms[roomId];
 
-/**
- * Remove a room everywhere: in customers, in the DSL and in this.rooms
- * Allow to delete a room with action admin/removeRooms or admin/removeRooms
- *
- * @this HotelClerk
- * @param roomId
- */
-function removeRoomEverywhere (roomId) {
-  return removeRoomForAllCustomers.call(this, roomId)
-    .then(() => {
-      this.rooms[roomId].customers = [];
-      return cleanUpRooms.call(this, roomId);
-    });
-}
+    if (notify) {
+      this.kuzzle.pluginsManager.trigger('core:hotelClerk:removeRoomForCustomer', {requestContext, roomId});
+    }
 
-/** MANAGE CUSTOMERS **/
+    let volatile = null;
+    if (this.customers[requestContext.connectionId] && this.customers[requestContext.connectionId][roomId] !== undefined) {
+      volatile = this.customers[requestContext.connectionId][roomId];
+      if (Object.keys(this.customers[requestContext.connectionId]).length > 1) {
+        delete this.customers[requestContext.connectionId][roomId];
+      }
+      else {
+        delete this.customers[requestContext.connectionId];
+      }
+    }
 
-/**
- * Remove the room from subscribed room from the user
- * Return the roomId in user mapping
- *
- * @this HotelClerk
- * @param {RequestContext} requestContext
- * @param {string} roomId
- * @param {Boolean} [notify]
- * @return {Promise<string>} promise
- */
-function removeRoomForCustomer (requestContext, roomId, notify = true) {
-  if (notify) {
-    this.kuzzle.pluginsManager.trigger('core:hotelClerk:removeRoomForCustomer', {requestContext, roomId});
-  }
+    if (room === undefined) {
+      throw new NotFoundError(`The room id ${roomId} does not exist`);
+    }
+    room.customers.delete(requestContext.connectionId);
 
-  if (!this.customers[requestContext.connectionId]) {
-    return Bluebird.reject(new NotFoundError(`The user with connection ${requestContext.connectionId} doesn't exist`));
-  }
+    for (const channel of Object.keys(this.rooms[roomId].channels)) {
+      this.kuzzle.entryPoints.proxy.leaveChannel({channel, connectionId: requestContext.connectionId});
+      this.kuzzle.pluginsManager.trigger('proxy:leaveChannel', {channel, connectionId: requestContext.connectionId});
+    }
 
-  if (this.customers[requestContext.connectionId][roomId] === undefined) {
-    return Bluebird.reject(new NotFoundError(`The user with connectionId ${requestContext.connectionId} doesn't listen the room ${roomId}`));
-  }
+    if (room.customers.size === 0) {
+      delete this.rooms[roomId];
+      this._removeRoomFromDsl(roomId);
+    }
 
-  Object.keys(this.rooms[roomId].channels).forEach(channel => {
-    this.kuzzle.entryPoints.proxy.leaveChannel({channel, connectionId: requestContext.connectionId});
-    this.kuzzle.pluginsManager.trigger('proxy:leaveChannel', {channel, connectionId: requestContext.connectionId});
-  });
-
-  this.rooms[roomId].customers.splice(this.rooms[roomId].customers.indexOf(requestContext.connectionId), 1);
-
-  return cleanUpRooms.call(this, roomId)
-    .then(() => {
-      const count = this.rooms[roomId] ? this.rooms[roomId].customers.length : 0;
+    {
+      const count = room.customers.size;
 
       if (count > 0) {
         const request = new Request({
           controller: 'realtime',
           action: 'unsubscribe',
-          index: this.rooms[roomId].index,
-          collection: this.rooms[roomId].collection,
-          volatile: this.customers[requestContext.connectionId][roomId]
+          index: room.index,
+          collection: room.collection,
+          volatile
         }, requestContext);
 
         this.kuzzle.notifier.notify([roomId], request, {count});
       }
 
-      if (Object.keys(this.customers[requestContext.connectionId]).length > 1) {
-        delete this.customers[requestContext.connectionId][roomId];
-      } else {
-        delete this.customers[requestContext.connectionId];
-      }
-
       return roomId;
-    });
-}
+    }
+  }
 
-/**
- * Remove a roomId for all customers (allow to delete a room everywhere)
- *
- * @this HotelClerk
- * @param roomId
- * @returns {Promise} resolve nothing
- */
-function removeRoomForAllCustomers (roomId) {
-  Object.keys(this.customers).forEach(customerId => {
-    Object.keys(this.customers[customerId]).forEach(customerRoomId => {
-      if (customerRoomId === roomId) {
-        delete this.customers[customerId][customerRoomId];
-      }
-    });
-  });
+  /**
+   * Delete room if no user has subscribed to it, and remove it also from the DSL
+   *
+   * @this HotelClerk
+   * @param {string} roomId
+   */
+  _removeRoomFromDsl (roomId) {
+    this.kuzzle.pluginsManager.trigger('room:remove', roomId);
+    this.kuzzle.dsl.remove(roomId);
+  }
 
-  return Bluebird.resolve();
-}
+  /**
+   * subscribe the user to an existing room.
+   *
+   * @this HotelClerk
+   * @param {string} roomId
+   * @param {Request} request
+   * @returns {Object}
+   */
+  _subscribeToRoom (roomId, request) {
+    const channel = this._createChannelConfiguration(request);
 
-/** MANAGE FILTERS TREE **/
+    let changed = false;
+    const
+      channelName = `${roomId}-${this.kuzzle.constructor.hash(channel)}`,
+      diff = {hcR: {
+        i: request.input.resource.index,
+        c: request.input.resource.collection,
+        ch: [ channelName, channel ],
+        r: roomId,
+        cx: {i: request.context.connectionId, p: request.context.protocol},
+        m: request.input.volatile
+      }};
 
-/**
- * subscribe the user to an existing room.
- *
- * @this HotelClerk
- * @param {string} roomId
- * @param {Request} request
- * @returns {Promise<Object>}
- */
-function subscribeToRoom (roomId, request) {
-  return createChannelConfiguration(request)
-    .then(channel => {
-      let changed = false;
-      const
-        channelName = `${roomId}-${this.kuzzle.constructor.hash(channel)}`,
-        diff = {hcR: {
-          i: request.input.resource.index,
-          c: request.input.resource.collection,
-          ch: [ channelName, channel ],
-          r: roomId,
-          cx: {i: request.context.connectionId, p: request.context.protocol},
-          m: request.input.volatile
-        }};
+    if (!this.customers[request.context.connectionId] || this.customers[request.context.connectionId][roomId] === undefined) {
+      changed = true;
+      this._addRoomForCustomer(request, roomId, request.input.volatile);
+      this.kuzzle.notifier.notify([roomId], request, {count: this.rooms[roomId].customers.length});
+    }
 
-      if (!this.customers[request.context.connectionId] || this.customers[request.context.connectionId][roomId] === undefined) {
-        changed = true;
-        addRoomForCustomer.call(this, request, roomId, request.input.volatile);
-        this.kuzzle.notifier.notify([roomId], request, {count: this.rooms[roomId].customers.length});
-      }
+    this.kuzzle.entryPoints.proxy.joinChannel({channel: channelName, connectionId: request.context.connectionId});
+    this.kuzzle.pluginsManager.trigger('proxy:joinChannel', {channel: channelName, connectionId: request.context.connectionId});
+    if (!this.rooms[roomId].channels[channelName]) {
+      changed = true;
+      this.rooms[roomId].channels[channelName] = channel;
+    }
 
-      this.kuzzle.entryPoints.proxy.joinChannel({channel: channelName, connectionId: request.context.connectionId});
-      this.kuzzle.pluginsManager.trigger('proxy:joinChannel', {channel: channelName, connectionId: request.context.connectionId});
-      if (!this.rooms[roomId].channels[channelName]) {
-        changed = true;
-        this.rooms[roomId].channels[channelName] = channel;
-      }
-
-      return {diff: changed && diff, data: {roomId, channel: channelName}};
-    });
+    return {diff: changed && diff, data: {roomId, channel: channelName}};
+  }
 }
 
 module.exports = HotelClerk;

--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -231,7 +231,6 @@ class HotelClerk {
   /**
    * This function will delete a user from this.customers, and
    * decrement the subscribers count in all rooms where he has subscribed to
-   * Call the cleanUpRooms function to manage empty rooms
    * Usually called on a user disconnection event
    *
    * @param {RequestContext} requestContext

--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -169,7 +169,7 @@ class HotelClerk {
     const roomId = request.input.body.roomId;
 
     if (!this.rooms[roomId]) {
-      throw new NotFoundError('No room found for id ' + roomId);
+      throw new NotFoundError(`The room id "${roomId}" does not exist`);
     }
 
     const response = this._subscribeToRoom(roomId, request);
@@ -316,34 +316,25 @@ class HotelClerk {
    * Create a channel object and resolve it
    *
    * @param {Request} request
-   * @return {Promise<NotificationObject>}
+   * @return {NotificationObject}
    */
   _createChannelConfiguration (request) {
     const channel = {};
 
     if (request.input.args.state && ['all', 'done', 'pending'].indexOf(request.input.args.state) === -1) {
       throw new BadRequestError('Incorrect value for the "state" parameter. Expected: all, done or pending. Got: ' + request.input.args.state);
-    } else if (!request.input.args.state) {
-      channel.state = 'done';
-    } else {
-      channel.state = request.input.args.state;
     }
+    channel.state = request.input.args.state || 'done';
 
     if (request.input.args.scope && ['all', 'in', 'out', 'none'].indexOf(request.input.args.scope) === -1) {
       throw new BadRequestError('Incorrect value for the "scope" parameter. Expected: all, in, out or none. Got: ' + request.input.args.scope);
-    } else if (!request.input.args.scope) {
-      channel.scope = 'all';
-    } else {
-      channel.scope = request.input.args.scope;
     }
+    channel.scope = request.input.args.scope || 'all';
 
     if (request.input.args.users && ['all', 'in', 'out', 'none'].indexOf(request.input.args.users) === -1) {
       throw new BadRequestError('Incorrect value for the "users" parameter. Expected: all, in, out or none. Got: ' + request.input.args.users);
-    } else if (!request.input.args.users) {
-      channel.users = 'none';
-    } else {
-      channel.users = request.input.args.users;
     }
+    channel.users = request.input.args.users || 'none';
 
     return channel;
   }

--- a/lib/api/core/models/security/user.js
+++ b/lib/api/core/models/security/user.js
@@ -19,6 +19,8 @@
  * limitations under the License.
  */
 
+'use strict';
+
 const
   Policies = require('./policies'),
   Bluebird = require('bluebird'),

--- a/lib/api/dsl/storage/index.js
+++ b/lib/api/dsl/storage/index.js
@@ -225,7 +225,6 @@ class Storage {
   /**
    * Remove a filter ID from the storage
    * @param {string} filterId
-   * @return {Promise<*>}
    */
   remove (filterId) {
     if (!this.filters[filterId]) {

--- a/lib/api/dsl/storage/index.js
+++ b/lib/api/dsl/storage/index.js
@@ -22,7 +22,6 @@
 'use strict';
 
 const
-  Bluebird = require('bluebird'),
   NotFoundError = require('kuzzle-common-objects').errors.NotFoundError,
   OperandsStorage = require('./storeOperands'),
   OperandsRemoval = require('./removeOperands'),
@@ -230,16 +229,16 @@ class Storage {
    */
   remove (filterId) {
     if (!this.filters[filterId]) {
-      return Bluebird.reject(new NotFoundError(`Unable to remove filter "${filterId}": filter not found`));
+      throw new NotFoundError(`Unable to remove filter "${filterId}": filter not found`);
     }
 
     const {index, collection} = this.filters[filterId];
 
     this._removeFromTestTables(index, collection, this.filters[filterId]);
 
-    this.filters[filterId].subfilters.forEach(subfilter => {
+    for (const subfilter of this.filters[filterId].subfilters) {
       if (subfilter.filters.length === 1) {
-        subfilter.conditions.forEach(condition => {
+        for (const condition of subfilter.conditions) {
           this.removeOperand[condition.keyword](this.foPairs, index, collection, subfilter, condition);
 
           if (condition.subfilters.length === 1) {
@@ -248,14 +247,14 @@ class Storage {
           else {
             condition.subfilters.splice(condition.subfilters.indexOf(subfilter), 1);
           }
-        });
+        }
 
         Storage.destroy(this.subfilters, index, collection, subfilter.id);
       }
       else {
         subfilter.filters.splice(subfilter.filters.indexOf(this.filters[filterId]), 1);
       }
-    });
+    }
 
     if (this.filtersIndex[index][collection].length === 1) {
       if (containsOne(this.filtersIndex[index])) {
@@ -270,8 +269,6 @@ class Storage {
     }
 
     delete this.filters[filterId];
-
-    return Bluebird.resolve();
   }
 
   /**
@@ -477,22 +474,22 @@ class Storage {
    */
   _reindexTestTable (index, collection) {
     /*
-     * Since the reindexation has been triggered, the test table might have been
+     * Since the reindexation has been triggered, the test table &/|| filters might have been
      * destroyed
      */
     if (!this.testTables[index] || !this.testTables[index][collection] || !this.testTables[index][collection].reindexing) {
       return;
     }
-
-    const tt = this.testTables[index][collection];
-
-    /*
-     * If there is a huge increase in new subscriptions, we should postpone the
-     * reindexation to a later time.
-     */
-    if (tt.removedConditions.array.length < tt.clength / 10) {
+    if (!this.filtersIndex[index]) {
+      delete this.testTables[index];
       return;
     }
+    if (!this.filtersIndex[index][collection]) {
+      delete this.testTables[index][collection];
+      return;
+    }
+
+    const tt = this.testTables[index][collection];
 
     // rebuild conditions index
     {
@@ -517,7 +514,7 @@ class Storage {
     // rebuild filter index pointers
     if (tt.removedFiltersCount) {
       let i; // perf cf https://jsperf.com/bvidis-for-oddities - NOSONAR
-      for (i = 0; i < Object.keys(this.filtersIndex[index][collection]).length; i++) {
+      for (i = 0; i < this.filtersIndex[index][collection].length; i++) {
         const
           filterId = this.filtersIndex[index][collection][i],
           filter = this.filters[filterId];
@@ -527,7 +524,7 @@ class Storage {
     }
 
     // updates the test table indicators
-    tt.filtersCount = Object.keys(this.filtersIndex[index][collection]).length;
+    tt.filtersCount = this.filtersIndex[index][collection].length;
     tt.removedFilters = {};
     tt.removedFiltersCount = 0;
     tt.removedConditions.array = [];

--- a/test/api/controllers/collectionController.test.js
+++ b/test/api/controllers/collectionController.test.js
@@ -414,11 +414,7 @@ describe('Test: collection controller', () => {
   describe('#list', () => {
     beforeEach(() => {
       kuzzle.services.list.storageEngine.listCollections.returns(Promise.resolve({collections: {stored: ['foo']}}));
-      kuzzle.hotelClerk.getRealtimeCollections.returns([
-        {name: 'foo', index: 'index'},
-        {name: 'bar', index: 'index'},
-        {name: 'baz', index: 'wrong'}
-      ]);
+      kuzzle.hotelClerk.getRealtimeCollections.returns(['foo', 'bar']);
     });
 
     it('should resolve to a full collections list', () => {
@@ -470,9 +466,7 @@ describe('Test: collection controller', () => {
     it('should return a portion of the collection list if from and size are specified', () => {
       request = new Request({index: 'index', type: 'all', from: 2, size: 3});
       kuzzle.services.list.storageEngine.listCollections.returns(Promise.resolve({collections: {stored: ['astored', 'bstored', 'cstored', 'dstored', 'estored']}}));
-      kuzzle.hotelClerk.getRealtimeCollections.returns([
-        {name: 'arealtime', index: 'index'}, {name: 'brealtime', index: 'index'}, {name: 'crealtime', index: 'index'}, {name: 'drealtime', index: 'index'}, {name: 'erealtime', index: 'index'}, {name: 'baz', index: 'wrong'}
-      ]);
+      kuzzle.hotelClerk.getRealtimeCollections.returns(['arealtime', 'brealtime', 'crealtime', 'drealtime', 'erealtime']);
 
       return collectionController.list(request)
         .then(response => {
@@ -491,9 +485,7 @@ describe('Test: collection controller', () => {
     it('should return a portion of the collection list if from is specified', () => {
       request = new Request({index: 'index', type: 'all', from: 8});
       kuzzle.services.list.storageEngine.listCollections.returns(Promise.resolve({collections: {stored: ['astored', 'bstored', 'cstored', 'dstored', 'estored']}}));
-      kuzzle.hotelClerk.getRealtimeCollections.returns([
-        {name: 'arealtime', index: 'index'}, {name: 'brealtime', index: 'index'}, {name: 'crealtime', index: 'index'}, {name: 'drealtime', index: 'index'}, {name: 'erealtime', index: 'index'}, {name: 'baz', index: 'wrong'}
-      ]);
+      kuzzle.hotelClerk.getRealtimeCollections.returns(['arealtime', 'brealtime', 'crealtime', 'drealtime', 'erealtime']);
 
       return collectionController.list(request)
         .then(response => {
@@ -513,14 +505,7 @@ describe('Test: collection controller', () => {
       kuzzle.services.list.storageEngine.listCollections.returns(Promise.resolve({
         collections: {stored: ['astored', 'bstored', 'cstored', 'dstored', 'estored']}
       }));
-      kuzzle.hotelClerk.getRealtimeCollections.returns([
-        {name: 'arealtime', index: 'index'},
-        {name: 'brealtime', index: 'index'},
-        {name: 'crealtime', index: 'index'},
-        {name: 'drealtime', index: 'index'},
-        {name: 'erealtime', index: 'index'},
-        {name: 'baz', index: 'wrong'}
-      ]);
+      kuzzle.hotelClerk.getRealtimeCollections.returns(['arealtime', 'brealtime', 'crealtime', 'drealtime', 'erealtime']);
 
       return collectionController.list(request)
         .then(response => {

--- a/test/api/core/entryPoints/proxy.test.js
+++ b/test/api/core/entryPoints/proxy.test.js
@@ -1,7 +1,7 @@
 /**
  * This component initializes
  */
-var
+const
   should = require('should'),
   rewire = require('rewire'),
   sinon = require('sinon'),
@@ -12,7 +12,7 @@ var
   RequestContext = require('kuzzle-common-objects').models.RequestContext;
 
 describe('Test: entryPoints/proxy', () => {
-  var
+  let
     kuzzle,
     entryPoint;
 
@@ -93,7 +93,7 @@ describe('Test: entryPoints/proxy', () => {
   });
 
   it('should call the router removeConnection on event onDisconnect', () => {
-    var data = {data: {}, options: {connectionId: 'myId', protocol: 'socketio'}};
+    const data = {data: {}, options: {connectionId: 'myId', protocol: 'socketio'}};
 
     KuzzleProxy.__get__('onDisconnect').call(entryPoint, data);
 

--- a/test/api/core/hotelClerk/addSubscription.test.js
+++ b/test/api/core/hotelClerk/addSubscription.test.js
@@ -262,42 +262,6 @@ describe('Test: hotelClerk.addSubscription', () => {
     return should(kuzzle.hotelClerk.addSubscription(request)).be.fulfilled();
   });
 
-  it('should delay a room creation if it has been marked for destruction', done => {
-    var
-      request1 = new Request({
-        controller: 'realtime',
-        index: index,
-        collection: collection
-      }, context),
-      request2 = new Request({
-        controller: 'realtime',
-        index: index,
-        collection: collection
-      }, {connectionId: 'anotherID', user: null});
-
-    kuzzle.hotelClerk.addSubscription(request1)
-      .then(response => {
-        kuzzle.hotelClerk.rooms[response.roomId].destroyed = true;
-
-        kuzzle.hotelClerk.addSubscription(request2)
-          .then(recreated => {
-            should(recreated.roomId).be.exactly(response.roomId);
-            should(kuzzle.hotelClerk.rooms[recreated.roomId].destroyed).be.undefined();
-            should(kuzzle.hotelClerk.rooms[recreated.roomId].customers.length).be.exactly(1);
-            should(kuzzle.hotelClerk.rooms[recreated.roomId].customers).match(['anotherID']);
-            done();
-
-            return null;
-          })
-          .catch(error => done(error));
-
-        process.nextTick(() => delete kuzzle.hotelClerk.rooms[response.roomId]);
-
-        return null;
-      })
-      .catch(error => done(error));
-  });
-
   it('should allow to subscribe to an existing room', done => {
     var
       anotherRoomId,
@@ -354,7 +318,7 @@ describe('Test: hotelClerk.addSubscription', () => {
 
   });
 
-  it('#join should reject the promise if the room does not exist', () => {
+  it('#join should throw if the room does not exist', () => {
     const request = new Request({
       collection: collection,
       index: index,
@@ -363,8 +327,8 @@ describe('Test: hotelClerk.addSubscription', () => {
       body: {roomId: 'no way I can exist'}
     }, context);
 
-    return should(kuzzle.hotelClerk.join(request))
-      .be.rejectedWith(NotFoundError);
+    return should(() => kuzzle.hotelClerk.join(request))
+      .throw(NotFoundError);
   });
 
   it('should reject the subscription if the given state argument is incorrect', () => {

--- a/test/api/core/hotelClerk/countSubscription.test.js
+++ b/test/api/core/hotelClerk/countSubscription.test.js
@@ -15,15 +15,18 @@ describe('Test: hotelClerk.countSubscription', () => {
   it('should reject the request if the provided room ID is unknown to Kuzzle', () => {
     const request = new Request({body: {roomId: 'foobar'}});
 
-    return should(kuzzle.hotelClerk.countSubscription(request)).be.rejectedWith(NotFoundError, {message: 'The room Id "foobar" does not exist'});
+    return should(() => kuzzle.hotelClerk.countSubscription(request))
+      .throw(NotFoundError, {message: 'The room Id "foobar" does not exist'});
   });
 
   it('should return the right subscriptions count when handling a correct request', () => {
     const request = new Request({body: {roomId: 'foobar'}});
 
-    kuzzle.hotelClerk.rooms.foobar = {customers: ['foo', 'bar']};
+    kuzzle.hotelClerk.rooms.foobar = {customers: new Set(['foo', 'bar'])};
 
-    return kuzzle.hotelClerk.countSubscription(request)
-      .then(response => should(response.count).be.exactly(2));
+    const response = kuzzle.hotelClerk.countSubscription(request);
+
+    should(response.count)
+      .be.exactly(2);
   });
 });

--- a/test/api/core/hotelClerk/getRealtimeCollections.test.js
+++ b/test/api/core/hotelClerk/getRealtimeCollections.test.js
@@ -1,40 +1,41 @@
-var
+const
   should = require('should'),
-  Kuzzle = require('../../../../lib/api/kuzzle');
+  KuzzleMock = require('../../../mocks/kuzzle.mock'),
+  HotelClerck = require('../../../../lib/api/core/hotelClerk');
 
 describe('Test: hotelClerk.getRealtimeCollections', () => {
-  var
-    index = 'foo',
-    kuzzle;
+  let
+    kuzzle,
+    hotelClerk;
 
   beforeEach(() => {
-    kuzzle = new Kuzzle();
+    kuzzle = new KuzzleMock();
+    kuzzle.dsl.storage = {
+      filtersIndex: {}
+    };
+
+    hotelClerk = new HotelClerck(kuzzle);
   });
 
   it('should return an empty array if there is no subscription', () => {
-    should(kuzzle.hotelClerk.getRealtimeCollections()).be.an.Array().and.be.empty();
+    should(hotelClerk.getRealtimeCollections('index'))
+      .be.an.Array()
+      .and.be.empty();
   });
 
   it('should return an array of unique collection names', () => {
-    kuzzle.hotelClerk.rooms = {
-      foo: {
-        collection: 'foo',
-        index: index
+    kuzzle.dsl.storage.filtersIndex = {
+      index: {
+        foo: true,
+        bar: true,
       },
-      bar: {
-        collection: 'bar',
-        index: index
-      },
-      foobar: {
-        collection: 'foo',
-        index: index
-      },
-      barfoo: {
-        collection: 'barfoo',
-        index: index
+      anotherIndex: {
+        baz: true
       }
     };
 
-    should(kuzzle.hotelClerk.getRealtimeCollections()).be.an.Array().and.match([{name: 'foo', index: index}, {name: 'bar', index: index}, {name: 'barfoo', index: index}]);
+    const collections = hotelClerk.getRealtimeCollections('index');
+    should(collections)
+      .match(['foo', 'bar']);
   });
 });

--- a/test/api/core/hotelClerk/removeRoomForCustomer.test.js
+++ b/test/api/core/hotelClerk/removeRoomForCustomer.test.js
@@ -1,95 +1,78 @@
 const
-  Promise = require('bluebird'),
-  rewire = require('rewire'),
   sinon = require('sinon'),
   should = require('should'),
-  HotelClerk = rewire('../../../../lib/api/core/hotelClerk'),
+  Dsl = require('../../../../lib/api/dsl'),
+  HotelClerk = require('../../../../lib/api/core/hotelClerk'),
   KuzzleMock = require('../../../mocks/kuzzle.mock'),
   NotFoundError = require('kuzzle-common-objects').errors.NotFoundError,
   RequestContext = require('kuzzle-common-objects').models.RequestContext;
 
-describe ('lib/core/hotelclerck:removeRoomForCustomer', () => {
+describe ('lib/core/hotelclerk:removeRoomForCustomer', () => {
   let
-    context,
-    cleanUpRooms,       // eslint-disable-line no-unused-vars
-    removeRoomForCustomers,
     requestContext,
-    reset;
+    kuzzle,
+    hotelClerk;
 
   beforeEach(() => {
-    context = {
-      customers: {},
-      rooms: {
-        roomId: {
-          channels: {
-            ch1: true,
-            ch2: true
-          },
-          customers: ['connectionId']
-        }
-      },
-      kuzzle: new KuzzleMock()
-    };
+    kuzzle = new KuzzleMock();
+    kuzzle.dsl = new Dsl(kuzzle);
+    hotelClerk = new HotelClerk(kuzzle);
 
-    cleanUpRooms = sinon.stub().returns(Promise.resolve());
-    reset = HotelClerk.__set__({
-      cleanUpRooms
-    });
+    hotelClerk.customers = {};
+    hotelClerk.rooms = {
+      roomId: {
+        channels: {
+          ch1: true,
+          ch2: true
+        },
+        customers: new Set(['connectionId'])
+      }
+    };
+    hotelClerk._removeRoomFromDsl = sinon.spy();
 
     requestContext = new RequestContext({
       connectionId: 'connectionId',
       protocol: 'protocol'
     });
 
-    removeRoomForCustomers = HotelClerk.__get__('removeRoomForCustomer').bind(context);
   });
 
-  afterEach(() => {
-    reset();
+  it('should throw if the room cannot be found', () => {
+    return should(() => hotelClerk._removeRoomForCustomer(requestContext, 'idontexist'))
+      .throw(NotFoundError);
   });
 
-  it('should reject if the connection cannot be found', () => {
-    return should(removeRoomForCustomers(requestContext, 'roomId'))
-      .be.rejectedWith(NotFoundError);
-  });
-
-  it('should reject if the customer did not subscribe to the room', () => {
-    context.customers.connectionId = {};
-
-    return should(removeRoomForCustomers(requestContext, 'roomId'))
-      .be.rejectedWith(NotFoundError);
+  it('should process without error if the customer did not subscribe to the room', () => {
+    hotelClerk.customers.connectionId = {};
+    hotelClerk._removeRoomForCustomer(requestContext, 'roomId');
   });
 
   it('should remove the room from the customer list and remove the connection entry if empty', () => {
-    context.customers.connectionId = {roomId: null};
+    hotelClerk.customers.connectionId = {roomId: null};
 
-    return removeRoomForCustomers(requestContext, 'roomId', false)
-      .then(roomId => {
-        should(context.customers)
-          .be.empty();
+    const response = hotelClerk._removeRoomForCustomer(requestContext, 'roomId', false);
+    should(hotelClerk.customers)
+      .be.empty();
 
-        should(cleanUpRooms)
-          .be.calledOnce();
+    should(hotelClerk._removeRoomFromDsl)
+      .be.calledOnce()
+      .be.calledWith('roomId');
 
-        should(roomId)
-          .be.eql('roomId');
-      });
+    should(response)
+      .be.eql('roomId');
   });
 
   it('should remove the room from the customer list and keep other existing rooms', () => {
-    context.customers.connectionId = {
+    hotelClerk.customers.connectionId = {
       roomId: null,
       anotherRoom: null
     };
 
-    return removeRoomForCustomers(requestContext, 'roomId', false)
-      .then(() => {
-        should(context.customers.connectionId)
-          .eql({
-            anotherRoom: null
-          });
+    hotelClerk._removeRoomForCustomer(requestContext, 'roomId', false);
+    should(hotelClerk.customers.connectionId)
+      .eql({
+        anotherRoom: null
       });
-
   });
 
 });

--- a/test/api/core/hotelClerk/removeRooms.test.js
+++ b/test/api/core/hotelClerk/removeRooms.test.js
@@ -51,7 +51,8 @@ describe('Test: hotelClerk.removeRooms', () => {
       body: {}
     }, context);
 
-    return should(kuzzle.hotelClerk.removeRooms(request)).rejectedWith(NotFoundError);
+    return should(() => kuzzle.hotelClerk.removeRooms(request))
+      .throw(NotFoundError);
   });
 
   it('should reject an error if there is no subscription on this collection', () => {
@@ -73,7 +74,8 @@ describe('Test: hotelClerk.removeRooms', () => {
 
     return kuzzle.hotelClerk.addSubscription(subscribeRequest)
       .then(() => {
-        return should(kuzzle.hotelClerk.removeRooms(removeRequest)).rejectedWith(NotFoundError);
+        return should(() => kuzzle.hotelClerk.removeRooms(removeRequest))
+          .throw(NotFoundError);
       });
   });
 
@@ -95,10 +97,10 @@ describe('Test: hotelClerk.removeRooms', () => {
       }, context);
 
     return kuzzle.hotelClerk.addSubscription(subscribeRequest)
-      .then(() => kuzzle.hotelClerk.removeRooms(removeRequest))
-      .then(response => {
-        should(response).have.property('acknowledge');
-        should(response.acknowledge).be.true();
+      .then(() => {
+        const response = kuzzle.hotelClerk.removeRooms(removeRequest);
+        should(response).have.property('acknowledged');
+        should(response.acknowledged).be.true();
 
         should(kuzzle.hotelClerk.rooms).be.empty().Object();
       });
@@ -124,8 +126,8 @@ describe('Test: hotelClerk.removeRooms', () => {
     return kuzzle.hotelClerk.addSubscription(subscribeRequest)
       .then(() => kuzzle.hotelClerk.removeRooms(removeRequest))
       .then(response => {
-        should(response).have.property('acknowledge');
-        should(response.acknowledge).be.true();
+        should(response).have.property('acknowledged');
+        should(response.acknowledged).be.true();
 
         should(kuzzle.hotelClerk.rooms).be.empty().Object();
       });
@@ -157,10 +159,10 @@ describe('Test: hotelClerk.removeRooms', () => {
 
     return kuzzle.hotelClerk.addSubscription(globalSubscribeRequest)
       .then(() => kuzzle.hotelClerk.addSubscription(filterSubscribeRequest))
-      .then(() => kuzzle.hotelClerk.removeRooms(removeRequest))
-      .then(response => {
-        should(response).have.property('acknowledge');
-        should(response.acknowledge).be.true();
+      .then(() => {
+        const response = kuzzle.hotelClerk.removeRooms(removeRequest);
+        should(response).have.property('acknowledged');
+        should(response.acknowledged).be.true();
 
         should(kuzzle.hotelClerk.rooms).be.empty().Object();
       });
@@ -194,15 +196,15 @@ describe('Test: hotelClerk.removeRooms', () => {
       .then(() => kuzzle.hotelClerk.addSubscription(subscribeCollection2))
       .then(() => kuzzle.hotelClerk.removeRooms(removeRequest))
       .then(response => {
-        should(response).have.property('acknowledge');
-        should(response.acknowledge).be.true();
+        should(response).have.property('acknowledged');
+        should(response.acknowledged).be.true();
 
         should(kuzzle.hotelClerk.rooms).be.Object();
         should(Object.keys(kuzzle.hotelClerk.rooms).length).be.exactly(1);
       });
   });
 
-  it('should reject an error if room is provided but is not an array', () => {
+  it('should throw if room is provided but is not an array', () => {
     const
       subscribeCollection1 = new Request({
         controller: 'realtime',
@@ -221,7 +223,8 @@ describe('Test: hotelClerk.removeRooms', () => {
 
     return kuzzle.hotelClerk.addSubscription(subscribeCollection1)
       .then(() => {
-        return should(kuzzle.hotelClerk.removeRooms(removeRequest)).be.rejectedWith(BadRequestError);
+        return should(() => kuzzle.hotelClerk.removeRooms(removeRequest))
+          .throw(BadRequestError);
       });
   });
 
@@ -293,10 +296,10 @@ describe('Test: hotelClerk.removeRooms', () => {
       .then(result => {
         index2RoomName = result.roomId;
         removeRequest.input.body.rooms.push(index2RoomName);
-        return kuzzle.hotelClerk.removeRooms(removeRequest);
-      })
-      .then((response) => {
-        should(response.acknowledge).be.true();
+
+        const response = kuzzle.hotelClerk.removeRooms(removeRequest);
+
+        should(response.acknowledged).be.true();
         should(response.partialErrors.length).be.exactly(1);
         should(response.partialErrors).be.an.Array().and.match([`The room ${index2RoomName} does not match index ${index}`]);
       });
@@ -332,10 +335,9 @@ describe('Test: hotelClerk.removeRooms', () => {
       .then(result => {
         collection2RoomName = result.roomId;
         removeRequest.input.body.rooms.push(collection2RoomName);
-        return kuzzle.hotelClerk.removeRooms(removeRequest);
-      })
-      .then((response) => {
-        should(response.acknowledge).be.true();
+
+        const response = kuzzle.hotelClerk.removeRooms(removeRequest);
+        should(response.acknowledged).be.true();
         should(response.partialErrors.length).be.exactly(1);
         should(response.partialErrors).be.an.Array().and.match([`The room ${collection2RoomName} does not match collection ${collection1}`]);
       });
@@ -360,9 +362,9 @@ describe('Test: hotelClerk.removeRooms', () => {
       }, context);
 
     return kuzzle.hotelClerk.addSubscription(subscribeRequest, context)
-      .then(() => kuzzle.hotelClerk.removeRooms(removeRequest))
-      .then(response => {
-        should(response.acknowledge).be.true();
+      .then(() => {
+        const response = kuzzle.hotelClerk.removeRooms(removeRequest);
+        should(response.acknowledged).be.true();
         should(response.partialErrors.length).be.exactly(1);
         should(response.partialErrors).be.an.Array().and.match(['No room with id ' + badRoomName]);
       });

--- a/test/api/core/hotelClerk/removeSubscription.test.js
+++ b/test/api/core/hotelClerk/removeSubscription.test.js
@@ -1,6 +1,5 @@
-var
+const
   should = require('should'),
-  Promise = require('bluebird'),
   sinon = require('sinon'),
   sandbox = sinon.sandbox.create(),
   Request = require('kuzzle-common-objects').Request,
@@ -10,7 +9,7 @@ var
   KuzzleMock = require('../../../mocks/kuzzle.mock');
 
 describe('Test: hotelClerk.removeSubscription', () => {
-  var
+  let
     kuzzle,
     connectionId = 'connectionid',
     context = {
@@ -42,13 +41,13 @@ describe('Test: hotelClerk.removeSubscription', () => {
 
     kuzzle.hotelClerk.rooms = {
       'foo': {
-        customers: [connectionId],
+        customers: new Set([connectionId]),
         index,
         collection,
         channels: ['foobar']
       },
       'bar': {
-        customers: [connectionId],
+        customers: new Set([connectionId]),
         index,
         collection,
         channels: ['barfoo']
@@ -63,87 +62,90 @@ describe('Test: hotelClerk.removeSubscription', () => {
 
   it('should do nothing if a bad room name is given', () => {
     unsubscribeRequest.input.body.roomId = 'qux';
-    return should(kuzzle.hotelClerk.removeSubscription(unsubscribeRequest)).be.rejectedWith(NotFoundError);
+    return should(() => kuzzle.hotelClerk.removeSubscription(unsubscribeRequest))
+      .throw(NotFoundError);
   });
 
   it('should not delete all subscriptions when we want to just remove one', () => {
-    var mock = sandbox.mock(kuzzle.dsl).expects('remove').once().returns(Promise.resolve());
+    kuzzle.dsl.remove = sinon.stub();
+    const response = kuzzle.hotelClerk.removeSubscription(unsubscribeRequest, context);
+    should(response)
+      .be.exactly(unsubscribeRequest.input.body.roomId);
 
-    return kuzzle.hotelClerk.removeSubscription(unsubscribeRequest, context)
-      .finally(() => {
-        mock.verify();
-        should(kuzzle.notifier.notify.called).be.false();
+    should(kuzzle.dsl.remove)
+      .be.calledOnce();
 
-        should(kuzzle.hotelClerk.rooms).be.an.Object();
-        should(kuzzle.hotelClerk.rooms).have.property('bar');
-        should(kuzzle.hotelClerk.rooms).not.have.property('foo');
+    should(kuzzle.notifier.notify.called).be.false();
 
-        should(kuzzle.hotelClerk.customers).be.an.Object();
-        should(kuzzle.hotelClerk.customers).not.be.empty();
-      });
+    should(kuzzle.hotelClerk.rooms).be.an.Object();
+    should(kuzzle.hotelClerk.rooms).have.property('bar');
+    should(kuzzle.hotelClerk.rooms).not.have.property('foo');
+
+    should(kuzzle.hotelClerk.customers).be.an.Object();
+    should(kuzzle.hotelClerk.customers).not.be.empty();
   });
 
   it('should clean up customers, rooms object', () => {
-    var mock = sandbox.mock(kuzzle.dsl).expects('remove').once().returns(Promise.resolve());
+    kuzzle.dsl.remove = sinon.stub();
 
     delete kuzzle.hotelClerk.rooms.bar;
     delete kuzzle.hotelClerk.customers[connectionId].bar;
 
-    return kuzzle.hotelClerk.removeSubscription(unsubscribeRequest, context)
-      .finally(() => {
-        mock.verify();
-        should(kuzzle.notifier.notify.called).be.false();
+    const response = kuzzle.hotelClerk.removeSubscription(unsubscribeRequest, context);
+    should(response)
+      .be.exactly(unsubscribeRequest.input.body.roomId);
 
-        should(kuzzle.hotelClerk.rooms).be.an.Object();
-        should(kuzzle.hotelClerk.rooms).be.empty();
+    should(kuzzle.dsl.remove)
+      .be.calledOnce()
+      .be.calledWith(unsubscribeRequest.input.body.roomId);
 
-        should(kuzzle.hotelClerk.customers).be.an.Object();
-        should(kuzzle.hotelClerk.customers).be.empty();
-      });
+    should(kuzzle.notifier.notify.called).be.false();
+
+    should(kuzzle.hotelClerk.rooms).be.an.Object();
+    should(kuzzle.hotelClerk.rooms).be.empty();
+
+    should(kuzzle.hotelClerk.customers).be.an.Object();
+    should(kuzzle.hotelClerk.customers).be.empty();
   });
 
   it('should send a notification to other users connected on that room', () => {
-    var
-      mockDsl = sandbox.mock(kuzzle.dsl).expects('remove').never();
+    kuzzle.dsl.remove = sinon.spy();
 
-    kuzzle.hotelClerk.rooms.foo.customers.push('another connection');
+    kuzzle.hotelClerk.rooms.foo.customers.add('another connection');
+    kuzzle.hotelClerk.removeSubscription(unsubscribeRequest, context);
 
-    return kuzzle.hotelClerk.removeSubscription(unsubscribeRequest, context)
-      .finally(() => {
-        mockDsl.verify();
+    should(kuzzle.dsl.remove)
+      .have.callCount(0);
 
-        should(kuzzle.notifier.notify)
-          .be.calledOnce();
+    should(kuzzle.notifier.notify)
+      .be.calledOnce();
 
-        // testing roomId argument
-        should(kuzzle.notifier.notify.args[0][0]).match(['foo']);
+    // testing roomId argument
+    should(kuzzle.notifier.notify.args[0][0]).match(['foo']);
 
-        // testing requestObject argument
-        should(kuzzle.notifier.notify.args[0][1]).be.instanceOf(Request);
-        should(kuzzle.notifier.notify.args[0][1].input.controller).be.exactly('realtime');
-        should(kuzzle.notifier.notify.args[0][1].input.action).be.exactly('unsubscribe');
-        should(kuzzle.notifier.notify.args[0][1].input.resource.index).be.exactly(index);
+    // testing requestObject argument
+    should(kuzzle.notifier.notify.args[0][1]).be.instanceOf(Request);
+    should(kuzzle.notifier.notify.args[0][1].input.controller).be.exactly('realtime');
+    should(kuzzle.notifier.notify.args[0][1].input.action).be.exactly('unsubscribe');
+    should(kuzzle.notifier.notify.args[0][1].input.resource.index).be.exactly(index);
 
-        // testing payload argument
-        should(kuzzle.notifier.notify.args[0][2].count).be.exactly(1);
-      });
+    // testing payload argument
+    should(kuzzle.notifier.notify.args[0][2].count).be.exactly(1);
   });
 
   it('should trigger a proxy:leaveChannel hook', function () {
-    sandbox.stub(kuzzle.dsl, 'remove').returns(Promise.resolve());
+    kuzzle.dsl.remove = sinon.stub();
 
-    return kuzzle.hotelClerk.removeSubscription(unsubscribeRequest, context)
-      .then(() => {
-        var data;
+    kuzzle.hotelClerk.removeSubscription(unsubscribeRequest, context);
 
-        should(kuzzle.pluginsManager.trigger)
-          .be.calledWith('proxy:leaveChannel');
+    should(kuzzle.pluginsManager.trigger)
+      .be.calledWith('proxy:leaveChannel');
 
-        data = kuzzle.pluginsManager.trigger.secondCall.args[1];
+    const data = kuzzle.pluginsManager.trigger.secondCall.args[1];
 
-        should(data).be.an.Object();
-        should(data.channel).be.a.String();
-        should(data.connectionId).be.eql(context.connectionId);
-      });
+    should(data).be.an.Object();
+    should(data.channel).be.a.String();
+    should(data.connectionId).be.eql(context.connectionId);
   });
+
 });

--- a/test/api/dsl/dslApi.test.js
+++ b/test/api/dsl/dslApi.test.js
@@ -169,7 +169,8 @@ describe('DSL API', () => {
 
   describe('#remove', () => {
     it('should reject if the filter ID does not exist', () => {
-      return should(dsl.remove('foo')).be.rejectedWith(NotFoundError);
+      return should(() => dsl.remove('foo'))
+        .throw(NotFoundError);
     });
 
     it('should unsubscribe a filter from a multi-filter subfilter', () => {

--- a/test/api/dsl/keywords/notgeospatial.test.js
+++ b/test/api/dsl/keywords/notgeospatial.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var
+const
   should = require('should'),
   SortedArray = require('sorted-array'),
   FieldOperand = require('../../../../lib/api/dsl/storage/objects/fieldOperand'),
@@ -200,10 +200,8 @@ describe('DSL.keyword.notgeospatial', () => {
     });
 
     it('should destroy the whole structure when removing the last item', () => {
-      return dsl.remove(filterId)
-        .then(() => {
-          should(dsl.storage.foPairs).be.an.Object().and.be.empty();
-        });
+      dsl.remove(filterId);
+      should(dsl.storage.foPairs).be.an.Object().and.be.empty();
     });
 
     it('should remove a single subfilter from a multi-filter condition', () => {

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -210,7 +210,9 @@ class KuzzleMock extends Kuzzle {
         },
         proxyBroker: {
           listen: sinon.spy(),
-          send: sinon.stub().returns(Bluebird.resolve())
+          onConnectHandlers: [],
+          send: sinon.stub().returns(Bluebird.resolve()),
+
         },
         gc: {
           init: sinon.spy(),


### PR DESCRIPTION
:warning: **To merge only with [its proxy counterpart](https://github.com/kuzzleio/kuzzle-proxy/pull/79)**

# Description

This PR fixes several situations where some unhandled exceptions could be sent by Kuzzle when clients disconnect.
It also tries to improve the consistency of Kuzzle internal state after some disconnections occur

# Related issue

* #836 

## Implementation

### proxy

connection with Proxy: The proxy now waits for Kuzzle to emit a `ready` event before sending the active client connections. On Kuzzle side, unknown connection requests are discarded. This to prevent situations where a `join` or a `subscribe` could be accepted after the client disconnects itself.

### hotelclerk

* do not block on error during multiple rooms removal to improve the consistency of kuzzle internal state
* transform as many possible promises into synchronous methods when possible