### PR TITLE
Add meta to Security documents (User, Profile, Role)

### DIFF
--- a/features/step_definitions/role.js
+++ b/features/step_definitions/role.js
@@ -165,11 +165,11 @@ var apiSteps = function () {
             }
 
             if (!aBody.result.hits) {
-              return callbackAsync('Expected ' + count + ' roles, get 0');
+              return callbackAsync('Expected ' + count + ' roles, got 0');
             }
 
             if (aBody.result.hits.length !== parseInt(count)) {
-              return callbackAsync('Expected ' + count + ' roles, get ' + aBody.result.hits.length);
+              return callbackAsync('Expected ' + count + ' roles, got ' + aBody.result.hits.length);
             }
 
             callbackAsync();

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -488,6 +488,7 @@ class SecurityController {
     assertHasId(request);
 
     return this.kuzzle.repositories.user.load(request.input.resource._id)
+      .then(user => updateMetadata(user, request))
       .then(user => this.kuzzle.repositories.user.persist(_.extend(user, request.input.body), {database: {method: 'update'}}))
       .then(updatedUser => formatProcessing.formatUserForSerialization(this.kuzzle, updatedUser));
   }
@@ -509,6 +510,14 @@ class SecurityController {
     pojoUser = request.input.body;
     pojoUser._id = request.input.resource._id;
 
+    // Add metadata
+    pojoUser._kuzzle_info = {
+      author: request.context.user ? String(request.context.user._id) : null,
+      createdAt: Date.now(),
+      updatedAt: null,
+      updater: null
+    };
+
     return this.kuzzle.repositories.user.load(request.input.resource._id)
       .then(loadedUser => (!loadedUser) ? Bluebird.reject(new NotFoundError(`User with id ${request.input.resource._id} not found`)) : Bluebird.resolve())
       .then(() => this.kuzzle.repositories.user.hydrate(user, pojoUser))
@@ -527,6 +536,7 @@ class SecurityController {
     assertHasId(request);
 
     return this.kuzzle.repositories.profile.loadProfile(request.input.resource._id)
+      .then(profile => updateMetadata(profile, request))
       .then(profile => this.kuzzle.repositories.profile.validateAndSaveProfile(_.extend(profile, request.input.body), {method: 'update'}))
       .then(updatedProfile => formatProcessing.formatProfileForSerialization(updatedProfile));
   }
@@ -547,8 +557,9 @@ class SecurityController {
           return Bluebird.reject(new NotFoundError(`Cannot update role ${request.input.resource._id}: role not found`));
         }
 
-        return this.kuzzle.repositories.role.validateAndSaveRole(_.extend(role, request.input.body), {method: 'update'});
+        return updateMetadata(role, request);
       })
+      .then(role => this.kuzzle.repositories.role.validateAndSaveRole(_.extend(role, request.input.body), {method: 'update'}))
       .then(updatedRole => formatProcessing.formatRoleForSerialization(updatedRole));
   }
 
