### PR TITLE
Allow plugins to create Request objects from POJOs

### DIFF
--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -47,9 +47,10 @@ const
  * @class CacheItem
  */
 class CacheItem {
-  constructor(request, callback) {
+  constructor(executor, request, callback) {
     this.request = request;
     this.callback = callback;
+    this.executor = executor;
   }
 }
 
@@ -98,17 +99,27 @@ class FunnelController {
   /**
    * Asks the overload-protection system for a request slot.
    *
-   * Resolves the callback with the provided request once
-   * the request can be processed.
+   * Returns immediately a truthy value if the request can be
+   * executed.
+   * 
+   * Otherwise, a falsey value is returned, and the caller MUST
+   * stop the request execution. 
+   * In this case:
+   *   - if it can be bufferized, then the request is left untouched
+   *     and the executor function will be called later when a slot
+   *     becomes available
+   *   - if the buffer limit has been reached, a ServiceUnavailable error 
+   *     is set to the request. In that case, the executor is free to 
+   *     retry submitting the request later, or to abort it and return 
+   *     the request as it is
    *
-   * Rejects it with a ServiceUnavailable error if Kuzzle is overloaded
-   * and if the buffer limit has been reached
-   *
+   * @param {String} executor - The name of the function to use to execute the provided 
+   *                            request. Must be an exposed function of this object.
    * @param {Request} request - Can be mutated in case of overload error
    * @param {Function} executeCallback - the original callback given to `execute`
    * @returns {boolean}
    */
-  getRequestSlot(request, executeCallback) {
+  getRequestSlot(executor, request, executeCallback) {
     this.pendingRequests[request.id] = request;
 
     if (this.overloaded) {
@@ -154,7 +165,7 @@ class FunnelController {
     }
 
     if (!this.requestsCacheById[request.id]) {
-      this.requestsCacheById[request.id] = new CacheItem(request, executeCallback);
+      this.requestsCacheById[request.id] = new CacheItem(executor, request, executeCallback);
       this.requestsCacheQueue.push(request.id);
 
       if (!this.overloaded) {
@@ -186,10 +197,10 @@ class FunnelController {
    *
    * @param {Request} request
    * @param {Function} callback
-   * @returns {Number} -1: request delayed, 0: request processing, 1: error while trying to get the request slot
+   * @returns {Number} -1: request delayed, 0: request processing, 1: error 
    */
   execute(request, callback) {
-    const processNow = this.getRequestSlot(request, callback);
+    const processNow = this.getRequestSlot('execute', request, callback);
 
     if (request.error) {
       // "handleErrorDump" shouldn't need to be called for 503 errors
@@ -223,7 +234,7 @@ class FunnelController {
    * @returns {Number} -1: request delayed, 0: request processing, 1: error while trying to get the request slot
    */
   mExecute(request, callback) {
-    const processNow = this.getRequestSlot(request, callback);
+    const processNow = this.getRequestSlot('mExecute', request, callback);
 
     if (request.error) {
       callback(null, request);
@@ -274,8 +285,13 @@ class FunnelController {
             errorMessage = errorMessage.split('\n')[0];
           }
 
-          errorMessage = errorMessage.toLowerCase().replace(/[^a-zA-Z0-9-_]/g, '-').replace(/[-]+/g, '-').split('-');
-          errorMessage = errorMessage.filter(value => value !== '').join('-');
+          errorMessage = errorMessage
+            .toLowerCase()
+            .replace(/[^a-zA-Z0-9-_]/g, '-')
+            .replace(/[-]+/g, '-')
+            .split('-')
+            .filter(value => value !== '')
+            .join('-');
 
           request.input.args.suffix = `handled-${errorType.toLocaleLowerCase()}-${errorMessage}`;
 
@@ -321,11 +337,11 @@ class FunnelController {
 
           request.setError(error);
 
-          return triggerEvent(this.kuzzle, request, 'request:onUnauthorized')
+          return this.kuzzle.pluginsManager.trigger('request:onUnauthorized', request)
             .finally(() => Bluebird.reject(error));
         }
 
-        return triggerEvent(this.kuzzle, request, 'request:onAuthorized');
+        return this.kuzzle.pluginsManager.trigger('request:onAuthorized', request);
       });
   }
 
@@ -337,80 +353,106 @@ class FunnelController {
    * @return {Promise}
    */
   processRequest(request) {
-    let controllers;
+    delete this.pendingRequests[request.id];
 
-    if (this.controllers[request.input.controller]) {
-      controllers = this.controllers;
-    }
-    else if (this.pluginsControllers[request.input.controller]) {
-      controllers = this.pluginsControllers;
-    }
-    else {
-      delete this.pendingRequests[request.id];
-      throw new BadRequestError(`Unknown controller ${request.input.controller}`);
-    }
-
-    const action = controllers[request.input.controller][request.input.action];
-
-    if (!action || typeof action !== 'function') {
-      delete this.pendingRequests[request.id];
-      throw new BadRequestError(`No corresponding action ${request.input.action} in controller ${request.input.controller}`);
-    }
+    const controllers = this.getControllers(request);
 
     this.kuzzle.statistics.startRequest(request);
     this.concurrentRequests++;
+    this._historize(request);
 
-    if (this.historized > this.kuzzle.config.limits.requestsHistorySize) {
-      this.requestHistory.shift();
-    }
-    else {
-      this.historized++;
-    }
-
-    this.requestHistory.push(request);
-
-    const beforeEvent = this.getEventName(request.input.controller, 'before', request.input.action);
     let modifiedRequest = request;
 
-    return triggerEvent(this.kuzzle, request, beforeEvent)
+    return this.kuzzle.pluginsManager.trigger(this.getEventName(request, 'before'), request)
       .then(newRequest => {
         modifiedRequest = newRequest;
 
         return controllers[request.input.controller][request.input.action](newRequest);
       })
       .then(responseData => {
-        const afterEvent = this.getEventName(request.input.controller, 'after', request.input.action);
         modifiedRequest.setResult(responseData, {status: request.status === 102 ? 200 : request.status});
 
-        return triggerEvent(this.kuzzle, modifiedRequest, afterEvent);
+        return this.kuzzle.pluginsManager.trigger(this.getEventName(request, 'after'), modifiedRequest);
       })
       .then(newRequest => {
         this.kuzzle.statistics.completedRequest(request);
 
-        // do not trigger global events on plugins' subrequests
-        if (newRequest.origin === null) {
-          return triggerEvent(this.kuzzle, newRequest, 'request:onSuccess');
-        }
-
-        return newRequest;
+        return this.kuzzle.pluginsManager.trigger('request:onSuccess', newRequest);
       })
       .catch(error => this.handleProcessRequestError(modifiedRequest, request, controllers, error))
       .finally(() => {
         this.concurrentRequests--;
-        delete this.pendingRequests[request.id];
       });
+  }
+
+  /**
+   * Exposes API requests execution to plugins
+   * 
+   * Similar to execute, except that:
+   *   - plugin requests do not trigger API events
+   *   - plugin requests are not counted towards requests statistics
+   *   - plugins can choose to disable the overload protection mechanism
+   *   
+   * @param {Request} request 
+   * @param {boolean} overloadProtect
+   * @param {Function} callback
+   * @returns {Number} -1: delayed, 0: processing, 1: error
+   */
+  executePluginRequest(request, overloadProtect, callback) {
+    request.clearError();
+    request.status = 102;
+    
+    let controllers;
+
+    try {
+      controllers = this.getControllers(request);
+    }
+    catch(e) {
+      callback(e);
+      return 1;
+    }
+
+    if (overloadProtect) {
+      const processNow = this.getRequestSlot('executePluginRequest', request, callback);
+
+      if (request.error) {
+        callback(null, request);
+        return 1;
+      }
+
+      if (!processNow) {
+        return -1;
+      }
+    }
+
+    this._historize(request);
+
+    controllers[request.input.controller][request.input.action](request)
+      .then(response => {
+        request.setResult(response, {status: request.status === 102 ? 200 : request.status});
+        callback(null, request);
+        return null;
+      })
+      .catch(e => {
+        request.setError(e);
+        this.handleErrorDump(e);
+        callback(e);
+        return null;
+      });
+
+    return 0;
   }
 
   handleProcessRequestError(modifiedRequest, request, controllers, error) {
     let _error = error;
-    const eventError = this.getEventName(modifiedRequest.input.controller, 'error', modifiedRequest.input.action);
+    const eventError = this.getEventName(modifiedRequest, 'error');
 
     if (controllers === this.pluginsControllers && !(error instanceof KuzzleError)) {
       _error = new PluginImplementationError(error);
     }
     modifiedRequest.setError(_error);
 
-    return triggerEvent(this.kuzzle, modifiedRequest, eventError)
+    return this.kuzzle.pluginsManager.trigger(eventError, modifiedRequest)
       .then(modifiedRequestError => {
         // If there is no pipe attached on this event, the same request is passed in resolve and we should reject it
         if (modifiedRequestError.error !== null) {
@@ -430,23 +472,18 @@ class FunnelController {
 
         modifiedRequest.setError(_error);
 
-        // do not trigger global events on plugins' subrequests
-        if (modifiedRequest.origin === null) {
-          return triggerEvent(this.kuzzle, modifiedRequest, 'request:onError')
-            .then(modifiedRequestError => {
-              if (modifiedRequestError !== modifiedRequest) {
-                return modifiedRequestError;
-              }
+        return this.kuzzle.pluginsManager.trigger('request:onError', modifiedRequest)
+          .then(modifiedRequestError => {
+            if (modifiedRequestError !== modifiedRequest) {
+              return modifiedRequestError;
+            }
 
-              return Bluebird.reject(modifiedRequest.error);
-            })
-            .catch(() => {
-              this.kuzzle.statistics.failedRequest(request);
-              return Bluebird.reject(_error);
-            });
-        }
-
-        return Bluebird.reject(_error);
+            return Bluebird.reject(modifiedRequest.error);
+          })
+          .catch(() => {
+            this.kuzzle.statistics.failedRequest(request);
+            return Bluebird.reject(_error);
+          });
       });
   }
 
@@ -454,15 +491,14 @@ class FunnelController {
    * Helper function meant to normalize event names
    * by retrieving controller aliases' original names.
    *
-   * @param {string} controller name or alias
+   * @param {Request} Executed request
    * @param {string} prefix - event prefix
-   * @param {string} action - executed action
    * @returns {string} event name
    */
-  getEventName (controller, prefix, action) {
-    const event = controller === 'memoryStorage' ? 'ms' : controller;
+  getEventName (request, prefix) {
+    const event = request.input.controller === 'memoryStorage' ? 'ms' : request.input.controller;
 
-    return event + ':' + prefix + capitalizeFirstLetter(action);
+    return event + ':' + prefix + capitalizeFirstLetter(request.input.action);
   }
 
   /**
@@ -472,6 +508,36 @@ class FunnelController {
    */
   get remainingRequests () {
     return this.concurrentRequests + this.requestsCacheQueue.length;
+  }
+
+  /**
+   * Returns the controllers object corresponding to the action asked
+   * by the request
+   *  
+   * @param  {Request} request
+   * @return {Object} controllers object
+   * @throws {BadRequestError} If the asked controller or action is unknown
+   */
+  getControllers(request) {
+    let controllers;
+
+    if (this.controllers[request.input.controller]) {
+      controllers = this.controllers;
+    }
+    else if (this.pluginsControllers[request.input.controller]) {
+      controllers = this.pluginsControllers;
+    }
+    else {
+      throw new BadRequestError(`Unknown controller ${request.input.controller}`);
+    }
+
+    const action = controllers[request.input.controller][request.input.action];
+
+    if (!action || typeof action !== 'function') {
+      throw new BadRequestError(`No corresponding action ${request.input.action} in controller ${request.input.controller}`);
+    }
+
+    return controllers;
   }
 
   /**
@@ -510,7 +576,7 @@ class FunnelController {
       let i; // perf cf https://jsperf.com/bvidis-for-oddities - NOSONAR
       for (i = 0; i < quantityToInject; i++) {
         const cachedItem = this.requestsCacheById[this.requestsCacheQueue.peekFront()];
-        if (this.execute(cachedItem.request, cachedItem.callback) === -1) {
+        if (this[cachedItem.executor](cachedItem.request, cachedItem.callback) === -1) {
           // no slot found again. We stop here and try next time
           break;
         }
@@ -535,6 +601,22 @@ class FunnelController {
       }
     }
   }
+
+  /**
+   * Push a request in the history queue, for debugging purposes
+   * 
+   * @param  {Request} request 
+   */
+  _historize (request) {
+    if (this.historized > this.kuzzle.config.limits.requestsHistorySize) {
+      this.requestHistory.shift();
+    }
+    else {
+      this.historized++;
+    }
+
+    this.requestHistory.push(request);
+  }
 }
 
 
@@ -544,24 +626,6 @@ class FunnelController {
  */
 function capitalizeFirstLetter(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
-}
-
-/**
- * Triggers an event if the request has not already
- * emitted it during its lifecycle
- *
- * @param {Kuzzle} kuzzle
- * @param {KuzzleRequest} request
- * @param {string} event
- * @return {Promise.<KuzzleRequest>}
- */
-function triggerEvent(kuzzle, request, event) {
-  if (request.hasTriggered(event)) {
-    return Bluebird.resolve(request);
-  }
-
-  request.triggers(event);
-  return kuzzle.pluginsManager.trigger(event, request);
 }
 
 module.exports = FunnelController;

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -416,7 +416,7 @@ class FunnelController {
       const processNow = this.getRequestSlot('executePluginRequest', request, callback);
 
       if (request.error) {
-        callback(null, request);
+        callback(request.error);
         return 1;
       }
 

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -82,7 +82,7 @@ class PluginContext {
 
       Object.defineProperty(this.accessors, 'execute', {
         enumerable: true,
-        get: (...args) => execute(kuzzle, ...args)
+        get: () => (...args) => execute(kuzzle, ...args)
       });
 
       Object.defineProperty(this.accessors, 'validation', {

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -160,6 +160,17 @@ function execute (kuzzle, request, overloadProtect = true, callback = null) {
     reject = null, 
     deferred = null;
 
+  let error = null;
+  const overloadProtectType = typeof overloadProtect;
+
+  if (overloadProtectType === 'function') {
+    callback = overloadProtect;
+    overloadProtect = true;
+  }
+  else if (overloadProtectType !== 'boolean') {
+    error = new PluginImplementationError('Invalid argument: the overload protection flag must be a boolean');
+  }
+
   if (!callback) {
     deferred = new Bluebird((res, rej) => {
       resolve = res;
@@ -167,20 +178,8 @@ function execute (kuzzle, request, overloadProtect = true, callback = null) {
     });
   }
 
-  let error = null;
-  if (!request || !(request instanceof Request)) {
+  if (!error && (!request || !(request instanceof Request))) {
     error = new PluginImplementationError('Invalid argument: a Request object must be supplied');
-  }
-  else {
-    const overloadProtectType = typeof overloadProtect;
-
-    if (overloadProtectType === 'function') {
-      callback = overloadProtect;
-      overloadProtect = true;
-    }
-    else if (overloadProtectType !== 'boolean') {
-      error = new PluginImplementationError('Invalid argument: the overload protection flag must be a boolean');
-    }
   }
 
   if (error) {

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -158,20 +158,22 @@ class PluginContext {
 function execute (kuzzle, request, overloadProtect = true, callback = null) {
   let resolve = null,
     reject = null, 
-    deferred = null;
+    deferred = null,
+    _callback = callback,
+    _overloadProtect = overloadProtect;
 
   let error = null;
-  const overloadProtectType = typeof overloadProtect;
+  const overloadProtectType = typeof _overloadProtect;
 
   if (overloadProtectType === 'function') {
-    callback = overloadProtect;
-    overloadProtect = true;
+    _callback = _overloadProtect;
+    _overloadProtect = true;
   }
   else if (overloadProtectType !== 'boolean') {
     error = new PluginImplementationError('Invalid argument: the overload protection flag must be a boolean');
   }
 
-  if (!callback) {
+  if (!_callback) {
     deferred = new Bluebird((res, rej) => {
       resolve = res;
       reject = rej;
@@ -183,18 +185,18 @@ function execute (kuzzle, request, overloadProtect = true, callback = null) {
   }
 
   if (error) {
-    if (callback) {
-      return callback(error);
+    if (_callback) {
+      return _callback(error);
     }
 
     reject(error);
     return deferred;
   }
 
-  kuzzle.funnel.executePluginRequest(request, overloadProtect, (err, response) => {
-    if (callback) {
+  kuzzle.funnel.executePluginRequest(request, _overloadProtect, (err, response) => {
+    if (_callback) {
       try {
-        callback(err, response);
+        _callback(err, response);
       }
       catch (e) {
         kuzzle.pluginsManager.trigger('log:error', new PluginImplementationError(`Uncatched error by a plugin callback: ${e}`));
@@ -213,7 +215,7 @@ function execute (kuzzle, request, overloadProtect = true, callback = null) {
     }
   });
 
-  if (!callback) {
+  if (!_callback) {
     return deferred;
   }
 }

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -82,7 +82,7 @@ class PluginContext {
 
       Object.defineProperty(this.accessors, 'execute', {
         enumerable: true,
-        get: () => execute.bind(kuzzle)
+        get: (...args) => execute(kuzzle, ...args)
       });
 
       Object.defineProperty(this.accessors, 'validation', {
@@ -117,7 +117,7 @@ class PluginContext {
 
       Object.defineProperty(this.accessors, 'trigger', {
         enumerable: true,
-        get: () => curryTrigger(pluginName).bind(kuzzle)
+        get: () => curryTrigger(kuzzle, pluginName)
       });
 
       /**
@@ -150,45 +150,73 @@ class PluginContext {
 }
 
 /**
- * @this {Kuzzle}
+ * @param {Kuzzle} kuzzle 
  * @param {Request} request
- * @param {function} callback
+ * @param {boolean} [overloadProtect]
+ * @param {Function} [callback]
  */
-function execute (request, callback) {
-  const kuzzle = this;
+function execute (kuzzle, request, overloadProtect = true, callback = null) {
+  let resolve = null,
+    reject = null, 
+    deferred = null;
 
-  return kuzzle.funnel.processRequest(request)
-    .then(response => {
-      if (callback) {
-        try {
-          callback(null, response);
-        }
-        catch (e) {
-          kuzzle.pluginsManager.trigger('log:error', new PluginImplementationError(`Uncatched error by a plugin callback: ${e}`));
-        }
+  if (!callback) {
+    deferred = new Bluebird((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+  }
 
-        return;
+  let error = null;
+  if (!request || !(request instanceof Request)) {
+    error = new PluginImplementationError('Invalid argument: a Request object must be supplied');
+  }
+  else {
+    const overloadProtectType = typeof overloadProtect;
+
+    if (overloadProtectType === 'function') {
+      callback = overloadProtect;
+      overloadProtect = true;
+    }
+    else if (overloadProtectType !== 'boolean') {
+      error = new PluginImplementationError('Invalid argument: the overload protection flag must be a boolean');
+    }
+  }
+
+  if (error) {
+    if (callback) {
+      return callback(error);
+    }
+
+    reject(error);
+    return deferred;
+  }
+
+  kuzzle.funnel.executePluginRequest(request, overloadProtect, (err, response) => {
+    if (callback) {
+      try {
+        callback(err, response);
       }
+      catch (e) {
+        kuzzle.pluginsManager.trigger('log:error', new PluginImplementationError(`Uncatched error by a plugin callback: ${e}`));
 
-      return Bluebird.resolve(response);
-    })
-    .catch(err => {
-      request.setError(err);
-      kuzzle.funnel.handleErrorDump(err);
-
-      if (callback) {
-        try {
-          callback(err, request);
-        }
-        catch (e) {
-          kuzzle.pluginsManager.trigger('log:error', new PluginImplementationError(`Uncatched error by a plugin callback: ${e}`));
+        if (err) {
           kuzzle.pluginsManager.trigger('log:error', `Previous error: ${err}`);
         }
-        return;
       }
+    }
+    else {
+      if (err) {
+        return reject(err);
+      }
+     
+      resolve(response);
+    }
+  });
 
-      return Bluebird.reject(err);
-    });
+  if (!callback) {
+    return deferred;
+  }
 }
 
 /**
@@ -196,20 +224,19 @@ function execute (request, callback) {
  * is injected in the returned function as it is prepended to the custom event
  * name. This is done to avoid colliding with the kuzzle native events.
  *
+ * @param  {Kuzzle} kuzzle 
  * @param  {String} pluginName The name of the plugin calling trigger.
  * @return {Function}          A trigger function that makes some checks on the
  *                             event name and prepends the plugin name to the
  *                             event name.
  */
-function curryTrigger (pluginName) {
+function curryTrigger (kuzzle, pluginName) {
   /**
    * @this   {Kuzzle}
    * @param  {String} eventName The name of the custom event to trigger.
    * @param  {Object} payload   The payload of the event.
    */
   return function trigger (eventName, payload) {
-    const kuzzle = this;
-
     if (eventName.indexOf(':') !== -1) {
       kuzzle.pluginsManager.trigger(
         'log:error',
@@ -233,30 +260,46 @@ function curryTrigger (pluginName) {
  * @return {Request}
  */
 function instantiateRequest(request, data, options = {}) {
-  if (!request || !(request instanceof Request)) {
-    throw new PluginImplementationError('A Request object must be provided');
+  let
+    _request = request,
+    _data = data,
+    _options = options;
+
+  if (!_request) {
+    throw new PluginImplementationError('A Request object and/or request data must be provided');
   }
 
-  Object.assign(options, request.context.toJSON());
-
-  const target = new Request(data, options);
-  target.origin = target.previous = request;
-
-  // forward informations from the provided request object
-  ['_id', 'index', 'collection'].forEach(resource => {
-    if (!target.input.resource[resource]) {
-      target.input.resource[resource] = request.input.resource[resource];
+  if (!(_request instanceof Request)) {
+    if (_data) {
+      _options = _data;
     }
-  });
 
-  Object.keys(request.input.args).forEach(arg => {
-    if (!target.input.args[arg]) {
-      target.input.args[arg] = request.input.args[arg];
+    _data = _request;
+    _request = null;
+  }
+  else {
+    Object.assign(_options, _request.context.toJSON());
+  }
+
+  const target = new Request(_data, _options);
+
+  // forward informations if a request object was supplied
+  if (_request) {
+    for (const resource of ['_id', 'index', 'collection']) {
+      if (!target.input.resource[resource]) {
+        target.input.resource[resource] = _request.input.resource[resource];
+      }
     }
-  });
 
-  if (!target.input.jwt) {
-    target.input.jwt = request.input.jwt;
+    for (const arg of Object.keys(_request.input.args)) {
+      if (!target.input.args[arg]) {
+        target.input.args[arg] = _request.input.args[arg];
+      }
+    }
+
+    if (!target.input.jwt) {
+      target.input.jwt = _request.input.jwt;
+    }
   }
 
   return target;

--- a/test/api/controllers/funnelController/execute.test.js
+++ b/test/api/controllers/funnelController/execute.test.js
@@ -41,9 +41,6 @@ describe('funnelController.execute', () => {
     sinon.stub(funnel, '_playCachedRequests');
   });
 
-  afterEach(() => {
-  });
-
   after(() => {
     if (clock) {
       clock.restore();
@@ -58,8 +55,7 @@ describe('funnelController.execute', () => {
           // 102 is the default status of a request, it should be 200 when coming out from the execute
           should(res.status).be.exactly(102);
           should(res).be.instanceOf(Request);
-          should(funnel.processRequest)
-            .be.calledOnce();
+          should(funnel.processRequest).be.calledOnce();
           should(funnel.processRequest.calledOnce).be.true();
           done();
         } catch (error) {
@@ -133,7 +129,7 @@ describe('funnelController.execute', () => {
       should(funnel.requestsCacheQueue.length).be.eql(1);
       should(funnel.requestsCacheQueue.shift())
         .eql(request.id);
-      should(funnel.requestsCacheById[request.id]).eql(new (FunnelController.__get__('CacheItem'))(request, callback));
+      should(funnel.requestsCacheById[request.id]).eql(new (FunnelController.__get__('CacheItem'))('execute', request, callback));
       should(funnel._playCachedRequests)
         .be.calledOnce();
     });

--- a/test/api/controllers/funnelController/executePluginRequest.test.js
+++ b/test/api/controllers/funnelController/executePluginRequest.test.js
@@ -1,0 +1,157 @@
+'use strict';
+
+const
+  should = require('should'),
+  sinon = require('sinon'),
+  Request = require('kuzzle-common-objects').Request,
+  KuzzleMock = require('../../../mocks/kuzzle.mock'),
+  FunnelController = require('../../../../lib/api/controllers/funnelController'),
+  BadRequestError = require('kuzzle-common-objects').errors.BadRequestError;
+
+describe('funnelController.executePluginRequest', () => {
+  let
+    kuzzle,
+    funnel;
+
+  beforeEach(() => {
+    kuzzle = new KuzzleMock();
+    funnel = new FunnelController(kuzzle);
+    funnel.controllers.testme = {action: sinon.stub()};
+    funnel.getRequestSlot = sinon.stub();
+    funnel._historize = sinon.stub();
+    funnel.handleErrorDump = sinon.stub();
+  });
+
+  it('should fail if an unknown controller is invoked', done => {
+    const rq = new Request({controller: 'foo', action: 'bar'});
+
+    const ret = funnel.executePluginRequest(rq, true, (err, res) => {
+      try {
+        should(res).be.undefined();
+        should(err).be.instanceOf(BadRequestError);
+        should(err.message).be.eql('Unknown controller foo');
+        should(funnel.getRequestSlot.called).be.false();
+        should(kuzzle.pluginsManager.trigger.called).be.false();
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+
+    should(ret).be.eql(1);
+  });
+
+  it('should execute without requesting a slot if asked to', done => {
+    const rq = new Request({controller: 'testme', action: 'action'});
+
+    funnel.controllers.testme.action.resolves(rq);
+
+    const ret = funnel.executePluginRequest(rq, false, (err, res) => {
+      try {
+        should(err).be.null();
+        should(res).be.eql(rq);
+        should(funnel.getRequestSlot.called).be.false();
+        should(funnel._historize).calledOnce().calledWith(rq);
+        should(rq.status).be.eql(200);
+        should(kuzzle.pluginsManager.trigger.called).be.false();
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+
+    should(ret).be.eql(0);
+  });
+
+  it('should execute the request if a slot is immediately available', done => {
+    const rq = new Request({controller: 'testme', action: 'action'});
+
+    funnel.controllers.testme.action.callsFake(() => {
+      rq.status = 333;
+      return Promise.resolve(rq);
+    });
+    funnel.getRequestSlot.returns(true);
+
+    const callback = (err, res) => {
+      try {
+        should(err).be.null();
+        should(res).be.eql(rq);
+        should(funnel.getRequestSlot).calledOnce().calledWith('executePluginRequest', rq, callback);
+        should(funnel._historize).calledOnce().calledWith(rq);
+        should(rq.status).be.eql(333);
+        should(kuzzle.pluginsManager.trigger.called).be.false();
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    };
+
+    should(funnel.executePluginRequest(rq, true, callback)).be.eql(0);
+  });
+
+  it('should delay the request if a slot is not yet available', () => {
+    const 
+      rq = new Request({controller: 'testme', action: 'action'}),
+      callback = sinon.stub();
+
+    funnel.getRequestSlot.returns(false);
+
+    should(funnel.executePluginRequest(rq, true, callback)).be.eql(-1);
+    should(funnel.getRequestSlot).calledOnce().calledWith('executePluginRequest', rq, callback);
+    should(funnel.controllers.testme.action.called).be.false();
+    should(funnel._historize.called).be.false();
+    should(rq.status).be.eql(102);
+    should(callback.called).be.false();
+    should(kuzzle.pluginsManager.trigger.called).be.false();
+  });
+
+  it('should reject the request if unable to get a slot', () => {
+    const 
+      rq = new Request({controller: 'testme', action: 'action'}),
+      callback = sinon.stub(),
+      error = new BadRequestError('foobar');
+
+    funnel.getRequestSlot.callsFake(() => {
+      rq.setError(error);
+      return false;
+    });
+
+    should(funnel.executePluginRequest(rq, true, callback)).be.eql(1);
+    should(funnel.getRequestSlot).calledOnce().calledWith('executePluginRequest', rq, callback);
+    should(funnel.controllers.testme.action.called).be.false();
+    should(funnel._historize.called).be.false();
+    should(rq.status).be.eql(error.status);
+    should(callback).calledOnce().calledWith(error);
+    should(kuzzle.pluginsManager.trigger.called).be.false();
+  });
+
+  it('should forward a controller error to the callback', done => {
+    const 
+      rq = new Request({controller: 'testme', action: 'action'}),
+      error = new Error('foobar');
+
+    funnel.controllers.testme.action.rejects(error);
+    funnel.getRequestSlot.returns(true);
+
+    const callback = (err, res) => {
+      try {
+        should(err).be.eql(error);
+        should(res).be.undefined();
+        should(funnel.getRequestSlot).calledOnce().calledWith('executePluginRequest', rq, callback);
+        should(funnel._historize).calledOnce().calledWith(rq);
+        should(rq.status).be.eql(500);
+        should(funnel.handleErrorDump.called).be.true();
+        should(kuzzle.pluginsManager.trigger.called).be.false();
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    };
+
+    should(funnel.executePluginRequest(rq, true, callback)).be.eql(0);
+  });
+});

--- a/test/api/controllers/funnelController/processRequest.test.js
+++ b/test/api/controllers/funnelController/processRequest.test.js
@@ -3,7 +3,7 @@
 const
   should = require('should'),
   sinon = require('sinon'),
-  Promise = require('bluebird'),
+  Bluebird = require('bluebird'),
   Request = require('kuzzle-common-objects').Request,
   FunnelController = require('../../../../lib/api/controllers/funnelController'),
   KuzzleMock = require('../../../mocks/kuzzle.mock'),
@@ -21,14 +21,14 @@ describe('funnelController.processRequest', () => {
     // injects fake controllers for unit tests
     funnel.controllers = {
       'fakeController': {
-        ok: sinon.stub().returns(Promise.resolve()),
+        ok: sinon.stub().returns(Bluebird.resolve()),
         fail: sinon.stub()
       }
     };
 
     funnel.pluginsControllers = {
       'fakePlugin/controller': {
-        ok: sinon.stub().returns(Promise.resolve()),
+        ok: sinon.stub().returns(Bluebird.resolve()),
         fail: sinon.stub()
       }
     };
@@ -130,7 +130,7 @@ describe('funnelController.processRequest', () => {
       action: 'fail',
     });
 
-    funnel.controllers.fakeController.fail.returns(Promise.reject(new Error('rejected')));
+    funnel.controllers.fakeController.fail.returns(Bluebird.reject(new Error('rejected')));
 
     return funnel.processRequest(request)
       .then(() => {
@@ -161,7 +161,7 @@ describe('funnelController.processRequest', () => {
 
     subrequest.origin = request;
 
-    funnel.controllers.fakeController.fail.returns(Promise.reject(new Error('rejected')));
+    funnel.controllers.fakeController.fail.returns(Bluebird.reject(new Error('rejected')));
 
     return funnel.processRequest(subrequest)
       .then(() => {
@@ -191,7 +191,7 @@ describe('funnelController.processRequest', () => {
       action: 'fail',
     });
 
-    funnel.pluginsControllers['fakePlugin/controller'].fail.returns(Promise.reject(new Error('rejected')));
+    funnel.pluginsControllers['fakePlugin/controller'].fail.returns(Bluebird.reject(new Error('rejected')));
 
     return funnel.processRequest(request)
       .then(() => {

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -80,7 +80,8 @@ class KuzzleMock extends Kuzzle {
       mExecute: sinon.stub(),
       processRequest: sinon.stub().returns(Bluebird.resolve()),
       checkRights: sinon.stub(),
-      getEventName: sinon.spy()
+      getEventName: sinon.spy(),
+      executePluginRequest: sinon.stub()
     };
 
     this.gc = {


### PR DESCRIPTION
# Description

Prior to this PR, plugin developers had to provide a `Request` object to the Request constructor.
This was done to keep track of request chains in order to prevent events infinite loops.

This choice proved to be constraining in some use cases. Moreover, if multiple plugins are installed, side-effects can quickly grow out of hands. So it has been collectively decided to change that behavior. Now:

- Requests can still be created by providing a Request object. If so, relevant information will be forwarded from the supplied Request to the created one
- Requests can be instantiated without having to supply a Request object.
- API commands ran by plugins **won't trigger events anymore**. Only user requests can now trigger events. This makes sure that there won't be any infinite loops.
* Plugin developers may chose to bypass the overload-protection mechanism to ensure that their API request will be run immediately (documentation needed). By default, requests submitted by plugins have to ask for a request slot to be executed

# Other changes

The `execute` function exposed by the plugin context do not return a promise anymore when a callback is provided.