### PR TITLE
document:deleteByQuery and collection:truncate should only delete live documents

### DIFF
--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -530,7 +530,7 @@ class ElasticSearch extends Service {
   }
 
   /**
-   * Delete all document that match the given filter
+   * Delete all documents matching the provided filters
    *
    * @param {Request} request
    * @returns {Promise} resolve an object with ids

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -550,7 +550,7 @@ class ElasticSearch extends Service {
       return Bluebird.reject(new BadRequestError('Query cannot be empty'));
     }
 
-    return getAllIdsFromQuery(this.client, esRequestSearch)
+    return getAllIdsFromQuery(this.client, addActiveFilter(esRequestSearch))
       .then(ids => {
         ids.forEach(id => {
           esRequestBulk.body.push({update: {_index: esRequestBulk.index, _type: esRequestBulk.type, _id: id}});
@@ -1065,7 +1065,7 @@ function getIndex(request) {
  *
  * @param {object} client - elasticsearch client
  * @param {object} esRequest
- * @returns {Promise} resolve an array
+ * @returns {Promise} resolve to an array of documents IDs
  */
 function getAllIdsFromQuery(client, esRequest) {
   const ids = [];
@@ -1116,6 +1116,7 @@ function getPaginatedIdsFromQuery(client, data) {
 /**
  * Add filter to get only the active documents
  * @param {object} esRequest
+ * @return {object} modified filter
  */
 function addActiveFilter(esRequest) {
   const


### PR DESCRIPTION
# Description

Both the `collection:truncate` and `document:deleteByQuery` API calls were indiscriminately looking to delete live and deactivated documents in order to deactivate them.

This PR makes these API calls look for live documents only.

# Solved issue

#848 
