### PR TITLE
Prevent users to be created or updated with unknown Profiles

### DIFF
--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -420,8 +420,6 @@ class SecurityController {
   deleteUser(request) {
     assertHasId(request);
 
-    const deleteGenerator = Bluebird.coroutine(securityDeleteUserGenerator);
-
     return this.kuzzle.repositories.user.delete(request.input.resource._id, {refresh: request.input.args.refresh})
       .then(() => this.kuzzle.repositories.token.deleteByUserId(request.input.resource._id))
       .then(() => deleteGenerator(this.kuzzle, request))
@@ -449,7 +447,7 @@ class SecurityController {
     const pojoUser = request.input.body.content;
     pojoUser._id = request.input.resource._id || uuid.v4();
 
-    return Bluebird.coroutine(persistUserAndCredentials)(this.kuzzle, request, pojoUser);
+    return createGenerator(this.kuzzle, request, pojoUser);
   }
 
   /**
@@ -474,7 +472,7 @@ class SecurityController {
 
     pojoUser.profileIds = this.kuzzle.config.security.restrictedProfileIds;
 
-    return Bluebird.coroutine(persistUserAndCredentials)(this.kuzzle, request, pojoUser);
+    return createGenerator(this.kuzzle, request, pojoUser);
   }
 
   /**
@@ -488,7 +486,12 @@ class SecurityController {
     assertHasId(request);
 
     return this.kuzzle.repositories.user.load(request.input.resource._id)
-      .then(user => this.kuzzle.repositories.user.persist(_.extend(user, request.input.body), {database: {method: 'update'}}))
+      .then(user => {
+        const pojo = request.input.body;
+        pojo._id = request.input.resource._id;
+        return this.kuzzle.repositories.user.hydrate(user, pojo);
+      })
+      .then(user => this.kuzzle.repositories.user.persist(user, {database: {method: 'update'}}))
       .then(updatedUser => formatProcessing.formatUserForSerialization(this.kuzzle, updatedUser));
   }
 
@@ -963,79 +966,67 @@ function formatUserSearchResult(kuzzle, formatter, raw) {
  * @param {Request} request
  * @param {object} pojoUser
  */
-function* persistUserAndCredentials (kuzzle, request, pojoUser) {
-  const
-    user = new User(),
-    loadedUser = yield Bluebird.resolve(kuzzle.repositories.user.load(pojoUser._id));
-  let
-    errorStep = null,
-    creationError = null,
-    errorMessage,
-    createdUser,
-    errors;
+const createGenerator = Bluebird.coroutine(function* persistUserAndCredentials (kuzzle, request, pojoUser) {
+  const loadedUser = yield Bluebird.resolve(kuzzle.repositories.user.load(pojoUser._id));
 
   if (loadedUser !== null) {
     throw new PreconditionError(`user "${pojoUser._id}" already exist.`);
   }
 
-  const strategies = request.input.body.credentials ? Object.keys(request.input.body.credentials) : [];
+  const 
+    strategies = request.input.body.credentials ? Object.keys(request.input.body.credentials) : [],
+    registeredStrategies = kuzzle.pluginsManager.listStrategies();
 
-  if (strategies.length > 0) {
-    const registeredStrategies = kuzzle.pluginsManager.listStrategies();
-
-    for (const strategy of strategies) {
-      if (registeredStrategies.indexOf(strategy) === -1) {
-        throw new BadRequestError(`strategy "${strategy}" is not a known strategy.`);
-      }
-
-      const existMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'exists');
-      const exists = yield existMethod(request, pojoUser._id, strategy);
-
-      if (exists === true) {
-        throw new KuzzleInternalError(`Internal database inconsistency detected: existing credentials found on non-existing user ${pojoUser._id}`);
-      }
-
-      const validateMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'validate');
-
-      try {
-        yield validateMethod(
-          request, 
-          request.input.body.credentials[strategy], 
-          pojoUser._id, 
-          strategy, 
-          false
-        );
-      }
-      catch (error) {
-        throw new BadRequestError(error);
-      }
+  // Credentials validation
+  for (const strategy of strategies) {
+    if (registeredStrategies.indexOf(strategy) === -1) {
+      throw new BadRequestError(`strategy "${strategy}" is not a known strategy.`);
     }
 
-    for (let i = 0; i < strategies.length; i++) {
-      const
-        strategy = strategies[i],
-        createMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'create');
+    const existMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'exists');
+    const exists = yield existMethod(request, pojoUser._id, strategy);
 
-      try {
-        yield createMethod(request, request.input.body.credentials[strategy], pojoUser._id, strategy);
-      }
-      catch (error) {
-        errorStep = i;
-        creationError = error;
-        break;
-      }
+    if (exists === true) {
+      throw new KuzzleInternalError(`Internal database inconsistency detected: existing credentials found on non-existing user ${pojoUser._id}`);
+    }
+
+    const validateMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'validate');
+
+    try {
+      yield validateMethod(
+        request, 
+        request.input.body.credentials[strategy], 
+        pojoUser._id, 
+        strategy, 
+        false
+      );
+    }
+    catch (error) {
+      throw new BadRequestError(error);
     }
   }
 
-  if (errorStep === null) {
+  // Throw in case of failure with the right KuzzleError object
+  const createdUser = yield kuzzle.repositories.user.hydrate(new User(), pojoUser)
+    .then(modifiedUser => kuzzle.repositories.user.persist(modifiedUser, {database: {method: 'create'}}))
+    .then(modifiedUser => formatProcessing.formatUserForSerialization(kuzzle, modifiedUser));
+
+  // Creating credentials
+  const errors = [];
+  let errorStep = null;
+
+  for (let i = 0; i < strategies.length; i++) {
+    const
+      strategy = strategies[i],
+      createMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'create');
+
     try {
-      createdUser = yield kuzzle.repositories.user.hydrate(user, pojoUser)
-        .then(modifiedUser => kuzzle.repositories.user.persist(modifiedUser, {database: {method: 'create'}}))
-        .then(modifiedUser => formatProcessing.formatUserForSerialization(kuzzle, modifiedUser));
+      yield createMethod(request, request.input.body.credentials[strategy], pojoUser._id, strategy);
     }
     catch (error) {
-      errorStep = strategies.length - 1;
-      creationError = error;
+      errorStep = i;
+      errors.push(error);
+      break;
     }
   }
 
@@ -1043,37 +1034,37 @@ function* persistUserAndCredentials (kuzzle, request, pojoUser) {
     return Bluebird.resolve(createdUser);
   }
 
-  errors = [creationError];
-
-  // We try to delete the strategy that was in error as well
+  /*
+    Failed to create credentials: rollbacking
+    We try to delete the errored strategy as well
+   */ 
   for (let i = 0; i <= errorStep; i++) {
     const
       strategy = strategies[i],
       deleteMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'delete');
 
     // We catch any error produced by delete as we want to make as much cleanup as possible
-    yield deleteMethod(request, request.input.resource._id, strategy)
+    yield deleteMethod(request, pojoUser._id, strategy)
       .catch(error => {
         errors.push(error);
         return Bluebird.resolve();
       });
   }
 
-  errorMessage = `An error occured during the creation of user "${request.input.resource._id}": ` + errors.map(error => error.message).join(';');
-
-  if (creationError !== null) {
-    throw new KuzzleInternalError(errorMessage);
-  }
-  else {
-    throw new PluginImplementationError(errorMessage);
-  }
-}
+  return kuzzle.repositories.user.delete(pojoUser._id)
+    .finally(() => {
+      throw new PluginImplementationError(
+        `An error occured during the creation of user "${pojoUser._id}":\n` 
+        + errors.map(error => error.message).join('\n')
+      );
+    });
+});
 
 /**
  * @param {Kuzzle} kuzzle 
  * @param {Request} request 
  */
