### PR TITLE
fix #880 - realtime/list crash on just deleted room

### DIFF
--- a/docker-compose/dev.yml
+++ b/docker-compose/dev.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 services:
   proxy:
@@ -27,12 +27,12 @@ services:
       - kuzzle_services__memoryStorage__node__host=redis
       - kuzzle_services__proxyBroker__host=proxy
       - NODE_ENV=development
-      - DEBUG=kuzzle:*
-      - DEBUG_DEPTH=0
-      - DEBUG_MAX_ARRAY_LENGTH=100
-      - DEBUG_EXPAND=off
-      - DEBUG_SHOW_HIDDEN=on
-      - DEBUG_COLORS=on
+      - DEBUG="${DEBUG:-kuzzle:*}"
+      - DEBUG_DEPTH=${DEBUG_DEPTH:-0}
+      - DEBUG_MAX_ARRAY_LENGTH=${DEBUG_MAX_ARRAY:-100}
+      - DEBUG_EXPAND=${DEBUG_EXPAND:-off}
+      - DEBUG_SHOW_HIDDEN={$DEBUG_SHOW_HIDDEN:-on}
+      - DEBUG_COLORS=${DEBUG_COLORS:-on}
 
   redis:
     image: redis:3.2

--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -205,18 +205,23 @@ class HotelClerk {
               return;
             }
 
-            if (!list[index]) {
-              list[index] = {};
-            }
-            if (!list[index][collection]) {
-              list[index][collection] = {};
+            // the room may have been deleted in the meantime
+            if (!dslIndex[index] || !dslIndex[index][collection]) {
+              return;
             }
 
             for (const roomId of dslIndex[index][collection]) {
               const room = this.rooms[roomId];
               // the room may be currently registering in the dsl and not ready in the hotel clerk
-              // or already deleted in from the hotel clerk and still in the dsl
+              // or already deleted from the hotel clerk and still in the dsl
               if (room) {
+                if (!list[index]) {
+                  list[index] = {};
+                }
+                if (!list[index][collection]) {
+                  list[index][collection] = {};
+                }
+
                 list[index][collection][roomId] = room.customers.size;
               }
             }


### PR DESCRIPTION
# Description

This PR fixes the case where a room would be deleted in between the time a `realtime/list` request is sent and when Kuzzle gets the information wheter the user is allowed to list the deleted room.

# Related issue

* #880 

# Boyscouting

* Let dev users set the `DEBUG` environment value to their will (NB: needs docker-compose 1.10+ and docker engine 1.13+)