### PR TITLE
Re-add HTTP GET route for user login

### DIFF
--- a/features/support/apiRT.js
+++ b/features/support/apiRT.js
@@ -589,10 +589,10 @@ ApiRT.prototype.login = function (strategy, credentials) {
       controller: 'auth',
       action: 'login',
       strategy: strategy,
+      expiresIn: credentials.expiresIn,
       body: {
         username: credentials.username,
-        password: credentials.password,
-        expiresIn: credentials.expiresIn
+        password: credentials.password
       }
     };
 

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -26,16 +26,14 @@ const
   _ = require('lodash'),
   Token = require('../core/models/security/token'),
   formatProcessing = require('../core/auth/formatProcessing'),
-  {
-    InternalError: KuzzleInternalError,
-    BadRequestError
-  } = require('kuzzle-common-objects').errors,
+  KuzzleInternalError = require('kuzzle-common-objects').errors.InternalError,
   {
     assertIsStrategyRegistered,
     assertIsConnected,
     assertHasBody,
     assertHasStrategy,
     assertBodyHasNotAttribute,
+    assertArgsHasAttribute,
     assertBodyHasAttribute
   } = require('../../util/requestAssertions');
 
@@ -76,20 +74,16 @@ class AuthController {
    * @returns {Promise<Token>}
    */
   login(request) {
-    assertHasBody(request);
-
-    if (!request.input.args.strategy) {
-      throw new BadRequestError('No strategy specified');
-    }
+    assertArgsHasAttribute(request, 'strategy');
 
     const strategy = request.input.args.strategy;
 
-    return this.kuzzle.passport.authenticate({query: request.input.body, original: request}, strategy)
+    return this.kuzzle.passport.authenticate({body: request.input.body, query: request.input.args}, strategy)
       .then(userObject => {
         const options = {};
         if (!userObject.headers) {
-          if (request.input.body.expiresIn) {
-            options.expiresIn = request.input.body.expiresIn;
+          if (request.input.args.expiresIn) {
+            options.expiresIn = request.input.args.expiresIn;
           }
           return this.kuzzle.repositories.token.generateToken(userObject, request, options);
         }

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -78,7 +78,7 @@ class AuthController {
 
     const strategy = request.input.args.strategy;
 
-    return this.kuzzle.passport.authenticate({body: request.input.body, query: request.input.args}, strategy)
+    return this.kuzzle.passport.authenticate({body: request.input.body, query: request.input.args, original: request}, strategy)
       .then(userObject => {
         const options = {};
         if (!userObject.headers) {

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -27,6 +27,9 @@ module.exports = [
   {verb: 'get', url: '/users/_me/_rights', controller: 'auth', action: 'getMyRights'},
   {verb: 'get', url: '/strategies', controller: 'auth', action: 'getStrategies'},
 
+  // We need to expose a GET method for "login" action in order to make authentication protocol like Oauth2 or CAS work:
+  {verb: 'get', url: '/_login/:strategy', controller: 'auth', action: 'login'},
+
   {verb: 'get', url: '/:index/:collection/_exists', controller: 'collection', action: 'exists'},
   {verb: 'get', url: '/:index/:collection/_mapping', controller: 'collection', action: 'getMapping'},
   {verb: 'get', url: '/:index/:collection/_specifications', controller: 'collection', action: 'getSpecifications'},

--- a/lib/util/requestAssertions.js
+++ b/lib/util/requestAssertions.js
@@ -45,6 +45,17 @@ module.exports = {
   },
 
   /**
+   *
+   * @param {Request} request
+   * @param {string} attribute
+   */
+  assertArgsHasAttribute: (request, attribute) => {
+    if (!request.input.args || !request.input.args.hasOwnProperty(attribute)) {
+      throw new BadRequestError(`The request must specify an attribute "${attribute}".`);
+    }
+  },
+
+  /**
    * @param {Request} request
    * @param {string} attribute
    */

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -30,7 +30,8 @@ describe('Test the auth controller', () => {
       strategy: 'mockup',
       body: {
         username: 'jdoe'
-      }
+      },
+      foo: 'bar'
     });
 
     authController = new AuthController(kuzzle);
@@ -62,6 +63,12 @@ describe('Test the auth controller', () => {
         });
     });
 
+    it('should call passport.authenticate with input body and query string', () => {
+      authController.login(request);
+      should(kuzzle.passport.authenticate).be.calledOnce();
+      should(kuzzle.passport.authenticate).be.calledWithMatch({body: {username: 'jdoe'}, query: {foo: 'bar'}});
+    });
+
     it('should throw if no strategy is specified', () => {
       delete request.input.args.strategy;
 
@@ -78,7 +85,7 @@ describe('Test the auth controller', () => {
 
       kuzzle.repositories.token.generateToken.returns(Bluebird.resolve(token));
 
-      request.input.body.expiresIn = '1s';
+      request.input.args.expiresIn = '1s';
 
       return authController.login(request)
         .then(response => {


### PR DESCRIPTION
\+ inject both request body and query string into passport.authenticate arguments.

(So that strategies like OAuth or CAS can handle authentication queries with a GET request and arguments coming from the query string)

Refs #831 

**Breaking change**
The `expiresIn` attribute is now moved from `input.body` to `input.args`
That means:

* HTTP requests will now look like:
```
POST http://kuzzle:7512/_login/local?expiresIn=1h
{
  "username": "jdoe",
  "password": "foobar"
}
```

* Other protocols request will look like:
```javascript
{
  controller: 'auth',
  action: 'login',
  strategy: 'local',
  expiresIn: '1h',
  body: {
    username:  'jdoe',
    password: 'foobar'
  }
}
```
