### PR TITLE
Add new trigger on error

### DIFF
--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -525,7 +525,7 @@ function handleProcessRequestError(modifiedRequest, request, controllers, error)
   return triggerEvent(this.kuzzle, modifiedRequest, eventError)
     .then(modifiedRequestError => {
       // If there is no pipe attached on this event, the same request is passed in resolve and we should reject it
-      if (modifiedRequestError === modifiedRequest) {
+      if (modifiedRequestError.error !== null) {
         return Bluebird.reject(modifiedRequest.error);
       }
 

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -204,8 +204,8 @@ class FunnelController {
     this.checkRights(request)
       .then(modifiedRequest => this.processRequest(modifiedRequest))
       .then(processResult => callback(null, processResult))
-      .catch(() => {
-        this._executeError(request, true, callback);
+      .catch(err => {
+        this._executeError(err, request, true, callback);
         result = 1;
       });
 
@@ -233,8 +233,8 @@ class FunnelController {
     let result = 0;
     this.processRequest(request)
       .then(response => callback(null, response))
-      .catch(() => {
-        this._executeError(request, false, callback);
+      .catch(err => {
+        this._executeError(err, request, false, callback);
         result = 1;
       });
 
@@ -388,10 +388,54 @@ class FunnelController {
 
         return newRequest;
       })
-      .catch(error => handleProcessRequestError.call(this, modifiedRequest, request, controllers, error))
+      .catch(error => this.handleProcessRequestError(modifiedRequest, request, controllers, error))
       .finally(() => {
         this.concurrentRequests--;
         delete this.pendingRequests[request.id];
+      });
+  }
+
+  handleProcessRequestError(modifiedRequest, request, controllers, error) {
+    let _error = error;
+    const eventError = this.getEventName(modifiedRequest.input.controller, 'error', modifiedRequest.input.action);
+
+    if (controllers === this.pluginsControllers && !(error instanceof KuzzleError)) {
+      _error = new PluginImplementationError(error);
+    }
+    modifiedRequest.setError(_error);
+
+    return triggerEvent(this.kuzzle, modifiedRequest, eventError)
+      .then(modifiedRequestError => {
+        // If there is no pipe attached on this event, the same request is passed in resolve and we should reject it
+        if (modifiedRequestError.error !== null) {
+          return Bluebird.reject(modifiedRequest.error);
+        }
+
+        return modifiedRequestError;
+      })
+      .catch(customError => {
+        if (controllers === this.pluginsControllers && !(customError instanceof KuzzleError)) {
+          _error = new PluginImplementationError(customError);
+        }
+        modifiedRequest.setError(_error);
+
+        // do not trigger global events on plugins' subrequests
+        if (modifiedRequest.origin === null) {
+          return triggerEvent(this.kuzzle, modifiedRequest, 'request:onError')
+            .then(modifiedRequestError => {
+              if (modifiedRequestError !== modifiedRequest) {
+                return modifiedRequestError;
+              }
+
+              return Bluebird.reject(modifiedRequest.error);
+            })
+            .catch(() => {
+              this.kuzzle.statistics.failedRequest(request);
+              return Bluebird.reject(_error);
+            });
+        }
+
+        return Bluebird.reject();
       });
   }
 
@@ -429,16 +473,18 @@ class FunnelController {
    * @returns {null}
    * @private
    */
-  _executeError (request, asError, callback) {
+  _executeError (error, request, asError, callback) {
     // JSON.stringify(new NativeError()) === '{}', i.e. Error, SyntaxError, TypeError, ReferenceError, etc.
-    this.kuzzle.pluginsManager.trigger('log:error', request.error instanceof Error && !(request.error instanceof KuzzleError)
-      ? request.error.message + '\n' + request.error.stack
-      : request.error
+    this.kuzzle.pluginsManager.trigger('log:error', error instanceof Error && !(error instanceof KuzzleError)
+      ? error.message + '\n' + error.stack
+      : error
     );
 
+    request.setError(error);
+
     if (asError) {
-      callback(request.error, request);
-      this.handleErrorDump(request.error);
+      callback(error, request);
+      this.handleErrorDump(error);
     }
     else {
       callback(null, request);
@@ -511,50 +557,6 @@ function triggerEvent(kuzzle, request, event) {
 
   request.triggers(event);
   return kuzzle.pluginsManager.trigger(event, request);
-}
-
-function handleProcessRequestError(modifiedRequest, request, controllers, error) {
-  let _error = error;
-  const eventError = this.getEventName(modifiedRequest.input.controller, 'error', modifiedRequest.input.action);
-
-  if (controllers === this.pluginsControllers && !(error instanceof KuzzleError)) {
-    _error = new PluginImplementationError(error);
-  }
-  modifiedRequest.setError(_error);
-
-  return triggerEvent(this.kuzzle, modifiedRequest, eventError)
-    .then(modifiedRequestError => {
-      // If there is no pipe attached on this event, the same request is passed in resolve and we should reject it
-      if (modifiedRequestError.error !== null) {
-        return Bluebird.reject(modifiedRequest.error);
-      }
-
-      return modifiedRequestError;
-    })
-    .catch(customError => {
-      if (controllers === this.pluginsControllers && !(customError instanceof KuzzleError)) {
-        _error = new PluginImplementationError(customError);
-      }
-      modifiedRequest.setError(_error);
-
-      // do not trigger global events on plugins' subrequests
-      if (modifiedRequest.origin === null) {
-        return triggerEvent(this.kuzzle, modifiedRequest, 'request:onError')
-          .then(modifiedRequestError => {
-            if (modifiedRequestError !== modifiedRequest) {
-              return modifiedRequestError;
-            }
-
-            return Bluebird.reject(modifiedRequest.error);
-          })
-          .catch(() => {
-            this.kuzzle.statistics.failedRequest(request);
-            return Bluebird.reject(_error);
-          });
-      }
-
-      return Bluebird.reject();
-    });
 }
 
 module.exports = FunnelController;

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -204,8 +204,8 @@ class FunnelController {
     this.checkRights(request)
       .then(modifiedRequest => this.processRequest(modifiedRequest))
       .then(processResult => callback(null, processResult))
-      .catch(err => {
-        this._executeError(err, request, true, callback);
+      .catch(() => {
+        this._executeError(request, true, callback);
         result = 1;
       });
 
@@ -233,8 +233,8 @@ class FunnelController {
     let result = 0;
     this.processRequest(request)
       .then(response => callback(null, response))
-      .catch(e => {
-        this._executeError(e, request, false, callback);
+      .catch(() => {
+        this._executeError(request, false, callback);
         result = 1;
       });
 
@@ -388,23 +388,7 @@ class FunnelController {
 
         return newRequest;
       })
-      .catch(error => {
-        let _error = error;
-
-        this.kuzzle.statistics.failedRequest(request);
-
-        if (controllers === this.pluginsControllers && !(error instanceof KuzzleError)) {
-          _error = new PluginImplementationError(error);
-        }
-
-        // do not trigger global events on plugins' subrequests
-        if (modifiedRequest.origin === null) {
-          return triggerEvent(this.kuzzle, modifiedRequest, 'request:onError')
-            .finally(() => Bluebird.reject(_error));
-        }
-
-        return Bluebird.reject(_error);
-      })
+      .catch(error => handleProcessRequestError.call(this, modifiedRequest, request, controllers, error))
       .finally(() => {
         this.concurrentRequests--;
         delete this.pendingRequests[request.id];
@@ -445,17 +429,16 @@ class FunnelController {
    * @returns {null}
    * @private
    */
-  _executeError (error, request, asError, callback) {
+  _executeError (request, asError, callback) {
     // JSON.stringify(new NativeError()) === '{}', i.e. Error, SyntaxError, TypeError, ReferenceError, etc.
-    this.kuzzle.pluginsManager.trigger('log:error', error instanceof Error && !(error instanceof KuzzleError)
-      ? error.message + '\n' + error.stack
-      : error
+    this.kuzzle.pluginsManager.trigger('log:error', request.error instanceof Error && !(request.error instanceof KuzzleError)
+      ? request.error.message + '\n' + request.error.stack
+      : request.error
     );
 
-    request.setError(error);
     if (asError) {
-      callback(error, request);
-      this.handleErrorDump(error);
+      callback(request.error, request);
+      this.handleErrorDump(request.error);
     }
     else {
       callback(null, request);
@@ -528,6 +511,50 @@ function triggerEvent(kuzzle, request, event) {
 
   request.triggers(event);
   return kuzzle.pluginsManager.trigger(event, request);
+}
+
+function handleProcessRequestError(modifiedRequest, request, controllers, error) {
+  let _error = error;
+  const eventError = this.getEventName(modifiedRequest.input.controller, 'error', modifiedRequest.input.action);
+
+  if (controllers === this.pluginsControllers && !(error instanceof KuzzleError)) {
+    _error = new PluginImplementationError(error);
+  }
+  modifiedRequest.setError(_error);
+
+  return triggerEvent(this.kuzzle, modifiedRequest, eventError)
+    .then(modifiedRequestError => {
+      // If there is no pipe attached on this event, the same request is passed in resolve and we should reject it
+      if (modifiedRequestError === modifiedRequest) {
+        return Bluebird.reject(modifiedRequest.error);
+      }
+
+      return modifiedRequestError;
+    })
+    .catch(customError => {
+      if (controllers === this.pluginsControllers && !(customError instanceof KuzzleError)) {
+        _error = new PluginImplementationError(customError);
+      }
+      modifiedRequest.setError(_error);
+
+      // do not trigger global events on plugins' subrequests
+      if (modifiedRequest.origin === null) {
+        return triggerEvent(this.kuzzle, modifiedRequest, 'request:onError')
+          .then(modifiedRequestError => {
+            if (modifiedRequestError !== modifiedRequest) {
+              return modifiedRequestError;
+            }
+
+            return Bluebird.reject(modifiedRequest.error);
+          })
+          .catch(() => {
+            this.kuzzle.statistics.failedRequest(request);
+            return Bluebird.reject(_error);
+          });
+      }
+
+      return Bluebird.reject();
+    });
 }
 
 module.exports = FunnelController;

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -414,9 +414,12 @@ class FunnelController {
         return modifiedRequestError;
       })
       .catch(customError => {
+        _error = customError;
+
         if (controllers === this.pluginsControllers && !(customError instanceof KuzzleError)) {
           _error = new PluginImplementationError(customError);
         }
+
         modifiedRequest.setError(_error);
 
         // do not trigger global events on plugins' subrequests
@@ -435,7 +438,7 @@ class FunnelController {
             });
         }
 
-        return Bluebird.reject();
+        return Bluebird.reject(_error);
       });
   }
 

--- a/test/api/controllers/funnelController/processRequest.test.js
+++ b/test/api/controllers/funnelController/processRequest.test.js
@@ -61,6 +61,7 @@ describe('funnelController.processRequest', () => {
     should(funnel.requestHistory.isEmpty()).be.true();
     should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
     should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.false();
+    should(kuzzle.pluginsManager.trigger.calledWithMatch('fakeController:errorCreate', request)).be.false();
     should(kuzzle.statistics.startRequest.called).be.false();
   });
 
@@ -71,6 +72,7 @@ describe('funnelController.processRequest', () => {
     should(funnel.requestHistory.isEmpty()).be.true();
     should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
     should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.false();
+    should(kuzzle.pluginsManager.trigger.calledWithMatch('fakePlugin/controller:errorCreate', request)).be.false();
     should(kuzzle.statistics.startRequest.called).be.false();
   });
 
@@ -88,6 +90,7 @@ describe('funnelController.processRequest', () => {
         should(kuzzle.pluginsManager.trigger).calledWith('fakeController:afterOk');
         should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.true();
         should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.false();
+        should(kuzzle.pluginsManager.trigger.calledWithMatch('fakeController:errorOk', request)).be.false();
         should(kuzzle.statistics.startRequest.called).be.true();
         should(kuzzle.statistics.completedRequest.called).be.true();
         should(kuzzle.statistics.failedRequest.called).be.false();
@@ -114,6 +117,7 @@ describe('funnelController.processRequest', () => {
         should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', subrequest)).be.false();
         should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
         should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.false();
+        should(kuzzle.pluginsManager.trigger.calledWithMatch('fakeController:errorOk', request)).be.false();
         should(kuzzle.statistics.startRequest.called).be.true();
         should(kuzzle.statistics.completedRequest.called).be.true();
         should(kuzzle.statistics.failedRequest.called).be.false();
@@ -140,6 +144,7 @@ describe('funnelController.processRequest', () => {
         should(kuzzle.pluginsManager.trigger).not.be.calledWith('fakeController:afterFail');
         should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
         should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.true();
+        should(kuzzle.pluginsManager.trigger.calledWithMatch('fakeController:errorFail', request)).be.true();
         should(kuzzle.statistics.startRequest.called).be.true();
         should(kuzzle.statistics.completedRequest.called).be.false();
         should(kuzzle.statistics.failedRequest.called).be.true();
@@ -172,6 +177,7 @@ describe('funnelController.processRequest', () => {
         should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', subrequest)).be.false();
         should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
         should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.false();
+        should(kuzzle.pluginsManager.trigger.calledWithMatch('fakeController:errorFail', request)).be.false();
         should(kuzzle.statistics.startRequest.called).be.true();
         should(kuzzle.statistics.completedRequest.called).be.false();
         should(kuzzle.statistics.failedRequest.called).be.true();
@@ -199,6 +205,7 @@ describe('funnelController.processRequest', () => {
         should(kuzzle.pluginsManager.trigger).not.be.calledWith('fakePlugin/controller:afterFail');
         should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
         should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.true();
+        should(kuzzle.pluginsManager.trigger.calledWithMatch('fakePlugin/controller:errorFail', request)).be.true();
         should(kuzzle.statistics.startRequest.called).be.true();
         should(kuzzle.statistics.completedRequest.called).be.false();
         should(kuzzle.statistics.failedRequest.called).be.true();
@@ -221,6 +228,7 @@ describe('funnelController.processRequest', () => {
         should(kuzzle.pluginsManager.trigger).calledWith('fakeController:afterOk');
         should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.true();
         should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.false();
+        should(kuzzle.pluginsManager.trigger.calledWithMatch('fakeController:errorOk', request)).be.false();
         should(kuzzle.statistics.startRequest.called).be.true();
         should(kuzzle.statistics.completedRequest.called).be.true();
         should(kuzzle.statistics.failedRequest.called).be.false();


### PR DESCRIPTION
This PR allows to attach pipes on events `<controller>:error<Action>`, like `document:errorGet`.
The aim is to intercept error and change it to a normal response.