### PR TITLE
Replace deprecated node-uuid module with uuid

### DIFF
--- a/features/support/apiWebsocket.js
+++ b/features/support/apiWebsocket.js
@@ -3,7 +3,7 @@
 const
   config = require('./config'),
   Bluebird = require('bluebird'),
-  uuid = require('node-uuid'),
+  uuid = require('uuid/v4'),
   io = require('socket.io-client'),
   ApiRT = require('./apiRT');
 
@@ -74,7 +74,7 @@ ApiWebsocket.prototype.send = function (msg, getAnswer, socketName) {
     listen = (getAnswer !== undefined) ? getAnswer : true;
 
   if (!msg.requestId) {
-    msg.requestId = uuid.v4();
+    msg.requestId = uuid();
   }
 
   msg.volatile = this.world.volatile;
@@ -120,7 +120,7 @@ ApiWebsocket.prototype.sendAndListen = function (msg, socketName) {
     routename = 'kuzzle';
 
   if (!msg.requestId) {
-    msg.requestId = uuid.v4();
+    msg.requestId = uuid();
   }
 
   msg.volatile = this.world.volatile;

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -23,7 +23,7 @@
 
 const
   _ = require('lodash'),
-  uuid = require('node-uuid'),
+  uuid = require('uuid/v4'),
   Bluebird = require('bluebird'),
   formatProcessing = require('../core/auth/formatProcessing'),
   Request = require('kuzzle-common-objects').Request,
@@ -591,7 +591,7 @@ class SecurityController {
     }
 
     const pojoUser = request.input.body.content;
-    pojoUser._id = request.input.resource._id || uuid.v4();
+    pojoUser._id = request.input.resource._id || uuid();
 
     return persistUser(this.kuzzle, request, pojoUser);
   }
@@ -614,7 +614,7 @@ class SecurityController {
     }
 
     const pojoUser = request.input.body.content;
-    pojoUser._id = request.input.resource._id || uuid.v4();
+    pojoUser._id = request.input.resource._id || uuid();
 
     pojoUser.profileIds = this.kuzzle.config.security.restrictedProfileIds;
 
@@ -734,7 +734,7 @@ class SecurityController {
 
         delete request.input.args.reset;
         request.input.body.content.profileIds = ['admin'];
-        request.input.resource._id = request.input.resource._id || uuid.v4();
+        request.input.resource._id = request.input.resource._id || uuid();
 
         return this.createUser(request);
       })

--- a/lib/api/core/models/repositories/userRepository.js
+++ b/lib/api/core/models/repositories/userRepository.js
@@ -24,7 +24,7 @@
 const
   _ = require('lodash'),
   Bluebird = require('bluebird'),
-  uuid = require('node-uuid'),
+  uuid = require('uuid/v4'),
   User = require('../security/user'),
   Repository = require('./repository'),
   {
@@ -77,7 +77,7 @@ class UserRepository extends Repository {
       cacheOptions = options.cache || {};
 
     if (user._id === undefined || user._id === null) {
-      user._id = uuid.v4();
+      user._id = uuid();
     }
 
     if (user._id === this.anonymous()._id && user.profileIds.indexOf('anonymous') === -1) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "1.0.0-RC10",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "dependencies": {
     "@types/core-js": {
@@ -680,7 +680,7 @@
         "uuid": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+          "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
           "dev": true
         }
       }
@@ -900,7 +900,7 @@
     "elasticsearch": {
       "version": "13.1.1",
       "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-13.1.1.tgz",
-      "integrity": "sha512-bas9Thby8HRZ4NH4d3x9+67QnYhRllm4xdOzFOBPYdgcDbfFGIeFioCzB3RSQ9G9vZKLIjAg8LQSQ7eg9QtcNA==",
+      "integrity": "sha1-g9u1z3bsyb3T/861znTV/H0j55g=",
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
@@ -1270,7 +1270,8 @@
         },
         "caseless": {
           "version": "0.11.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
           "optional": true
         },
         "chalk": {
@@ -1322,7 +1323,8 @@
         },
         "debug": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "optional": true
         },
         "deep-extend": {
@@ -1423,7 +1425,8 @@
         },
         "har-validator": {
           "version": "2.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
           "optional": true
         },
         "has-ansi": {
@@ -1469,7 +1472,8 @@
         },
         "is-my-json-valid": {
           "version": "2.15.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+          "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
           "optional": true
         },
         "is-property": {
@@ -1543,7 +1547,8 @@
         },
         "ms": {
           "version": "0.7.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
           "optional": true
         },
         "node-pre-gyp": {
@@ -1626,7 +1631,8 @@
         },
         "request": {
           "version": "2.79.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
           "optional": true
         },
         "rimraf": {
@@ -1758,7 +1764,8 @@
         },
         "xtend": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "optional": true
         }
       }
@@ -1813,7 +1820,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU="
     },
     "glob-base": {
       "version": "0.3.0",
@@ -2233,7 +2240,7 @@
         "uuid": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+          "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
         }
       }
     },
@@ -2394,7 +2401,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM="
     },
     "minimist": {
       "version": "1.2.0",
@@ -2404,7 +2411,7 @@
     "minipass": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.1.1.tgz",
-      "integrity": "sha512-xZjdNWL+9Z5Ut0Ay+S/2JJranFcuJJMmXIRKbFEpzETZITghn5w3Gf524kwfrpB7Jm8QplXwKJnkDn/pdF3/7Q=="
+      "integrity": "sha1-yAyAo0kcGA1AcdjyGb0bSwKEmZ0="
     },
     "minizlib": {
       "version": "1.0.3",
@@ -2533,11 +2540,6 @@
       "resolved": "https://registry.npmjs.org/node-units/-/node-units-0.1.7.tgz",
       "integrity": "sha1-nTF2pcU1v4rwZQbArfbcga+zl3s="
     },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-    },
     "noop-logger": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
@@ -2551,7 +2553,7 @@
     "npmlog": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
-      "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA=="
+      "integrity": "sha1-3Fm+6F9k8A7UJO+yrweD3yXRwLU="
     },
     "nssocket": {
       "version": "0.6.0",
@@ -3783,7 +3785,7 @@
     "pm2": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/pm2/-/pm2-2.5.0.tgz",
-      "integrity": "sha512-yBUY+3XjBrRZrQuUHijZebF8qi/muoaGf0geNKdD5vzwnDTxhMLzUAo4xzKDcnZj4IQiKwDB279ehJ6EPKcpgw==",
+      "integrity": "sha1-EcD/NJfCKSPmIh6deACLHLRYS9E=",
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -4541,6 +4543,11 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
+    "uuid": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+    },
     "validator": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-7.0.0.tgz",
@@ -4572,14 +4579,14 @@
         "uuid": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+          "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
         }
       }
     },
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w=="
+      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA="
     },
     "wordwrap": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "ngeohash": "0.6.0",
     "node-interval-tree": "^1.1.4",
     "node-units": "0.1.7",
-    "node-uuid": "1.4.8",
     "passport": "0.3.2",
     "pm2": "^2.5.0",
     "rc": "1.2.1",
@@ -56,6 +55,7 @@
     "reify": "^0.11.24",
     "sorted-array": "^2.0.1",
     "utf-8-validate": "^3.0.2",
+    "uuid": "^3.1.0",
     "validator": "^7.0.0",
     "ws": "3.0.0"
   },


### PR DESCRIPTION
# Description

Replaces the [node-uuid](https://www.npmjs.com/package/node-uuid) module, which is deprecated for quite some time now, with [uuid](https://www.npmjs.com/package/uuid).
