### PR TITLE
Make Kuzzle CLI feel quicker

### DIFF
--- a/bin/commands/clearCache.js
+++ b/bin/commands/clearCache.js
@@ -24,7 +24,6 @@
 const
   rc = require('rc'),
   params = rc('kuzzle'),
-  Kuzzle = require('../../lib/api/kuzzle'),
   readlineSync = require('readline-sync'),
   clc = require('cli-color');
 
@@ -56,7 +55,7 @@ function commandClearCache (database, options) {
   }
 
   if (userIsSure) {
-    const kuzzle = new Kuzzle();
+    const kuzzle = new (require('../../lib/api/kuzzle'))();
 
     console.log(notice('[ℹ] Processing...\n'));
     return kuzzle.cli.doAction('clearCache', data)

--- a/bin/commands/createFirstAdmin.js
+++ b/bin/commands/createFirstAdmin.js
@@ -26,8 +26,6 @@ const
   Bluebird = require('bluebird'),
   readlineSync = require('readline-sync'),
   rc = require('rc'),
-  Kuzzle = require('../../lib/api/kuzzle'),
-  kuzzle = new Kuzzle(),
   params = rc('kuzzle');
 
 let
@@ -79,6 +77,7 @@ function confirm (username, resetRoles) {
 }
 
 function commandCreateFirstAdmin (options) {
+  const kuzzle = new (require('../../lib/api/kuzzle'))();
   let
     username,
     password,

--- a/bin/commands/dump.js
+++ b/bin/commands/dump.js
@@ -22,8 +22,7 @@
 /* eslint-disable no-console */
 
 const
-  clc = require('cli-color'),
-  Kuzzle = require('../../lib/api/kuzzle');
+  clc = require('cli-color');
 
 module.exports = function commandDump (options) {
   const
@@ -31,7 +30,7 @@ module.exports = function commandDump (options) {
     ok = string => options.parent.noColors ? string: clc.green.bold(string),
     notice = string => options.parent.noColors ? string : clc.cyanBright(string),
     warn = string => options.parent.noColors ? string : clc.yellow(string),
-    kuzzle = new Kuzzle();
+    kuzzle = new (require('../../lib/api/kuzzle'))();
 
   console.log(notice('[ℹ] Creating dump file...'));
 

--- a/bin/commands/reset.js
+++ b/bin/commands/reset.js
@@ -24,14 +24,13 @@
 const
   rc = require('rc'),
   params = rc('kuzzle'),
-  Kuzzle = require('../../lib/api/kuzzle'),
   readlineSync = require('readline-sync'),
   fs = require('fs'),
   clc = require('cli-color');
 
 function commandReset (options) {
   const
-    kuzzle = new Kuzzle(),
+    kuzzle = new (require('../../lib/api/kuzzle'))(),
     error = string => options.parent.noColors ? string : clc.red(string),
     warn = string => options.parent.noColors ? string : clc.yellow(string),
     notice = string => options.parent.noColors ? string : clc.cyanBright(string),

--- a/bin/commands/shutdown.js
+++ b/bin/commands/shutdown.js
@@ -22,12 +22,11 @@
 /* eslint-disable no-console */
 
 const
-  Kuzzle = require('../../lib/api/kuzzle'),
   clc = require('cli-color');
 
 function commandShutdown(options) {
   const
-    kuzzle = new Kuzzle(),
+    kuzzle = new (require('../../lib/api/kuzzle'))(),
     notice = string => options.parent.noColors ? string : clc.cyanBright(string),
     error = string => options.parent.noColors ? string : clc.red(string);
 

--- a/bin/commands/start.js
+++ b/bin/commands/start.js
@@ -25,14 +25,13 @@ const
   fs = require('fs'),
   rc = require('rc'),
   params = rc('kuzzle'),
-  Kuzzle = require('../../lib/api/kuzzle'),
   Request = require('kuzzle-common-objects').Request,
   Bluebird = require('bluebird'),
   clc = require('cli-color');
 
 function commandStart (options) {
   const
-    kuzzle = new Kuzzle(),
+    kuzzle = new (require('../../lib/api/kuzzle'))(),
     error = string => options.parent.noColors ? string : clc.red(string),
     notice = string => options.parent.noColors ? string : clc.cyanBright(string),
     kuz = string => options.parent.noColors ? string : clc.greenBright.bold(string);

--- a/bin/kuzzle
+++ b/bin/kuzzle
@@ -70,7 +70,7 @@ program
   .option('    --mappings <mappings>', 'load and apply mappings from file')
   .action(require('./commands/start'));
 
-// $ kuzzle createFirstAdmin
+// $ kuzzle dump
 program
   .command('dump')
   .description('create a dump of current state of kuzzle')


### PR DESCRIPTION
# Description

Kuzzle CLI felt slow to users when simply trying to get the options list or get the current Kuzzle version tag.

The problem has been pinpoint to Kuzzle constructor, instantiating the PluginsManager which, in turn, requires the PM2 client. This client, as soon as it is required, performs operations in order to detect and access to the PM2 daemon.
This is usually not a problem, except when starting the CLI, giving clients the false impression that it is slow.

This PR is purely cosmetic, making CLI commands require Kuzzle only when they need to, postponing the PM2 operations when CLI clients are ready to wait half a second for the CLI to operate.

# Solved issue

#787 
