### PR TITLE
Default statusUpdate to console.log if undefined

### DIFF
--- a/lib/api/controllers/cli/cleanDb.js
+++ b/lib/api/controllers/cli/cleanDb.js
@@ -34,7 +34,8 @@ module.exports = function cliResetStorage (kuzzle) {
  * @param {Function} statusUpdate 
  * @returns Promise
  */
-function resetStorage (kuzzle, statusUpdate) {
+// eslint-disable-next-line no-console
+function resetStorage (kuzzle, statusUpdate = console.log) {
   statusUpdate('Kuzzle reset initiated: this may take a while...');
   
   return deleteUsers(kuzzle, statusUpdate)

--- a/lib/api/controllers/cli/dump.js
+++ b/lib/api/controllers/cli/dump.js
@@ -43,7 +43,8 @@ let
  * @param {Function} statusUpdate 
  * @returns {Promise}
  */
-function dump (request, statusUpdate) {
+// eslint-disable-next-line no-console
+function dump (request, statusUpdate = console.log) {
   if (_lock) {
     statusUpdate('A dump is already being generated. Skipping.');
     return Bluebird.resolve();

--- a/lib/api/controllers/cli/shutdown.js
+++ b/lib/api/controllers/cli/shutdown.js
@@ -36,7 +36,8 @@ let
  * @param {Function} statusUpdate
  * @returns {Promise}
  */
-function cliRunShutdown (request, statusUpdate) {
+// eslint-disable-next-line no-console
+function cliRunShutdown (request, statusUpdate = console.log) {
   // pm2.delete sends a SIGINT signal
   // we keep track of how many shutdowns are asked
   // to detect when pm2 has finished deleting Kuzzle


### PR DESCRIPTION
# Description

Fix a bug introduced by #867: internal calls to CLI commands `shutdown` and `dump` make kuzzle crash due to the new `statusUpdate` function not being provided by core code.