### PR TITLE
Fix a crash occuring when a HTTP request throws an error

### DIFF
--- a/lib/api/core/entrypoints/embedded/protocols/http.js
+++ b/lib/api/core/entrypoints/embedded/protocols/http.js
@@ -33,7 +33,8 @@ const
   {
     BadRequestError,
     SizeLimitError
-  } = require('kuzzle-common-objects').errors;
+  } = require('kuzzle-common-objects').errors,
+  Request = require('kuzzle-common-objects').Request;
 
 /**
  * @class HttpProtocol
@@ -234,7 +235,7 @@ class HttpProtocol extends Protocol {
 
     debug('[%s] replyWithError: %a', connectionId, error);
 
-    this.entryPoint.logAccess(connectionId, payload, error, result);
+    this.entryPoint.logAccess(new Request(payload, {error, connectionId}), payload);
 
     response.writeHead(error.status, {
       'Content-Type': 'application/json',

--- a/test/api/core/entrypoints/embedded/protocols/http.test.js
+++ b/test/api/core/entrypoints/embedded/protocols/http.test.js
@@ -3,6 +3,7 @@ const
   HttpProtocol = require('../../../../../../lib/api/core/entrypoints/embedded/protocols/http'),
   KuzzleMock = require('../../../../../mocks/kuzzle.mock'),
   Request = require('kuzzle-common-objects').Request,
+  KuzzleError = require('kuzzle-common-objects').errors.KuzzleError,
   should = require('should'),
   sinon = require('sinon');
 
@@ -371,21 +372,26 @@ describe('/lib/api/core/entrypoints/embedded/protocols/http', () => {
     });
 
     it('should log the access and reply with error', () => {
-      const error = new Error('test');
-      error.status = 'status';
+      const 
+        error = new KuzzleError('test'),
+        connectionId = 'connectionId',
+        payload = {requestId: 'foobar'};
+      error.status = 123;
 
-      protocol._replyWithError('connectionId', 'payload', response, error);
+      const rq = new Request(payload, {connectionId, error});
+      protocol._replyWithError(connectionId, payload, response, error);
 
       should(entrypoint.logAccess)
         .be.calledOnce()
-        .be.calledWithMatch('connectionId', 'payload', error, {
-          raw: true,
-          content: JSON.stringify(error)
-        });
+        .be.calledWithMatch(rq, {});
+
+      should(entrypoint.logAccess.firstCall.args[0].context.connectionId).be.eql(connectionId);
+      should(entrypoint.logAccess.firstCall.args[0].status).be.eql(123);
+      should(entrypoint.logAccess.firstCall.args[0].error).be.eql(error);
 
       should(response.writeHead)
         .be.calledOnce()
-        .be.calledWith('status', {
+        .be.calledWith(123, {
           'Content-Type': 'application/json',
           'Access-Control-Allow-Origin': '*',
           'Access-Control-Allow-Methods' : 'GET,POST,PUT,DELETE,OPTIONS',
@@ -399,7 +405,7 @@ describe('/lib/api/core/entrypoints/embedded/protocols/http', () => {
 
       entrypoint.clients.connectionId = {};
 
-      protocol._replyWithError('connectionId', 'payload', response, error);
+      protocol._replyWithError('connectionId', {}, response, error);
 
       should(entrypoint.clients)
         .be.empty();


### PR DESCRIPTION
# Description

Whenever a HTTP request generates an error in the protocol handler (not during an API request execution), Kuzzle crashes.

For instance, when a HTTP request is submitted with non-JSON content, or if the content size exceeds the configured server limit.

This crash occurs because of the access logs: before sending the error back to the client, Kuzzle invokes the `logAccess` method of the entry points with the wrong arguments. This generates an exception, which is catched only by Kuzzle main error handler, which deals with the problem by generating a diagnostic dump and stopping the process.
