### PR TITLE
Stop startup sequence if a hook/pipe target function does not exist

### DIFF
--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -515,13 +515,14 @@ class PluginsManager {
     }
 
     _.forEach(plugin.object.pipes, (fn, pipe) => {
-      if (Array.isArray(fn)) {
-        fn
-          .filter(target => typeof plugin.object[target] === 'function')
-          .forEach(func => this.registerPipe(plugin, _warnTime, _timeout, pipe, func));
-      }
-      else if (typeof plugin.object[fn] === 'function') {
-        this.registerPipe(plugin, _warnTime, _timeout, pipe, fn);
+      const list = Array.isArray(fn) ? fn : [fn];
+
+      for (const target of list) {
+        if (!isFunction(plugin.object[target])) {
+          throw new PluginImplementationError(`Unable to configure pipe with method ${plugin.name}.${target}: function not found`);
+        }
+
+        this.registerPipe(plugin, _warnTime, _timeout, pipe, target);
       }
     });
   }
@@ -531,13 +532,14 @@ class PluginsManager {
    */
   _initHooks (plugin) {
     _.forEach(plugin.object.hooks, (fn, event) => {
-      if (Array.isArray(fn)) {
-        fn
-          .filter(target => typeof plugin.object[target] === 'function')
-          .forEach(func => this.registerHook(plugin, event, func));
-      }
-      else if (typeof plugin.object[fn] === 'function') {
-        this.registerHook(plugin, event, fn);
+      const list = Array.isArray(fn) ? fn : [fn];
+
+      for (const target of list) {
+        if (!isFunction(plugin.object[target])) {
+          throw new PluginImplementationError(`Unable to configure hook with method ${plugin.name}.${target}: function not found`);
+        }
+
+        this.registerHook(plugin, event, target);
       }
     });
   }

--- a/test/api/core/pluginsManager/run.test.js
+++ b/test/api/core/pluginsManager/run.test.js
@@ -129,6 +129,14 @@ describe('Test plugins manager run', () => {
       });
   });
 
+  it('should throw if a hook target does not exist', () => {
+    plugin.object.hooks = {
+      'foo:bar': 'foo'
+    };
+
+    return should(pluginsManager.run()).be.rejectedWith(PluginImplementationError);
+  });
+
   it('should attach pipes event', () => {
     plugin.object.pipes = {
       'foo:bar': 'foo',
@@ -180,6 +188,14 @@ describe('Test plugins manager run', () => {
     return pluginsManager.run()
       .then(() => pluginsManager.trigger('foo:bar'))
       .then(() => pluginMock.verify());
+  });
+
+  it('should throw if a pipe target does not exist', () => {
+    plugin.object.pipes = {
+      'foo:bar': 'foo'
+    };
+
+    return should(pluginsManager.run()).be.rejectedWith(PluginImplementationError);
   });
 
   it('should attach pipes event and reject if an attached function return an error', () => {


### PR DESCRIPTION
# Description

Prevent Kuzzle from starting if a plugin target for a hook or a pipe does not exist. This is already Kuzzle's behavior for non-existing authentication strategy methods or controller functions.

Before that PR, Kuzzle would discard non-existing methods, silently accepting invalid hook/pipe configurations.  Plugin developers would not detect the problem immediately and, even then, with no log or anything, it is not obvious for them to understand why their methods do not seem to be called.

# Solved issue

#965 
