### PR TITLE
Removed password from users's collection mapping

### DIFF
--- a/features/HTTP.feature
+++ b/features/HTTP.feature
@@ -340,8 +340,7 @@ Feature: Test HTTP API
   @usingHttp @cleanSecurity
   Scenario: User mapping
     Given I get the user mapping
-    Then The mapping should contain "password" field of type "keyword"
-    And The mapping should contain "profileIds" field of type "keyword"
+X    Then The mapping should contain "profileIds" field of type "keyword"
     When I change the user mapping
     Then I get the user mapping
     Then The mapping should contain "foo" field of type "text"

--- a/features/HTTP.feature
+++ b/features/HTTP.feature
@@ -340,7 +340,7 @@ Feature: Test HTTP API
   @usingHttp @cleanSecurity
   Scenario: User mapping
     Given I get the user mapping
-X    Then The mapping should contain "profileIds" field of type "keyword"
+    Then The mapping should contain "profileIds" field of type "keyword"
     When I change the user mapping
     Then I get the user mapping
     Then The mapping should contain "foo" field of type "text"

--- a/features/Websocket.feature
+++ b/features/Websocket.feature
@@ -464,8 +464,7 @@ Feature: Test websocket API
   @usingWebsocket @cleanSecurity
   Scenario: User mapping
     Given I get the user mapping
-    Then The mapping should contain "password" field of type "keyword"
-    And The mapping should contain "profileIds" field of type "keyword"
+    Then The mapping should contain "profileIds" field of type "keyword"
     When I change the user mapping
     Then I get the user mapping
     Then The mapping should contain "foo" field of type "text"

--- a/lib/services/internalEngine/bootstrap.js
+++ b/lib/services/internalEngine/bootstrap.js
@@ -146,10 +146,6 @@ class InternalEngineBootstrap {
       properties: {
         profileIds: {
           type: 'keyword'
-        },
-        password: {
-          index: false,
-          type: 'keyword'
         }
       }
     })

--- a/test/services/internalEngine/bootstrap.test.js
+++ b/test/services/internalEngine/bootstrap.test.js
@@ -277,10 +277,6 @@ describe('services/internalEngine/bootstrap.js', () => {
                 properties: {
                   profileIds: {
                     type: 'keyword'
-                  },
-                  password: {
-                    index: false,
-                    type: 'keyword'
                   }
                 }
               });


### PR DESCRIPTION
Password is now part of the credentials so we should not create it's default mapping in the 'users' collection when starting Kuzzle.

fix #864 