-function* securityDeleteUserGenerator (kuzzle, request) {
+const deleteGenerator = Bluebird.coroutine(function* securityDeleteUserGenerator (kuzzle, request) {
   const
     availableStrategies = kuzzle.pluginsManager.listStrategies(),
     userStrategies = [],
@@ -1106,4 +1097,4 @@ function* securityDeleteUserGenerator (kuzzle, request) {
   if (errors.length > 0) {
     throw new KuzzleInternalError(`was not able to remove bad credentials of user "${request.input.resource._id}": ` + errors.map(error => error.message).join(';'));
   }
-}
+});

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -58,8 +58,8 @@ const
  * @param {Request} request
  * @param {object} pojoUser
  */
-const createGenerator = Bluebird.coroutine(function* persistUserAndCredentials (kuzzle, request, pojoUser) {
-  const loadedUser = yield Bluebird.resolve(kuzzle.repositories.user.load(pojoUser._id));
+const persistUser = Bluebird.coroutine(function* persistUserGenerator (kuzzle, request, pojoUser) {
+  const loadedUser = yield kuzzle.repositories.user.load(pojoUser._id);
 
   if (loadedUser !== null) {
     throw new PreconditionError(`user "${pojoUser._id}" already exist.`);
@@ -156,7 +156,7 @@ const createGenerator = Bluebird.coroutine(function* persistUserAndCredentials (
  * @param {Kuzzle} kuzzle 
  * @param {Request} request 
  */
-const deleteGenerator = Bluebird.coroutine(function* securityDeleteUserGenerator (kuzzle, request) {
+const removeUser = Bluebird.coroutine(function* removeUserGenerator (kuzzle, request) {
   const
     availableStrategies = kuzzle.pluginsManager.listStrategies(),
     userStrategies = [],
@@ -560,7 +560,7 @@ class SecurityController {
 
     return this.kuzzle.repositories.user.delete(request.input.resource._id, {refresh: request.input.args.refresh})
       .then(() => this.kuzzle.repositories.token.deleteByUserId(request.input.resource._id))
-      .then(() => deleteGenerator(this.kuzzle, request))
+      .then(() => removeUser(this.kuzzle, request))
       .then(() => ({ _id: request.input.resource._id}));
   }
 
@@ -585,7 +585,7 @@ class SecurityController {
     const pojoUser = request.input.body.content;
     pojoUser._id = request.input.resource._id || uuid.v4();
 
-    return createGenerator(this.kuzzle, request, pojoUser);
+    return persistUser(this.kuzzle, request, pojoUser);
   }
 
   /**
@@ -610,7 +610,7 @@ class SecurityController {
 
     pojoUser.profileIds = this.kuzzle.config.security.restrictedProfileIds;
 
-    return createGenerator(this.kuzzle, request, pojoUser);
+    return persistUser(this.kuzzle, request, pojoUser);
   }
 
   /**

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -55,6 +55,144 @@ const
 
 /**
  * @param {Kuzzle} kuzzle
+ * @param {Request} request
+ * @param {object} pojoUser
+ */
+const createGenerator = Bluebird.coroutine(function* persistUserAndCredentials (kuzzle, request, pojoUser) {
+  const loadedUser = yield Bluebird.resolve(kuzzle.repositories.user.load(pojoUser._id));
+
+  if (loadedUser !== null) {
+    throw new PreconditionError(`user "${pojoUser._id}" already exist.`);
+  }
+
+  const 
+    strategies = request.input.body.credentials ? Object.keys(request.input.body.credentials) : [],
+    registeredStrategies = kuzzle.pluginsManager.listStrategies();
+
+  // Credentials validation
+  for (const strategy of strategies) {
+    if (registeredStrategies.indexOf(strategy) === -1) {
+      throw new BadRequestError(`strategy "${strategy}" is not a known strategy.`);
+    }
+
+    const existMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'exists');
+    const exists = yield existMethod(request, pojoUser._id, strategy);
+
+    if (exists === true) {
+      throw new KuzzleInternalError(`Internal database inconsistency detected: existing credentials found on non-existing user ${pojoUser._id}`);
+    }
+
+    const validateMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'validate');
+
+    try {
+      yield validateMethod(
+        request, 
+        request.input.body.credentials[strategy], 
+        pojoUser._id, 
+        strategy, 
+        false
+      );
+    }
+    catch (error) {
+      throw new BadRequestError(error);
+    }
+  }
+
+  // Throw in case of failure with the right KuzzleError object
+  const createdUser = yield kuzzle.repositories.user.hydrate(new User(), pojoUser)
+    .then(modifiedUser => kuzzle.repositories.user.persist(modifiedUser, {database: {method: 'create'}}))
+    .then(modifiedUser => formatProcessing.formatUserForSerialization(kuzzle, modifiedUser));
+
+  // Creating credentials
+  const errors = [];
+  let errorStep = null;
+
+  for (let i = 0; i < strategies.length; i++) {
+    const
+      strategy = strategies[i],
+      createMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'create');
+
+    try {
+      yield createMethod(request, request.input.body.credentials[strategy], pojoUser._id, strategy);
+    }
+    catch (error) {
+      errorStep = i;
+      errors.push(error);
+      break;
+    }
+  }
+
+  if (errorStep === null) {
+    return Bluebird.resolve(createdUser);
+  }
+
+  /*
+    Failed to create credentials: rollbacking
+    We try to delete the errored strategy as well
+   */ 
+  for (let i = 0; i <= errorStep; i++) {
+    const
+      strategy = strategies[i],
+      deleteMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'delete');
+
+    // We catch any error produced by delete as we want to make as much cleanup as possible
+    yield deleteMethod(request, pojoUser._id, strategy)
+      .catch(error => {
+        errors.push(error);
+        return Bluebird.resolve();
+      });
+  }
+
+  return kuzzle.repositories.user.delete(pojoUser._id)
+    .finally(() => {
+      throw new PluginImplementationError(
+        `An error occured during the creation of user "${pojoUser._id}":\n` 
+        + errors.map(error => error.message).join('\n')
+      );
+    });
+});
+
+/**
+ * @param {Kuzzle} kuzzle 
+ * @param {Request} request 
+ */
+const deleteGenerator = Bluebird.coroutine(function* securityDeleteUserGenerator (kuzzle, request) {
+  const
+    availableStrategies = kuzzle.pluginsManager.listStrategies(),
+    userStrategies = [],
+    errors = [];
+
+  for (const strategy of availableStrategies) {
+    const
+      existsMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'exists'),
+      existStrategy = yield existsMethod(request, request.input.resource._id, strategy);
+
+    if (existStrategy) {
+      userStrategies.push(strategy);
+    }
+  }
+
+  if (userStrategies.length > 0) {
+    for (const strategy of userStrategies) {
+      const
+        deleteMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'delete');
+
+      // We catch any error produced by delete as we want to make as much cleanup as possible
+      yield deleteMethod(request, request.input.resource._id, strategy)
+        .catch(error => {
+          errors.push(error);
+          return Bluebird.reject(error);
+        });
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new KuzzleInternalError(`was not able to remove bad credentials of user "${request.input.resource._id}": ` + errors.map(error => error.message).join(';'));
+  }
+});
+
+/**
+ * @param {Kuzzle} kuzzle
  * @constructor
  * @property {Kuzzle} kuzzle
  */
@@ -960,141 +1098,3 @@ function formatUserSearchResult(kuzzle, formatter, raw) {
       return users;
     });
 }
-
-/**
- * @param {Kuzzle} kuzzle
- * @param {Request} request
- * @param {object} pojoUser
- */
-const createGenerator = Bluebird.coroutine(function* persistUserAndCredentials (kuzzle, request, pojoUser) {
-  const loadedUser = yield Bluebird.resolve(kuzzle.repositories.user.load(pojoUser._id));
-
-  if (loadedUser !== null) {
-    throw new PreconditionError(`user "${pojoUser._id}" already exist.`);
-  }
-
-  const 
-    strategies = request.input.body.credentials ? Object.keys(request.input.body.credentials) : [],
-    registeredStrategies = kuzzle.pluginsManager.listStrategies();
-
-  // Credentials validation
-  for (const strategy of strategies) {
-    if (registeredStrategies.indexOf(strategy) === -1) {
-      throw new BadRequestError(`strategy "${strategy}" is not a known strategy.`);
-    }
-
-    const existMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'exists');
-    const exists = yield existMethod(request, pojoUser._id, strategy);
-
-    if (exists === true) {
-      throw new KuzzleInternalError(`Internal database inconsistency detected: existing credentials found on non-existing user ${pojoUser._id}`);
-    }
-
-    const validateMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'validate');
-
-    try {
-      yield validateMethod(
-        request, 
-        request.input.body.credentials[strategy], 
-        pojoUser._id, 
-        strategy, 
-        false
-      );
-    }
-    catch (error) {
-      throw new BadRequestError(error);
-    }
-  }
-
-  // Throw in case of failure with the right KuzzleError object
-  const createdUser = yield kuzzle.repositories.user.hydrate(new User(), pojoUser)
-    .then(modifiedUser => kuzzle.repositories.user.persist(modifiedUser, {database: {method: 'create'}}))
-    .then(modifiedUser => formatProcessing.formatUserForSerialization(kuzzle, modifiedUser));
-
-  // Creating credentials
-  const errors = [];
-  let errorStep = null;
-
-  for (let i = 0; i < strategies.length; i++) {
-    const
-      strategy = strategies[i],
-      createMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'create');
-
-    try {
-      yield createMethod(request, request.input.body.credentials[strategy], pojoUser._id, strategy);
-    }
-    catch (error) {
-      errorStep = i;
-      errors.push(error);
-      break;
-    }
-  }
-
-  if (errorStep === null) {
-    return Bluebird.resolve(createdUser);
-  }
-
-  /*
-    Failed to create credentials: rollbacking
-    We try to delete the errored strategy as well
-   */ 
-  for (let i = 0; i <= errorStep; i++) {
-    const
-      strategy = strategies[i],
-      deleteMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'delete');
-
-    // We catch any error produced by delete as we want to make as much cleanup as possible
-    yield deleteMethod(request, pojoUser._id, strategy)
-      .catch(error => {
-        errors.push(error);
-        return Bluebird.resolve();
-      });
-  }
-
-  return kuzzle.repositories.user.delete(pojoUser._id)
-    .finally(() => {
-      throw new PluginImplementationError(
-        `An error occured during the creation of user "${pojoUser._id}":\n` 
-        + errors.map(error => error.message).join('\n')
-      );
-    });
-});
-
-/**
- * @param {Kuzzle} kuzzle 
- * @param {Request} request 
- */
-const deleteGenerator = Bluebird.coroutine(function* securityDeleteUserGenerator (kuzzle, request) {
-  const
-    availableStrategies = kuzzle.pluginsManager.listStrategies(),
-    userStrategies = [],
-    errors = [];
-
-  for (const strategy of availableStrategies) {
-    const
-      existsMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'exists'),
-      existStrategy = yield existsMethod(request, request.input.resource._id, strategy);
-
-    if (existStrategy) {
-      userStrategies.push(strategy);
-    }
-  }
-
-  if (userStrategies.length > 0) {
-    for (const strategy of userStrategies) {
-      const
-        deleteMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'delete');
-
-      // We catch any error produced by delete as we want to make as much cleanup as possible
-      yield deleteMethod(request, request.input.resource._id, strategy)
-        .catch(error => {
-          errors.push(error);
-          return Bluebird.reject(error);
-        });
-    }
-  }
-
-  if (errors.length > 0) {
-    throw new KuzzleInternalError(`was not able to remove bad credentials of user "${request.input.resource._id}": ` + errors.map(error => error.message).join(';'));
-  }
-});

