### PR TITLE
Expose trigger method to plugin context

### DIFF
--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -105,6 +105,11 @@ class PluginContext {
         }
       });
 
+      Object.defineProperty(this.accessors, 'trigger', {
+        enumerable: true,
+        get: () => curryTrigger(pluginName).bind(kuzzle)
+      });
+
       /**
        * @param {string} collection
        * @param {?function} ObjectConstructor
@@ -174,6 +179,37 @@ function execute (request, callback) {
 
       return Bluebird.reject(err);
     });
+}
+
+/**
+ * Returns a currified version of pluginsManager.trigger. The pluginName param
+ * is injected in the returned function as it is pre-pended to the custom event
+ * name. This is done to avoid colliding with the kuzzle native events.
+ *
+ * @param  {String} pluginName The name of the plugin calling trigger.
+ * @return {Function}          A trigger function that makes some checks on the
+ *                             event name and prepends the plugin name to the
+ *                             event name.
+ */
+function curryTrigger (pluginName) {
+  /**
+   * @this   {Kuzzle}
+   * @param  {String} eventName The name of the custom event to trigger.
+   * @param  {Object} payload   The payload of the event.
+   */
+  return function trigger (eventName, payload) {
+    const kuzzle = this;
+
+    if (eventName.indexOf(':') !== -1) {
+      kuzzle.pluginsManager.trigger(
+        'log:error',
+        new PluginImplementationError(`Custom event invalid name (${eventName}). Colons are not allowed in custom events.`)
+      );
+      return;
+    }
+
+    kuzzle.pluginsManager.trigger(`plugin-${pluginName}:${eventName}`, payload);
+  };
 }
 
 /**

--- a/test/api/core/pluginContext/pluginContext.test.js
+++ b/test/api/core/pluginContext/pluginContext.test.js
@@ -125,7 +125,7 @@ describe('Plugin Context', () => {
       });
 
       should(context.accessors).be.an.Object().and.not.be.empty();
-      should(context.accessors).have.properties(['execute', 'validation', 'storage']);
+      should(context.accessors).have.properties(['execute', 'validation', 'storage', 'trigger']);
     });
 
     it('should expose a correctly constructed validation accessor', () => {
@@ -141,11 +141,41 @@ describe('Plugin Context', () => {
       should(execute).be.a.Function();
     });
 
+    it('should expose correctly a trigger accessor', () => {
+      const trigger = context.accessors.trigger;
+
+      should(trigger).be.a.Function();
+    });
+
     it('should expose a correctly constructed storage accessor', () => {
       const storage = context.accessors.storage;
 
       should(storage.bootstrap).be.a.Function();
       should(storage.createCollection).be.a.Function();
+    });
+  });
+
+  describe('#trigger', () => {
+    it('should trigger a log:error if eventName contains a colon', () => {
+      const trigger = kuzzle.pluginsManager.trigger;
+      context.accessors.trigger('event:with:colons');
+      should(trigger).be.calledWith('log:error');
+    });
+
+    it('should call trigger with the given event name and payload', () => {
+      const trigger = kuzzle.pluginsManager.trigger;
+      const eventName = 'backHome';
+      const payload = {
+        question: 'who\'s is this motorcycle?',
+        answer: 'it\'s a chopper, baby.',
+        anotherQuestion: 'who\'s is this chopper, then?',
+        anotherAnswer: 'it\'s Zed\'s',
+        yetAnotherQuestion: 'who\'s Zed?',
+        yetAnotherAnswer: 'Zed\'s dead, baby, Zed\'s dead.'
+      };
+
+      context.accessors.trigger(eventName, payload);
+      should(trigger).be.calledWithExactly(`plugin-pluginName:${eventName}`, payload);
     });
   });
 


### PR DESCRIPTION
Fix #909 

The `pluginsManager.trigger` method is wrapped and exposed in the `PluginContext` object. The wrapper performs minor checks and pre-pends the plugin name in order to avoid collisions with Kuzzle native events.