### PR TITLE
Embeds non-KuzzleError errors from pipe plugins in PluginImplementationError error

### DIFF
--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -24,7 +24,6 @@
 const
   debug = require('../../../kuzzleDebug')('kuzzle:plugins'),
   Request = require('kuzzle-common-objects').Request,
-  KuzzleError = require('kuzzle-common-objects').errors.KuzzleError,
   PluginContext = require('./pluginContext'),
   PrivilegedPluginContext = require('./privilegedPluginContext'),
   async = require('async'),
@@ -34,7 +33,12 @@ const
   CircularList = require('easy-circular-list'),
   fs = require('fs'),
   pm2 = require('pm2'),
-  {GatewayTimeoutError, PluginImplementationError, UnauthorizedError} = require('kuzzle-common-objects').errors;
+  {
+    KuzzleError,
+    GatewayTimeoutError,
+    PluginImplementationError,
+    UnauthorizedError
+  } = require('kuzzle-common-objects').errors;
 
 let
   pm2Promise = null;
@@ -583,7 +587,11 @@ function triggerPipes(pipes, event, data) {
   return new Bluebird((resolve, reject) => {
     async.waterfall([callback => callback(null, data)].concat(preparedPipes), (error, result) => {
       if (error) {
-        return reject(error);
+        if (error instanceof KuzzleError) {
+          return reject(error);
+        }
+
+        return reject(new PluginImplementationError(error));
       }
 
       resolve(result);
@@ -637,9 +645,7 @@ function triggerWorkers(workers, event, data) {
           message: dataToSend
         },
         id: pmId
-      }, (err, res) => {
-        callback(err, res);
-      });
+      }, callback);
     }, err => {
       if (err) {
         return reject(err);


### PR DESCRIPTION
# Description

Ensures that error values returned by pipe plugins are `KuzzleError` objects. If not, the plugins manager embeds the returned value in a `PluginImplementationError` object.

This solves a Kuzzle crash occuring because of an assertion check while trying to set a non-error object as a `Request` error value.

# Solved issue

#862 
