### PR TITLE
use native elasticsearch constructor options

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -349,22 +349,18 @@
     // [db]
     // The database layer is by default relying on Elasticsearch and is
     // currently the only available database layer.
-    // sample settings for Elasticsearch service (see also https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/configuration.html):
-    // 1. using a single Elasticsearch server:
-    //   * host:
-    //       Host name/address of a Elasticsearch server.
-    //       Can be a hostname, an URI or an IP address.
-    //   * port:
-    //       Network port opened by the Elasticsearch server
-    //   * apiVersion:
-    //      The version of Elasticsearch API to use.
-    //      Kuzzle currently only supports Elasticsearch API "5.x"
+    //   * client:
+    //       Elasticsearch constructor options.
+    //       cf https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/configuration.html
+    //       for detailed documentation
     "db": {
       "backend": "elasticsearch",
       "aliases": ["storageEngine"],
-      "host": "elasticsearch",
-      "port": 9200,
-      "apiVersion": "5.0",
+      "client": {
+        "host": "elasticsearch",
+        "port": 9200,
+        "apiVersion": "5.x"
+      },
       "defaults": {
         // Number of retries to attempt on an update conflict
         // before throwing an error

--- a/default.config.js
+++ b/default.config.js
@@ -189,9 +189,10 @@ module.exports = {
     db: {
       aliases: ['storageEngine'],
       backend: 'elasticsearch',
-      host: 'localhost',
-      port: 9200,
-      apiVersion: '5.x',
+      client: {
+        host: 'http://localhost:9200',
+        apiVersion: '5.x'
+      },
       defaults: {
         onUpdateConflictRetries: 0,
         scrollTTL: '15s'

--- a/docker-compose/dev.yml
+++ b/docker-compose/dev.yml
@@ -20,10 +20,9 @@ services:
       - redis
       - elasticsearch
     ports:
-      - "8080:8080"
       - "9229:9229"
     environment:
-      - kuzzle_services__db__host=elasticsearch
+      - kuzzle_services__db__client__host=http://elasticsearch:9200
       - kuzzle_services__internalCache__node__host=redis
       - kuzzle_services__memoryStorage__node__host=redis
       - kuzzle_services__proxyBroker__host=proxy

--- a/docker-compose/scripts/run-dev.sh
+++ b/docker-compose/scripts/run-dev.sh
@@ -1,22 +1,23 @@
 #!/bin/sh
 
-ELASTIC_HOST=${kuzzle_services__db__host:-elasticsearch}
-ELASTIC_PORT=${kuzzle_services__db__port:-9200}
+set -e
+
+elastic_host=${kuzzle_services__db__client__host:-http://elasticsearch:9200}
 
 npm install
 docker-compose/scripts/install-plugins.sh
 
 echo "[$(date --rfc-3339 seconds)] - Waiting for elasticsearch to be available"
-while ! curl -f -s -o /dev/null "http://$ELASTIC_HOST:$ELASTIC_PORT"
+while ! curl -f -s -o /dev/null "$elastic_host"
 do
-    echo "[$(date --rfc-3339 seconds)] - Still trying to connect to http://$ELASTIC_HOST:$ELASTIC_PORT"
+    echo "[$(date --rfc-3339 seconds)] - Still trying to connect to $elastic_host"
     sleep 1
 done
 # create a tmp index just to force the shards to init
-curl -XPUT -s -o /dev/null "http://$ELASTIC_HOST:$ELASTIC_PORT/%25___tmp"
+curl -XPUT -s -o /dev/null "$elastic_host/%25___tmp"
 echo "[$(date --rfc-3339 seconds)] - Elasticsearch is up. Waiting for shards to be active (can take a while)"
-E=$(curl -s "http://$ELASTIC_HOST:$ELASTIC_PORT/_cluster/health?wait_for_status=yellow&wait_for_active_shards=1&timeout=60s")
-curl -XDELETE -s -o /dev/null "http://$ELASTIC_HOST:$ELASTIC_PORT/%25___tmp"
+E=$(curl -s "$elastic_host/_cluster/health?wait_for_status=yellow&wait_for_active_shards=1&timeout=60s")
+curl -XDELETE -s -o /dev/null "$elastic_host/%25___tmp"
 
 if ! (echo ${E} | grep -E '"status":"(yellow|green)"' > /dev/null); then
     echo "[$(date --rfc-3339 seconds)] - Could not connect to elasticsearch in time. Aborting..."

--- a/docker-compose/scripts/run-test.sh
+++ b/docker-compose/scripts/run-test.sh
@@ -2,24 +2,23 @@
 
 set -e
 
-ELASTIC_HOST=${kuzzle_services__db__host:-elasticsearch}
-ELASTIC_PORT=${kuzzle_services__db__port:-9200}
+elastic_host=${kuzzle_services__db__client__host:-http://elasticsearch:9200}
 
 npm install
 npm install --only=dev
 docker-compose/scripts/install-plugins.sh
 
 echo "[$(date --rfc-3339 seconds)] - Waiting for elasticsearch to be available"
-while ! curl -f -s -o /dev/null "http://$ELASTIC_HOST:$ELASTIC_PORT"
+while ! curl -f -s -o /dev/null "$elastic_host"
 do
-    echo "[$(date --rfc-3339 seconds)] - Still trying to connect to http://$ELASTIC_HOST:$ELASTIC_PORT"
+    echo "[$(date --rfc-3339 seconds)] - Still trying to connect to $elastic_host"
     sleep 1
 done
 # create a tmp index just to force the shards to init
-curl -XPUT -s -o /dev/null "http://$ELASTIC_HOST:$ELASTIC_PORT/%25___tmp"
+curl -XPUT -s -o /dev/null "$elastic_host/%25___tmp"
 echo "[$(date --rfc-3339 seconds)] - Elasticsearch is up. Waiting for shards to be active (can take a while)"
-E=$(curl -s "http://$ELASTIC_HOST:$ELASTIC_PORT/_cluster/health?wait_for_status=yellow&wait_for_active_shards=1&timeout=60s")
-curl -XDELETE -s -o /dev/null "http://$ELASTIC_HOST:$ELASTIC_PORT/%25___tmp"
+E=$(curl -s "$elastic_host/_cluster/health?wait_for_status=yellow&wait_for_active_shards=1&timeout=60s")
+curl -XDELETE -s -o /dev/null "$elastic_host/%25___tmp"
 
 if ! (echo ${E} | grep -E '"status":"(yellow|green)"' > /dev/null); then
     echo "[$(date --rfc-3339 seconds)] - Could not connect to elasticsearch in time. Aborting..."

--- a/docker-compose/test.yml
+++ b/docker-compose/test.yml
@@ -3,8 +3,6 @@ version: '2'
 services:
   proxy:
     image: kuzzleio/proxy${DOCKER_PROXY_TAG}
-    ports:
-      - "7512:7512"
 
   kuzzle:
     image: kuzzleio/dev
@@ -20,7 +18,7 @@ services:
       - redis
       - elasticsearch
     environment:
-      - kuzzle_services__db__host=elasticsearch
+      - kuzzle_services__db__client__host=http://elasticsearch:9200
       - kuzzle_services__internalCache__node__host=redis
       - kuzzle_services__memoryStorage__node__host=redis
       - kuzzle_services__proxyBroker__host=proxy

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -70,7 +70,7 @@ const errorMessagesMapping = [
   {
     // [mapper_parsing_exception] Mapping definition for [flags] has unsupported parameters:  [index : not_analyzed]
     // eslint-disable-next-line no-regex-spaces
-    regex: /^\[mapper_parsing_exception] Mapping definition for \[(.*?)] has unsupported parameters:  \[(.*?)]$/,
+    regex: /^\[mapper_parsing_exception] Mapping definition for \[(.*?)] has unsupported parameters: \[(.*?)]$/,
     replacement: 'Parameter "$2" is not supported for field "$1"'
   },
   {
@@ -141,7 +141,7 @@ class ElasticSearch extends Service {
           return Bluebird.reject(`Your elasticsearch version is ${this.esVersion.number}; Only elasticsearch version 5.0.0 and above are supported.`);
         }
 
-        return Bluebird.resolve(this);
+        return this;
       });
   }
 
@@ -334,7 +334,7 @@ class ElasticSearch extends Service {
     esRequest.body = request.input.body;
 
     assertNoRouting(esRequest);
-    assertWellFormedRefresh(this.config.apiVersion, esRequest);
+    assertWellFormedRefresh(esRequest);
 
     // Add metadata
     esRequest.body._kuzzle_info = {
@@ -399,7 +399,7 @@ class ElasticSearch extends Service {
     esRequest.body = request.input.body;
 
     assertNoRouting(esRequest);
-    assertWellFormedRefresh(this.config.apiVersion, esRequest);
+    assertWellFormedRefresh(esRequest);
 
     // Add metadata
     esRequest.body._kuzzle_info = {
@@ -430,7 +430,7 @@ class ElasticSearch extends Service {
     esRequest.body = request.input.body;
 
     assertNoRouting(esRequest);
-    assertWellFormedRefresh(this.config.apiVersion, esRequest);
+    assertWellFormedRefresh(esRequest);
 
     // injecting retryOnConflict default configuration
     if (!esRequest.hasOwnProperty('retryOnConflict') && this.config.defaults.onUpdateConflictRetries > 0) {
@@ -471,7 +471,7 @@ class ElasticSearch extends Service {
     esRequest.body = request.input.body;
 
     assertNoRouting(esRequest);
-    assertWellFormedRefresh(this.config.apiVersion, esRequest);
+    assertWellFormedRefresh(esRequest);
 
     // Add metadata
     esRequest.body._kuzzle_info = {
@@ -506,7 +506,7 @@ class ElasticSearch extends Service {
 
     esRequest.id = request.input.resource._id;
 
-    assertWellFormedRefresh(this.config.apiVersion, esRequest);
+    assertWellFormedRefresh(esRequest);
 
     // injecting retryOnConflict default configuration
     if (!esRequest.hasOwnProperty('retryOnConflict') && this.config.defaults.onUpdateConflictRetries > 0) {
@@ -540,7 +540,7 @@ class ElasticSearch extends Service {
       esRequestSearch = initESRequest(request, ['from', 'size', 'scroll']),
       esRequestBulk = initESRequest(request, ['refresh']);
 
-    assertWellFormedRefresh(this.config.apiVersion, esRequestBulk);
+    assertWellFormedRefresh(esRequestBulk);
 
     esRequestSearch.body = request.input.body;
     esRequestSearch.scroll = '30s';
@@ -577,7 +577,7 @@ class ElasticSearch extends Service {
       esRequestSearch = initESRequest(request, ['from', 'size', 'scroll']),
       esRequestBulk = initESRequest(request, ['refresh']);
 
-    assertWellFormedRefresh(this.config.apiVersion, esRequestBulk);
+    assertWellFormedRefresh(esRequestBulk);
 
     esRequestSearch.body = request.input.body;
     esRequestSearch.scroll = '30s';
@@ -657,7 +657,7 @@ class ElasticSearch extends Service {
       esRequest = initESRequest(request, ['consistency', 'refresh', 'timeout', 'fields']);
     let error = null;
 
-    assertWellFormedRefresh(this.config.apiVersion, esRequest);
+    assertWellFormedRefresh(esRequest);
 
     if (!request.input.body || !(request.input.body.bulkData instanceof Object)) {
       return Bluebird.reject(new BadRequestError('import must specify a body attribute "bulkData" of type Object.'));
@@ -1180,10 +1180,21 @@ function flattenSearchResults(result) {
  * @returns {object}
  */
 function buildClient(config) {
-  return new es.Client({
-    hosts: config.hosts || config.host + ':' + config.port,
-    apiVersion: config.apiVersion
-  });
+  let options;
+
+  if (config.client) {
+    options = Object.assign({}, config.client);
+  }
+  else {
+    // keep compatibility layer for the time being
+    // @todo: once the install base is clean, remove this
+    options = {
+      hosts: config.hosts || config.host + ':' + config.port,
+      apiVersion: config.apiVersion
+    };
+  }
+
+  return new es.Client(options);
 }
 
 /**
@@ -1200,17 +1211,13 @@ function assertNoRouting(esRequest) {
 /**
  * Checks if the optional "refresh" argument is well-formed
  *
- * @param {string} version - ES API version
  * @param {object} esRequest
  * @throws
  */
-function assertWellFormedRefresh(version, esRequest) {
-  if (esRequest.hasOwnProperty('refresh')) {
-    if (compareVersions(version, '5.0') < 0) {
-      throw new BadRequestError(`Refresh parameter is not supported by the version "${version}" of Elasticsearch API`);
-    }
-    if (esRequest.refresh !== 'wait_for' && esRequest.refresh !== 'false' && esRequest.refresh !== false) {
-      throw new BadRequestError('Refresh parameter only supports the value "wait_for" or false');
-    }
+function assertWellFormedRefresh(esRequest) {
+  if (esRequest.hasOwnProperty('refresh')
+    && ['wait_for', 'false', false].indexOf(esRequest.refresh) < 0
+  ) {
+    throw new BadRequestError('Refresh parameter only supports the value "wait_for" or false');
   }
 }

--- a/lib/services/internalEngine/index.js
+++ b/lib/services/internalEngine/index.js
@@ -79,10 +79,21 @@ class InternalEngine {
     this.bootstrap = bootstrap;
 
     if (!this.client) {
-      this.client = new es.Client({
-        hosts: this.config.hosts || this.config.host + ':' + this.config.port,
-        apiVersion: this.config.apiVersion
-      });
+      let options;
+
+      if (this.config.client) {
+        options = Object.assign({}, this.config.client);
+      }
+      else {
+        // keep compatibility layer for the time being
+        // @todo: once the install base is clean, remove this
+        options = {
+          hosts: this.config.hosts || `${this.config.host}:${this.config.port}`,
+          apiVersion: this.config.apiVersion
+        };
+      }
+
+      this.client = new es.Client(options);
     }
 
     return this.kuzzle.indexCache.initInternal(this)

--- a/test/mocks/services/elasticsearchClient.mock.js
+++ b/test/mocks/services/elasticsearchClient.mock.js
@@ -15,7 +15,11 @@ function ElasticsearchClientMock () {
   this.exists = sinon.stub();
   this.get = sinon.stub();
   this.index = sinon.stub();
-  this.info = sinon.stub().returns(Promise.resolve({}));
+  this.info = sinon.stub().returns(Promise.resolve({
+    version: {
+      number: '5.4.0'
+    }
+  }));
   this.mget = sinon.stub();
   this.update = sinon.stub();
   this.search = sinon.stub();

--- a/test/services/implementations/broker.test.js
+++ b/test/services/implementations/broker.test.js
@@ -34,7 +34,7 @@ describe('Test: Internal broker', () => {
       retryInterval: 1000
     };
 
-    clock = sinon.useFakeTimers(new Date().getTime());
+    clock = sinon.useFakeTimers(Date.now());
   });
 
   beforeEach(() =>{
@@ -1027,8 +1027,8 @@ describe('Test: Internal broker', () => {
       it('should never resolve unless a client connects', () => {
         const response = server.waitForClients('test');
 
-        // wait 1h
-        clock.tick(1000 * 3600);
+        // wait 30m
+        clock.tick(1000 * 1800);
         should(response.isPending()).be.true();
 
         server.rooms = { test: true };


### PR DESCRIPTION
# Description

This PR allows to use native Elasticsearch constructor options.
For the time being, the previous way of configuring Elasticsearch is kept in a compatibility layer.

# Related issue

* #772