--- a/lib/api/core/models/repositories/userRepository.js
+++ b/lib/api/core/models/repositories/userRepository.js
@@ -81,7 +81,7 @@ class UserRepository extends Repository {
     }
 
     if (user._id === this.anonymous()._id && user.profileIds.indexOf('anonymous') === -1) {
-      return Promise.reject(new BadRequestError('Anonymous user must be assigned the anonymous profile'));
+      return Bluebird.reject(new BadRequestError('Anonymous user must be assigned the anonymous profile'));
     }
 
     return this.persistToDatabase(user, databaseOptions)

--- a/test/api/controllers/securityController/users.test.js
+++ b/test/api/controllers/securityController/users.test.js
@@ -12,6 +12,7 @@ const
     BadRequestError,
     NotFoundError,
     InternalError: KuzzleInternalError,
+    PluginImplementationError,
     SizeLimitError,
     PreconditionError,
   } = require('kuzzle-common-objects').errors,
@@ -298,17 +299,23 @@ describe('Test: security controller - users', () => {
   });
 
   describe('#persistUserAndCredentials', () => {
+    beforeEach(() => {
+      request = new Request({
+        _id: 'test',
+        body: {
+          content: {name: 'John Doe', profileIds: ['anonymous']},
+          credentials: {someStrategy: {some: 'credentials'}}
+        }
+      });
+    });
+
     it('should reject an error if a strategy is unknown', () => {
       kuzzle.repositories.user.load = sandbox.stub().returns(Bluebird.resolve(null));
       kuzzle.pluginsManager.listStrategies = sandbox.stub().returns(['someStrategy']);
 
-      return should(securityController.createUser(new Request({
-        _id: 'test',
-        body: {
-          content: {name: 'John Doe', profileIds: ['anonymous']},
-          credentials: {unknownStrategy: {some: 'credentials'}}
-        }
-      }))).be.rejectedWith(BadRequestError);
+      request.input.body.credentials = {unknownStrategy: {some: 'credentials'}};
+
+      return should(securityController.createUser(request)).be.rejectedWith(BadRequestError);
     });
 
     it('should reject an error if credentials don\'t validate the strategy', () => {
@@ -324,13 +331,7 @@ describe('Test: security controller - users', () => {
         .withArgs('someStrategy', 'validate')
         .returns(sinon.stub().returns(Bluebird.reject(new Error('error'))));
 
-      return should(securityController.createUser(new Request({
-        _id: 'test',
-        body: {
-          content: {name: 'John Doe', profileIds: ['anonymous']},
-          credentials: {someStrategy: {some: 'credentials'}}
-        }
-      }))).be.rejectedWith(BadRequestError);
+      return should(securityController.createUser(request)).be.rejectedWith(BadRequestError);
     });
 
     it('should reject if credentials already exist on the provided user id', () => {
@@ -342,16 +343,10 @@ describe('Test: security controller - users', () => {
         .withArgs('someStrategy', 'exists')
         .returns(sinon.stub().returns(Bluebird.resolve(true)));
 
-      return should(securityController.createUser(new Request({
-        _id: 'test',
-        body: {
-          content: {name: 'John Doe', profileIds: ['anonymous']},
-          credentials: {someStrategy: {some: 'credentials'}}
-        }
-      }))).be.rejectedWith(KuzzleInternalError);
+      return should(securityController.createUser(request)).be.rejectedWith(KuzzleInternalError);
     });
 
-    it('should throw an error and try to delete if credentials don\'t create properly', () => {
+    it('should throw an error and rollback if credentials don\'t create properly', done => {
       const
         validateStub = sandbox.stub().returns(Bluebird.resolve()),
         existsStub = sandbox.stub().returns(Bluebird.resolve(false)),
@@ -367,16 +362,19 @@ describe('Test: security controller - users', () => {
       kuzzle.pluginsManager.getStrategyMethod.withArgs('someStrategy', 'create').returns(createStub);
       kuzzle.pluginsManager.getStrategyMethod.withArgs('someStrategy', 'delete').returns(deleteStub);
 
-      return should(securityController.createUser(new Request({
-        _id: 'test',
-        body: {
-          content: {name: 'John Doe', profileIds: ['anonymous']},
-          credentials: {someStrategy: {some: 'credentials'}}
-        }
-      }))).rejectedWith(KuzzleInternalError);
+      securityController.createUser(request)
+        .then(() => done('Expected promise to fail'))
+        .catch(error => {
+          should(error).be.instanceof(PluginImplementationError);
+          should(kuzzle.repositories.user.delete)
+            .calledOnce()
+            .calledWith('test');
+
+          done();
+        });
     });
 
-    it('should intercept errors during deletion of a recovery phase', () => {
+    it('should intercept errors during deletion of a recovery phase', done => {
       const
         validateStub = sandbox.stub().returns(Bluebird.resolve()),
         existsStub = sandbox.stub().returns(Bluebird.resolve(false)),
@@ -392,39 +390,42 @@ describe('Test: security controller - users', () => {
       kuzzle.pluginsManager.getStrategyMethod.withArgs('someStrategy', 'create').returns(createStub);
       kuzzle.pluginsManager.getStrategyMethod.withArgs('someStrategy', 'delete').returns(deleteStub);
 
-      return should(securityController.createUser(new Request({
-        _id: 'test',
-        body: {
-          content: {name: 'John Doe', profileIds: ['anonymous']},
-          credentials: {someStrategy: {some: 'credentials'}}
-        }
-      }))).rejectedWith(KuzzleInternalError);
+      securityController.createUser(request)
+        .then(() => done('Expected promise to fail'))
+        .catch(error => {
+          should(error).be.instanceof(PluginImplementationError);
+          should(kuzzle.repositories.user.delete)
+            .calledOnce()
+            .calledWith('test');
+
+          done();
+        });
     });
 
-    it('should revert credential creations if user creation fails', () => {
+    it('should not create credentials if user creation fails', done => {
       const
+        error = new Error('foobar'),
         validateStub = sandbox.stub().returns(Bluebird.resolve()),
         existsStub = sandbox.stub().returns(Bluebird.resolve(false)),
-        createStub = sandbox.stub().returns(Bluebird.resolve()),
-        deleteStub = sandbox.stub().returns(Bluebird.resolve());
+        createStub = sandbox.stub().returns(Bluebird.resolve());
 
       kuzzle.repositories.user.load = sandbox.stub().returns(Bluebird.resolve(null));
       kuzzle.pluginsManager.listStrategies = sandbox.stub().returns(['someStrategy']);
       kuzzle.pluginsManager.getStrategyMethod = sandbox.stub();
-      kuzzle.repositories.user.persist = sandbox.stub().returns(Bluebird.reject(new Error('some error')));
+      kuzzle.repositories.user.persist = sandbox.stub().returns(Bluebird.reject(error));
 
       kuzzle.pluginsManager.getStrategyMethod.withArgs('someStrategy', 'validate').returns(validateStub);
       kuzzle.pluginsManager.getStrategyMethod.withArgs('someStrategy', 'exists').returns(existsStub);
       kuzzle.pluginsManager.getStrategyMethod.withArgs('someStrategy', 'create').returns(createStub);
-      kuzzle.pluginsManager.getStrategyMethod.withArgs('someStrategy', 'delete').returns(deleteStub);
 
-      return should(securityController.createUser(new Request({
-        _id: 'test',
-        body: {
-          content: {name: 'John Doe', profileIds: ['anonymous']},
-          credentials: {someStrategy: {some: 'credentials'}}
-        }
-      }))).rejectedWith(KuzzleInternalError);
+      securityController.createUser(request)
+        .then(() => done('Expected promise to fail'))
+        .catch(err => {
+          should(err).be.eql(error);
+          should(kuzzle.repositories.user.delete).not.be.called();
+          should(createStub).not.be.called();
+          done();
+        });
     });
   });
 

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -182,7 +182,8 @@ class KuzzleMock extends Kuzzle {
         ObjectConstructor: sinon.stub().returns({}),
         hydrate: sinon.stub().returns(Bluebird.resolve()),
         persist: sinon.stub().returns(Bluebird.resolve({})),
-        anonymous: sinon.stub().returns({_id: '-1'})
+        anonymous: sinon.stub().returns({_id: '-1'}),
+        delete: sinon.stub().returns(Bluebird.resolve())
       },
       token: {
         anonymous: sinon.stub().returns({_id: 'anonymous'}),


### PR DESCRIPTION
# Description

* Prevent `security:updateUser` to add unknown profiles to a user
* Fix wrong user ID provided to auth plugins during the rollback process when a user creation failed
* Refactor the `security:createUser` method to make it create the user in Kuzzle first, and then its credentials. This allows for more consistent behavior if an error occurs during the creation phase or even during the rollback one

# Solved issue

#893 
