### PR TITLE
Fix incoherent behaviors regarding user credentials management

### DIFF
--- a/lib/api/cli/index.js
+++ b/lib/api/cli/index.js
@@ -36,31 +36,13 @@ class CliActions {
 
     this.actions = {
       adminExists: new Action(),
-      cleanDb: new Action(),
+      cleanDb: new Action({
+        timeOutCB: () => { /* deactivate timeout: cleaning users can take a LONG time */ }
+      }),
       clearCache: new Action(),
       createFirstAdmin: new Action(),
       data: new Action(),
       dump: new Action(),
-      managePlugins: new Action({
-        timeout: 1000,
-        timeOutCB: () => {
-          if (!this.maxTimeout) {
-            this.maxTimeout = 5 * 60 * 1000;
-            this.spent = this.timeout;
-          }
-
-          this.spent += this.timeout;
-
-          if (this.spent < this.maxTimeout) {
-            process.stdout.write('.');
-            this.initTimeout();
-          }
-          else {
-            console.error(`ERROR: No response from Kuzzle within ̀${this.maxTimeout / 1000}s. Exiting`); // eslint-disable-line no-console
-            process.exit(1);
-          }
-        }
-      }),
       shutdown: new Action()
     };
   }
@@ -92,6 +74,8 @@ class CliActions {
 
         this.kuzzle.pluginsManager.trigger(beforeEvent, request)
           .then(updatedRequest => {
+            // eslint-disable-next-line no-console
+            this.kuzzle.services.list.broker.listen(`status-${updatedRequest.id}`, message => console.log(message));
             this.kuzzle.services.list.broker.listen(updatedRequest.id, action.onListenCB.bind(action));
             this.kuzzle.services.list.broker.send(this.kuzzle.config.queues.cliQueue, updatedRequest.serialize());
           });

--- a/lib/api/controllers/cli/cleanDb.js
+++ b/lib/api/controllers/cli/cleanDb.js
@@ -40,15 +40,11 @@ function resetStorage (kuzzle, statusUpdate) {
   return deleteUsers(kuzzle, statusUpdate)
     .then(() => kuzzle.internalEngine.deleteIndex())
     .then(() => statusUpdate('Kuzzle internal database deleted'))
-    .then(() => {
-      const promises = ['internalCache', 'memoryStorage']
-        .map(id => kuzzle.services.list[id].flushdb());
-
-      return Bluebird.all(promises);
-    })
-    .then(() => statusUpdate('Kuzzle memory cache deleted'))
+    .then(() => kuzzle.services.list.internalCache.flushdb())
     .then(() => {
       kuzzle.indexCache.remove(kuzzle.internalEngine.index);
+      statusUpdate('Kuzzle internal cache flushed');
+
       return kuzzle.internalEngine.bootstrap.all();
     });
 }

--- a/lib/api/controllers/cli/cleanDb.js
+++ b/lib/api/controllers/cli/cleanDb.js
@@ -19,6 +19,94 @@
  * limitations under the License.
  */
 
+const 
+  Bluebird = require('bluebird'),
+  Request = require('kuzzle-common-objects').Request;
+
 module.exports = function cliResetStorage (kuzzle) {
-  return () => kuzzle.resetStorage();
+  return (request, statusUpdate) => resetStorage(kuzzle, statusUpdate);
 };
+
+/**
+ * Flushes the internal storage components (internalEngine index, cache and memory storage)
+ *
+ * @param {Kuzzle} kuzzle 
+ * @param {Function} statusUpdate 
+ * @returns Promise
+ */
+function resetStorage (kuzzle, statusUpdate) {
+  statusUpdate('Kuzzle reset initiated: this may take a while...');
+  
+  return deleteUsers(kuzzle, statusUpdate)
+    .then(() => kuzzle.internalEngine.deleteIndex())
+    .then(() => statusUpdate('Kuzzle internal database deleted'))
+    .then(() => {
+      const promises = ['internalCache', 'memoryStorage']
+        .map(id => kuzzle.services.list[id].flushdb());
+
+      return Bluebird.all(promises);
+    })
+    .then(() => statusUpdate('Kuzzle memory cache deleted'))
+    .then(() => {
+      kuzzle.indexCache.remove(kuzzle.internalEngine.index);
+      return kuzzle.internalEngine.bootstrap.all();
+    });
+}
+
+
+/**
+ * @param {Kuzzle} kuzzle 
+ * @param {Function} statusUpdate 
+ * @param {object} part
+ * @param {Promise<undefined>}
+ */
+function deleteUsers(kuzzle, statusUpdate, part = null) {
+  if (part === null) {
+    return kuzzle.repositories.user.search({}, {scroll: '10m', size: 100})
+      .then(users => {
+        statusUpdate(`${users.total} users found`);
+
+        return deleteUsersPart(kuzzle, users)
+          .then(() => {
+            statusUpdate(`... ${users.hits.length}/${users.total} users deleted`);
+
+            if (users.hits.length < users.total) {
+              return deleteUsers(kuzzle, statusUpdate, {
+                total: users.total, 
+                deleted: users.hits.length, 
+                scrollId: users.scrollId
+              });
+            }
+
+            return null;
+          });
+      });
+  }
+
+  return kuzzle.repositories.user.scroll(part.scrollId, '10m')
+    .then(users => {
+      return deleteUsersPart(kuzzle, users)
+        .then(() => {
+          part.deleted += users.hits.length;
+          statusUpdate(`... ${part.deleted}/${part.total} users deleted`);
+
+          if (part.deleted < part.total) {
+            part.scrollId = users.scrollId;
+            return deleteUsers(kuzzle, statusUpdate, part);
+          }
+
+          return null;
+        });
+    });
+}
+
+function deleteUsersPart (kuzzle, users) {
+  const promises = [];
+
+  for (let i = 0; i < users.hits.length; i++) {
+    const request = new Request({_id: users.hits[i]._id});
+    promises.push(kuzzle.funnel.controllers.security.deleteUser(request));
+  }
+
+  return Bluebird.all(promises);
+}

--- a/lib/api/controllers/cli/dump.js
+++ b/lib/api/controllers/cli/dump.js
@@ -21,8 +21,6 @@
 
 'use strict';
 
-/* eslint-disable no-console */
-
 const
   Bluebird = require('bluebird'),
   path = require('path'),
@@ -42,11 +40,12 @@ let
  * Create a dump
  *
  * @param {Request} request
+ * @param {Function} statusUpdate 
  * @returns {Promise}
  */
-function dump (request) {
+function dump (request, statusUpdate) {
   if (_lock) {
-    console.log('A dump is already being generated. Skipping.');
+    statusUpdate('A dump is already being generated. Skipping.');
     return Bluebird.resolve();
   }
 
@@ -60,34 +59,34 @@ function dump (request) {
       moment().format(_kuzzle.config.dump.dateFormat).concat(suffix)
     );
 
-    console.log('===========================================================================');
-    cleanUpHistory();
+    statusUpdate('===========================================================================');
+    cleanUpHistory(statusUpdate);
 
-    console.log('Generating dump in '.concat(dumpPath));
+    statusUpdate(`Generating dump in ${dumpPath}`);
     try {
       fs.mkdirsSync(dumpPath);
     }
     catch (e) {
       if (e.message.startsWith('EEXIST')) {
-        console.log('Dump directory already exists. Skipping..');
+        statusUpdate('Dump directory already exists. Skipping..');
         return resolve();
       }
 
-      console.log('ERROR: unknown error while trying to create dump folder');
-      console.error(e);
+      statusUpdate('ERROR: unknown error while trying to create dump folder');
+      statusUpdate(e);
       return reject();
     }
 
     // dumping kuzzle configuration
-    console.log('> dumping kuzzle configuration');
+    statusUpdate('> dumping kuzzle configuration');
     fs.writeFileSync(path.join(dumpPath, 'config.json'), JSON.stringify(_kuzzle.config, null, ' ').concat('\n'));
 
     // dumping plugins configuration
-    console.log('> dumping plugins configuration');
+    statusUpdate('> dumping plugins configuration');
     fs.writeFileSync(path.join(dumpPath, 'plugins.json'), JSON.stringify(_kuzzle.pluginsManager.getPluginsFeatures(), null, ' ').concat('\n'));
 
     // dumping nodejs configuration
-    console.log('> dumping nodejs configuration');
+    statusUpdate('> dumping nodejs configuration');
     fs.writeFileSync(path.join(dumpPath, 'nodejs.json'), JSON.stringify({
       env: process.env,
       config: process.config,
@@ -98,7 +97,7 @@ function dump (request) {
     }, null, ' ').concat('\n'));
 
     // dumping os configuration
-    console.log('> dumping os configuration');
+    statusUpdate('> dumping os configuration');
     fs.writeFileSync(path.join(dumpPath, 'os.json'), JSON.stringify({
       platform: os.platform(),
       loadavg: os.loadavg(),
@@ -112,16 +111,16 @@ function dump (request) {
     }, null, ' ').concat('\n'));
 
     // dumping std err/out
-    console.log('> dumping std err/out');
+    statusUpdate('> dumping std err/out');
     if (!process.env.pm_err_log_path && !process.env.pm_log_path) {
-      console.log('... no logs found');
+      statusUpdate('... no logs found');
       return resolve();
     }
 
     const logDir = path.dirname(process.env.pm_err_log_path || process.env.pm_log_path);
     fs.readdir(logDir, (err, files) => {
       if (err) {
-        console.log('... error reading log directory');
+        statusUpdate('... error reading log directory');
         return resolve();
       }
 
@@ -164,25 +163,25 @@ function dump (request) {
           resolve();
         })
         .catch(e => {
-          console.error('fileStats', e);
+          statusUpdate('fileStats', e);
           resolve();
         });
     });
   })
     .then(() => new Bluebird((resolve, reject) => {
       // core-dump
-      console.log('> generating core-dump');
+      statusUpdate('> generating core-dump');
       dumpme(_kuzzle.config.dump.gcore || 'gcore', `${dumpPath}/core`);
 
       // Gzip the core
       glob(`${dumpPath}/core*`, (err, res) => {
         if (err) {
-          console.error(err);
+          statusUpdate(err);
           return reject(err);
         }
 
         if (!res[0]) {
-          console.log('> warning: could not generate dump');
+          statusUpdate('> warning: could not generate dump');
           return resolve();
         }
 
@@ -206,19 +205,19 @@ function dump (request) {
     }))
     .then(() => {
       // copy node binary
-      console.log('> copy node binary');
+      statusUpdate('> copy node binary');
       fs.copySync(process.execPath, path.join(dumpPath, 'node'));
 
       // dumping Kuzzle's stats
-      console.log('> dumping kuzzle\'s stats');
+      statusUpdate('> dumping kuzzle\'s stats');
       return _kuzzle.statistics.getAllStats(new Request({action: 'getAllStats', controller: 'statistics'}));
     })
     .then(response => {
       fs.writeFileSync(path.join(dumpPath, 'statistics.json'), JSON.stringify(response.hits, null, ' ').concat('\n'));
 
-      console.log('Done.');
-      console.log('[ℹ] You can send the folder to the kuzzle core team at support@kuzzle.io');
-      console.log('===========================================================================');
+      statusUpdate('Done.');
+      statusUpdate('[ℹ] You can send the folder to the kuzzle core team at support@kuzzle.io');
+      statusUpdate('===========================================================================');
     })
     .then(() => dumpPath)
     .finally(() => {
@@ -226,7 +225,7 @@ function dump (request) {
     });
 }
 
-function cleanUpHistory() {
+function cleanUpHistory(statusUpdate) {
   const
     config = _kuzzle.config.dump,
     dumpPath = path.normalize(_kuzzle.config.dump.path);
@@ -255,7 +254,7 @@ function cleanUpHistory() {
   while (dumps.length >= config.history.reports) {
     const dir = dumps.shift().path;
 
-    console.log(`> removing dump directory from history: ${dir}`);
+    statusUpdate(`> removing dump directory from history: ${dir}`);
     fs.removeSync(dir);
   }
 

--- a/lib/api/controllers/cli/shutdown.js
+++ b/lib/api/controllers/cli/shutdown.js
@@ -19,8 +19,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable no-console */
-
 'use strict';
 
 const
@@ -34,9 +32,11 @@ let
 /**
  * Gracefully exits after processing remaining requests
  *
+ * @param {Request} request - UNUSED
+ * @param {Function} statusUpdate
  * @returns {Promise}
  */
-function cliRunShutdown () {
+function cliRunShutdown (request, statusUpdate) {
   // pm2.delete sends a SIGINT signal
   // we keep track of how many shutdowns are asked
   // to detect when pm2 has finished deleting Kuzzle
@@ -47,30 +47,30 @@ function cliRunShutdown () {
     return Bluebird.resolve();
   }
 
-  console.warn('Initiating shutdown...');
+  statusUpdate('Initiating shutdown...');
 
   return new Bluebird(resolve => {
     _kuzzle.entryPoints.proxy.dispatch('shutdown');
 
     // Gives time for the proxy to receive the shutdown signal
     // and eventually to receive the last batch of requests to process
-    setTimeout(() => waitRemainingRequests(resolve), 1000);
+    setTimeout(() => waitRemainingRequests(resolve, statusUpdate), 1000);
   });
 }
 
-function waitRemainingRequests(resolve) {
+function waitRemainingRequests(resolve, statusUpdate) {
   const remaining = _kuzzle.funnel.remainingRequests;
 
   if (remaining !== 0) {
-    console.warn(`Waiting: ${remaining} remaining requests`);
-    return setTimeout(() => waitRemainingRequests(resolve), 1000);
+    statusUpdate(`Waiting: ${remaining} remaining requests`);
+    return setTimeout(() => waitRemainingRequests(resolve, statusUpdate), 1000);
   }
 
   resolve();
 
   pm2.list((listerr, processes) => {
     if (listerr) {
-      return halt();
+      return halt(statusUpdate);
     }
 
     const kuzzleProcess = processes
@@ -79,20 +79,20 @@ function waitRemainingRequests(resolve) {
     // not started with PM2 or development mode => exit immediately
     if (kuzzleProcess.length === 0 || kuzzleProcess[0].pm2_env.watch) {
       if (kuzzleProcess.length !== 0) {
-        console.warn('PM2 Watch activated: restarting Kuzzle');
+        statusUpdate('PM2 Watch activated: restarting Kuzzle');
 
         return _kuzzle.pluginsManager.shutdownWorkers()
           .then(() => pm2.restart(kuzzleProcess[0].pm_id));
       }
 
-      return halt();
+      return halt(statusUpdate);
     }
 
     // production mode: ask PM2 to stop & delete Kuzzle to prevent
     // a restart
     pm2.delete(kuzzleProcess[0].pm_id, delerr => {
-      console.error('PM2 failed to delete Kuzzle: ', delerr);
-      console.error('Exiting anyway.');
+      statusUpdate('PM2 failed to delete Kuzzle: ', delerr);
+      statusUpdate('Exiting anyway.');
     });
 
     // pm2.delete does not notify when deletion is finished,
@@ -101,17 +101,17 @@ function waitRemainingRequests(resolve) {
     const interval = setInterval(() => {
       if (_shutdown > 1) {
         clearInterval(interval);
-        halt();
+        halt(statusUpdate);
       }
     }, 200);
   });
 }
 
-function halt() {
-  console.warn('Shutting down worker plugins...');
+function halt(statusUpdate) {
+  statusUpdate('Shutting down worker plugins...');
   _kuzzle.pluginsManager.shutdownWorkers()
     .then(() => {
-      console.warn('Halted.');
+      statusUpdate('Halted.');
       process.exit(0);
     });
 }

--- a/lib/api/controllers/cliController.js
+++ b/lib/api/controllers/cliController.js
@@ -59,7 +59,13 @@ class CliController {
       return this.kuzzle.services.list.broker.send(request.id, request.serialize());
     }
 
-    return this.actions[request.input.action](request)
+    /*
+      Provides a statusUpdate(message) method to actions, allowing
+      to send regular updates to CLI users
+     */
+    const fnStatusUpdate = message => this.kuzzle.services.list.broker.send(`status-${request.id}`, message);
+
+    return this.actions[request.input.action](request, fnStatusUpdate)
       .then(response => {
         request.setResult(response);
 

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -694,11 +694,24 @@ class SecurityController {
     assertHasBody(request);
 
     const
-      createMethod = this.kuzzle.pluginsManager.getStrategyMethod(request.input.args.strategy, 'create'),
-      validateMethod = this.kuzzle.pluginsManager.getStrategyMethod(request.input.args.strategy, 'validate');
+      id = request.input.resource._id,
+      strategy = request.input.args.strategy;
 
-    return validateMethod(request, request.input.body, request.input.resource._id, request.input.args.strategy, false)
-      .then(() => createMethod(request, request.input.body, request.input.resource._id, request.input.args.strategy));
+    return this.kuzzle.repositories.user.load(id)
+      .then(user => {
+        if (user === null) {
+          throw new BadRequestError(`Cannot create credentials: unknown kuid "${id}"`);
+        }
+
+        const validateMethod = this.kuzzle.pluginsManager.getStrategyMethod(strategy, 'validate');
+
+        return validateMethod(request, request.input.body, id, strategy, false);
+      })
+      .then(() => {
+        const createMethod = this.kuzzle.pluginsManager.getStrategyMethod(strategy, 'create');
+
+        return createMethod(request, request.input.body, id, strategy);
+      });
   }
 
   /**
@@ -711,12 +724,25 @@ class SecurityController {
     assertHasId(request);
     assertHasBody(request);
 
-    const
-      updateMethod = this.kuzzle.pluginsManager.getStrategyMethod(request.input.args.strategy, 'update'),
-      validateMethod = this.kuzzle.pluginsManager.getStrategyMethod(request.input.args.strategy, 'validate');
+    const 
+      id = request.input.resource._id,
+      strategy = request.input.args.strategy;
 
-    return validateMethod(request, request.input.body, request.input.resource._id, request.input.args.strategy, true)
-      .then(() => updateMethod(request, request.input.body, request.input.resource._id, request.input.args.strategy));
+    return this.kuzzle.repositories.user.load(id)
+      .then(user => {
+        if (user === null) {
+          throw new BadRequestError(`Cannot create credentials: unknown kuid "${id}"`);
+        }
+
+        const validateMethod = this.kuzzle.pluginsManager.getStrategyMethod(strategy, 'validate');
+
+        return validateMethod(request, request.input.body, id, strategy, true);
+      })
+      .then(() => {
+        const updateMethod = this.kuzzle.pluginsManager.getStrategyMethod(strategy, 'update');
+
+        return updateMethod(request, request.input.body, id, strategy);
+      });
   }
 
   /**
@@ -976,7 +1002,6 @@ function* persistUserAndCredentials (kuzzle, request, pojoUser) {
     user = new User(),
     loadedUser = yield Bluebird.resolve(kuzzle.repositories.user.load(pojoUser._id));
   let
-    strategies = [],
     errorStep = null,
     creationError = null,
     errorMessage,
@@ -987,20 +1012,26 @@ function* persistUserAndCredentials (kuzzle, request, pojoUser) {
     throw new PreconditionError(`user "${pojoUser._id}" already exist.`);
   }
 
-  if (request.input.body.credentials && Object.keys(request.input.body.credentials).length > 0) {
-    strategies = Object.keys(request.input.body.credentials);
+  const strategies = request.input.body.credentials ? Object.keys(request.input.body.credentials) : [];
+
+  if (strategies.length > 0) {
+    const registeredStrategies = kuzzle.pluginsManager.listStrategies();
 
     for (const strategy of strategies) {
-      let validateMethod;
-
-      if (kuzzle.pluginsManager.listStrategies().indexOf(strategy) === -1) {
+      if (registeredStrategies.indexOf(strategy) === -1) {
         throw new BadRequestError(`strategy "${strategy}" is not a known strategy.`);
       }
 
-      validateMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'validate');
+      const validateMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'validate');
 
       try {
-        yield validateMethod(request, request.input.body.credentials[strategy], pojoUser._id, request.input.args.strategy, false);
+        yield validateMethod(
+          request, 
+          request.input.body.credentials[strategy], 
+          pojoUser._id, 
+          request.input.args.strategy, 
+          false
+        );
       }
       catch (error) {
         throw new BadRequestError(error);

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -988,6 +988,13 @@ function* persistUserAndCredentials (kuzzle, request, pojoUser) {
         throw new BadRequestError(`strategy "${strategy}" is not a known strategy.`);
       }
 
+      const existMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'exists');
+      const exists = yield existMethod(request, pojoUser._id, strategy);
+
+      if (exists === true) {
+        throw new KuzzleInternalError(`User database inconsistency detected: existing credentials found on non-existing user ${pojoUser._id}`);
+      }
+
       const validateMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'validate');
 
       try {

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -992,7 +992,7 @@ function* persistUserAndCredentials (kuzzle, request, pojoUser) {
       const exists = yield existMethod(request, pojoUser._id, strategy);
 
       if (exists === true) {
-        throw new KuzzleInternalError(`User database inconsistency detected: existing credentials found on non-existing user ${pojoUser._id}`);
+        throw new KuzzleInternalError(`Intenral database inconsistency detected: existing credentials found on non-existing user ${pojoUser._id}`);
       }
 
       const validateMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'validate');

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -697,7 +697,7 @@ class SecurityController {
     return this.kuzzle.repositories.user.load(id)
       .then(user => {
         if (user === null) {
-          throw new BadRequestError(`Cannot create credentials: unknown kuid "${id}"`);
+          throw new BadRequestError(`Cannot update credentials: unknown kuid "${id}"`);
         }
 
         const validateMethod = this.kuzzle.pluginsManager.getStrategyMethod(strategy, 'validate');
@@ -992,7 +992,7 @@ function* persistUserAndCredentials (kuzzle, request, pojoUser) {
       const exists = yield existMethod(request, pojoUser._id, strategy);
 
       if (exists === true) {
-        throw new KuzzleInternalError(`Intenral database inconsistency detected: existing credentials found on non-existing user ${pojoUser._id}`);
+        throw new KuzzleInternalError(`Internal database inconsistency detected: existing credentials found on non-existing user ${pojoUser._id}`);
       }
 
       const validateMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'validate');

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -418,47 +418,13 @@ class SecurityController {
    * @returns {Promise<Object>}
    */
   deleteUser(request) {
-    const
-      kuzzle = this.kuzzle,
-      errors = [];
-
     assertHasId(request);
+
+    const deleteGenerator = Bluebird.coroutine(securityDeleteUserGenerator);
 
     return this.kuzzle.repositories.user.delete(request.input.resource._id, {refresh: request.input.args.refresh})
       .then(() => this.kuzzle.repositories.token.deleteByUserId(request.input.resource._id))
-      .then(Bluebird.coroutine(function* securityDeleteUserGenerator () {
-        const
-          availableStrategies = kuzzle.pluginsManager.listStrategies(),
-          userStrategies = [];
-
-        for (const strategy of availableStrategies) {
-          const
-            existsMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'exists'),
-            existStrategy = yield existsMethod(request, request.input.resource._id, request.input.args.strategy);
-
-          if (existStrategy) {
-            userStrategies.push(strategy);
-          }
-        }
-
-        if (userStrategies.length > 0) {
-          for (const strategy of userStrategies) {
-            const
-              deleteMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'delete');
-
-            // We catch any error produced by delete as we want to make as much cleanup as possible
-            yield deleteMethod(request, request.input.resource._id, request.input.args.strategy)
-              .catch(error => {
-                errors.push(error);
-                return Bluebird.reject(error);
-              });
-          }
-        }
-
-        if (errors.length > 0) {
-          throw new KuzzleInternalError(`was not able to remove bad credentials of user "${request.input.resource._id}": ` + errors.map(error => error.message).join(';'));
-        }
-      }))
+      .then(() => deleteGenerator(this.kuzzle, request))
       .then(() => ({ _id: request.input.resource._id}));
   }
 
@@ -1029,7 +995,7 @@ function* persistUserAndCredentials (kuzzle, request, pojoUser) {
           request, 
           request.input.body.credentials[strategy], 
           pojoUser._id, 
-          request.input.args.strategy, 
+          strategy, 
           false
         );
       }
@@ -1044,7 +1010,7 @@ function* persistUserAndCredentials (kuzzle, request, pojoUser) {
         createMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'create');
 
       try {
-        yield createMethod(request, request.input.body.credentials[strategy], pojoUser._id, request.input.args.strategy);
+        yield createMethod(request, request.input.body.credentials[strategy], pojoUser._id, strategy);
       }
       catch (error) {
         errorStep = i;
@@ -1076,10 +1042,10 @@ function* persistUserAndCredentials (kuzzle, request, pojoUser) {
   for (let i = 0; i <= errorStep; i++) {
     const
       strategy = strategies[i],
-      deleteMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'delete', request.input.args.strategy);
+      deleteMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'delete');
 
     // We catch any error produced by delete as we want to make as much cleanup as possible
-    yield deleteMethod(request, request.input.resource._id, request.input.args.strategy)
+    yield deleteMethod(request, request.input.resource._id, strategy)
       .catch(error => {
         errors.push(error);
         return Bluebird.resolve();
@@ -1093,5 +1059,44 @@ function* persistUserAndCredentials (kuzzle, request, pojoUser) {
   }
   else {
     throw new PluginImplementationError(errorMessage);
+  }
+}
+
+/**
+ * @param {Kuzzle} kuzzle 
+ * @param {Request} request 
+ */
+function* securityDeleteUserGenerator (kuzzle, request) {
+  const
+    availableStrategies = kuzzle.pluginsManager.listStrategies(),
+    userStrategies = [],
+    errors = [];
+
+  for (const strategy of availableStrategies) {
+    const
+      existsMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'exists'),
+      existStrategy = yield existsMethod(request, request.input.resource._id, strategy);
+
+    if (existStrategy) {
+      userStrategies.push(strategy);
+    }
+  }
+
+  if (userStrategies.length > 0) {
+    for (const strategy of userStrategies) {
+      const
+        deleteMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'delete');
+
+      // We catch any error produced by delete as we want to make as much cleanup as possible
+      yield deleteMethod(request, request.input.resource._id, strategy)
+        .catch(error => {
+          errors.push(error);
+          return Bluebird.reject(error);
+        });
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new KuzzleInternalError(`was not able to remove bad credentials of user "${request.input.resource._id}": ` + errors.map(error => error.message).join(';'));
   }
 }

--- a/lib/api/kuzzle.js
+++ b/lib/api/kuzzle.js
@@ -109,28 +109,6 @@ class Kuzzle extends EventEmitter {
   }
 
   /**
-   * Flushes the internal storage components (internalEngine index, cache and memory storage)
-   *
-   * @this {Kuzzle}
-   * @returns Promise
-   */
-  resetStorage() {
-    this.pluginsManager.trigger('log:warn', 'Kuzzle::resetStorage called');
-
-    return this.internalEngine.deleteIndex()
-      .then(response => {
-        const promises = ['internalCache', 'memoryStorage']
-          .map(id => this.services.list[id].flushdb());
-
-        return Bluebird.all(promises).then(() => response);
-      })
-      .then(() => {
-        this.indexCache.remove(this.internalEngine.index);
-        return this.internalEngine.bootstrap.all();
-      });
-  }
-
-  /**
    * Initializes all the needed components of a Kuzzle Server instance.
    *
    * By default, this script runs a standalone Kuzzle Server instance:

--- a/test/api/cli/index.test.js
+++ b/test/api/cli/index.test.js
@@ -76,8 +76,11 @@ describe('Tests: api/cli/index.js', () => {
       return cli.doAction.call(context, 'test', {})
         .then(response => {
           should(response).be.exactly('promise');
-          should(kuzzle.services.list.broker.listen).be.calledOnce();
-          should(kuzzle.services.list.broker.listen.firstCall.args[1]).be.a.Function();
+          should(kuzzle.services.list.broker.listen).be.calledTwice();
+          should(kuzzle.services.list.broker.listen.getCall(0).args[0]).be.eql('status-test');
+          should(kuzzle.services.list.broker.listen.getCall(0).args[1]).be.a.Function();
+          should(kuzzle.services.list.broker.listen.getCall(1).args[0]).be.eql('test');
+          should(kuzzle.services.list.broker.listen.getCall(1).args[1]).be.a.Function();
           should(kuzzle.services.list.broker.send).be.calledOnce();
           should(kuzzle.services.list.broker.send.firstCall.args[0]).be.exactly('cli-queue');
           should(kuzzle.services.list.broker.send.firstCall.args[1]).match({

--- a/test/api/controllers/cli/cleanDb.test.js
+++ b/test/api/controllers/cli/cleanDb.test.js
@@ -23,7 +23,6 @@ describe('Test: clean database', () => {
         should(kuzzle.repositories.user.scroll.called).be.false();
         should(kuzzle.internalEngine.deleteIndex).be.calledOnce();
         should(kuzzle.services.list.internalCache.flushdb).be.calledOnce();
-        should(kuzzle.services.list.memoryStorage.flushdb).be.calledOnce();
 
         should(kuzzle.indexCache.remove)
           .be.calledOnce()
@@ -36,7 +35,6 @@ describe('Test: clean database', () => {
         sinon.assert.callOrder(
           kuzzle.internalEngine.deleteIndex,
           kuzzle.services.list.internalCache.flushdb,
-          kuzzle.services.list.memoryStorage.flushdb,
           kuzzle.indexCache.remove,
           kuzzle.internalEngine.bootstrap.all
         );

--- a/test/api/controllers/cli/cleanDb.test.js
+++ b/test/api/controllers/cli/cleanDb.test.js
@@ -1,5 +1,7 @@
 const
   KuzzleMock = require('../../../mocks/kuzzle.mock'),
+  Bluebird = require('bluebird'),
+  sinon = require('sinon'),
   should = require('should');
 
 describe('Test: clean database', () => {
@@ -12,18 +14,68 @@ describe('Test: clean database', () => {
     cleanDb = require('../../../../lib/api/controllers/cli/cleanDb')(kuzzle);
   });
 
-  it('should call kuzzle.resetStorage', () => {
-    return cleanDb()
+  it('should erase the internal ES & Redis dbs', () => {
+    kuzzle.repositories.user.search.returns(Bluebird.resolve({total: 0, hits: []}));
+    
+    return cleanDb(null, sinon.stub())
       .then(() => {
-        try {
-          should(kuzzle.resetStorage).be.calledOnce();
+        should(kuzzle.repositories.user.search).be.calledOnce();
+        should(kuzzle.repositories.user.scroll.called).be.false();
+        should(kuzzle.internalEngine.deleteIndex).be.calledOnce();
+        should(kuzzle.services.list.internalCache.flushdb).be.calledOnce();
+        should(kuzzle.services.list.memoryStorage.flushdb).be.calledOnce();
 
-          return Promise.resolve();
-        }
-        catch (error) {
-          return Promise.reject(error);
-        }
+        should(kuzzle.indexCache.remove)
+          .be.calledOnce()
+          .be.calledWithExactly('internalIndex');
+
+        should(kuzzle.internalEngine.bootstrap.all).be.calledOnce();
+        should(kuzzle.validation).be.an.Object();
+        should(kuzzle.start).be.a.Function();
+
+        sinon.assert.callOrder(
+          kuzzle.internalEngine.deleteIndex,
+          kuzzle.services.list.internalCache.flushdb,
+          kuzzle.services.list.memoryStorage.flushdb,
+          kuzzle.indexCache.remove,
+          kuzzle.internalEngine.bootstrap.all
+        );
       });
   });
 
+  it('should scroll and delete all registered users', () => {
+    kuzzle.repositories.user.search.returns(Bluebird.resolve({total: 5, scrollId: 'foobar', hits: [
+      {_id: 'foo1' },
+      {_id: 'foo2' },
+      {_id: 'foo3' }
+    ]}));
+
+    kuzzle.repositories.user.scroll.onFirstCall().returns(Bluebird.resolve({
+      total: 1, 
+      scrollId: 'foobar2', 
+      hits: [{_id: 'foo4'}]
+    }));
+
+    kuzzle.repositories.user.scroll.onSecondCall().returns(Bluebird.resolve({
+      total: 1, 
+      scrollId: 'foobar2', 
+      hits: [{_id: 'foo5'}]
+    }));
+
+    return cleanDb(null, sinon.stub())
+      .then(() => {
+        should(kuzzle.repositories.user.search).be.calledOnce();
+        should(kuzzle.repositories.user.scroll).be.calledTwice();
+
+        should(kuzzle.repositories.user.scroll.getCall(0).args[0]).be.eql('foobar');
+        should(kuzzle.repositories.user.scroll.getCall(1).args[0]).be.eql('foobar2');
+
+        should(kuzzle.funnel.controllers.security.deleteUser.callCount).be.eql(5);
+        should(kuzzle.funnel.controllers.security.deleteUser.getCall(0).args[0].input.resource._id).be.eql('foo1');
+        should(kuzzle.funnel.controllers.security.deleteUser.getCall(1).args[0].input.resource._id).be.eql('foo2');
+        should(kuzzle.funnel.controllers.security.deleteUser.getCall(2).args[0].input.resource._id).be.eql('foo3');
+        should(kuzzle.funnel.controllers.security.deleteUser.getCall(3).args[0].input.resource._id).be.eql('foo4');
+        should(kuzzle.funnel.controllers.security.deleteUser.getCall(4).args[0].input.resource._id).be.eql('foo5');
+      });
+  });
 });

--- a/test/api/controllers/cli/dump.test.js
+++ b/test/api/controllers/cli/dump.test.js
@@ -87,7 +87,7 @@ describe('Test: dump', () => {
     it('should return computed dump path', () => {
       const expectedDumpPath = '/tmp/'.concat((new Date()).getFullYear()).concat('-tests');
 
-      return dump(new Request({suffix: 'tests'}))
+      return dump(new Request({suffix: 'tests'}), sinon.stub())
         .then(dumpPath => should(dumpPath).be.exactly(expectedDumpPath));
     });
 
@@ -97,7 +97,7 @@ describe('Test: dump', () => {
         osDump,
         baseDumpPath = '/tmp/'.concat((new Date()).getFullYear());
 
-      return dump()
+      return dump(null, sinon.stub())
         .then(() => {
           should(fsStub.mkdirsSync).be.calledOnce();
           should(fsStub.mkdirsSync.getCall(0).args[0]).be.exactly(baseDumpPath);
@@ -155,7 +155,7 @@ describe('Test: dump', () => {
           ctime: 3
         });
 
-      return dump()
+      return dump(null, sinon.stub())
         .then(() => {
           should(fsStub.createReadStream)
             .be.calledWith('/foo/bar/baz.log')
@@ -184,14 +184,14 @@ describe('Test: dump', () => {
     it('should do nothing if the dump path is not reachable', () => {
       fsStub.accessSync.throws(new Error('foobar'));
 
-      return dump()
+      return dump(null, sinon.stub())
         .then(() => should(fsStub.readdirSync).not.be.called());
     });
 
     it('should not delete reports nor coredumps if limits are not reached', () => {
       fsStub.readdirSync.returns(['foo', 'bar']);
 
-      return dump()
+      return dump(null, sinon.stub())
         .then(() => should(fsStub.removeSync).not.be.called());
     });
 
@@ -209,7 +209,7 @@ describe('Test: dump', () => {
 
       globStub.sync.returns([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
-      return dump()
+      return dump(null, sinon.stub())
         .then(() => {
           // readdir returns 9 directory + 1 non-directory
           // the limit is set to 5, so we should remove
@@ -232,7 +232,7 @@ describe('Test: dump', () => {
         .withArgs('/tmp', 0)
         .returns();
 
-      return dump()
+      return dump(null, sinon.stub())
         .then(() => {
           for (let i = 1; i < 8; i++) {
             should(globStub.sync)

--- a/test/api/controllers/cli/shutdown.test.js
+++ b/test/api/controllers/cli/shutdown.test.js
@@ -41,10 +41,6 @@ describe('CLI Action: shutdown', () => {
 
     shutdownFactory.__set__({
       process: processMock,
-      console: {
-        warn: sinon.stub(),
-        error: sinon.stub()
-      },
       // prevent waiting seconds for unit tests
       setTimeout: sinon.spy(function (...args) { setImmediate(args[0]); })
     });
@@ -59,7 +55,7 @@ describe('CLI Action: shutdown', () => {
   it('should exit immediately if unable to retrieve the PM2 process list', done => {
     pm2Mock.list.yields(new Error('foo'));
 
-    shutdown()
+    shutdown(null, sinon.stub())
       .then(() => {
         setTimeout(() => {
           should(kuzzle.entryPoints.proxy.dispatch)
@@ -78,7 +74,7 @@ describe('CLI Action: shutdown', () => {
   it('should exit immediately if kuzzle was not started with PM2', done => {
     pm2Mock.list.yields(null, []);
 
-    shutdown()
+    shutdown(null, sinon.stub())
       .then(() => {
         setTimeout(() => {
           should(kuzzle.entryPoints.proxy.dispatch)
@@ -103,7 +99,7 @@ describe('CLI Action: shutdown', () => {
       }
     }]);
 
-    shutdown()
+    shutdown(null, sinon.stub())
       .then(() => {
         setTimeout(() => {
           should(kuzzle.entryPoints.proxy.dispatch)
@@ -126,7 +122,7 @@ describe('CLI Action: shutdown', () => {
       pm2_env: {}
     }]);
 
-    shutdown()
+    shutdown(null, sinon.stub())
       .then(() => {
         // should wait until called a second time by PM2
         setTimeout(() => {
@@ -139,7 +135,7 @@ describe('CLI Action: shutdown', () => {
           should(pm2Mock.restart).not.be.called();
           should(kuzzle.pluginsManager.shutdownWorkers).not.be.called();
 
-          shutdown();
+          shutdown(null, sinon.stub());
 
           setTimeout(() => {
             should(kuzzle.entryPoints.proxy.dispatch)
@@ -164,7 +160,7 @@ describe('CLI Action: shutdown', () => {
 
     pm2Mock.list.yields(new Error('foo'));
 
-    shutdown()
+    shutdown(null, sinon.stub())
       .then(() => {
         setTimeout(() => {
           should(remainingChanged).be.true();

--- a/test/api/controllers/securityController/credentials.test.js
+++ b/test/api/controllers/securityController/credentials.test.js
@@ -127,7 +127,7 @@ describe('Test: security controller - credentials', () => {
       kuzzle.repositories.user.load.returns(Bluebird.resolve(null));
 
       return should(securityController.updateCredentials(request))
-        .rejectedWith(BadRequestError, {message: 'Cannot create credentials: unknown kuid "someUserId"'});
+        .rejectedWith(BadRequestError, {message: 'Cannot update credentials: unknown kuid "someUserId"'});
     });
   });
 

--- a/test/api/kuzzle.test.js
+++ b/test/api/kuzzle.test.js
@@ -40,38 +40,6 @@ describe('/lib/api/kuzzle.js', () => {
     kuzzle.emit('event', {});
   });
 
-  describe('#resetStorage', () => {
-    it('should erase the internal ES & Redis dbs', () => {
-      return kuzzle.resetStorage()
-        .then(() => {
-          should(kuzzle.pluginsManager.trigger)
-            .be.calledOnce()
-            .be.calledWithExactly('log:warn', 'Kuzzle::resetStorage called');
-
-          should(kuzzle.internalEngine.deleteIndex).be.calledOnce();
-          should(kuzzle.services.list.internalCache.flushdb).be.calledOnce();
-          should(kuzzle.services.list.memoryStorage.flushdb).be.calledOnce();
-
-          should(kuzzle.indexCache.remove)
-            .be.calledOnce()
-            .be.calledWithExactly('internalIndex');
-
-          should(kuzzle.internalEngine.bootstrap.all).be.calledOnce();
-          should(kuzzle.validation).be.an.Object();
-          should(kuzzle.start).be.a.Function();
-
-          sinon.assert.callOrder(
-            kuzzle.pluginsManager.trigger,
-            kuzzle.internalEngine.deleteIndex,
-            kuzzle.services.list.internalCache.flushdb,
-            kuzzle.services.list.memoryStorage.flushdb,
-            kuzzle.indexCache.remove,
-            kuzzle.internalEngine.bootstrap.all
-          );
-        });
-    });
-  });
-
   describe('#start', () => {
     it('should init the components in proper order', () => {
       return kuzzle.start()

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -54,7 +54,8 @@ class KuzzleMock extends Kuzzle {
           adminExists: sinon.stub(),
         },
         security: {
-          createFirstAdmin: sinon.spy()
+          createFirstAdmin: sinon.spy(),
+          deleteUser: sinon.spy()
         }
       },
       pluginsControllers: {
@@ -177,6 +178,7 @@ class KuzzleMock extends Kuzzle {
       user: {
         load: sinon.stub().returns(Bluebird.resolve(foo)),
         search: sinon.stub().returns(Bluebird.resolve()),
+        scroll: sinon.stub().returns(Bluebird.resolve()),
         ObjectConstructor: sinon.stub().returns({}),
         hydrate: sinon.stub().returns(Bluebird.resolve()),
         persist: sinon.stub().returns(Bluebird.resolve({})),
@@ -190,8 +192,6 @@ class KuzzleMock extends Kuzzle {
         deleteByUserId: sinon.stub().returns(Bluebird.resolve())
       }
     };
-
-    this.resetStorage = sinon.stub().returns(Bluebird.resolve());
 
     this.rootPath = '/kuzzle';
 


### PR DESCRIPTION
# Description

* The API now forbids to create or update credentials on non-existing users
* Several fixes on credentials plugin calls in the security controllers (wrong strategy argument passed)
* The `reset` CLI command now thoroughly deletes users and their credentials, preventing inconsistent data when a kuzzle reset is performed
* The `resetStorage` function performing a Kuzzle reset has been moved from the main `kuzzle.js` file to the `cleanDb` CLI action implementation
* Kuzzle now throws internal errors when credentials are found on a non-existing user when attempting to create it

# Other changes

CLI commands now provide feedbacks to their caller (kuzzle or a CLI user) instead of writing them exclusively in Kuzzle logs.
This has been done primarily to make CLI users wait when performing a `reset`, as deleting users may take minutes depending on the amount of users to delete, and feedback is necessary to indicate that the CLI is performing actions (prior to this, the command would provide no feedback and users may think that the CLI has frozen)
CLI feedbacks have been extended to the `dump` and `shutdown` CLI commands.

# Fixed issue

#861 
