### PR TITLE
Remove non-existent API route from HTTP definitions

### DIFF
--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -281,7 +281,6 @@ module.exports = [
 
   {verb: 'put', url: '/profiles/:_id', controller: 'security', action: 'createOrReplaceProfile'},
   {verb: 'put', url: '/roles/:_id', controller: 'security', action: 'createOrReplaceRole'},
-  {verb: 'put', url: '/users/:_id', controller: 'security', action: 'createOrReplaceUser'},
   {verb: 'put', url: '/credentials/:strategy/:_id/_update', controller: 'security', action: 'updateCredentials'},
   {verb: 'put', url: '/profiles/:_id/_update', controller: 'security', action: 'updateProfile'},
   {verb: 'put', url: '/roles/:_id/_update', controller: 'security', action: 'updateRole'},


### PR DESCRIPTION
# Description

Remove the obsolete `security/createOrReplaceUser` API call from the HTTP routes definitions

# Solved issue

#892 