@@ -959,6 +970,21 @@ function formatUserSearchResult(kuzzle, formatter, raw) {
 }
 
 /**
+ * Sets the metadata for an update request
+ * @param {object} securityDocument
+ * @param {Request} request
+ * @returns {object}
+ */
+function updateMetadata(securityDocument, request) {
+  securityDocument._kuzzle_info = _.assign(securityDocument._kuzzle_info, {
+    updatedAt: Date.now(),
+    updater: request.context.user ? String(request.context.user._id) : null
+  });
+
+  return securityDocument;
+}
+
+/**
  * @param {Kuzzle} kuzzle
  * @param {Request} request
  * @param {object} pojoUser
@@ -1026,6 +1052,14 @@ function* persistUserAndCredentials (kuzzle, request, pojoUser) {
       }
     }
   }
+
+  // Add metadata
+  pojoUser._kuzzle_info= {
+    author: request.context.user ? String(request.context.user._id) : null,
+    createdAt: Date.now(),
+    updatedAt: null,
+    updater: null
+  };
 
   if (errorStep === null) {
     try {

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -1093,7 +1093,7 @@ function* persistUserAndCredentials (kuzzle, request, pojoUser) {
       });
   }
 
-  errorMessage = `An error occured during the creation of user "${request.input.resource._id}": ` + errors.map(error => error.message).join(';');
+  errorMessage = `An error occurred during the creation of user "${request.input.resource._id}": ` + errors.map(error => error.message).join(';');
 
   if (creationError !== null) {
     throw new KuzzleInternalError(errorMessage);

--- a/lib/api/core/auth/formatProcessing.js
+++ b/lib/api/core/auth/formatProcessing.js
@@ -31,11 +31,13 @@ module.exports = {
   formatRoleForSerialization: role => {
     const response = {_id: role._id};
 
-    response._source = _.assignIn({}, role);
+    response._source = _.assignIn({}, _.omit(role, ['_kuzzle_info']));
 
     delete response._source._id;
     delete response._source.closures;
     delete response._source.restrictedTo;
+
+    response._meta = role._kuzzle_info || {};
 
     return response;
   },
@@ -49,8 +51,10 @@ module.exports = {
   formatProfileForSerialization: profile => {
     const response = {_id: profile._id};
 
-    response._source = _.assignIn({}, profile);
+    response._source = _.assignIn({}, _.omit(profile, ['_kuzzle_info']));
     delete response._source._id;
+
+    response._meta = profile._kuzzle_info || {};
 
     return response;
   },
@@ -66,7 +70,7 @@ module.exports = {
     return kuzzle.pluginsManager.trigger('security:formatUserForSerialization', user)
       .then(triggeredUser => {
 
-        const response = {_id: triggeredUser._id, _source: triggeredUser};
+        const response = {_id: triggeredUser._id, _source: _.omit(triggeredUser, ['_kuzzle_info']), _meta: triggeredUser._kuzzle_info || {}};
         delete response._source._id;
 
         return response;

--- a/lib/api/core/auth/formatProcessing.js
+++ b/lib/api/core/auth/formatProcessing.js
@@ -31,7 +31,7 @@ module.exports = {
   formatRoleForSerialization: role => {
     const response = {_id: role._id};
 
-    response._source = _.assignIn({}, _.omit(role, ['_kuzzle_info']));
+    response._source = _.omit(role, ['_kuzzle_info']);
 
     delete response._source._id;
     delete response._source.closures;
@@ -51,7 +51,7 @@ module.exports = {
   formatProfileForSerialization: profile => {
     const response = {_id: profile._id};
 
-    response._source = _.assignIn({}, _.omit(profile, ['_kuzzle_info']));
+    response._source = _.omit(profile, ['_kuzzle_info']);
     delete response._source._id;
 
     response._meta = profile._kuzzle_info || {};

--- a/lib/api/core/models/repositories/profileRepository.js
+++ b/lib/api/core/models/repositories/profileRepository.js
@@ -135,6 +135,13 @@ class ProfileRepository extends Repository {
       Object.assign(profile, request.input.body);
     }
 
+    profile._kuzzle_info = {
+      author: request.context.user ? String(request.context.user._id) : null,
+      createdAt: Date.now(),
+      updatedAt: null,
+      updater: null
+    };
+
     profile._id = request.input.resource._id;
 
     return Bluebird.resolve(profile);

--- a/lib/api/core/models/repositories/roleRepository.js
+++ b/lib/api/core/models/repositories/roleRepository.js
@@ -118,6 +118,13 @@ class RoleRepository extends Repository {
       }
     });
 
+    role._kuzzle_info = {
+      author: request.context.user ? String(request.context.user._id) : null,
+      createdAt: Date.now(),
+      updatedAt: null,
+      updater: null
+    };
+
     return role;
   }
 

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -316,8 +316,8 @@ class ElasticSearch extends Service {
   }
 
   /**
-   * Send to elasticsearch the new document
-   * Clean data for match the elasticsearch specification
+   * Sends the new document to elasticsearch
+   * Cleans data to match elasticsearch specifications
    *
    * @param {Request} request
    * @returns {Promise} resolve an object that contains _id
@@ -373,7 +373,7 @@ class ElasticSearch extends Service {
               .catch(error => Bluebird.reject(this.formatESError(error)));
           }
 
-          // A "real" error occured, we reject it
+          // A "real" error occurred, we reject it
           return Bluebird.reject(err);
         });
     }
@@ -420,7 +420,7 @@ class ElasticSearch extends Service {
   }
 
   /**
-   * Send to elasticsearch the partial document
+   * Sends the partial document to elasticsearch
    * with the id to update
    *
    * @param {Request} request
@@ -494,7 +494,7 @@ class ElasticSearch extends Service {
       deletedAt: null
     };
     // extends the response with the source from request
-    // When we write in ES, the response from it doesn't contain the initial document content
+    // When we write in ES, the response doesn't contain the initial document content
     return this.client.exists(existQuery)
       .then(exists => {
         if (exists) {
@@ -598,7 +598,7 @@ class ElasticSearch extends Service {
       return Bluebird.reject(new BadRequestError('null is not a valid document ID'));
     }
 
-    return getPaginatedIdsFromQuery(this.client, esRequestSearch)
+    return getAllIdsFromQuery(this.client, esRequestSearch)
       .then(ids => {
         return new Bluebird((resolve, reject) => {
           ids.forEach(id => {
@@ -705,7 +705,7 @@ class ElasticSearch extends Service {
         }
 
         if (!this.kuzzle.indexCache.exists(item[action]._index, item[action]._type)) {
-          error = new PreconditionError(`Index '${esRequest.index}' and/or collection ${esRequest.type} don\'t exist`);
+          error = new PreconditionError(`Index '${esRequest.index}' and/or collection ${esRequest.type} don't exist`);
           return false;
         }
 
@@ -1098,9 +1098,7 @@ function getAllIdsFromQuery(client, esRequest) {
         return reject(error);
       }
 
-      response.hits.hits.forEach(hit => {
-        ids.push(hit._id);
-      });
+      response.hits.hits.forEach(hit => ids.push(hit._id));
 
       if (response.hits.total !== ids.length) {
         client.scroll({
@@ -1111,26 +1109,6 @@ function getAllIdsFromQuery(client, esRequest) {
       else {
         resolve(ids);
       }
-    });
-  });
-}
-
-/**
- * Scroll index in elasticsearch and return all document ids that match the filter
- *
- * @param {object} client - elasticseach client
- * @param {Object} data
- * @returns {Promise} resolve an array
- */
-function getPaginatedIdsFromQuery(client, data) {
-  return new Bluebird((resolve, reject) => {
-    client.search(data, function getMoreUntilDone(error, response) {
-      if (error) {
-        return reject(error);
-      }
-
-      // todo: use real scroll here
-      resolve(response.hits.hits.map(hit => hit._id));
     });
   });
 }

