### PR TITLE
Allow plugins to dynamically (un)register authentication strategies

### DIFF
--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -29,7 +29,7 @@ const
   KuzzleInternalError = require('kuzzle-common-objects').errors.InternalError,
   {
     assertIsStrategyRegistered,
-    assertIsConnected,
+    assertIsAuthenticated,
     assertHasBody,
     assertHasStrategy,
     assertBodyHasNotAttribute,
@@ -195,7 +195,7 @@ class AuthController {
    * @returns {Promise<object>}
    */
   updateSelf(request) {
-    assertIsConnected(this.kuzzle, request);
+    assertIsAuthenticated(this.kuzzle, request);
     assertHasBody(request);
     assertBodyHasNotAttribute(request, '_id');
     assertBodyHasNotAttribute(request, 'profileIds');
@@ -218,7 +218,7 @@ class AuthController {
    * @returns {Promise.<Object>}
    */
   createMyCredentials(request) {
-    assertIsConnected(this.kuzzle, request);
+    assertIsAuthenticated(this.kuzzle, request);
     assertHasStrategy(request);
     assertIsStrategyRegistered(this.kuzzle, request);
     assertHasBody(request);
@@ -237,7 +237,7 @@ class AuthController {
    * @returns {Promise.<Object>}
    */
   updateMyCredentials(request) {
-    assertIsConnected(this.kuzzle, request);
+    assertIsAuthenticated(this.kuzzle, request);
     assertHasStrategy(request);
     assertIsStrategyRegistered(this.kuzzle, request);
     assertHasBody(request);
@@ -254,7 +254,7 @@ class AuthController {
    * @returns {Promise.<Object>}
    */
   credentialsExist(request) {
-    assertIsConnected(this.kuzzle, request);
+    assertIsAuthenticated(this.kuzzle, request);
     assertHasStrategy(request);
     assertIsStrategyRegistered(this.kuzzle, request);
 
@@ -268,7 +268,7 @@ class AuthController {
    * @returns {Promise.<Object>}
    */
   validateMyCredentials(request) {
-    assertIsConnected(this.kuzzle, request);
+    assertIsAuthenticated(this.kuzzle, request);
     assertHasStrategy(request);
     assertIsStrategyRegistered(this.kuzzle, request);
     assertHasBody(request);
@@ -283,7 +283,7 @@ class AuthController {
    * @returns {Promise.<Object>}
    */
   deleteMyCredentials(request) {
-    assertIsConnected(this.kuzzle, request);
+    assertIsAuthenticated(this.kuzzle, request);
     assertHasStrategy(request);
     assertIsStrategyRegistered(this.kuzzle, request);
 
@@ -298,7 +298,7 @@ class AuthController {
    * @returns {Promise.<Object>}
    */
   getMyCredentials(request) {
-    assertIsConnected(this.kuzzle, request);
+    assertIsAuthenticated(this.kuzzle, request);
     assertHasStrategy(request);
     assertIsStrategyRegistered(this.kuzzle, request);
 

--- a/lib/api/core/auth/passportWrapper.js
+++ b/lib/api/core/auth/passportWrapper.js
@@ -77,25 +77,25 @@ class PassportWrapper {
   }
 
   /**
-   * Adds options for a strategy in this.options
-   * Used by passport.authenticate
-   *
-   * @param {string} strategy name
-   * @param {Array} options - options to provide to authenticate for the strategy
-   */
-  injectAuthenticateOptions(strategy, options) {
-    this.options[strategy] = options;
-  }
-
-  /**
    * Exposes passport.use function
-   * Mainly used by the pluginContext
    *
    * @param {string} name - strategy name
    * @param {object} strategy - instantiated strategy object
+   * @param {object} opts - options to provide to authenticate with the strategy
    */
-  use(name, strategy) {
+  use(name, strategy, opts = {}) {
     passport.use(name, strategy);
+    this.options[strategy] = opts;
+  }
+
+  /**
+   * Exposes passport.unuse, unregistering a strategy from kuzzle
+   *  
+   * @param  {string} name - name of the strategy to unregister
+   */
+  unuse(name) {
+    passport.unuse(name);
+    delete this.options[name];
   }
 }
 

--- a/lib/api/core/auth/passportWrapper.js
+++ b/lib/api/core/auth/passportWrapper.js
@@ -53,26 +53,31 @@ class PassportWrapper {
     return new Bluebird((resolve, reject) => {
       response.addEndListener(() => resolve(response));
 
-      passport.authenticate(strategy, this.options[strategy] || {}, (err, user, info) => {
-        if (err !== null) {
-          if (err instanceof KuzzleError) {
-            reject(err);
+      try {
+        passport.authenticate(strategy, this.options[strategy] || {}, (err, user, info) => {
+          if (err !== null) {
+            if (err instanceof KuzzleError) {
+              reject(err);
+            }
+            else {
+              reject(new PluginImplementationError(err));
+            }
+          }
+          else if (!user) {
+            const error = new UnauthorizedError(info.message);
+            error.details = {
+              subCode: error.subCodes.AuthenticationError
+            };
+            reject(error);
           }
           else {
-            reject(new PluginImplementationError(err));
+            resolve(user);
           }
-        }
-        else if (!user) {
-          const error = new UnauthorizedError(info.message);
-          error.details = {
-            subCode: error.subCodes.AuthenticationError
-          };
-          reject(error);
-        }
-        else {
-          resolve(user);
-        }
-      })(request, response);
+        })(request, response);
+      }
+      catch(err) {
+        console.log('===== GOTCHA!', err.message);
+      }
     });
   }
 

--- a/lib/api/core/auth/passportWrapper.js
+++ b/lib/api/core/auth/passportWrapper.js
@@ -53,31 +53,26 @@ class PassportWrapper {
     return new Bluebird((resolve, reject) => {
       response.addEndListener(() => resolve(response));
 
-      try {
-        passport.authenticate(strategy, this.options[strategy] || {}, (err, user, info) => {
-          if (err !== null) {
-            if (err instanceof KuzzleError) {
-              reject(err);
-            }
-            else {
-              reject(new PluginImplementationError(err));
-            }
-          }
-          else if (!user) {
-            const error = new UnauthorizedError(info.message);
-            error.details = {
-              subCode: error.subCodes.AuthenticationError
-            };
-            reject(error);
+      passport.authenticate(strategy, this.options[strategy] || {}, (err, user, info) => {
+        if (err !== null) {
+          if (err instanceof KuzzleError) {
+            reject(err);
           }
           else {
-            resolve(user);
+            reject(new PluginImplementationError(err));
           }
-        })(request, response);
-      }
-      catch(err) {
-        console.log('===== GOTCHA!', err.message);
-      }
+        }
+        else if (!user) {
+          const error = new UnauthorizedError(info.message);
+          error.details = {
+            subCode: error.subCodes.AuthenticationError
+          };
+          reject(error);
+        }
+        else {
+          resolve(user);
+        }
+      })(request, response);
     });
   }
 

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -105,6 +105,16 @@ class PluginContext {
         }
       });
 
+      Object.defineProperty(this.accessors, 'strategies', {
+        enumerable: true,
+        get: () => {
+          return {
+            add: curryAddStrategy(kuzzle, pluginName),
+            remove: name => kuzzle.passport.unuse(name)
+          };
+        }
+      });
+
       Object.defineProperty(this.accessors, 'trigger', {
         enumerable: true,
         get: () => curryTrigger(pluginName).bind(kuzzle)
@@ -183,7 +193,7 @@ function execute (request, callback) {
 
 /**
  * Returns a currified version of pluginsManager.trigger. The pluginName param
- * is injected in the returned function as it is pre-pended to the custom event
+ * is injected in the returned function as it is prepended to the custom event
  * name. This is done to avoid colliding with the kuzzle native events.
  *
  * @param  {String} pluginName The name of the plugin calling trigger.
@@ -250,6 +260,28 @@ function instantiateRequest(request, data, options = {}) {
   }
 
   return target;
+}
+
+/**
+ * Returns a currified function of pluginsManager.registerStrategy
+ *  
+ * @param  {string} pluginName 
+ * @return {function} function taking a strategy name and properties, 
+ *                    registering it into kuzzle, and returning
+ *                    a promise
+ */
+function curryAddStrategy(kuzzle, pluginName) {
+  return function addStrategy(name, strategy) {
+    return new Bluebird((resolve, reject) => {
+      try {
+        kuzzle.pluginsManager.validateStrategy(pluginName, name, strategy);
+        kuzzle.pluginsManager.registerStrategy(pluginName, name, strategy);
+      }
+      catch(err) {
+        reject(err);
+      }
+    });
+  };
 }
 
 module.exports = PluginContext;

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -110,7 +110,7 @@ class PluginContext {
         get: () => {
           return {
             add: curryAddStrategy(kuzzle, pluginName),
-            remove: name => kuzzle.pluginsManager.unregisterStrategy(name)
+            remove: curryRemoveStrategy(kuzzle, pluginName)
           };
         }
       });
@@ -264,7 +264,8 @@ function instantiateRequest(request, data, options = {}) {
 
 /**
  * Returns a currified function of pluginsManager.registerStrategy
- *  
+ *
+ * @param  {Kuzzle} kuzzle 
  * @param  {string} pluginName 
  * @return {function} function taking a strategy name and properties, 
  *                    registering it into kuzzle, and returning
@@ -275,6 +276,29 @@ function curryAddStrategy(kuzzle, pluginName) {
     return new Bluebird((resolve, reject) => {
       try {
         kuzzle.pluginsManager.registerStrategy(pluginName, name, strategy);
+        resolve();
+      }
+      catch(err) {
+        reject(err);
+      }
+    });
+  };
+}
+
+/**
+ * Returns a currified function of pluginsManager.unregisterStrategy
+ *
+ * @param  {Kuzzle} kuzzle 
+ * @param  {string} pluginName 
+ * @return {function} function taking a strategy name and properties, 
+ *                    registering it into kuzzle, and returning
+ *                    a promise
+ */
+function curryRemoveStrategy(kuzzle, pluginName) {
+  return function removeStrategy(name) {
+    return new Bluebird((resolve, reject) => {
+      try {
+        kuzzle.pluginsManager.unregisterStrategy(pluginName, name);
         resolve();
       }
       catch(err) {

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -276,11 +276,14 @@ function curryAddStrategy(kuzzle, pluginName) {
     return new Bluebird((resolve, reject) => {
       try {
         kuzzle.pluginsManager.registerStrategy(pluginName, name, strategy);
-        resolve();
       }
       catch(err) {
-        reject(err);
+        return reject(err);
       }
+
+      kuzzle.pluginsManager.trigger('core:auth:strategyAdded', {name, strategy, pluginName})
+        .then(() => resolve())
+        .catch(err => reject(err));
     });
   };
 }
@@ -299,11 +302,14 @@ function curryRemoveStrategy(kuzzle, pluginName) {
     return new Bluebird((resolve, reject) => {
       try {
         kuzzle.pluginsManager.unregisterStrategy(pluginName, name);
-        resolve();
       }
       catch(err) {
-        reject(err);
+        return reject(err);
       }
+
+      kuzzle.pluginsManager.trigger('core:auth:strategyRemoved', {name, pluginName})
+        .then(() => resolve())
+        .catch(err => reject(err));
     });
   };
 }

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -110,7 +110,7 @@ class PluginContext {
         get: () => {
           return {
             add: curryAddStrategy(kuzzle, pluginName),
-            remove: name => kuzzle.passport.unuse(name)
+            remove: name => kuzzle.pluginsManager.unregisterStrategy(name)
           };
         }
       });
@@ -274,8 +274,8 @@ function curryAddStrategy(kuzzle, pluginName) {
   return function addStrategy(name, strategy) {
     return new Bluebird((resolve, reject) => {
       try {
-        kuzzle.pluginsManager.validateStrategy(pluginName, name, strategy);
         kuzzle.pluginsManager.registerStrategy(pluginName, name, strategy);
+        resolve();
       }
       catch(err) {
         reject(err);

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -34,8 +34,7 @@ const
   {
     KuzzleError,
     GatewayTimeoutError,
-    PluginImplementationError,
-    UnauthorizedError
+    PluginImplementationError
   } = require('kuzzle-common-objects').errors;
 
 // This is default manifest for all plugin, can be overriden by "manifest.json" file at root path of each plugin
@@ -449,8 +448,11 @@ class PluginsManager {
                 callback(null, false, `Was not able to log in using the strategy "${strategyName}"`);
               }
             }
+            else if (result === false) {
+              callback(null, false);
+            }
             else {
-              callback(new UnauthorizedError('Login failed.'));
+              callback(new PluginImplementationError('Unexpected authentification strategy result'));
             }
           })
           .catch(error => callback(error));

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -394,15 +394,15 @@ class PluginsManager {
 
   /**
    * Registers an authentication strategy.
-   * This method assumes that the provided strategy object is well-formed
-   * (see validateStrategy)
    *
    * @param {string} pluginName - plugin name
    * @param {string} strategyName - strategy name
    * @param {object} strategy - strategy properties
-   * @throws {PluginImplementationError} If registering the strategy fails
+   * @throws {PluginImplementationError} If the strategy is invalid or if registration fails
    */
   registerStrategy(pluginName, strategyName, strategy) {
+    this.validateStrategy(pluginName, strategyName, strategy);
+
     const 
       plugin = this.plugins[pluginName],
       methods = {};
@@ -469,6 +469,16 @@ class PluginsManager {
     catch (e) {
       throw new PluginImplementationError(`Unable to register "${strategyName}" authentication strategy: ${e.message}.`);
     }
+  }
+
+  /**
+   * Unregister
+   * @param  {[type]} strategyName [description]
+   * @return {[type]}              [description]
+   */
+  unregisterStrategy (strategyName) {
+    delete this.strategies[strategyName];
+    this.kuzzle.passport.unuse(strategyName);
   }
 
   /**
@@ -593,28 +603,26 @@ class PluginsManager {
 
   /**
    * @param {object} plugin
-   * @throws {PluginImplementationError} If one of the provided strategies is invalid
+   * @throws {PluginImplementationError} If strategies registration fails
    */
   _initAuthentication (plugin) {
     const errorPrefix = `Unable to inject authentication strategies from plugin "${plugin.name}": `;
 
     if (!isObject(plugin.object.strategies) || Object.keys(plugin.object.strategies).length === 0) {
-      throw new PluginImplementationError(`${errorPrefix}The plugin must provide an object "strategies".`);
+      throw new PluginImplementationError(`${errorPrefix}The exposed "strategies" plugin property must be a non-empty object`);
     }
 
     Object.keys(plugin.object.strategies).forEach(strategyName => {
-      /** @type AuthenticationStrategy */
       const strategy = plugin.object.strategies[strategyName];
 
       try {
-        this.validateStrategy(plugin.name, strategyName, strategy);
+        this.registerStrategy(plugin.name, strategyName, strategy);
       }
       catch (err) {
+        // registerStrategy can only throw PluginImplementationError exceptions
         err.message = errorPrefix + err.message;
         throw err;
       }
-
-      this.registerStrategy(plugin.name, strategyName, strategy);
     });
   }
 }

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -59,10 +59,9 @@ class PluginsManager {
     this.plugins = {};
     this.pipes = {};
     this.controllers = {};
-    this.authentications = {};
+    this.strategies = {};
     this.routes = [];
     this.config = kuzzle.config.plugins;
-    this.registeredStrategies = [];
   }
 
   /**
@@ -167,19 +166,19 @@ class PluginsManager {
           }
 
           if (plugin.object.controllers) {
-            initControllers(this, plugin);
+            this._initControllers(plugin);
           }
 
           if (plugin.object.strategies) {
-            initAuthentication(this, plugin);
+            this._initAuthentication(plugin);
           }
 
           if (plugin.object.hooks) {
-            initHooks(this, plugin);
+            this._initHooks(plugin);
           }
 
           if (plugin.object.pipes) {
-            initPipes(this, plugin, pipeWarnTime, pipeTimeout);
+            this._initPipes(plugin, pipeWarnTime, pipeTimeout);
           }
 
           debug('[%s] plugin started', plugin.name);
@@ -220,7 +219,7 @@ class PluginsManager {
    * @returns {string[]}
    */
   getStrategyFields (strategyName) {
-    return this.authentications[strategyName].strategy.config.fields;
+    return this.strategies[strategyName].strategy.config.fields;
   }
 
   /**
@@ -229,7 +228,7 @@ class PluginsManager {
    * @returns {boolean}
    */
   hasStrategyMethod (strategyName, methodName) {
-    return Boolean(this.authentications[strategyName].methods[methodName]);
+    return Boolean(this.strategies[strategyName].methods[methodName]);
   }
 
   /**
@@ -238,7 +237,7 @@ class PluginsManager {
    * @returns {function}
    */
   getStrategyMethod (strategyName, methodName) {
-    return this.authentications[strategyName].methods[methodName];
+    return this.strategies[strategyName].methods[methodName];
   }
 
   /**
@@ -246,7 +245,377 @@ class PluginsManager {
    * @returns {string[]}
    */
   listStrategies () {
-    return this.registeredStrategies;
+    return Object.keys(this.strategies);
+  }
+
+  /**
+   * Checks if a strategy is well-formed
+   * 
+   * @param {string} pluginName
+   * @param {string} strategyName 
+   * @param {object} strategy 
+   * @throws {PluginsImplementationError} If the strategy is invalid
+   */
+  validateStrategy (pluginName, strategyName, strategy) {
+    if (!isObject(strategy)) {
+      throw new PluginImplementationError(`Invalid properties for strategy "${strategyName}": must be an object.`);
+    }
+
+    if (this.strategies[strategyName]) {
+      throw new PluginImplementationError(`An authentication strategy "${strategyName}" has already been registered.`);
+    }
+
+    if (!isObject(strategy.methods)) {
+      throw new PluginImplementationError(`"methods" object missing from the strategy '${strategyName}' properties.`);
+    }
+    else {
+      const pluginObject = this.plugins[pluginName].object;
+
+      // required methods check
+      ['exists', 'create', 'update', 'delete', 'validate', 'verify'].forEach(methodName => {
+        if (!isString(strategy.methods[methodName])) {
+          throw new PluginImplementationError(`Missing method "${methodName}" in the strategy '${strategyName}' properties.`);
+        }
+
+        if (!isFunction(pluginObject[strategy.methods[methodName]])) {
+          throw new PluginImplementationError(`The strategy method "${strategy.methods[methodName]}" must point to a plugin function.`);
+        }
+      });
+
+      // optional methods check
+      ['getInfo', 'getById', 'afterRegister' ].forEach(name => {
+        const optionalMethodName = strategy.methods[name];
+
+        if (optionalMethodName && (!isString(optionalMethodName) || !isFunction(pluginObject[optionalMethodName]))) {
+          throw new PluginImplementationError(`The strategy method "${optionalMethodName}" must be a function.`);
+        }
+      });
+    }
+
+    if (!isObject(strategy.config)) {
+      throw new PluginImplementationError(`"config" object missing from the strategy '${strategyName}' properties.`);
+    }
+    else {
+      if (!isFunction(strategy.config.constructor)) {
+        throw new PluginImplementationError(`The constructor of the strategy "${strategyName}" must be a function.`);
+      }
+
+      if (!isObject(strategy.config.strategyOptions)) {
+        throw new PluginImplementationError(`The "strategyOptions" object of the strategy "${strategyName}" must be an object.`);
+      }
+
+      if (!isObject(strategy.config.authenticateOptions)) {
+        throw new PluginImplementationError(`The "authenticateOptions" object of the strategy "${strategyName}" must be an object.`);
+      }
+
+      if (!strategy.config.fields || !Array.isArray(strategy.config.fields)) {
+        throw new PluginImplementationError(`The "fields" property of the strategy "${strategyName}" must be an array.`);
+      }
+    }
+  }
+
+  /**
+   * Register a pipe function on an event
+   * 
+   * @param {object} plugin
+   * @param {number} warnDelay - delay before a warning is issued
+   * @param {number} timeoutDelay - delay after which the function is timed out
+   * @param {string} event name
+   * @param {function} fn - function to attach
+   */
+  registerPipe(plugin, warnDelay, timeoutDelay, event, fn) {
+    debug('[%s] register pipe on event "%s"', plugin.name, event);
+
+    if (!this.pipes[event]) {
+      this.pipes[event] = [];
+    }
+
+    this.pipes[event].push((data, callback) => {
+      let
+        pipeWarnTimer,
+        pipeTimeoutTimer,
+        timedOut = false;
+
+      if (warnDelay) {
+        pipeWarnTimer = setTimeout(() => {
+          this.trigger('log:warn', `Pipe plugin ${plugin.name} exceeded ${warnDelay}ms to execute.`);
+        }, warnDelay);
+      }
+
+      if (timeoutDelay) {
+        pipeTimeoutTimer = setTimeout(() => {
+          const errorMsg = `Timeout error. Pipe plugin ${plugin.name} exceeded ${timeoutDelay}ms to execute. Aborting pipe`;
+          this.trigger('log:error', errorMsg);
+
+          timedOut = true;
+          callback(new GatewayTimeoutError(errorMsg));
+        }, timeoutDelay);
+      }
+
+      try {
+        plugin.object[fn](data, (err, object) => {
+          if (pipeWarnTimer !== undefined) {
+            clearTimeout(pipeWarnTimer);
+          }
+          if (pipeTimeoutTimer !== undefined) {
+            clearTimeout(pipeTimeoutTimer);
+          }
+
+          if (!timedOut) {
+            callback(err, object);
+          }
+        });
+      }
+      catch (error) {
+        throw new PluginImplementationError(error);
+      }
+    });
+  }
+
+  /**
+   * Register a listener function on an event
+   *
+   * @param {object} plugin
+   * @param {string} event
+   * @param {string} fn - function to attach
+   */
+  registerHook(plugin, event, fn) {
+    debug('[%s] register hook on event "%s"', plugin.name, event);
+
+    this.kuzzle.on(event, message => {
+      try {
+        plugin.object[fn](message, event);
+      }
+      catch (error) {
+        throw new PluginImplementationError(error);
+      }
+    });
+  }
+
+  /**
+   * Registers an authentication strategy.
+   * This method assumes that the provided strategy object is well-formed
+   * (see validateStrategy)
+   *
+   * @param {string} pluginName - plugin name
+   * @param {string} strategyName - strategy name
+   * @param {object} strategy - strategy properties
+   * @throws {PluginImplementationError} If registering the strategy fails
+   */
+  registerStrategy(pluginName, strategyName, strategy) {
+    const 
+      plugin = this.plugins[pluginName],
+      methods = {};
+
+    // wrapping plugin methods to force their context and to 
+    // cast uncaught errors into PluginImplementationError errors
+    Object.keys(strategy.methods).filter(name => name !== 'verify').forEach(methodName => {
+      methods[methodName] = (...args) => {
+        return new Bluebird((resolve, reject) => {
+          try {
+            resolve(plugin.object[strategy.methods[methodName]].bind(plugin.object)(...args));
+          }
+          catch (error) {
+            reject(error instanceof KuzzleError ? error : new PluginImplementationError(error));
+          }
+        });
+      };
+    });
+
+    const 
+      opts = Object.assign(strategy.config.strategyOptions || {}, {passReqToCallback: true}),
+      verifyAdapter = (...args) => {
+        const callback = args[args.length - 1];
+
+        return plugin.object[strategy.methods.verify](...args.slice(0, -1))
+          .then(result => {
+            if (result && typeof result === 'object') {
+              if (result.kuid && typeof result.kuid === 'string') {
+                this.kuzzle.repositories.user.load(result.kuid)
+                  .then(user => {
+                    if (user === null) {
+                      callback(new PluginImplementationError(`The strategy "${strategyName}" returned an unknown Kuzzle user identifier.`));
+                    }
+                    else {
+                      callback(null, user);
+                    }
+                  })
+                  .catch(error => callback(error));
+              }
+              else if (result.message && typeof result.message === 'string') {
+                callback(null, false, result);
+              }
+              else {
+                callback(null, false, `Was not able to log in using the strategy "${strategyName}"`);
+              }
+            }
+            else {
+              callback(new UnauthorizedError('Login failed.'));
+            }
+          })
+          .catch(error => callback(error));
+      };
+
+    try {
+      const constructedStrategy = new strategy.config.constructor(opts, verifyAdapter);
+
+      this.strategies[strategyName] = {strategy, methods};
+      this.kuzzle.passport.use(strategyName, constructedStrategy, strategy.config.authenticateOptions);
+
+      if (methods.afterRegister) {
+        methods.afterRegister(constructedStrategy);
+      }
+    }
+    catch (e) {
+      throw new PluginImplementationError(`Unable to register "${strategyName}" authentication strategy: ${e.message}.`);
+    }
+  }
+
+  /**
+   * @param {object} plugin
+   * @param {number} pipeWarnTime
+   * @param {number} pipeTimeout
+   */
+  _initPipes (plugin, pipeWarnTime, pipeTimeout) {
+    let
+      _warnTime = pipeWarnTime,
+      _timeout = pipeTimeout;
+
+    if (plugin.config && plugin.config.pipeWarnTime !== undefined) {
+      _warnTime = plugin.config.pipeWarnTime;
+    }
+    if (plugin.config && plugin.config.pipeTimeout !== undefined) {
+      _timeout = plugin.config.pipeTimeout;
+    }
+
+    _.forEach(plugin.object.pipes, (fn, pipe) => {
+      if (Array.isArray(fn)) {
+        fn
+          .filter(target => typeof plugin.object[target] === 'function')
+          .forEach(func => this.registerPipe(plugin, _warnTime, _timeout, pipe, func));
+      }
+      else if (typeof plugin.object[fn] === 'function') {
+        this.registerPipe(plugin, _warnTime, _timeout, pipe, fn);
+      }
+    });
+  }
+
+  /**
+   * @param {object} plugin
+   */
+  _initHooks (plugin) {
+    _.forEach(plugin.object.hooks, (fn, event) => {
+      if (Array.isArray(fn)) {
+        fn
+          .filter(target => typeof plugin.object[target] === 'function')
+          .forEach(func => this.registerHook(plugin, event, func));
+      }
+      else if (typeof plugin.object[fn] === 'function') {
+        this.registerHook(plugin, event, fn);
+      }
+    });
+  }
+
+  /**
+   * Init plugin controllers
+   *
+   * @param {object} plugin
+   * @returns {boolean}
+   */
+  _initControllers (plugin) {
+    Object.keys(plugin.object.controllers).forEach(controller => {
+      debug('[%s][%s] starting controller registration', plugin.name, controller);
+
+      const
+        description = plugin.object.controllers[controller],
+        errorControllerPrefix = `Unable to inject controller "${controller}" from plugin "${plugin.name}":`;
+
+      if (!isObject(description)) {
+        throw new PluginImplementationError(`${errorControllerPrefix} Incorrect controller description type (expected object, got: "${typeof description}")`);
+      }
+
+      Object.keys(description).forEach(action => {
+        debug('[%s][%s][%s] starting action controller registration', plugin.name, controller, action);
+
+        if (typeof description[action] !== 'string' || description[action].length === 0) {
+          throw new PluginImplementationError(`${errorControllerPrefix} Invalid action description (expected non-empty string, got: "${typeof action}")`);
+        }
+
+        if (!isFunction(plugin.object[description[action]])) {
+          throw new PluginImplementationError(`${errorControllerPrefix} Action "${plugin.name + '.' + description[action]}" is not a function`);
+        }
+
+        if (!this.controllers[`${plugin.name}/${controller}`]) {
+          this.controllers[`${plugin.name}/${controller}`] = {};
+        }
+
+        this.controllers[`${plugin.name}/${controller}`][action] = plugin.object[description[action]].bind(plugin.object);
+      });
+    });
+
+    const allowedVerbs = ['get', 'head', 'post', 'put', 'delete'];
+
+    if (plugin.object.routes) {
+      plugin.object.routes.forEach(route => {
+        const errorRoutePrefix = `Unable to inject api route "${JSON.stringify(route)}" from plugin "${plugin.name}":`;
+
+        Object.keys(route).forEach(key => {
+          if (['verb', 'url', 'controller', 'action'].indexOf(key) === -1) {
+            throw new PluginImplementationError(`${errorRoutePrefix} Unknown route definition "${key}"`);
+          }
+
+          if (typeof route[key] !== 'string' || (route[key].length === 0 && key !== 'url')) {
+            throw new PluginImplementationError(`${errorRoutePrefix} "${key}" must be a non-empty string`);
+          }
+        });
+
+        if (!this.controllers[`${plugin.name}/${route.controller}`]) {
+          throw new PluginImplementationError(`${errorRoutePrefix} Undefined controller "${route.controller}"`);
+        }
+
+        if (!this.controllers[`${plugin.name}/${route.controller}`][route.action]) {
+          throw new PluginImplementationError(`${errorRoutePrefix} Undefined action "${route.action}"`);
+        }
+
+
+        if (allowedVerbs.indexOf(route.verb.toLowerCase()) === -1) {
+          throw new PluginImplementationError(`${errorRoutePrefix} Only following http verbs are allowed: "${allowedVerbs.join(', ')}"`);
+        }
+
+        route.url = '/' + plugin.name + route.url;
+        route.controller = plugin.name + '/' + route.controller;
+
+        debug('[%s] binding HTTP route "%s" to controller "%s"', plugin.name, route.url, route.controller);
+        this.routes.push(route);
+      });
+    }
+  }
+
+  /**
+   * @param {object} plugin
+   * @throws {PluginImplementationError} If one of the provided strategies is invalid
+   */
+  _initAuthentication (plugin) {
+    const errorPrefix = `Unable to inject authentication strategies from plugin "${plugin.name}": `;
+
+    if (!isObject(plugin.object.strategies) || Object.keys(plugin.object.strategies).length === 0) {
+      throw new PluginImplementationError(`${errorPrefix}The plugin must provide an object "strategies".`);
+    }
+
+    Object.keys(plugin.object.strategies).forEach(strategyName => {
+      /** @type AuthenticationStrategy */
+      const strategy = plugin.object.strategies[strategyName];
+
+      try {
+        this.validateStrategy(plugin.name, strategyName, strategy);
+      }
+      catch (err) {
+        err.message = errorPrefix + err.message;
+        throw err;
+      }
+
+      this.registerStrategy(plugin.name, strategyName, strategy);
+    });
   }
 }
 
@@ -352,373 +721,6 @@ function loadPlugins(config, kuzzleVersion, rootPath) {
 }
 
 /**
- * @param {PluginsManager} pluginsManager
- * @param {object} plugin
- * @param {number} pipeWarnTime
- * @param {number} pipeTimeout
- */
-function initPipes (pluginsManager, plugin, pipeWarnTime, pipeTimeout) {
-  let
-    _warnTime = pipeWarnTime,
-    _timeout = pipeTimeout;
-
-  if (plugin.config && plugin.config.pipeWarnTime !== undefined) {
-    _warnTime = plugin.config.pipeWarnTime;
-  }
-  if (plugin.config && plugin.config.pipeTimeout !== undefined) {
-    _timeout = plugin.config.pipeTimeout;
-  }
-
-  _.forEach(plugin.object.pipes, (fn, pipe) => {
-    if (Array.isArray(fn)) {
-      fn
-        .filter(target => typeof plugin.object[target] === 'function')
-        .forEach(func => registerPipe(pluginsManager, plugin, _warnTime, _timeout, pipe, func));
-    }
-    else if (typeof plugin.object[fn] === 'function') {
-      registerPipe(pluginsManager, plugin, _warnTime, _timeout, pipe, fn);
-    }
-  });
-}
-
-/**
- * @param {PluginsManager} pluginsManager
- * @param {object} plugin
- */
-function initHooks (pluginsManager, plugin) {
-  _.forEach(plugin.object.hooks, (fn, event) => {
-    if (Array.isArray(fn)) {
-      fn
-        .filter(target => typeof plugin.object[target] === 'function')
-        .forEach(func => registerHook(pluginsManager, plugin, event, func));
-    }
-    else if (typeof plugin.object[fn] === 'function') {
-      registerHook(pluginsManager, plugin, event, fn);
-    }
-  });
-}
-
-/**
- * Init plugin controllers
- *
- * @param {PluginsManager} pluginsManager
- * @param {object} plugin
- * @returns {boolean}
- */
-function initControllers (pluginsManager, plugin) {
-  Object.keys(plugin.object.controllers).forEach(controller => {
-    debug('[%s][%s] starting controller registration', plugin.name, controller);
-
-    const
-      description = plugin.object.controllers[controller],
-      errorControllerPrefix = `Unable to inject controller "${controller}" from plugin "${plugin.name}":`;
-
-    if (!isObject(description)) {
-      throw new PluginImplementationError(`${errorControllerPrefix} Incorrect controller description type (expected object, got: "${typeof description}")`);
-    }
-
-    Object.keys(description).forEach(action => {
-      debug('[%s][%s][%s] starting action controller registration', plugin.name, controller, action);
-
-      if (typeof description[action] !== 'string' || description[action].length === 0) {
-        throw new PluginImplementationError(`${errorControllerPrefix} Invalid action description (expected non-empty string, got: "${typeof action}")`);
-      }
-
-      if (!isFunction(plugin.object[description[action]])) {
-        throw new PluginImplementationError(`${errorControllerPrefix} Action "${plugin.name + '.' + description[action]}" is not a function`);
-      }
-
-      if (!pluginsManager.controllers[`${plugin.name}/${controller}`]) {
-        pluginsManager.controllers[`${plugin.name}/${controller}`] = {};
-      }
-
-      pluginsManager.controllers[`${plugin.name}/${controller}`][action] = plugin.object[description[action]].bind(plugin.object);
-    });
-  });
-
-  const allowedVerbs = ['get', 'head', 'post', 'put', 'delete'];
-
-  if (plugin.object.routes) {
-    plugin.object.routes.forEach(route => {
-      const errorRoutePrefix = `Unable to inject api route "${JSON.stringify(route)}" from plugin "${plugin.name}":`;
-
-      Object.keys(route).forEach(key => {
-        if (['verb', 'url', 'controller', 'action'].indexOf(key) === -1) {
-          throw new PluginImplementationError(`${errorRoutePrefix} Unknown route definition "${key}"`);
-        }
-
-        if (typeof route[key] !== 'string' || (route[key].length === 0 && key !== 'url')) {
-          throw new PluginImplementationError(`${errorRoutePrefix} "${key}" must be a non-empty string`);
-        }
-      });
-
-      if (!pluginsManager.controllers[`${plugin.name}/${route.controller}`]) {
-        throw new PluginImplementationError(`${errorRoutePrefix} Undefined controller "${route.controller}"`);
-      }
-
-      if (!pluginsManager.controllers[`${plugin.name}/${route.controller}`][route.action]) {
-        throw new PluginImplementationError(`${errorRoutePrefix} Undefined action "${route.action}"`);
-      }
-
-
-      if (allowedVerbs.indexOf(route.verb.toLowerCase()) === -1) {
-        throw new PluginImplementationError(`${errorRoutePrefix} Only following http verbs are allowed: "${allowedVerbs.join(', ')}"`);
-      }
-
-      route.url = '/' + plugin.name + route.url;
-      route.controller = plugin.name + '/' + route.controller;
-
-      debug('[%s] binding HTTP route "%s" to controller "%s"', plugin.name, route.url, route.controller);
-      pluginsManager.routes.push(route);
-    });
-  }
-}
-
-/**
- * @param {PluginsManager} pluginsManager
- * @param {object} plugin
- * @return {boolean} return true if authentication strategies was successfully injected
- */
-function initAuthentication(pluginsManager, plugin) {
-  const
-    mandatoryMethods = ['exists', 'create', 'update', 'delete', 'validate', 'verify'],
-    errorPrefix = `Unable to inject strategies from plugin "${plugin.name}":`;
-
-  if (!isObject(plugin.object.strategies) || Object.keys(plugin.object.strategies).length === 0) {
-    throw new PluginImplementationError(`${errorPrefix} The plugin must provide an object "strategies".`);
-  }
-
-  Object.keys(plugin.object.strategies).forEach(strategyName => {
-    /** @type AuthenticationStrategy */
-    const strategy = plugin.object.strategies[strategyName];
-
-    if (!isObject(strategy)) {
-      throw new PluginImplementationError(`${errorPrefix} The plugin must provide an object for strategy "${strategyName}".`);
-    }
-
-    if (pluginsManager.registeredStrategies.indexOf(strategyName) !== -1) {
-      throw new PluginImplementationError(`${errorPrefix} An authentication strategy "${strategyName}" has already been registered.`);
-    }
-
-    if (!isObject(strategy.methods)) {
-      throw new PluginImplementationError(`${errorPrefix} The plugin must provide a "methods" object in strategies['${strategyName}'] property.`);
-    }
-    else {
-      mandatoryMethods.forEach(methodName => {
-        if (!isString(strategy.methods[methodName])) {
-          throw new PluginImplementationError(`${errorPrefix} The plugin must provide a method "${methodName}" in strategy configuration.`);
-        }
-
-        if (!isFunction(plugin.object[strategy.methods[methodName]])) {
-          throw new PluginImplementationError(`${errorPrefix} The plugin property "${strategy.methods[methodName]}" must be a function.`);
-        }
-      });
-
-      if (strategy.methods.getInfo && (!isString(strategy.methods.getInfo) || !isFunction(plugin.object[strategy.methods.getInfo]))) {
-        throw new PluginImplementationError(`${errorPrefix} The plugin property "${strategy.methods.getInfo}" must be a function.`);
-      }
-
-      if (strategy.methods.getById && (!isString(strategy.methods.getById) || !isFunction(plugin.object[strategy.methods.getById]))) {
-        throw new PluginImplementationError(`${errorPrefix} The plugin property "${strategy.methods.getById}" must be a function.`);
-      }
-
-      if (strategy.methods.afterRegister && (!isString(strategy.methods.afterRegister) || !isFunction(plugin.object[strategy.methods.afterRegister]))) {
-        throw new PluginImplementationError(`${errorPrefix} The plugin property "${strategy.methods.afterRegister}" must be a function.`);
-      }
-    }
-
-    if (!isObject(strategy.config)) {
-      throw new PluginImplementationError(`${errorPrefix} The plugin must provide a "config" object in strategies['${strategyName}'] property.`);
-    }
-    else {
-      if (!isFunction(strategy.config.constructor)) {
-        throw new PluginImplementationError(`${errorPrefix} The constructor of the strategy "${strategyName}" must be a function.`);
-      }
-
-      if (!isObject(strategy.config.strategyOptions)) {
-        throw new PluginImplementationError(`${errorPrefix} The "strategyOptions" of the strategy "${strategyName}" must be an object.`);
-      }
-
-      if (!isObject(strategy.config.authenticateOptions)) {
-        throw new PluginImplementationError(`${errorPrefix} The "authenticateOptions" of the strategy "${strategyName}" must be an object.`);
-      }
-
-      if (!strategy.config.fields || !Array.isArray(strategy.config.fields)) {
-        throw new PluginImplementationError(`${errorPrefix} The "fields" of the strategy "${strategyName}" must be an array.`);
-      }
-    }
-  });
-
-  Object.keys(plugin.object.strategies).forEach(strategyName => {
-    const
-      strategy = plugin.object.strategies[strategyName],
-      methods = {};
-
-    Object.keys(strategy.methods).filter(name => name !== 'verify').forEach(methodName => {
-      methods[methodName] = (...args) => {
-        return new Bluebird((resolve, reject) => {
-          try {
-            resolve(plugin.object[strategy.methods[methodName]].bind(plugin.object)(...args));
-          }
-          catch (error) {
-            reject(error instanceof KuzzleError ? error : new PluginImplementationError(error));
-          }
-        });
-      };
-    });
-
-    pluginsManager.authentications[strategyName] = {
-      strategy,
-      methods
-    };
-
-    registerStrategy(pluginsManager, plugin, strategyName);
-    pluginsManager.kuzzle.passport.injectAuthenticateOptions(strategyName, strategy.config.authenticateOptions || {});
-  });
-}
-
-
-/**
- * Register a pipe function on an event
- * @param {PluginsManager} pluginsManager
- * @param {object} plugin
- * @param {number} warnDelay - delay before a warning is issued
- * @param {number} timeoutDelay - delay after which the function is timed out
- * @param {string} event name
- * @param {function} fn - function to attach
- */
-function registerPipe(pluginsManager, plugin, warnDelay, timeoutDelay, event, fn) {
-  debug('[%s] register pipe on event "%s"', plugin.name, event);
-
-  if (!pluginsManager.pipes[event]) {
-    pluginsManager.pipes[event] = [];
-  }
-
-  pluginsManager.pipes[event].push((data, callback) => {
-    let
-      pipeWarnTimer,
-      pipeTimeoutTimer,
-      timedOut = false;
-
-    if (warnDelay) {
-      pipeWarnTimer = setTimeout(() => {
-        pluginsManager.trigger('log:warn', `Pipe plugin ${plugin.name} exceeded ${warnDelay}ms to execute.`);
-      }, warnDelay);
-    }
-
-    if (timeoutDelay) {
-      pipeTimeoutTimer = setTimeout(() => {
-        const errorMsg = `Timeout error. Pipe plugin ${plugin.name} exceeded ${timeoutDelay}ms to execute. Aborting pipe`;
-        pluginsManager.trigger('log:error', errorMsg);
-
-        timedOut = true;
-        callback(new GatewayTimeoutError(errorMsg));
-      }, timeoutDelay);
-    }
-
-    try {
-      plugin.object[fn](data, (err, object) => {
-        if (pipeWarnTimer !== undefined) {
-          clearTimeout(pipeWarnTimer);
-        }
-        if (pipeTimeoutTimer !== undefined) {
-          clearTimeout(pipeTimeoutTimer);
-        }
-
-        if (!timedOut) {
-          callback(err, object);
-        }
-      });
-    }
-    catch (error) {
-      throw new PluginImplementationError(error);
-    }
-  });
-}
-
-/**
- * Register a listener function on an event
- *
- * @param {PluginsManager} pluginsManager
- * @param {object} plugin
- * @param {string} event
- * @param {string} fn - function to attach
- */
-function registerHook(pluginsManager, plugin, event, fn) {
-  debug('[%s] register hook on event "%s"', plugin.name, event);
-
-  pluginsManager.kuzzle.on(event, message => {
-    try {
-      plugin.object[fn](message, event);
-    }
-    catch (error) {
-      throw new PluginImplementationError(error);
-    }
-  });
-}
-
-/**
- * Registers an authentication strategy
- *
- * @param {PluginsManager} pluginsManager
- * @param {object} plugin
- * @param {string} strategyName - strategy name
- */
-function registerStrategy(pluginsManager, plugin, strategyName) {
-  const
-    {
-      strategy,
-      methods
-    } = pluginsManager.authentications[strategyName],
-    opts = Object.assign(strategy.config.strategyOptions || {}, {passReqToCallback: true}),
-    verifyAdapter = (...args) => {
-      const callback = args[args.length - 1];
-      return plugin.object[strategy.methods.verify](...args.slice(0, -1))
-        .then(result => {
-          if (result && typeof result === 'object') {
-            if (result.kuid && typeof result.kuid === 'string') {
-              pluginsManager.kuzzle.repositories.user.load(result.kuid)
-                .then(user => {
-                  if (user === null) {
-                    callback(new PluginImplementationError(`The strategy "${strategyName}" returned an unknown Kuzzle user identifier.`));
-                  }
-                  else {
-                    callback(null, user);
-                  }
-                })
-                .catch(error => callback(error));
-            }
-            else if (result.message && typeof result.message === 'string') {
-              callback(null, false, result);
-            }
-            else {
-              callback(null, false, `Was not able to log in with strategy "${strategyName}"`);
-            }
-          }
-          else {
-            callback(new UnauthorizedError('Login failed.'));
-          }
-        })
-        .catch(error => callback(error));
-    };
-
-  try {
-    const constructedStrategy = new strategy.config.constructor(opts, verifyAdapter);
-
-    pluginsManager.kuzzle.passport.use(strategyName, constructedStrategy);
-    pluginsManager.registeredStrategies.push(strategyName);
-
-    if (methods.afterRegister) {
-      methods.afterRegister(constructedStrategy);
-    }
-  }
-  catch (e) {
-    throw new PluginImplementationError(`Unable to register "${strategyName}" authentication strategy: ${e.message}.`);
-  }
-}
-
-
-/**
  * Emit event
  *
  * @param {EventEmitter} emitter
@@ -770,7 +772,6 @@ function triggerPipes(pipes, event, data) {
     });
   });
 }
-
 
 /**
  * For a specific event, return the corresponding wildcard

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -459,7 +459,7 @@ class PluginsManager {
     try {
       const constructedStrategy = new strategy.config.constructor(opts, verifyAdapter);
 
-      this.strategies[strategyName] = {strategy, methods};
+      this.strategies[strategyName] = {strategy, methods, owner: pluginName};
       this.kuzzle.passport.use(strategyName, constructedStrategy, strategy.config.authenticateOptions);
 
       if (methods.afterRegister) {
@@ -473,12 +473,25 @@ class PluginsManager {
 
   /**
    * Unregister
-   * @param  {[type]} strategyName [description]
-   * @return {[type]}              [description]
+   * @param {string} pluginName 
+   * @param  {string} strategyName
+   * @throws {PluginImplementationError} If not the owner of the strategy or if strategy 
+   *                                     does not exist
    */
-  unregisterStrategy (strategyName) {
-    delete this.strategies[strategyName];
-    this.kuzzle.passport.unuse(strategyName);
+  unregisterStrategy (pluginName, strategyName) {
+    const strategy = this.strategies[strategyName];
+
+    if (strategy) {
+      if (strategy.owner !== pluginName) {
+        throw new PluginImplementationError(`Cannot remove strategy ${strategyName}: owned by another plugin`);
+      }
+
+      delete this.strategies[strategyName];
+      this.kuzzle.passport.unuse(strategyName);
+    }
+    else {
+      throw new PluginImplementationError(`Cannot remove strategy ${strategyName}: strategy does not exist`);
+    }
   }
 
   /**

--- a/lib/api/kuzzle.js
+++ b/lib/api/kuzzle.js
@@ -207,9 +207,16 @@ function registerErrorHandlers(kuzzle) {
   process.removeAllListeners('unhandledRejection');
   process.on('unhandledRejection', err => {
     console.error(`ERROR: unhandledRejection: ${err.message}`, err.stack); // eslint-disable-line no-console
-    request.input.args.suffix = 'unhandled-rejection';
-    kuzzle.cliController.actions.dump(request)
-      .finally(() => process.exit(1));
+
+    // dump+exit is a good idea during development as it helps
+    // spotting code errors. But in production, these problems
+    // should only come from plugins, and it seems a really bad idea
+    // to stop Kuzzle because a plugin created an unchained, uncatchable
+    // promise that got rejected
+    if (process.env.NODE_ENV !== 'production') {
+      request.input.args.suffix = 'unhandled-rejection';
+      kuzzle.cliController.actions.dump(request).finally(() => process.exit(1));
+    }
   });
 
   process.removeAllListeners('uncaughtException');

--- a/lib/util/requestAssertions.js
+++ b/lib/util/requestAssertions.js
@@ -223,9 +223,9 @@ module.exports = {
    * @param {Kuzzle} kuzzle
    * @param {Request} request
    */
-  assertIsConnected: (kuzzle, request) => {
+  assertIsAuthenticated: (kuzzle, request) => {
     if (request.context.user._id === kuzzle.repositories.user.anonymous()._id) {
-      throw new UnauthorizedError('The user must be connected.');
+      throw new UnauthorizedError('The user must be authenticated.');
     }
   },
 

--- a/test/api/core/pluginContext/pluginContext.test.js
+++ b/test/api/core/pluginContext/pluginContext.test.js
@@ -294,6 +294,11 @@ describe('Plugin Context', () => {
       return result
         .then(() => {
           should(kuzzle.pluginsManager.registerStrategy).calledWith('pluginName', 'foo', mockedStrategy);
+          should(kuzzle.pluginsManager.trigger).calledWith('core:auth:strategyAdded', {
+            pluginName: 'pluginName',
+            name: 'foo',
+            strategy: mockedStrategy
+          });
         });
     });
 
@@ -316,6 +321,10 @@ describe('Plugin Context', () => {
       return result
         .then(() => {
           should(kuzzle.pluginsManager.unregisterStrategy).calledWith('pluginName', 'foo');
+          should(kuzzle.pluginsManager.trigger).calledWith('core:auth:strategyRemoved', {
+            pluginName: 'pluginName',
+            name: 'foo'
+          });
         });
     });
 

--- a/test/api/core/pluginContext/pluginContext.test.js
+++ b/test/api/core/pluginContext/pluginContext.test.js
@@ -4,7 +4,7 @@ const
   mockrequire = require('mock-require'),
   rewire = require('rewire'),
   should = require('should'),
-  Promise = require('bluebird'),
+  Bluebird = require('bluebird'),
   sinon = require('sinon'),
   KuzzleMock = require('../../../mocks/kuzzle.mock'),
   PluginImplementationError = require('kuzzle-common-objects').errors.PluginImplementationError,
@@ -65,7 +65,7 @@ describe('Plugin Context', () => {
       should(repository.update).be.a.Function();
     });
 
-    it('should throw when trying to instante a Request object without providing a request object', () => {
+    it('should throw when trying to instantiate a Request object without providing a request object', () => {
       should(function () { new context.constructors.Request({}); }).throw(PluginImplementationError);
     });
 
@@ -136,33 +136,40 @@ describe('Plugin Context', () => {
       });
 
       should(context.accessors).be.an.Object().and.not.be.empty();
-      should(context.accessors).have.properties(['execute', 'validation', 'storage', 'trigger']);
+      should(context.accessors).have.properties(['execute', 'validation', 'storage', 'trigger', 'strategies']);
     });
 
-    it('should expose a correctly constructed validation accessor', () => {
+    it('should expose a data validation accessor', () => {
       const validation = context.accessors.validation;
 
       should(validation.addType).be.eql(kuzzle.validation.addType.bind(kuzzle.validation));
       should(validation.validate).be.eql(kuzzle.validation.validationPromise.bind(kuzzle.validation));
     });
 
-    it('should expose a correctly execute accessor', () => {
+    it('should expose an API execution accessor', () => {
       const execute = context.accessors.execute;
 
       should(execute).be.a.Function();
     });
 
-    it('should expose correctly a trigger accessor', () => {
+    it('should expose an event trigger accessor', () => {
       const trigger = context.accessors.trigger;
 
       should(trigger).be.a.Function();
     });
 
-    it('should expose a correctly constructed storage accessor', () => {
+    it('should expose a private storage accessor', () => {
       const storage = context.accessors.storage;
 
       should(storage.bootstrap).be.a.Function();
       should(storage.createCollection).be.a.Function();
+    });
+
+    it('should expose an authentication strategies management accessor', () => {
+      const strategies = context.accessors.strategies;
+
+      should(strategies.add).be.a.Function();
+      should(strategies.remove).be.a.Function();
     });
   });
 
@@ -177,9 +184,9 @@ describe('Plugin Context', () => {
       const trigger = kuzzle.pluginsManager.trigger;
       const eventName = 'backHome';
       const payload = {
-        question: 'who\'s is this motorcycle?',
+        question: 'whose motorcycle is this?',
         answer: 'it\'s a chopper, baby.',
-        anotherQuestion: 'who\'s is this chopper, then?',
+        anotherQuestion: 'whose chopper is this, then?',
         anotherAnswer: 'it\'s Zed\'s',
         yetAnotherQuestion: 'who\'s Zed?',
         yetAnotherAnswer: 'Zed\'s dead, baby, Zed\'s dead.'
@@ -210,7 +217,7 @@ describe('Plugin Context', () => {
           done();
         });
 
-      kuzzle.funnel.processRequest.returns(Promise.resolve(request));
+      kuzzle.funnel.processRequest.returns(Bluebird.resolve(request));
 
       execute.bind(kuzzle)(request, callback);
     });
@@ -218,7 +225,7 @@ describe('Plugin Context', () => {
     it('should resolve a Promise with a result if everything went well', () => {
       const request = new Request({requestId: 'request'}, {connectionId: 'connectionid'});
 
-      kuzzle.funnel.processRequest.returns(Promise.resolve(request));
+      kuzzle.funnel.processRequest.returns(Bluebird.resolve(request));
 
       return execute.bind(kuzzle)(request)
         .then(res => {
@@ -240,7 +247,7 @@ describe('Plugin Context', () => {
             should(err).match(error);
             should(res).match({});
 
-            return Promise.resolve().then(() => {
+            return Bluebird.resolve().then(() => {
               // allows handleErrorDump to be called
               should(kuzzle.funnel.handleErrorDump).be.calledOnce();
               should(kuzzle.funnel.handleErrorDump.firstCall.args[0]).match(error);
@@ -249,7 +256,7 @@ describe('Plugin Context', () => {
             });
           });
 
-      kuzzle.funnel.processRequest.returns(Promise.reject(error));
+      kuzzle.funnel.processRequest.returns(Bluebird.reject(error));
 
       execute.bind(kuzzle)(request, callback);
     });
@@ -259,7 +266,7 @@ describe('Plugin Context', () => {
         request = new Request({body: {some: 'request'}}, {connectionId: 'connectionid'}),
         error = new Error('error');
 
-      kuzzle.funnel.processRequest.returns(Promise.reject(error));
+      kuzzle.funnel.processRequest.returns(Bluebird.reject(error));
 
       return execute.bind(kuzzle)(request)
         .catch((err) => {
@@ -267,12 +274,60 @@ describe('Plugin Context', () => {
 
           should(err).match(error);
 
-          return Promise.resolve().then(() => {
+          return Bluebird.resolve().then(() => {
             // allows handleErrorDump to be called
             should(kuzzle.funnel.handleErrorDump).be.calledOnce();
             should(kuzzle.funnel.handleErrorDump.firstCall.args[0]).match(error);
           });
         });
+    });
+  });
+
+  describe('#strategies', () => {
+    it('should allow to add a strategy and link it to its owner plugin', () => {
+      const 
+        mockedStrategy = {},
+        result = context.accessors.strategies.add('foo', mockedStrategy);
+
+      should(result).be.a.Promise();
+      
+      return result
+        .then(() => {
+          should(kuzzle.pluginsManager.registerStrategy).calledWith('pluginName', 'foo', mockedStrategy);
+        });
+    });
+
+    it('should reject the promise if the strategy registration throws', () => {
+      const error = new Error('foobar');
+      kuzzle.pluginsManager.registerStrategy.throws(error);
+
+      const result = context.accessors.strategies.add('foo', {});
+
+      should(result).be.a.Promise();
+
+      return should(result).be.rejectedWith(error);
+    });
+
+    it('should allow to remove a strategy', () => {
+      const result = context.accessors.strategies.remove('foo');
+
+      should(result).be.a.Promise();
+      
+      return result
+        .then(() => {
+          should(kuzzle.pluginsManager.unregisterStrategy).calledWith('pluginName', 'foo');
+        });
+    });
+
+    it('should reject the promise if the strategy removal throws', () => {
+      const error = new Error('foobar');
+      kuzzle.pluginsManager.unregisterStrategy.throws(error);
+
+      const result = context.accessors.strategies.remove('foo');
+
+      should(result).be.a.Promise();
+
+      return should(result).be.rejectedWith(error);
     });
   });
 });

--- a/test/api/core/pluginsManager/init.test.js
+++ b/test/api/core/pluginsManager/init.test.js
@@ -242,9 +242,11 @@ describe('PluginsManager', () => {
   });
   describe('Test plugins manager listStrategies', () => {
     it('should return a list of registrated authentication strategies', () => {
-      pluginsManager.registeredStrategies = ['strategy'];
+      pluginsManager.strategies = {foo: {strategy: {}, methods: {}}};
 
-      should(pluginsManager.listStrategies()).be.an.Array().of.length(1);
+      const strategies = pluginsManager.listStrategies();
+      should(strategies).be.an.Array().of.length(1);
+      should(strategies).match(['foo']);
     });
   });
 });

--- a/test/api/core/pluginsManager/strategy.test.js
+++ b/test/api/core/pluginsManager/strategy.test.js
@@ -178,7 +178,7 @@ describe('PluginsManager: strategy management', () => {
       plugin.object.strategies = {};
 
       should(() => pluginsManager._initAuthentication(plugin))
-        .throw(/the plugin must provide an object "strategies"/i);
+        .throw(/The exposed "strategies" plugin property must be a non-empty object/i);
     });
 
     it('should print an error in the console if the strategy is not an object', () => {

--- a/test/api/core/pluginsManager/strategy.test.js
+++ b/test/api/core/pluginsManager/strategy.test.js
@@ -27,6 +27,7 @@ describe('PluginsManager: strategy management', () => {
     kuzzle = new KuzzleMock();
     /** @type {PluginsManager} */
     pluginsManager = new PluginsManager(kuzzle);
+    pluginsManager.plugins[plugin.name] = plugin;
 
     plugin.object = {
       strategies: {
@@ -79,7 +80,7 @@ describe('PluginsManager: strategy management', () => {
       }
     };
 
-    pluginsManager.authentications.someStrategy = pluginManagerStrategy;
+    pluginsManager.strategies.someStrategy = pluginManagerStrategy;
 
     sandbox.reset();
   });
@@ -108,7 +109,6 @@ describe('PluginsManager: strategy management', () => {
 
   describe('#initAuthentication', () => {
     let
-      initAuthentication,
       consoleMock;
 
     beforeEach(() => {
@@ -117,37 +117,34 @@ describe('PluginsManager: strategy management', () => {
         warn: sandbox.stub(),
         error: sandbox.stub()
       };
-      pluginsManager.authentications = {};
-      initAuthentication = PluginsManager.__get__('initAuthentication');
+      pluginsManager.strategies = {};
       PluginsManager.__set__('console', consoleMock);
     });
 
-    it('should add the strategy in authentications if the strategy is well defined', done => {
+    it('should add the strategy in strategies if it is well-formed', done => {
       let verifyAdapter;
 
       plugin.object.existsFunction = sandbox.stub().returns(foo);
-      plugin.object.verifyFunction = sandbox.stub().returns(Promise.resolve({
-        kuid: 'foo'
-      }));
+      plugin.object.verifyFunction = sandbox.stub().returns(Promise.resolve({kuid: 'foo'}));
 
-      initAuthentication(pluginsManager, plugin);
-      should(pluginsManager.authentications.someStrategy.strategy).be.deepEqual(plugin.object.strategies.someStrategy);
-      should(pluginsManager.authentications.someStrategy.methods.afterRegister).be.Function();
+      pluginsManager._initAuthentication(plugin);
+      should(pluginsManager.strategies.someStrategy.strategy).be.deepEqual(plugin.object.strategies.someStrategy);
+      should(pluginsManager.strategies.someStrategy.methods.afterRegister).be.Function();
       should(plugin.object.afterRegisterFunction).be.calledOnce();
       should(plugin.object.afterRegisterFunction.firstCall.args[0]).be.instanceOf(plugin.object.strategies.someStrategy.config.constructor);
-      should(pluginsManager.authentications.someStrategy.methods.exists).be.Function();
-      should(pluginsManager.authentications.someStrategy.methods.create).be.Function();
-      should(pluginsManager.authentications.someStrategy.methods.update).be.Function();
-      should(pluginsManager.authentications.someStrategy.methods.delete).be.Function();
-      should(pluginsManager.authentications.someStrategy.methods.getById).be.Function();
-      should(pluginsManager.authentications.someStrategy.methods.getInfo).be.Function();
-      should(pluginsManager.authentications.someStrategy.methods.validate).be.Function();
+      should(pluginsManager.strategies.someStrategy.methods.exists).be.Function();
+      should(pluginsManager.strategies.someStrategy.methods.create).be.Function();
+      should(pluginsManager.strategies.someStrategy.methods.update).be.Function();
+      should(pluginsManager.strategies.someStrategy.methods.delete).be.Function();
+      should(pluginsManager.strategies.someStrategy.methods.getById).be.Function();
+      should(pluginsManager.strategies.someStrategy.methods.getInfo).be.Function();
+      should(pluginsManager.strategies.someStrategy.methods.validate).be.Function();
       should(plugin.object.strategies.someStrategy.config.constructor).be.calledOnce();
       should(plugin.object.strategies.someStrategy.config.constructor).be.calledWithNew();
 
       verifyAdapter = plugin.object.strategies.someStrategy.config.constructor.firstCall.args[1];
 
-      pluginsManager.authentications.someStrategy.methods.exists(foo)
+      pluginsManager.strategies.someStrategy.methods.exists(foo)
         .then(result => {
           should(result).be.deepEqual(foo);
           should(plugin.object.existsFunction).be.calledOnce();
@@ -165,112 +162,107 @@ describe('PluginsManager: strategy management', () => {
     it('method invocation should intercept a thrown error to transform it into PluginImplementationError', () => {
       plugin.object.existsFunction = sandbox.stub().throws(new Error('some error'));
 
-      initAuthentication(pluginsManager, plugin);
-      should(pluginsManager.authentications.someStrategy.strategy).be.deepEqual(plugin.object.strategies.someStrategy);
-      should(pluginsManager.authentications.someStrategy.methods.exists).be.Function();
-      should(pluginsManager.authentications.someStrategy.methods.create).be.Function();
-      should(pluginsManager.authentications.someStrategy.methods.update).be.Function();
-      should(pluginsManager.authentications.someStrategy.methods.delete).be.Function();
-      should(pluginsManager.authentications.someStrategy.methods.getInfo).be.Function();
-      should(pluginsManager.authentications.someStrategy.methods.validate).be.Function();
+      pluginsManager._initAuthentication(plugin);
+      should(pluginsManager.strategies.someStrategy.strategy).be.deepEqual(plugin.object.strategies.someStrategy);
+      should(pluginsManager.strategies.someStrategy.methods.exists).be.Function();
+      should(pluginsManager.strategies.someStrategy.methods.create).be.Function();
+      should(pluginsManager.strategies.someStrategy.methods.update).be.Function();
+      should(pluginsManager.strategies.someStrategy.methods.delete).be.Function();
+      should(pluginsManager.strategies.someStrategy.methods.getInfo).be.Function();
+      should(pluginsManager.strategies.someStrategy.methods.validate).be.Function();
 
-      return should(pluginsManager.authentications.someStrategy.methods.exists(foo)).be.rejectedWith(PluginImplementationError);
+      return should(pluginsManager.strategies.someStrategy.methods.exists(foo)).be.rejectedWith(PluginImplementationError);
     });
 
     it('should print an error in the console if strategies is not an object', () => {
       plugin.object.strategies = {};
 
-      should(() => initAuthentication(pluginsManager, plugin))
+      should(() => pluginsManager._initAuthentication(plugin))
         .throw(/the plugin must provide an object "strategies"/i);
     });
 
     it('should print an error in the console if the strategy is not an object', () => {
       plugin.object.strategies.someStrategy = 'notAnObject';
 
-      should(() => initAuthentication(pluginsManager, plugin))
-        .throw(/the plugin must provide an object for strategy "someStrategy"/i);
+      should(() => pluginsManager._initAuthentication(plugin))
+        .throw(/Invalid properties for strategy "someStrategy": must be an object/i);
     });
 
     it('should print an error in the console if methods are not specified', () => {
       plugin.object.strategies.someStrategy.methods = 'notAnObject';
 
-      should(() => initAuthentication(pluginsManager, plugin))
-        .throw(/the plugin must provide a "methods" object in strategies\['someStrategy'\] property/i);
+      should(() => pluginsManager._initAuthentication(plugin))
+        .throw(/"methods" object missing from the strategy 'someStrategy' properties/i);
     });
 
     it('should print an error in the console if config are not specified', () => {
       plugin.object.strategies.someStrategy.config = 'notAnObject';
 
-      should(() => initAuthentication(pluginsManager, plugin))
-        .throw(/he plugin must provide a "config" object in strategies\['someStrategy'\] property/i);
+      should(() => pluginsManager._initAuthentication(plugin))
+        .throw(/"config" object missing from the strategy 'someStrategy' properties/i);
     });
 
     it('should print an error in the console if a mandatory method is not specified', () => {
       delete plugin.object.strategies.someStrategy.methods.exists;
 
-      should(() => initAuthentication(pluginsManager, plugin))
-        .throw(/the plugin must provide a method "exists" in strategy configuration/i);
+      should(() => pluginsManager._initAuthentication(plugin))
+        .throw(/Missing method "exists" in the strategy 'someStrategy' properties/i);
     });
 
     it('should print an error in the console if a mandatory method is not available in the plugin object', () => {
-      delete plugin.object.existsFunction;
+      ['exists', 'create', 'update', 'delete', 'validate', 'verify'].forEach(methodName => {
+        const 
+          fnName = methodName + 'Function',
+          save = plugin.object[fnName];
 
-      should(() => initAuthentication(pluginsManager, plugin))
-        .throw(/the plugin property "existsFunction" must be a function/i);
+        delete plugin.object[fnName];
+
+        should(() => pluginsManager._initAuthentication(plugin))
+          .throw(new RegExp(`The strategy method "${fnName}" must point to a plugin function`, 'i'));
+
+        plugin.object[fnName] = save;
+      });
     });
 
-    it('should print an error in the console if the getInfo method is specified but the method is not available in the plugin object', () => {
+    it('should print an error in the console if an optional method is specified but does not point to a function', () => {
       delete plugin.object.getInfoFunction;
 
-      should(() => initAuthentication(pluginsManager, plugin))
-        .throw(/the plugin property "getInfoFunction" must be a function/i);
+      should(() => pluginsManager._initAuthentication(plugin))
+        .throw(/The strategy method "getInfoFunction" must be a function/i);
     });
 
     it('should print an error in the console if the strategy constructor is not provided', () => {
       plugin.object.strategies.someStrategy.config.constructor = 'notAFunction';
 
-      should(() => initAuthentication(pluginsManager, plugin))
-        .throw(/the constructor of the strategy "someStrategy" must be a function/i);
+      should(() => pluginsManager._initAuthentication(plugin))
+        .throw(/The constructor of the strategy "someStrategy" must be a function/i);
     });
 
     it('should print an error in the console if the "strategyOptions" config is not provided', () => {
       delete plugin.object.strategies.someStrategy.config.strategyOptions;
 
-      should(() => initAuthentication(pluginsManager, plugin))
-        .throw(/the "strategyOptions" of the strategy "someStrategy" must be an object/i);
+      should(() => pluginsManager._initAuthentication(plugin))
+        .throw(/the "strategyOptions" object of the strategy "someStrategy" must be an object/i);
     });
 
     it('should print an error in the console if the "authenticateOptions" config is not provided', () => {
       delete plugin.object.strategies.someStrategy.config.authenticateOptions;
 
-      should(() => initAuthentication(pluginsManager, plugin))
-        .throw(/the "authenticateOptions" of the strategy "someStrategy" must be an object/i);
+      should(() => pluginsManager._initAuthentication(plugin))
+        .throw(/the "authenticateOptions" object of the strategy "someStrategy" must be an object/i);
     });
 
     it('should print an error in the console if the "fields" config is not provided', () => {
       delete plugin.object.strategies.someStrategy.config.fields;
 
-      should(() => initAuthentication(pluginsManager, plugin))
-        .throw(/the "fields" of the strategy "someStrategy" must be an array/i);
-    });
-    it('should print an error in the console if the "verify" config is not provided', () => {
-      delete plugin.object.strategies.someStrategy.methods.verify;
-
-      should(() => initAuthentication(pluginsManager, plugin))
-        .throw(/the plugin must provide a method "verify" in strategy configuration/i);
-    });
-
-    it('should print an error in the console if the "verify" method is not available in the plugin object', () => {
-      delete plugin.object.verifyFunction;
-
-      should(() => initAuthentication(pluginsManager, plugin))
-        .throw(/the plugin property "verifyFunction" must be a function/i);
+      should(() => pluginsManager._initAuthentication(plugin))
+        .throw(/the "fields" property of the strategy "someStrategy" must be an array/i);
     });
 
     it('should throw an error if a strategy is registered twice', () => {
-      initAuthentication(pluginsManager, plugin);
+      pluginsManager._initAuthentication(plugin);
 
-      should(() => initAuthentication(pluginsManager, plugin))
+      should(() => pluginsManager._initAuthentication(plugin))
         .throw(/an authentication strategy "someStrategy" has already been registered/i);
     });
   });

--- a/test/api/core/pluginsManager/strategy.test.js
+++ b/test/api/core/pluginsManager/strategy.test.js
@@ -77,7 +77,8 @@ describe('PluginsManager: strategy management', () => {
         getInfo: plugin.object.getInfoFunction,
         validate: plugin.object.validateFunction,
         afterRegister: plugin.object.afterRegisterFunction
-      }
+      },
+      owner: plugin.name
     };
 
     pluginsManager.strategies.someStrategy = pluginManagerStrategy;
@@ -264,6 +265,24 @@ describe('PluginsManager: strategy management', () => {
 
       should(() => pluginsManager._initAuthentication(plugin))
         .throw(/an authentication strategy "someStrategy" has already been registered/i);
+    });
+  });
+
+  describe('#unregisterStrategy', () => {
+    it('should remove a strategy using its provided name', () => {
+      pluginsManager.unregisterStrategy(plugin.name, 'someStrategy');
+      should(pluginsManager.strategies).be.an.Object().and.be.empty();
+      should(kuzzle.passport.unuse).calledWith('someStrategy');
+    });
+
+    it('should throw if the strategy does not exist', () => {
+      should(() => pluginsManager.unregisterStrategy(plugin.name, 'foobar'))
+        .throw(/Cannot remove strategy foobar: strategy does not exist/i);
+    });
+
+    it('should throw if not the owner of the strategy', () => {
+      should(() => pluginsManager.unregisterStrategy('Frank William Abagnale Jr.', 'someStrategy'))
+        .throw(/Cannot remove strategy someStrategy: owned by another plugin/i);
     });
   });
 });

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -160,6 +160,7 @@ class KuzzleMock extends Kuzzle {
 
     this.passport = {
       use: sinon.stub(),
+      unuse: sinon.stub(),
       authenticate: sinon.stub().returns(Bluebird.resolve({})),
       injectAuthenticateOptions: sinon.stub()
     };
@@ -172,7 +173,9 @@ class KuzzleMock extends Kuzzle {
       trigger: sinon.spy((...args) => Bluebird.resolve(args[1])),
       listStrategies: sinon.stub().returns([]),
       getStrategyMethod: sinon.stub().returns(sinon.stub()),
-      registeredStrategies: []
+      strategies: {},
+      registerStrategy: sinon.stub(),
+      unregisterStrategy: sinon.stub()
     };
 
     this.repositories = {


### PR DESCRIPTION
# Description

Use cases were submitted and demonstrated that a way to add or remove authentication strategies dynamically was required for some businesses.

One of them involves a back-end managing several short-lived applications, each one of them needing its own unique OAUTH2 identifier. As there is roughly one new application per week, it seems very inconvenient to restart Kuzzle each time a new OAUTH2 identifier needs to be added.

This pull request adds a new `strategies` accessor in the plugin context, exposing two currified methods: `add` and `remove`

Strategy addition or removal triggers a `core:auth:strategy[Added|Removed]` event, propagating the action across a cluster

Documentation update: https://github.com/kuzzleio/documentation/pull/339
Cluster update: https://github.com/kuzzleio/kuzzle-plugin-cluster/pull/43

# Notes

Plugins are responsible of ensuring that, once a strategy is added on-the-fly, it'll also be added during startup, to ensure that there won't be inconsistencies if a cluster reboots

# Plugins Manager (slight) refactor

* To avoid going back & forth between the plugins manager class instance and external private methods, I had to move authentication initialization and registration inside the class. For the sake of consistency, I decided to move ALL of these init&register methods inside the class (e.g. initHooks, registerPipe, and so on)
* The properties `authentications` (strategies repository) and `registeredStrategies` (strategies list) have been merged into the new `strategies` property, as maintaining 2 variables seemed unnecessary

# Other changes

* Rename `assertIsConnected` to `assertIsAuthenticated`, as it makes more sense
* Fix a problem where a plugin creating an unchained, uncatchable rejected promise forces Kuzzle to trigger its diagtools and exit. This behavior is now triggered only if `NODE_ENV !== production` (as this still can be useful to quickly spot bugs during development), otherwise only an error message is logged.
