### PR TITLE
Allow plugins to execute Kuzzle API during initialization

### DIFF
--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -93,6 +93,10 @@ class FunnelController {
     this.controllers.security = new SecurityController(this.kuzzle);
     this.controllers.server = new ServerController(this.kuzzle);
 
+    return Bluebird.resolve();
+  }
+
+  loadPluginControllers() {
     this.pluginsControllers = this.kuzzle.pluginsManager.getPluginControllers();
   }
 

--- a/lib/api/kuzzle.js
+++ b/lib/api/kuzzle.js
@@ -127,15 +127,16 @@ class Kuzzle extends EventEmitter {
 
     return this.internalEngine.init(internalEngineBootstrap)
       .then(() => this.internalEngine.bootstrap.all())
-      .then(() => this.validation.init())
-      .then(() => this.pluginsManager.init())
-      .then(() => this.pluginsManager.run())
       .then(() => this.services.init())
+      .then(() => this.validation.init())
       .then(() => this.indexCache.init())
       .then(() => this.gc.init())
+      .then(() => this.funnel.init())
+      .then(() => this.pluginsManager.init())
+      .then(() => this.pluginsManager.run())
       .then(() => this.pluginsManager.trigger('log:info', 'Services initiated'))
       .then(() => {
-        this.funnel.init();
+        this.funnel.loadPluginControllers();
         this.router.init();
         this.statistics.init();
 

--- a/test/api/controllers/funnelController/init.test.js
+++ b/test/api/controllers/funnelController/init.test.js
@@ -24,6 +24,7 @@ describe('funnelController.init', () => {
     kuzzle.pluginsManager.getPluginControllers = sinon.stub().returns({foo: 'bar'});
 
     funnel.init();
+    funnel.loadPluginControllers();
 
     should(Object.keys(funnel.controllers).length).be.eql(10);
     should(funnel.controllers.auth).be.instanceOf(AuthController);

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -74,6 +74,7 @@ class KuzzleMock extends Kuzzle {
       pluginsControllers: {
       },
       init: sinon.spy(),
+      loadPluginControllers: sinon.spy(),
       getRequestSlot: sinon.stub().returns(true),
       handleErrorDump: sinon.spy(),
       execute: sinon.spy(),


### PR DESCRIPTION
# Description

Without this change, plugins cannot execute API requests during their initialization phase: doing so will result in the following error: `BadRequestError: unknown controller <perfectly valid controller name>`.

This error is so counterintuitive that I had trouble figuring out what was going on: the funnel controller is initialized after plugins.
Without this fix, plugin developers need to know Kuzzle's inner mechanism to know how to get past this problem. And this is clearly not Kuzzle's philosophy.

This fix brings the following changes:
* services are initialized at the early stages of Kuzzle start sequence
* the funnel controller is initialized right after that, but _only with native controllers_
* plugins are loaded and run
* and only after all that does the funnel load plugin controllers, if any