--- a/lib/services/internalEngine/bootstrap.js
+++ b/lib/services/internalEngine/bootstrap.js
@@ -81,6 +81,32 @@ class InternalEngineBootstrap {
       properties: {
         controllers: {
           enabled: false
+        },
+        _kuzzle_info: {
+          properties: {
+            author: {
+              type: 'text',
+              fields: {
+                keyword: {
+                  type: 'keyword'
+                }
+              }
+            },
+            createdAt: {
+              type: 'long'
+            },
+            updatedAt: {
+              type: 'long'
+            },
+            updater: {
+              type: 'text',
+              fields: {
+                keyword: {
+                  type: 'keyword'
+                }
+              }
+            }
+          }
         }
       }
     })
@@ -121,6 +147,32 @@ class InternalEngineBootstrap {
               type: 'keyword'
             }
           }
+        },
+        _kuzzle_info: {
+          properties: {
+            author: {
+              type: 'text',
+              fields: {
+                keyword: {
+                  type: 'keyword'
+                }
+              }
+            },
+            createdAt: {
+              type: 'long'
+            },
+            updatedAt: {
+              type: 'long'
+            },
+            updater: {
+              type: 'text',
+              fields: {
+                keyword: {
+                  type: 'keyword'
+                }
+              }
+            }
+          }
         }
       }
     })
@@ -146,6 +198,32 @@ class InternalEngineBootstrap {
       properties: {
         profileIds: {
           type: 'keyword'
+        },
+        _kuzzle_info: {
+          properties: {
+            author: {
+              type: 'text',
+              fields: {
+                keyword: {
+                  type: 'keyword'
+                }
+              }
+            },
+            createdAt: {
+              type: 'long'
+            },
+            updatedAt: {
+              type: 'long'
+            },
+            updater: {
+              type: 'text',
+              fields: {
+                keyword: {
+                  type: 'keyword'
+                }
+              }
+            }
+          }
         }
       }
     })

--- a/lib/services/internalEngine/index.js
+++ b/lib/services/internalEngine/index.js
@@ -266,7 +266,7 @@ class InternalEngine {
     }
 
     // extends the response with the source from request
-    // When we write in ES, the response from it doesn't contain the initial document content
+    // When we write in ES, the response doesn't contain the initial document content
     return this.client.create(request)
       .then(result => _.extend(result, {_source: content}))
       .catch(error => handleError(error));

