### PR TITLE
Fix Kuzzle returning an unknown request id to the proxy

### DIFF
--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -94,7 +94,7 @@ class RouterController {
         headers: {'content-type': 'application/json'}
       });
 
-      cb(request.response);
+      cb(request);
     });
 
     this.router.get('/swagger.yml', (request, cb) => {
@@ -104,7 +104,7 @@ class RouterController {
         headers: {'content-type': 'application/yaml'}
       });
 
-      cb(request.response);
+      cb(request);
     });
 
     // Register API routes
@@ -130,7 +130,7 @@ function executeFromHttp(funnel, params, request, cb) {
   request.input.action = params.action;
 
   funnel.execute(request, (err, result) => {
-    cb(result.response);
+    cb(result);
   });
 }
 

--- a/lib/api/core/entryPoints/kuzzleProxy.js
+++ b/lib/api/core/entryPoints/kuzzleProxy.js
@@ -77,9 +77,24 @@ function onRequest (data) {
   debug('[%s] received request from proxy: %a', request.id, data);
 
   this.kuzzle.funnel.execute(request, (error, result) => {
-    debug('[%s] sending request response to proxy: %a', request.id, result.response);
+    const response = result.response.toJSON();
 
-    this.kuzzle.services.list.proxyBroker.send('response', result.response);
+    /*
+      Makes sure that the proxy gets the same request id than
+      the one it sent to Kuzzle, so it can link it to a client
+      See https://github.com/kuzzleio/kuzzle/issues/874
+     */
+    if (response.requestId !== request.id) {
+      response.requestId = request.id;
+
+      if (!response.raw) {
+        response.content.requestId = request.id;
+      }
+    }
+
+    debug('[%s] sending request response to proxy: %a', response.requestId, response);
+
+    this.kuzzle.services.list.proxyBroker.send('response', response);
   });
 }
 
