### PR TITLE
Fix missing requestId in UserNotifications

### DIFF
--- a/lib/api/core/models/notifications/UserNotification.js
+++ b/lib/api/core/models/notifications/UserNotification.js
@@ -30,6 +30,7 @@
 class UserNotification {
   constructor(request, scope, content) {
     this.status = 200;
+    this.requestId = request.id;
     this.timestamp = request.timestamp;
     this.volatile = request.input.volatile;
     this.index = request.input.resource.index;


### PR DESCRIPTION
The Android SDK crashes upon receiving a UserNotification because of missing requestId (sub/unsub in|out|all).
This small PR adds the requestId to UserNotification responses.