### PR TITLE
Fixes an error when trying to update a non-existing SecurityDocument

### DIFF
--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -701,13 +701,7 @@ class SecurityController {
     assertHasId(request);
 
     return this.kuzzle.repositories.role.loadRole(request.input.resource._id)
-      .then(role => {
-        if (!role) {
-          return Bluebird.reject(new NotFoundError(`Cannot update role ${request.input.resource._id}: role not found`));
-        }
-
-        return updateMetadata(role, request);
-      })
+      .then(role => updateMetadata(role, request))
       .then(role => this.kuzzle.repositories.role.validateAndSaveRole(_.extend(role, request.input.body), {method: 'update'}))
       .then(updatedRole => formatProcessing.formatRoleForSerialization(updatedRole));
   }
@@ -1125,6 +1119,12 @@ function formatUserSearchResult(kuzzle, formatter, raw) {
  * @returns {object}
  */
 function updateMetadata(securityDocument, request) {
+  if (!securityDocument) {
+    return Bluebird.reject(
+      new NotFoundError(`Cannot update non-existing ${request.input.action.replace('update', '').toLowerCase()} "${request.input.resource._id}"`)
+    );
+  }
+
   securityDocument._kuzzle_info = _.assign(securityDocument._kuzzle_info, {
     updatedAt: Date.now(),
     updater: request.context.user ? String(request.context.user._id) : null

--- a/test/api/controllers/securityController/profiles.test.js
+++ b/test/api/controllers/securityController/profiles.test.js
@@ -314,6 +314,11 @@ describe('Test: security controller - profiles', () => {
     });
   });
 
+  it('should reject the promise if the profile cannot be found in the database', () => {
+    kuzzle.repositories.profile.loadProfile = sandbox.stub().returns(Promise.resolve(null));
+    return should(securityController.updateProfile(new Request({_id: 'badId', body: {}, context: {action: 'updateProfile'}}))).be.rejected();
+  });
+
   describe('#deleteProfile', () => {
     it('should return an object with on deleteProfile call', () => {
       kuzzle.repositories.profile.deleteProfile = sandbox.stub().returns(Promise.resolve({_id: 'test'}));

--- a/test/api/controllers/securityController/roles.test.js
+++ b/test/api/controllers/securityController/roles.test.js
@@ -210,7 +210,7 @@ describe('Test: security controller - roles', () => {
 
     it('should reject the promise if the role cannot be found in the database', () => {
       kuzzle.repositories.role.loadRole = sandbox.stub().returns(Promise.resolve(null));
-      return should(securityController.updateRole(new Request({_id: 'badId',body: {}}))).be.rejected();
+      return should(securityController.updateRole(new Request({_id: 'badId', body: {}, context: {action: 'updateRole'}}))).be.rejected();
     });
   });
 

--- a/test/api/controllers/securityController/users.test.js
+++ b/test/api/controllers/securityController/users.test.js
@@ -506,6 +506,11 @@ describe('Test: security controller - users', () => {
         });
     });
 
+    it('should reject the promise if the user cannot be found in the database', () => {
+      kuzzle.repositories.user.load = sandbox.stub().returns(Promise.resolve(null));
+      return should(securityController.updateUser(new Request({_id: 'badId', body: {}, context: {action: 'updateProfile'}}))).be.rejected();
+    });
+
     it('should return an error if an unknown profile is provided', () => {
       return should(() => {
         securityController.updateUser(new Request({


### PR DESCRIPTION
Fixes an error when trying to update a non-existing SecurityDocument (User|Profile|Role)