### PR TITLE
Force lowercase on plugin names

### DIFF
--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -60,7 +60,14 @@ class PluginsManager {
     this.controllers = {};
     this.strategies = {};
     this.routes = [];
-    this.config = kuzzle.config.plugins;
+
+    // As we must lowercase all plugin names, we also need to
+    // do the same on the configuration entries
+    this.config = {};
+    
+    for (const entry of Object.keys(kuzzle.config.plugins)) {
+      this.config[entry.toLowerCase()] = kuzzle.config.plugins[entry];
+    }
   }
 
   /**
@@ -687,6 +694,10 @@ function loadPlugins(config, kuzzleVersion, rootPath) {
     catch(e) {
       throw new PluginImplementationError(`Unable to load plugin from path "${pluginDirName}"; No package.json found.`);
     }
+
+    // This is needed to allow creating an Elasticsearch named after the plugin's name
+    // (ES forbid index names containing uppercased characters)
+    packageJson.name = packageJson.name.toLowerCase();
 
     if (loadedPlugins[packageJson.name]) {
       throw new PluginImplementationError(`A plugin named ${packageJson.name} already exists`);


### PR DESCRIPTION
# Description

Elasticsearch forbids index names containing uppercased characters: 

```
Error: [invalid_index_name_exception] Invalid index name [%plugin:Foobar], must be lowercase, with { index_uuid="_na_" & index="%plugin:Foobar" }
```

This is problematic since we need to create an index named after the exposed `name` property in the `package.json` file of the plugin.

This pull request lowercases plugin names to allow creating the corresponding plugin repositories. This also has the benefit to make the duplicate plugin test case-insensitive.

Plugin configuration entry names are now case-insensitive, to make it easier for users to add configuration to plugins whose names are being lowercased by Kuzzle.

