### PR TITLE
Fix problems with plugin names being case insensitive

### DIFF
--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -61,7 +61,10 @@ class PluginContext {
 
     if (kuzzle instanceof Kuzzle) {
       const
-        internalEngineIndex = `%plugin:${pluginName}`,
+        // Lowercasing the plugin name is needed to allow creating an Elasticsearch 
+        //  collection named after it
+        // (ES forbid index names containing uppercased characters)
+        internalEngineIndex = `%plugin:${pluginName}`.toLowerCase(),
         pluginInternalEngine = new InternalEngine(kuzzle, internalEngineIndex);
 
       pluginInternalEngine.init(new PluginInternalEngineBootstrap(kuzzle, pluginInternalEngine));

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -61,9 +61,8 @@ class PluginContext {
 
     if (kuzzle instanceof Kuzzle) {
       const
-        // Lowercasing the plugin name is needed to allow creating an Elasticsearch 
-        //  collection named after it
-        // (ES forbid index names containing uppercased characters)
+        // Lowercasing the plugin name is needed because Elasticsearch
+        // forbids uppercased characters in index names.
         internalEngineIndex = `%plugin:${pluginName}`.toLowerCase(),
         pluginInternalEngine = new InternalEngine(kuzzle, internalEngineIndex);
 

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -61,12 +61,10 @@ class PluginsManager {
     this.strategies = {};
     this.routes = [];
 
-    // As we must lowercase all plugin names, we also need to
-    // do the same on the configuration entries
     this.config = {};
     
     for (const entry of Object.keys(kuzzle.config.plugins)) {
-      this.config[entry.toLowerCase()] = kuzzle.config.plugins[entry];
+      this.config[entry] = kuzzle.config.plugins[entry];
     }
   }
 
@@ -609,7 +607,6 @@ class PluginsManager {
           throw new PluginImplementationError(`${errorRoutePrefix} Undefined action "${route.action}"`);
         }
 
-
         if (allowedVerbs.indexOf(route.verb.toLowerCase()) === -1) {
           throw new PluginImplementationError(`${errorRoutePrefix} Only following http verbs are allowed: "${allowedVerbs.join(', ')}"`);
         }
@@ -695,12 +692,15 @@ function loadPlugins(config, kuzzleVersion, rootPath) {
       throw new PluginImplementationError(`Unable to load plugin from path "${pluginDirName}"; No package.json found.`);
     }
 
-    // This is needed to allow creating an Elasticsearch named after the plugin's name
-    // (ES forbid index names containing uppercased characters)
-    packageJson.name = packageJson.name.toLowerCase();
+    // We need to ignore the case of plugin names while checking for name conflicts,
+    // because we have to lowercase the name of the plugin to create a dedicated
+    // Elasticsearch index.
+    const lowercased = packageJson.name.toLowerCase();
 
-    if (loadedPlugins[packageJson.name]) {
-      throw new PluginImplementationError(`A plugin named ${packageJson.name} already exists`);
+    for (const name of Object.keys(loadedPlugins)) {
+      if (lowercased === name.toLowerCase()) {
+        throw new PluginImplementationError(`A plugin named ${lowercased} already exists`);
+      }
     }
 
     const

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -61,11 +61,7 @@ class PluginsManager {
     this.strategies = {};
     this.routes = [];
 
-    this.config = {};
-    
-    for (const entry of Object.keys(kuzzle.config.plugins)) {
-      this.config[entry] = kuzzle.config.plugins[entry];
-    }
+    this.config = kuzzle.config.plugins;
   }
 
   /**

--- a/test/api/core/pluginsManager/init.test.js
+++ b/test/api/core/pluginsManager/init.test.js
@@ -169,35 +169,6 @@ describe('PluginsManager', () => {
       should(pluginsManager.plugins[instanceName].path).be.ok();
     });
 
-
-    it('should lowercase plugin names and configuration must be case insensitive', () => {
-      const instanceName = 'tHiS-Is-sO-l33t';
-      const config = {
-        foo: 'bar'
-      };
-
-      kuzzle.config.plugins['ThIs-iS-So-L33T'] = config;
-
-      fsStub.readdirSync.returns(['kuzzle-plugin-test']);
-      fsStub.statSync.returns({
-        isDirectory: () => true
-      });
-
-      mockrequire('/kuzzle/plugins/enabled/kuzzle-plugin-test', function () {});
-      mockrequire('/kuzzle/plugins/enabled/kuzzle-plugin-test/package.json', { name: instanceName });
-      PluginsManager = mockrequire.reRequire('../../../../lib/api/core/plugins/pluginsManager');
-
-      pluginsManager = new PluginsManager(kuzzle);
-
-      should(() => pluginsManager.init()).not.throw();
-      should(pluginsManager.plugins[instanceName.toLowerCase()]).be.Object();
-      should(pluginsManager.plugins[instanceName.toLowerCase()]).have.keys('name', 'object', 'config', 'manifest', 'path');
-      should(pluginsManager.plugins[instanceName.toLowerCase()].name).be.eql(instanceName.toLowerCase());
-      should(pluginsManager.plugins[instanceName.toLowerCase()].config).be.eql(config);
-      should(pluginsManager.plugins[instanceName.toLowerCase()].object).be.ok();
-      should(pluginsManager.plugins[instanceName.toLowerCase()].path).be.ok();
-    });
-
     it('should throw if trying to set a privileged plugin which does not support privileged mode', () => {
       const instanceName = 'kuzzle-plugin-test';
       const manifest = {


### PR DESCRIPTION
# Description

Multiple problems were introduced by https://github.com/kuzzleio/kuzzle/pull/933:

* plugin names in rights configuration are still case sensitive
* plugin's names in URLs injected in HTTP API are lowercased

Overall, Kuzzle's behavior regarding plugin names is inconsistent since #933 has been merged.

This PR rolls back #933, and fix the Elasticsearch issue regarding uppercased characters in index names a different way:

* plugin names are now once again case sensitive. Configuration and URLs match exactly what plugin developers have configured
* the plugin manager verifies that no other plugin has been registered under the same name, and this one check is **case insensitive**. This is important because of the following point:
* the internal storage bootstrap for plugins lowercase the index name of plugins. This is transparent for plugin developers, since they do not have access to their dedicated index name