@@ -110,7 +125,22 @@ function onDisconnect (data) {
 function onHttpRequest (message) {
   debug('received HTTP request from proxy: %a', message);
 
-  this.kuzzle.router.router.route(message, response => {
+  this.kuzzle.router.router.route(message, result => {
+    const response = result.response.toJSON();
+
+    /*
+      Makes sure that the proxy gets the same request id than
+      the one it sent to Kuzzle, so it can link it to a client
+      See https://github.com/kuzzleio/kuzzle/issues/874
+     */
+    if (message.requestId !== response.requestId) {
+      response.requestId = message.requestId;
+
+      if (!response.raw) {
+        response.content.requestId = message.requestId;
+      }
+    }
+
     debug('sending HTTP request response to proxy: %a', response);
 
     this.kuzzle.services.list.proxyBroker.send('httpResponse', response);

--- a/lib/api/core/httpRouter/index.js
+++ b/lib/api/core/httpRouter/index.js
@@ -66,7 +66,7 @@ class Router {
     attach('/', (request, cb) => {
       Object.assign(request.input.args, this.defaultHeaders);
       request.setResult({}, 200);
-      cb(request.response);
+      cb(request);
     }, this.routes.HEAD);
   }
 
@@ -127,7 +127,7 @@ class Router {
 
         return this.kuzzle.pluginsManager.trigger('http:options', request)
           .then(result => {
-            cb(result.response);
+            cb(result);
             return null;
           })
           .catch(error => replyWithError(cb, request, error));
@@ -215,7 +215,7 @@ function attachParts(parts, handler, target) {
 function replyWithError(cb, request, error) {
   request.setError(error);
 
-  cb(request.response);
+  cb(request);
 }
 
 /**

--- a/test/api/controllers/routerController/httpRequest.test.js
+++ b/test/api/controllers/routerController/httpRequest.test.js
@@ -63,11 +63,11 @@ describe('Test: routerController.httpRequest', () => {
       try {
         should(response.input.controller).be.eql('ms');
         should(response.input.action).be.eql('getrange');
-        should(result.requestId).be.eql(httpRequest.requestId);
-        should(result.headers['content-type']).be.eql('application/json');
-        should(result.headers['Access-Control-Allow-Origin']).be.eql('foobar');
-        should(result.status).be.eql(1234);
-        should(result).be.exactly(response.response);
+        should(result.response.requestId).be.eql(httpRequest.requestId);
+        should(result.response.headers['content-type']).be.eql('application/json');
+        should(result.response.headers['Access-Control-Allow-Origin']).be.eql('foobar');
+        should(result.response.status).be.eql(1234);
+        should(result.response).be.exactly(response.response);
         done();
       }
       catch (e) {
@@ -85,10 +85,10 @@ describe('Test: routerController.httpRequest', () => {
       try {
         should(response.input.controller).be.eql('security');
         should(response.input.action).be.eql('updateProfile');
-        should(result.requestId).be.eql(httpRequest.requestId);
-        should(result.headers['content-type']).be.eql('application/json');
-        should(result.status).be.eql(1234);
-        should(result).be.exactly(response.response);
+        should(result.response.requestId).be.eql(httpRequest.requestId);
+        should(result.response.headers['content-type']).be.eql('application/json');
+        should(result.response.status).be.eql(1234);
+        should(result.response).be.exactly(response.response);
         done();
       }
       catch (e) {
@@ -106,10 +106,10 @@ describe('Test: routerController.httpRequest', () => {
       try {
         should(response.input.controller).be.eql('auth');
         should(response.input.action).be.eql('updateSelf');
-        should(result.requestId).be.eql(httpRequest.requestId);
-        should(result.headers['content-type']).be.eql('application/json');
-        should(result.status).be.eql(1234);
-        should(result).be.exactly(response.response);
+        should(result.response.requestId).be.eql(httpRequest.requestId);
+        should(result.response.headers['content-type']).be.eql('application/json');
+        should(result.response.status).be.eql(1234);
+        should(result.response).be.exactly(response.response);
         done();
       }
       catch (e) {
@@ -126,10 +126,10 @@ describe('Test: routerController.httpRequest', () => {
       try {
         should(response.input.controller).be.eql('index');
         should(response.input.action).be.eql('delete');
-        should(result.requestId).be.eql(httpRequest.requestId);
-        should(result.headers['content-type']).be.eql('application/json');
-        should(result.status).be.eql(1234);
-        should(result).be.exactly(response.response);
+        should(result.response.requestId).be.eql(httpRequest.requestId);
+        should(result.response.headers['content-type']).be.eql('application/json');
+        should(result.response.status).be.eql(1234);
+        should(result.response).be.exactly(response.response);
         done();
       }
       catch (e) {
@@ -146,10 +146,10 @@ describe('Test: routerController.httpRequest', () => {
       try {
         should(response.input.controller).be.eql('server');
         should(response.input.action).be.eql('info');
-        should(result.requestId).be.eql(httpRequest.requestId);
-        should(result.headers['content-type']).be.eql('application/json');
-        should(result.status).be.eql(1234);
-        should(result).be.exactly(response.response);
+        should(result.response.requestId).be.eql(httpRequest.requestId);
+        should(result.response.headers['content-type']).be.eql('application/json');
+        should(result.response.status).be.eql(1234);
+        should(result.response).be.exactly(response.response);
         done();
       }
       catch (e) {
@@ -164,9 +164,9 @@ describe('Test: routerController.httpRequest', () => {
 
     routeController.router.route(httpRequest, result => {
       try {
-        should(result.requestId).be.eql(httpRequest.requestId);
-        should(result.headers['content-type']).be.eql('application/json');
-        should(result.status).be.eql(200);
+        should(result.response.requestId).be.eql(httpRequest.requestId);
+        should(result.response.headers['content-type']).be.eql('application/json');
+        should(result.response.status).be.eql(200);
         done();
       }
       catch (e) {
@@ -181,9 +181,9 @@ describe('Test: routerController.httpRequest', () => {
 
     routeController.router.route(httpRequest, result => {
       try {
-        should(result.requestId).be.eql(httpRequest.requestId);
-        should(result.headers['content-type']).be.eql('application/yaml');
-        should(result.status).be.eql(200);
+        should(result.response.requestId).be.eql(httpRequest.requestId);
+        should(result.response.headers['content-type']).be.eql('application/yaml');
+        should(result.response.status).be.eql(200);
         done();
       }
       catch (e) {
@@ -200,10 +200,10 @@ describe('Test: routerController.httpRequest', () => {
       try {
         should(response.input.controller).be.eql('foo');
         should(response.input.action).be.eql('bar');
-        should(result.requestId).be.eql(httpRequest.requestId);
-        should(result.headers['content-type']).be.eql('application/json');
-        should(result.status).be.eql(1234);
-        should(result).be.exactly(response.response);
+        should(result.response.requestId).be.eql(httpRequest.requestId);
+        should(result.response.headers['content-type']).be.eql('application/json');
+        should(result.response.status).be.eql(1234);
+        should(result.response).be.exactly(response.response);
         done();
       }
       catch (e) {
@@ -218,10 +218,10 @@ describe('Test: routerController.httpRequest', () => {
 
     routeController.router.route(httpRequest, result => {
       try {
-        should(result.requestId).be.eql(httpRequest.requestId);
-        should(result.headers['content-type']).be.eql('application/json');
-        should(result.status).be.eql(404);
-        should(result.error.message).be.eql('API URL not found: /foo/bar');
+        should(result.response.requestId).be.eql(httpRequest.requestId);
+        should(result.response.headers['content-type']).be.eql('application/json');
+        should(result.response.status).be.eql(404);
+        should(result.response.error.message).be.eql('API URL not found: /foo/bar');
         done();
       }
       catch (e) {

--- a/test/api/core/httpRouter/httpRouter.test.js
+++ b/test/api/core/httpRouter/httpRouter.test.js
@@ -141,10 +141,10 @@ describe('core/httpRouter', () => {
         foo: 'bar'
       };
 
-      router.route(rq, response => {
+      router.route(rq, result => {
         should(handler.called).be.false();
 
-        should(response.toJSON()).match({
+        should(result.response.toJSON()).match({
           raw: false,
           status: 200,
           requestId: rq.requestId,
@@ -171,10 +171,10 @@ describe('core/httpRouter', () => {
         foo: 'bar'
       };
 
-      router.route(rq, response => {
+      router.route(rq, result => {
         should(handler.called).be.false();
 
-        should(response.toJSON()).match({
+        should(result.response.toJSON()).match({
           raw: false,
           status: 200,
           requestId: rq.requestId,
@@ -198,11 +198,11 @@ describe('core/httpRouter', () => {
       rq.headers['content-type'] = 'application/json';
       rq.content = '{"foo": "bar"}';
 
-      router.route(rq, response => {
+      router.route(rq, result => {
         should(handler)
           .have.callCount(0);
 
-        should(response.toJSON())
+        should(result.response.toJSON())
           .match({
             raw: false,
             status: 400,
@@ -230,10 +230,10 @@ describe('core/httpRouter', () => {
       rq.headers['content-type'] = 'application/json';
       rq.content = '{bad JSON syntax}';
 
-      router.route(rq, response => {
+      router.route(rq, result => {
         should(handler.called).be.false();
 
-        should(response.toJSON()).be.match({
+        should(result.response.toJSON()).be.match({
           raw: false,
           status: 400,
           requestId: rq.requestId,
@@ -260,10 +260,10 @@ describe('core/httpRouter', () => {
       rq.headers['content-type'] = 'application/foobar';
       rq.content = '{"foo": "bar"}';
 
-      router.route(rq, response => {
+      router.route(rq, result => {
         should(handler.called).be.false();
 
-        should(response.toJSON()).match({
+        should(result.response.toJSON()).match({
           raw: false,
           status: 400,
           requestId: rq.requestId,
@@ -290,10 +290,10 @@ describe('core/httpRouter', () => {
       rq.headers['content-type'] = 'application/json; charset=iso8859-1';
       rq.content = '{"foo": "bar"}';
 
-      router.route(rq, response => {
+      router.route(rq, result => {
         should(handler.called).be.false();
 
-        should(response.toJSON()).match({
+        should(result.response.toJSON()).match({
           raw: false,
           status: 400,
           requestId: rq.requestId,
@@ -321,10 +321,10 @@ describe('core/httpRouter', () => {
       rq.headers['content-type'] = 'application/json';
       rq.content = '{"foo": "bar"}';
 
-      router.route(rq, response => {
+      router.route(rq, result => {
         should(handler.called).be.false();
 
-        should(response.toJSON()).match({
+        should(result.response.toJSON()).match({
           raw: false,
           status: 404,
           requestId: rq.requestId,

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -200,6 +200,11 @@ class KuzzleMock extends Kuzzle {
       init: sinon.spy(),
       newConnection: sinon.stub().returns(Bluebird.resolve(foo)),
       removeConnection: sinon.spy(),
+      router: {
+        router: {
+          route: sinon.stub()
+        }
+      }
     };
 
     this.services = {


### PR DESCRIPTION
# Description

Ensures that the source request identifier is always returned in the response provided to the proxy, allowing it to link the response to the requesting client.

# Unrelated change

The HTTP router `route` method creates a `Request` object generated from the provided raw JSON `message`.
This method now resolves the provided callback with this request object, instead of a `RequestResponse` derivated from it. This seems more logical and allows more control if needs be.

# Solved issue

#874 
