### PR TITLE
Remove obsolete "proxy:*" events

### DIFF
--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -507,7 +507,6 @@ class HotelClerk {
 
     for (const channel of Object.keys(room.channels)) {
       this.kuzzle.entryPoints.proxy.leaveChannel({channel, connectionId: requestContext.connectionId});
-      this.kuzzle.pluginsManager.trigger('proxy:leaveChannel', {channel, connectionId: requestContext.connectionId});
     }
 
     if (room.customers.size === 0) {
@@ -575,7 +574,7 @@ class HotelClerk {
     }
 
     this.kuzzle.entryPoints.proxy.joinChannel({channel: channelName, connectionId: request.context.connectionId});
-    this.kuzzle.pluginsManager.trigger('proxy:joinChannel', {channel: channelName, connectionId: request.context.connectionId});
+
     if (!this.rooms[roomId].channels[channelName]) {
       changed = true;
       this.rooms[roomId].channels[channelName] = channel;

--- a/lib/api/core/notifier.js
+++ b/lib/api/core/notifier.js
@@ -73,7 +73,6 @@ class NotifierController {
       };
 
       this.kuzzle.entryPoints.proxy.dispatch(eventName, data);
-      this.kuzzle.pluginsManager.trigger('proxy:' + eventName, data);
     }
 
     return true;

--- a/test/api/core/hotelClerk/addSubscription.test.js
+++ b/test/api/core/hotelClerk/addSubscription.test.js
@@ -48,7 +48,7 @@ describe('Test: hotelClerk.addSubscription', () => {
   });
 
   it('should have the new room and customer', () => {
-    var request = new Request({
+    const request = new Request({
       controller: 'realtime',
       action: 'subscribe',
       requestId: roomName,
@@ -63,8 +63,6 @@ describe('Test: hotelClerk.addSubscription', () => {
 
     return kuzzle.hotelClerk.addSubscription(request)
       .then(response => {
-        var customer;
-
         try {
           should(kuzzle.hotelClerk.rooms).be.an.Object();
           should(kuzzle.hotelClerk.rooms).not.be.empty();
@@ -80,7 +78,7 @@ describe('Test: hotelClerk.addSubscription', () => {
 
           roomId = kuzzle.hotelClerk.rooms[response.roomId].id;
 
-          customer = kuzzle.hotelClerk.customers[connectionId];
+          const customer = kuzzle.hotelClerk.customers[connectionId];
           should(customer).be.an.Object();
           should(customer).not.be.empty();
           should(customer[roomId]).not.be.undefined().and.match(request.input.volatile);
@@ -101,37 +99,14 @@ describe('Test: hotelClerk.addSubscription', () => {
       });
   });
 
-  it('should trigger a proxy:joinChannel hook', () => {
-    var request = new Request({
-      controller: 'realtime',
-      collection: collection,
-      index: index,
-      body: filter
-    }, context);
-
-    return kuzzle.hotelClerk.addSubscription(request)
-      .then(() => {
-        var data;
-
-        should(kuzzle.pluginsManager.trigger)
-          .be.calledWith('proxy:joinChannel');
-
-        data = kuzzle.pluginsManager.trigger.secondCall.args[1];
-
-        should(data).be.an.Object();
-        should(data.channel).be.a.String();
-        should(data.connectionId).be.eql(context.connectionId);
-      });
-  });
-
   it('should return the same response when the user has already subscribed to the filter', done => {
-    var request = new Request({
+    const request = new Request({
       controller: 'realtime',
       collection: collection,
       index: index,
       body: filter
     }, context);
-    var response;
+    let response;
 
     kuzzle.hotelClerk.addSubscription(request)
       .then(result => {
@@ -161,36 +136,32 @@ describe('Test: hotelClerk.addSubscription', () => {
   });
 
   it('should reject with an error if no index is provided', () => {
-    var
-      pAddSubscription,
-      request = new Request({
-        controller: 'realtime',
-        action: 'subscribe',
-        collection,
-        body: {}
-      }, context);
+    const request = new Request({
+      controller: 'realtime',
+      action: 'subscribe',
+      collection,
+      body: {}
+    }, context);
 
-    pAddSubscription = kuzzle.hotelClerk.addSubscription(request);
+    const pAddSubscription = kuzzle.hotelClerk.addSubscription(request);
     return should(pAddSubscription).be.rejectedWith(BadRequestError);
   });
 
   it('should reject with an error if no collection is provided', () => {
-    var
-      pAddSubscription,
-      request = new Request({
-        controller: 'realtime',
-        action: 'subscribe',
-        index,
-        body: {}
-      }, context);
+    const request = new Request({
+      controller: 'realtime',
+      action: 'subscribe',
+      index,
+      body: {}
+    }, context);
 
-    pAddSubscription = kuzzle.hotelClerk.addSubscription(request);
+    const pAddSubscription = kuzzle.hotelClerk.addSubscription(request);
     return should(pAddSubscription).be.rejectedWith(BadRequestError);
   });
 
 
   it('should return the same room ID if the same filters are used', done => {
-    var
+    const
       request1 = new Request({
         controller: 'realtime',
         collection: collection,
@@ -234,8 +205,8 @@ describe('Test: hotelClerk.addSubscription', () => {
             }
           ]
         }
-      }, context),
-      response;
+      }, context);
+    let response;
 
     kuzzle.hotelClerk.addSubscription(request1)
       .then(result => {
@@ -252,7 +223,7 @@ describe('Test: hotelClerk.addSubscription', () => {
   });
 
   it('should allow subscribing with an empty filter', () => {
-    var
+    const
       request = new Request({
         controller: 'realtime',
         index: index,
@@ -263,13 +234,13 @@ describe('Test: hotelClerk.addSubscription', () => {
   });
 
   it('should allow to subscribe to an existing room', done => {
-    var
-      anotherRoomId,
+    const
       request1 = new Request({
         controller: 'realtime',
         index: index,
         collection: collection
       }, {connectionId: 'connection1', user: null});
+    let anotherRoomId;
 
     kuzzle.hotelClerk.addSubscription(request1)
       .then(result => {
@@ -285,7 +256,7 @@ describe('Test: hotelClerk.addSubscription', () => {
         }
       })
       .then(id => {
-        var request2 = new Request({
+        const request2 = new Request({
           collection: collection,
           index: index,
           controller: 'realtime',
@@ -332,7 +303,7 @@ describe('Test: hotelClerk.addSubscription', () => {
   });
 
   it('should reject the subscription if the given state argument is incorrect', () => {
-    var request = new Request({
+    const request = new Request({
       collection: collection,
       controller: 'realtime',
       action: 'subscribe',
@@ -344,7 +315,7 @@ describe('Test: hotelClerk.addSubscription', () => {
   });
 
   it('should reject the subscription if the given scope argument is incorrect', () => {
-    var request = new Request({
+    const request = new Request({
       collection: collection,
       controller: 'realtime',
       action: 'subscribe',
@@ -356,7 +327,7 @@ describe('Test: hotelClerk.addSubscription', () => {
   });
 
   it('should reject the subscription if the given users argument is incorrect', () => {
-    var request = new Request({
+    const request = new Request({
       collection: collection,
       controller: 'realtime',
       action: 'subscribe',
@@ -368,7 +339,7 @@ describe('Test: hotelClerk.addSubscription', () => {
   });
 
   it('should treat null/undefined filters as empty filters', done => {
-    var
+    const
       request1 = new Request({
         controller: 'realtime',
         collection: collection,
@@ -380,8 +351,8 @@ describe('Test: hotelClerk.addSubscription', () => {
         collection: collection,
         index: index,
         body: null
-      }, context),
-      response;
+      }, context);
+    let response;
 
     kuzzle.hotelClerk.addSubscription(request1)
       .then(result => {

--- a/test/api/core/hotelClerk/removeSubscription.test.js
+++ b/test/api/core/hotelClerk/removeSubscription.test.js
@@ -132,20 +132,4 @@ describe('Test: hotelClerk.removeSubscription', () => {
     // testing payload argument
     should(kuzzle.notifier.notify.args[0][2].count).be.exactly(1);
   });
-
-  it('should trigger a proxy:leaveChannel hook', function () {
-    kuzzle.dsl.remove = sinon.stub();
-
-    kuzzle.hotelClerk.removeSubscription(unsubscribeRequest, context);
-
-    should(kuzzle.pluginsManager.trigger)
-      .be.calledWith('proxy:leaveChannel');
-
-    const data = kuzzle.pluginsManager.trigger.secondCall.args[1];
-
-    should(data).be.an.Object();
-    should(data.channel).be.a.String();
-    should(data.connectionId).be.eql(context.connectionId);
-  });
-
 });

--- a/test/api/core/notifier/notify.test.js
+++ b/test/api/core/notifier/notify.test.js
@@ -1,4 +1,4 @@
-var
+const
   should = require('should'),
   sinon = require('sinon'),
   sandbox = sinon.sandbox.create(),
@@ -8,16 +8,12 @@ var
   Request = require('kuzzle-common-objects').Request;
 
 describe('Test: notifier.notify', () => {
-  var
+  let
     kuzzle,
     notifier,
     notification,
     dispatchStub,
-    triggerStub,
     addToChannelsStub, request;
-
-  before(() => {
-  });
 
   beforeEach(() => {
     request = new Request({});
@@ -25,7 +21,6 @@ describe('Test: notifier.notify', () => {
     notification = new NotificationObject({}, request);
 
     dispatchStub = kuzzle.entryPoints.proxy.dispatch;
-    triggerStub = kuzzle.pluginsManager.trigger;
     kuzzle.hotelClerk.addToChannels = sinon.spy(c => c.push('foobar'));
     addToChannelsStub = kuzzle.hotelClerk.addToChannels;
 
@@ -39,31 +34,26 @@ describe('Test: notifier.notify', () => {
   it('should do nothing when no rooms to notify are provided', () => {
     should(notifier.notify(undefined, request, {})).be.false();
     should(dispatchStub.called).be.false();
-    should(triggerStub.called).be.false();
     should(addToChannelsStub.called).be.false();
   });
 
   it('should notify instead of broadcasting if there is a connectionId', () => {
-    var data = {payload: notification.toJson(), channels: ['foobar'], connectionId: 'someID'};
+    const data = {payload: notification.toJson(), channels: ['foobar'], connectionId: 'someID'};
 
     notifier.notify(['foobar'], request, {}, 'someID');
 
     should(addToChannelsStub.calledOnce).be.true();
     should(dispatchStub.calledOnce).be.true();
-    should(triggerStub.calledOnce).be.true();
     should(dispatchStub).calledWithMatch('notify', data);
-    should(triggerStub).calledWithMatch('proxy:notify', data);
   });
 
   it('should aggregate channels from multiple rooms', () => {
-    var data = {payload: notification.toJson(), channels: ['foobar', 'foobar', 'foobar'], id: undefined};
+    const data = {payload: notification.toJson(), channels: ['foobar', 'foobar', 'foobar'], id: undefined};
 
     notifier.notify(['room1', 'room2', 'room3'], request, {});
 
     should(addToChannelsStub.calledThrice).be.true();
     should(dispatchStub.calledOnce).be.true();
-    should(triggerStub.calledOnce).be.true();
     should(dispatchStub).calledWithMatch('broadcast', data);
-    should(triggerStub).calledWithMatch('proxy:broadcast', data);
   });
 });


### PR DESCRIPTION
# Description

Following https://github.com/kuzzleio/kuzzle/issues/790#issuecomment-308458272 , obsolete "proxy:*" events are removed.
Other, more specialized events will be added in the future