### PR TITLE
Changed deleteSpecifications API return type

### DIFF
--- a/lib/api/controllers/collectionController.js
+++ b/lib/api/controllers/collectionController.js
@@ -165,7 +165,7 @@ class CollectionController {
    * Add a specification collections
    *
    * @param {Request} request
-   * @returns {Promise<Boolean>}
+   * @returns {Promise<Object>}
    */
   deleteSpecifications(request) {
     assertHasIndexAndCollection(request);
@@ -174,7 +174,7 @@ class CollectionController {
       this.kuzzle.validation.specification[request.input.resource.index] === undefined ||
       this.kuzzle.validation.specification[request.input.resource.index][request.input.resource.collection] === undefined
     ) {
-      return Bluebird.resolve(true);
+      return Bluebird.resolve({acknowledged: true});
     }
 
     return this.internalEngine.delete('validations', `${request.input.resource.index}#${request.input.resource.collection}`)
@@ -185,7 +185,7 @@ class CollectionController {
       })
       .then(() => this.kuzzle.internalEngine.refresh())
       .then(() => this.kuzzle.validation.curateSpecification())
-      .then(() => Bluebird.resolve(true));
+      .then(() => Bluebird.resolve({acknowledged: true}));
   }
 
   /**

--- a/lib/api/controllers/collectionController.js
+++ b/lib/api/controllers/collectionController.js
@@ -165,7 +165,7 @@ class CollectionController {
    * Add a specification collections
    *
    * @param {Request} request
-   * @returns {Promise<Object>}
+   * @returns {Promise<Boolean>}
    */
   deleteSpecifications(request) {
     assertHasIndexAndCollection(request);
@@ -174,7 +174,7 @@ class CollectionController {
       this.kuzzle.validation.specification[request.input.resource.index] === undefined ||
       this.kuzzle.validation.specification[request.input.resource.index][request.input.resource.collection] === undefined
     ) {
-      return Bluebird.resolve({});
+      return Bluebird.resolve(true);
     }
 
     return this.internalEngine.delete('validations', `${request.input.resource.index}#${request.input.resource.collection}`)
@@ -185,7 +185,7 @@ class CollectionController {
       })
       .then(() => this.kuzzle.internalEngine.refresh())
       .then(() => this.kuzzle.validation.curateSpecification())
-      .then(() => Bluebird.resolve({}));
+      .then(() => Bluebird.resolve(true));
   }
 
   /**

--- a/test/api/controllers/collectionController.test.js
+++ b/test/api/controllers/collectionController.test.js
@@ -382,7 +382,7 @@ describe('Test: collection controller', () => {
 
           try {
             should(kuzzle.internalEngine.delete).be.calledOnce();
-            should(response).match({});
+            should(response).match(true);
 
             return Promise.resolve();
           }
@@ -400,7 +400,7 @@ describe('Test: collection controller', () => {
         .then(response => {
           try {
             should(kuzzle.internalEngine.delete).not.be.called();
-            should(response).match({});
+            should(response).match(true);
 
             return Promise.resolve();
           }

--- a/test/api/controllers/collectionController.test.js
+++ b/test/api/controllers/collectionController.test.js
@@ -382,7 +382,7 @@ describe('Test: collection controller', () => {
 
           try {
             should(kuzzle.internalEngine.delete).be.calledOnce();
-            should(response).match(true);
+            should(response).match({acknowledged: true});
 
             return Promise.resolve();
           }
@@ -400,7 +400,7 @@ describe('Test: collection controller', () => {
         .then(response => {
           try {
             should(kuzzle.internalEngine.delete).not.be.called();
-            should(response).match(true);
+            should(response).match({acknowledged: true});
 
             return Promise.resolve();
           }


### PR DESCRIPTION
Small PR to change the `deleteSpecifications` API return type (when resolved) to a more logical one (empty `array` to `boolean`).
Doc change underway.