### PR TITLE
switch to es 5.4

### DIFF
--- a/docker-compose/dev.yml
+++ b/docker-compose/dev.yml
@@ -20,7 +20,6 @@ services:
       - redis
       - elasticsearch
     ports:
-      - "8080:8080"
       - "9229:9229"
     environment:
       - kuzzle_services__db__host=elasticsearch
@@ -39,4 +38,12 @@ services:
     image: redis:3.2
 
   elasticsearch:
-    image: elasticsearch:5.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.4.1
+    environment:
+      - cluster.name=kuzzle
+      # disable xpack
+      - xpack.security.enabled=false
+      - xpack.monitoring.enabled=false
+      - xpack.graph.enabled=false
+      - xpack.watcher.enabled=false
+

--- a/docker-compose/test.yml
+++ b/docker-compose/test.yml
@@ -3,8 +3,6 @@ version: '2'
 services:
   proxy:
     image: kuzzleio/proxy${DOCKER_PROXY_TAG}
-    ports:
-      - "7512:7512"
 
   kuzzle:
     image: kuzzleio/dev
@@ -39,4 +37,12 @@ services:
     image: redis:3.2
 
   elasticsearch:
-    image: elasticsearch:5.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.4.1
+    environment:
+      - cluster.name=kuzzle
+      # disable xpack
+      - xpack.security.enabled=false
+      - xpack.monitoring.enabled=false
+      - xpack.graph.enabled=false
+      - xpack.watcher.enabled=false
+

--- a/features/step_definitions/readDocument.js
+++ b/features/step_definitions/readDocument.js
@@ -141,11 +141,11 @@ var apiSteps = function () {
 
   this.Then(/^I am ?(not)* able to scroll previous search$/, function (not) {
     if (!this.scrollId) {
-      if (!not) {
-        return Promise.reject(new Error('No scroll id from previous search available'));
+      if (not) {
+        return Promise.resolve();
       }
 
-      return Promise.resolve();
+      return Promise.reject(new Error('No scroll id from previous search available'));
     }
 
     return this.api.scroll(this.scrollId)

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -286,15 +286,13 @@ class ElasticSearch extends Service {
 
     esRequest.body = request.input.body;
 
-    if (!request.input.args.includeTrash) {
-      addActiveFilter(esRequest);
-    }
-
     return this.client.mget(esRequest)
       .then(result => {
         // harmonize response format based upon the search one
         if (result.docs) {
-          result.hits = result.docs;
+          result.hits = request.input.args.includeTrash
+            ? result.docs
+            : result.docs.filter(doc => doc._kuzzle_info === undefined || doc._kuzzle_info.active);
           delete result.docs;
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,11 @@
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
       "dev": true
     },
+    "agentkeepalive": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-2.2.0.tgz",
+      "integrity": "sha1-xdG9SxKQCPEWPyNvhuX66iAm4u8="
+    },
     "ajv": {
       "version": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
@@ -127,10 +132,6 @@
     "arrify": {
       "version": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
-    },
-    "asap": {
-      "version": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
-      "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8="
     },
     "asn1": {
       "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
@@ -562,8 +563,16 @@
       "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE="
     },
     "elasticsearch": {
-      "version": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-12.1.3.tgz",
-      "integrity": "sha1-UQjmeuXYPl5/MNPSlP1wF98ON3E="
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-13.0.1.tgz",
+      "integrity": "sha1-+lggQjMFLEzSIehyHkjzkGs4WzI=",
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+        }
+      }
     },
     "emitter-listener": {
       "version": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.0.1.tgz",
@@ -804,7 +813,8 @@
     },
     "forever-agent": {
       "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
     "form-data": {
       "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
@@ -1842,6 +1852,11 @@
       "version": "https://registry.npmjs.org/lodash.findindex/-/lodash.findindex-4.6.0.tgz",
       "integrity": "sha1-oyRd7mH7m24GJLU1ElYku2nBEQY="
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.isarguments": {
       "version": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
@@ -1849,6 +1864,11 @@
     "lodash.isarray": {
       "version": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+    },
+    "lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
     },
     "lodash.isequal": {
       "version": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
@@ -1865,6 +1885,11 @@
     "lodash.once": {
       "version": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "lodash.trimend": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/lodash.trimend/-/lodash.trimend-4.5.1.tgz",
+      "integrity": "sha1-EoBENyhrmMrYmWt5QU4RMAEUCC8="
     },
     "lolex": {
       "version": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
@@ -3212,10 +3237,6 @@
       "version": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
-    },
-    "promise": {
-      "version": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
-      "integrity": "sha1-SJZUxpJha4qlWwck+oCbt9tJxb8="
     },
     "proper-lockfile": {
       "version": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "denque": "^1.1.1",
     "dumpme": "^1.0.1",
     "easy-circular-list": "^1.0.13",
-    "elasticsearch": "12.1.3",
+    "elasticsearch": "13.0.1",
     "espresso-logic-minimizer": "^2.0.1",
     "eventemitter2": "^3.0.0",
     "fs-extra": "^1.0.0",


### PR DESCRIPTION
# Description

This PR makes Kuzzle work with Elasticsearch 5.4.1.

Changes:

* elasticsearch library update to version 13.0.1 (needed to fix a bug with the scroll not recognizing the given scrollId)
* bug fix on `mGet` which was previously attaching an invalid `query` parameter to the request (and would silently fail?..)



