### PR TITLE
Fix event leak in unit tests

### DIFF
--- a/lib/api/kuzzle.js
+++ b/lib/api/kuzzle.js
@@ -60,6 +60,7 @@ const
 class Kuzzle extends EventEmitter {
   constructor() {
     super({
+      verboseMemoryLeak: true,
       wildcard: true,
       maxListeners: 30,
       delimiter: ':'

--- a/test/api/core/pluginsManager/run.test.js
+++ b/test/api/core/pluginsManager/run.test.js
@@ -130,6 +130,7 @@ describe('Test plugins manager run', () => {
 
   beforeEach(() => {
     kuzzle = new EventEmitter({
+      verboseMemoryLeak: true,
       wildcard: true,
       maxListeners: 30,
       delimiter: ':'

--- a/test/api/core/pluginsManager/trigger.test.js
+++ b/test/api/core/pluginsManager/trigger.test.js
@@ -13,6 +13,7 @@ describe('Test plugins manager trigger', () => {
   it('should trigger hooks event', function (done) {
     var
       kuzzle = new EventEmitter({
+        verboseMemoryLeak: true,
         wildcard: true,
         maxListeners: 30,
         delimiter: ':'


### PR DESCRIPTION
# Description

An event leak has been detected in unit tests (and in unit tests only). This PR fixes it.

It also activates the `verboseMemoryLeak` flag when creating the Kuzzle event emitter, to allow tracing event leaks if they occur during Kuzzle execution.
