### PR TITLE
Fix dumps triggered by authentication plugins rejecting with non-Error values

### DIFF
--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -26,7 +26,11 @@ const
   _ = require('lodash'),
   User = require('../core/models/security/user'),
   formatProcessing = require('../core/auth/formatProcessing'),
-  KuzzleInternalError = require('kuzzle-common-objects').errors.InternalError,
+  {
+    InternalError: KuzzleInternalError,
+    PluginImplementationError,
+    KuzzleError
+  } = require('kuzzle-common-objects').errors,
   {
     assertIsStrategyRegistered,
     assertIsAuthenticated,
@@ -133,14 +137,14 @@ class AuthController {
           return Bluebird.resolve([]);
         }
 
-        for (let i = 0; i < availableStrategies.length; i++) {
+        for (const strategy of availableStrategies) {
           const
-            strategy = availableStrategies[i],
             existsMethod = this.kuzzle.pluginsManager.getStrategyMethod(strategy, 'exists');
 
           promises.push(
             existsMethod(request, request.context.token.userId, strategy)
               .then(exists => exists ? strategy : null)
+              .catch(err => wrapPluginError(err))
           );
         }
 
@@ -229,7 +233,8 @@ class AuthController {
 
 
     return validateMethod(request, request.input.body, request.context.user._id, request.input.args.strategy, false)
-      .then(() => createMethod(request, request.input.body, request.context.user._id, request.input.args.strategy));
+      .then(() => createMethod(request, request.input.body, request.context.user._id, request.input.args.strategy))
+      .catch(err => wrapPluginError(err));
   }
 
   /**
@@ -246,7 +251,8 @@ class AuthController {
       validateMethod = this.kuzzle.pluginsManager.getStrategyMethod(request.input.args.strategy, 'validate');
 
     return validateMethod(request, request.input.body, request.context.user._id, request.input.args.strategy, true)
-      .then(() => updateMethod(request, request.input.body, request.context.user._id, request.input.args.strategy));
+      .then(() => updateMethod(request, request.input.body, request.context.user._id, request.input.args.strategy))
+      .catch(err => wrapPluginError(err));
   }
 
   /**
@@ -260,7 +266,8 @@ class AuthController {
 
     const existsMethod = this.kuzzle.pluginsManager.getStrategyMethod(request.input.args.strategy, 'exists');
 
-    return existsMethod(request, request.context.user._id, request.input.args.strategy);
+    return existsMethod(request, request.context.user._id, request.input.args.strategy)
+      .catch(err => wrapPluginError(err));
   }
 
   /**
@@ -275,7 +282,8 @@ class AuthController {
 
     const validateMethod = this.kuzzle.pluginsManager.getStrategyMethod(request.input.args.strategy, 'validate');
 
-    return validateMethod(request, request.input.body, request.context.user._id, request.input.args.strategy, false);
+    return validateMethod(request, request.input.body, request.context.user._id, request.input.args.strategy, false)
+      .catch(err => wrapPluginError(err));
   }
 
   /**
@@ -290,7 +298,8 @@ class AuthController {
     const deleteMethod = this.kuzzle.pluginsManager.getStrategyMethod(request.input.args.strategy, 'delete');
 
     return deleteMethod(request, request.context.user._id, request.input.args.strategy)
-      .then(() => ({acknowledged: true}));
+      .then(() => ({acknowledged: true}))
+      .catch(err => wrapPluginError(err));
   }
 
   /**
@@ -305,11 +314,20 @@ class AuthController {
     if (this.kuzzle.pluginsManager.hasStrategyMethod(request.input.args.strategy, 'getInfo')) {
       const getInfoMethod = this.kuzzle.pluginsManager.getStrategyMethod(request.input.args.strategy, 'getInfo');
 
-      return getInfoMethod(request, request.context.user._id, request.input.args.strategy);
+      return getInfoMethod(request, request.context.user._id, request.input.args.strategy)
+        .catch(err => wrapPluginError(err));
     }
 
     return Bluebird.resolve({});
   }
+}
+
+function wrapPluginError(error) {
+  if (!(error instanceof KuzzleError)) {
+    throw new PluginImplementationError(error);
+  }
+
+  throw error;
 }
 
 module.exports = AuthController;


### PR DESCRIPTION
# Description

Methods on the `auth` controller invoke authentication plugins, if any. If one of those plugins rejects with a non-Error value (e.g. a string), then this value is passed as-is to the `funnel` controller which, in turn, uses it to set the request's error property.  
Problem is: passing a non-Error object to the `setError` method of a `Request` object throws an `InternalError` exception. This forces the funnel controller to trigger the diagnostic tools because of an erroneous value of a plugin.

This PR wraps errors returned by authentication plugins in `PluginImplementationError` errors if a non-KuzzleError is returned.