--- a/test/api/controllers/securityController/profiles.test.js
+++ b/test/api/controllers/securityController/profiles.test.js
@@ -72,7 +72,7 @@ describe('Test: security controller - profiles', () => {
 
   describe('#createOrReplaceProfile', () => {
     it('should resolve to an object on a createOrReplaceProfile call', () => {
-      kuzzle.repositories.profile.validateAndSaveProfile = sandbox.stub().returns(Promise.resolve({_id: 'test', _source: {}}));
+      kuzzle.repositories.profile.validateAndSaveProfile = sandbox.stub().returns(Promise.resolve({_id: 'test', _source: {}, _meta: {}}));
 
       return securityController.createOrReplaceProfile(new Request({_id: 'test', body: {policies: [{roleId: 'role1'}]}}))
         .then(response => {
@@ -101,7 +101,7 @@ describe('Test: security controller - profiles', () => {
     });
 
     it('should resolve to an object on a createProfile call', () => {
-      kuzzle.repositories.profile.validateAndSaveProfile = sandbox.stub().returns(Promise.resolve({_id: 'test', _source: {}}));
+      kuzzle.repositories.profile.validateAndSaveProfile = sandbox.stub().returns(Promise.resolve({_id: 'test', _source: {}, _meta: {}}));
 
       return should(securityController.createProfile(new Request({_id: 'test', body: {policies: [{roleId:'role1'}]}})))
         .be.fulfilled();
@@ -116,7 +116,7 @@ describe('Test: security controller - profiles', () => {
 
   describe('#getProfile', () => {
     it('should resolve to an object on a getProfile call', () => {
-      kuzzle.repositories.profile.loadProfile = sandbox.stub().returns(Promise.resolve({_id: 'test', _source: {}}));
+      kuzzle.repositories.profile.loadProfile = sandbox.stub().returns(Promise.resolve({_id: 'test', _source: {}, _meta: {}}));
 
       return securityController.getProfile(new Request({_id: 'test'}))
         .then(response => {
@@ -168,7 +168,7 @@ describe('Test: security controller - profiles', () => {
     });
 
     it('should resolve to an object with roles on a mGetProfiles call with hydrate', () => {
-      kuzzle.repositories.profile.loadMultiFromDatabase = sandbox.stub().returns(Promise.resolve([{_id: 'test', _source: {}}]));
+      kuzzle.repositories.profile.loadMultiFromDatabase = sandbox.stub().returns(Promise.resolve([{_id: 'test', _source: {}, _meta: {}}]));
 
       return securityController.mGetProfiles(new Request({
         body: {ids: ['test'], hydrate: true}
@@ -216,6 +216,7 @@ describe('Test: security controller - profiles', () => {
           should(response.hits[0]._id).be.exactly('test');
           should(response.hits[0]._source.policies).be.an.Array();
           should(response.hits[0]._source.policies[0].roleId).be.exactly('default');
+          should(response.hits[0]._meta).be.instanceof(Object);
           should(response.total).be.eql(1);
           should(response.scrollId).be.eql('foobar');
           should(kuzzle.repositories.profile.searchProfiles).be.calledWithMatch(['role1'], {});
@@ -263,6 +264,7 @@ describe('Test: security controller - profiles', () => {
           should(response.hits[0]._id).be.exactly('test');
           should(response.hits[0]._source.policies).be.an.Array();
           should(response.hits[0]._source.policies[0].roleId).be.exactly('default');
+          should(response.hits[0]._meta).be.instanceof(Object);
           should(response.total).be.eql(1);
           should(response.scrollId).be.eql('foobar');
           should(kuzzle.repositories.profile.scroll).be.calledWithMatch('foobar', undefined);
@@ -285,6 +287,7 @@ describe('Test: security controller - profiles', () => {
           should(response.hits[0]._id).be.exactly('test');
           should(response.hits[0]._source.policies).be.an.Array();
           should(response.hits[0]._source.policies[0].roleId).be.exactly('default');
+          should(response.hits[0]._meta).be.instanceof(Object);
           should(response.total).be.eql(1);
           should(response.scrollId).be.eql('foobar');
           should(kuzzle.repositories.profile.scroll).be.calledWithMatch('foobar', '4s');

--- a/test/api/controllers/securityController/roles.test.js
+++ b/test/api/controllers/securityController/roles.test.js
@@ -130,7 +130,7 @@ describe('Test: security controller - roles', () => {
     });
 
     it('should resolve to an object', done => {
-      kuzzle.repositories.role.loadMultiFromDatabase = sandbox.stub().returns(Promise.resolve([{_id: 'test', _source: null}]));
+      kuzzle.repositories.role.loadMultiFromDatabase = sandbox.stub().returns(Promise.resolve([{_id: 'test', _source: null, _meta: {}}]));
       securityController.mGetRoles(new Request({body: {ids: ['test']}}))
         .then(response => {
           should(response).be.instanceof(Object);

--- a/test/api/controllers/securityController/users.test.js
+++ b/test/api/controllers/securityController/users.test.js
@@ -95,7 +95,7 @@ describe('Test: security controller - users', () => {
       });
 
       kuzzle.repositories.user.search = sandbox.stub().returns(Bluebird.resolve({
-        hits: [{_id: 'admin', _source: { profileIds: ['admin'] }}],
+        hits: [{_id: 'admin', _source: { profileIds: ['admin'] }, _meta: {}}],
         total: 2,
         scrollId: 'foobar'
       }));
@@ -110,7 +110,7 @@ describe('Test: security controller - users', () => {
 
     it('should handle empty body requests', () => {
       kuzzle.repositories.user.search = sandbox.stub().returns(Bluebird.resolve({
-        hits: [{_id: 'admin', _source: { profileIds: ['admin'] }}],
+        hits: [{_id: 'admin', _source: { profileIds: ['admin'] }, _meta: {}}],
         total: 2,
         scrollId: 'foobar'
       }));
@@ -154,7 +154,7 @@ describe('Test: security controller - users', () => {
       request = new Request({scrollId: 'foobar'});
 
       kuzzle.repositories.user.scroll = sandbox.stub().returns(Bluebird.resolve({
-        hits: [{_id: 'admin', _source: { profileIds: ['admin'] }}],
+        hits: [{_id: 'admin', _source: { profileIds: ['admin'] }, _meta: {}}],
         total: 2,
         scrollId: 'foobar'
       }));
@@ -171,7 +171,7 @@ describe('Test: security controller - users', () => {
       request = new Request({scrollId: 'foobar', scroll: 'qux'});
 
       kuzzle.repositories.user.scroll = sandbox.stub().returns(Bluebird.resolve({
-        hits: [{_id: 'admin', _source: { profileIds: ['admin'] }}],
+        hits: [{_id: 'admin', _source: { profileIds: ['admin'] }, _meta: {}}],
         total: 2,
         scrollId: 'foobar'
       }));
@@ -246,7 +246,7 @@ describe('Test: security controller - users', () => {
           should(kuzzle.repositories.user.persist).be.calledOnce();
           should(kuzzle.repositories.user.persist.firstCall.args[1]).match({database: {method: 'create'}});
           should(response).be.instanceof(Object);
-          should(response).be.match({_id: 'test', _source: {}});
+          should(response).be.match({_id: 'test', _source: {}, _meta: {}});
         });
     });
 
@@ -267,7 +267,7 @@ describe('Test: security controller - users', () => {
           should(kuzzle.repositories.user.persist).be.calledOnce();
           should(kuzzle.repositories.user.hydrate).be.calledOnce();
           should(response).be.instanceof(Object);
-          should(response).be.match({_id: 'test', _source: {}});
+          should(response).be.match({_id: 'test', _source: {}, _meta: {}});
           should(kuzzle.repositories.user.persist.firstCall.args[1]).match({database: {method: 'create'}});
           should(kuzzle.repositories.user.hydrate.firstCall.args[1]._id).match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
         });
@@ -440,7 +440,7 @@ describe('Test: security controller - users', () => {
         .then(response => {
           should(kuzzle.repositories.user.persist).be.calledOnce();
           should(response.userContext).be.instanceof(Object);
-          should(response).be.match({_id: 'test', _source: {}});
+          should(response).be.match({_id: 'test', _source: {}, _meta: {}});
           should(kuzzle.repositories.user.persist.firstCall.args[1]).match({database: {method: 'create'}});
         });
     });
@@ -455,7 +455,7 @@ describe('Test: security controller - users', () => {
           should(kuzzle.repositories.user.persist).be.calledOnce();
           should(kuzzle.repositories.user.hydrate).be.calledOnce();
           should(response).be.instanceof(Object);
-          should(response).be.match({_id: 'test', _source: {}});
+          should(response).be.match({_id: 'test', _source: {}, _meta: {}});
           should(kuzzle.repositories.user.persist.firstCall.args[1]).match({database: {method: 'create'}});
           should(kuzzle.repositories.user.hydrate.firstCall.args[1]._id).match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
         });
@@ -471,13 +471,13 @@ describe('Test: security controller - users', () => {
   describe('#updateUser', () => {
     it('should return a valid response', () => {
       kuzzle.repositories.user.persist = sandbox.stub().returns(Bluebird.resolve({_id: 'test'}));
-      kuzzle.repositories.profile.loadProfile = sandbox.stub().returns(Bluebird.resolve({_id: 'anonymous', _source: {}}));
+      kuzzle.repositories.profile.loadProfile = sandbox.stub().returns(Bluebird.resolve({_id: 'anonymous', _source: {}, _meta: {}}));
 
       return securityController.updateUser(new Request({_id: 'test', body: {foo: 'bar'}}))
         .then(response => {
           should(kuzzle.repositories.user.persist).be.calledOnce();
           should(response).be.instanceof(Object);
-          should(response).be.match({_id: 'test', _source: {}});
+          should(response).be.match({_id: 'test', _source: {}, _meta: {}});
           should(kuzzle.repositories.user.persist.firstCall.args[1]).match({database: {method: 'update'}});
         });
     });
@@ -490,7 +490,7 @@ describe('Test: security controller - users', () => {
 
     it('should update the profile correctly', () => {
       kuzzle.repositories.user.persist = sandbox.stub().returns(Bluebird.resolve({_id: 'test', profileIds: ['anonymous'], foo: 'bar'}));
-      kuzzle.repositories.profile.loadProfile = sandbox.stub().returns(Bluebird.resolve({_id: 'default', _source: {}}));
+      kuzzle.repositories.profile.loadProfile = sandbox.stub().returns(Bluebird.resolve({_id: 'default', _source: {}, _meta: {}}));
 
       return securityController.updateUser(new Request({
         _id: 'test',
@@ -501,6 +501,7 @@ describe('Test: security controller - users', () => {
           should(response._id).be.exactly('test');
           should(response._source.profile).be.an.instanceOf(Object);
           should(response._source.foo).be.exactly('bar');
+          should(response._meta).be.an.instanceOf(Object);
         });
     });
   });
@@ -514,7 +515,7 @@ describe('Test: security controller - users', () => {
 
     it('should replace the user correctly', () => {
       kuzzle.repositories.user.persist = sandbox.stub().returns(Bluebird.resolve({_id: 'test', profileIds: ['anonymous'], foo: 'bar'}));
-      kuzzle.repositories.user.load = userId => Bluebird.resolve({_id: userId, _source: {}});
+      kuzzle.repositories.user.load = userId => Bluebird.resolve({_id: userId, _source: {}, _meta: {}});
 
       return securityController.replaceUser(new Request({
         _id: 'test',
@@ -524,7 +525,8 @@ describe('Test: security controller - users', () => {
           should(response).be.instanceOf(Object);
           should(response).match({
             _id: 'test',
-            _source: {profileIds: ['anonymous']}
+            _source: {profileIds: ['anonymous']},
+            _meta: {}
           });
         });
     });

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -895,7 +895,7 @@ describe('Test: ElasticSearch service', () => {
       elasticsearch.client.search.yields(null, {hits: {hits: [{_id: 'foo'}, {_id: 'bar'}, {_id: 'baz'}], total: mockupIds.length}});
 
       return ES.__with__({
-        getPaginatedIdsFromQuery: getAllIdsStub,
+        getAllIdsFromQuery: getAllIdsStub,
         Date: {
           now: () => 42
         }


### PR DESCRIPTION
## Introduces
- Meta in Security documents

## Boyscoot
- Removed `getPaginatedIdsFromQuery` function from `elasticsearch.js` service in favor of `getAllIdsFromQuery`
- Typos

## Linked PRs
- Backoffice: https://github.com/kuzzleio/kuzzle-backoffice/pull/327
- SDK JS: https://github.com/kuzzleio/sdk-javascript/pull/236
- SDK PHP: https://github.com/kuzzleio/sdk-php/pull/81
- SDK Android: https://github.com/kuzzleio/sdk-android/pull/144
- Documentation: https://github.com/kuzzleio/documentation/pull/320