### PR TITLE
Keep original stacktrace when requiring a plugin fails

### DIFF
--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -734,7 +734,11 @@ function loadPlugins(config, kuzzleVersion, rootPath) {
       const PluginClass = require(plugin.path);
       plugin.object = new PluginClass();
     } catch (e) {
-      throw new PluginImplementationError(`Unable to require plugin "${plugin.name}" from directory "${plugin.path}"; ${e.message}`);
+      if (e.message.match(/not a constructor/i)) {
+        throw new PluginImplementationError(`Plugin ${plugin.name} is not a constructor`);
+      }
+
+      throw new PluginImplementationError(e);
     }
 
     // check plugin privileged prerequisites

--- a/test/api/core/pluginsManager/init.test.js
+++ b/test/api/core/pluginsManager/init.test.js
@@ -261,11 +261,25 @@ describe('PluginsManager', () => {
         isDirectory: () => true
       });
 
+      mockrequire('/kuzzle/plugins/enabled/kuzzle-plugin-test', function () { throw new Error('foobar'); });
+      mockrequire('/kuzzle/plugins/enabled/kuzzle-plugin-test/package.json', { name: 'kuzzle-plugin-test' });
+      PluginsManager = mockrequire.reRequire('../../../../lib/api/core/plugins/pluginsManager');
+
+      should(() => pluginsManager.init()).throw(/foobar/);
+      should(pluginsManager.plugins).be.empty();
+    });
+
+    it('should reject all plugin initialization if a plugin is not a constructor', () => {
+      fsStub.readdirSync.returns(['kuzzle-plugin-test']);
+      fsStub.statSync.returns({
+        isDirectory: () => true
+      });
+
       mockrequire('/kuzzle/plugins/enabled/kuzzle-plugin-test', undefined);
       mockrequire('/kuzzle/plugins/enabled/kuzzle-plugin-test/package.json', { name: 'kuzzle-plugin-test' });
       PluginsManager = mockrequire.reRequire('../../../../lib/api/core/plugins/pluginsManager');
 
-      should(() => pluginsManager.init()).throw(/unable to require plugin "kuzzle-plugin-test" from directory/i);
+      should(() => pluginsManager.init()).throw(/Plugin kuzzle-plugin-test is not a constructor/i);
       should(pluginsManager.plugins).be.empty();
     });
   });


### PR DESCRIPTION
# Description

When the plugins manager tries to require a plugin and fails, an error is thrown, but the stacktrace is overwritten with the manager's custom error message.
This is an inconvenience for plugin developers as it's hard to trace from where an error comes.

This PR changes that behaviour by dropping the custom message and generating a `PluginImplementationError` from the catched error (and not only its message).

The only exception is if the `try...catch` is triggered because the object returned by a plugin cannot be instantiated with `new`: in that case we need to throw a custom message to make the problem clearer for plugin developers.
