### PR TITLE
Fix Kuzzle crash when creating invalid Role + incorrect error message

### DIFF
--- a/lib/api/core/models/security/role.js
+++ b/lib/api/core/models/security/role.js
@@ -151,14 +151,15 @@ class Role {
         return Object.keys(controllerRights.actions).every(actionKey => {
           const actionRights = controllerRights.actions[actionKey];
 
-          if (actionRights === null || ['object', 'boolean'].indexOf(typeof actionRights) === -1) {
+          if (actionRights === null || (['object', 'boolean'].indexOf(typeof actionRights) === -1 || Array.isArray(actionRights))) {
             reject(new BadRequestError(`Invalid definition for [${controllerKey}, ${actionKey}]: must be a boolean or an object`));
             return false;
           }
 
           if (typeof actionRights === 'object') {
             if (!actionRights.test) {
-              return Bluebird.reject(new BadRequestError(`Invalid definition for ${[controllerKey, actionKey]}. Permissions defined as closures must have a "test" element.`));
+              reject(new BadRequestError(`Invalid definition for ${[controllerKey, actionKey]}. Permissions defined as closures must have a "test" element.`));
+              return false;
             }
 
             promises.push((() => {


### PR DESCRIPTION
When creating a Role with an incorrect payload (`*` action should be a boolean, not an array of boolean):

```
kuzzle.security.createRole('patcr02Role', {controllers: {"*": {actions: {"*": [true]}}}}, function (err, (res) {
  (...)
});
```

Kuzzle crashes and the error message is incorrect:
User gets: `Invalid definition. Permissions defined as closures must have a "test" element`
Should get: `Invalid definition: must be a boolean or an object`