### PR TITLE
Fix request statistics counters in case of a request failure

### DIFF
--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -484,9 +484,7 @@ class FunnelController {
 
             return Bluebird.reject(modifiedRequest.error);
           })
-          .catch(() => {
-            return Bluebird.reject(_error);
-          });
+          .catch(() => Bluebird.reject(_error));
       });
   }
 

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -225,9 +225,7 @@ class FunnelController {
 
     this.checkRights(request)
       .then(modifiedRequest => this.processRequest(modifiedRequest))
-      .then(processResult => {
-        callback(null, processResult);
-      })
+      .then(processResult => callback(null, processResult))
       .catch(err => this._executeError(err, request, true, callback));
 
     return 0;
@@ -380,10 +378,10 @@ class FunnelController {
 
         return this.kuzzle.pluginsManager.trigger(this.getEventName(request, 'after'), modifiedRequest);
       })
+      .then(newRequest => this.kuzzle.pluginsManager.trigger('request:onSuccess', newRequest))
       .then(newRequest => {
         this.kuzzle.statistics.completedRequest(request);
-
-        return this.kuzzle.pluginsManager.trigger('request:onSuccess', newRequest);
+        return newRequest;
       })
       .catch(error => this.handleProcessRequestError(modifiedRequest, request, controllers, error))
       .finally(() => {
@@ -462,7 +460,6 @@ class FunnelController {
       .then(modifiedRequestError => {
         // If there is no pipe attached on this event, the same request is passed in resolve and we should reject it
         if (modifiedRequestError.error !== null) {
-          this.kuzzle.statistics.failedRequest(request);
           return Bluebird.reject(modifiedRequest.error);
         }
 
@@ -477,6 +474,7 @@ class FunnelController {
         }
 
         modifiedRequest.setError(_error);
+        this.kuzzle.statistics.failedRequest(request);
 
         return this.kuzzle.pluginsManager.trigger('request:onError', modifiedRequest)
           .then(modifiedRequestError => {
@@ -487,7 +485,6 @@ class FunnelController {
             return Bluebird.reject(modifiedRequest.error);
           })
           .catch(() => {
-            this.kuzzle.statistics.failedRequest(request);
             return Bluebird.reject(_error);
           });
       });


### PR DESCRIPTION
# Description

Fix erroneous request statistics:

* requests possibly being counted as both completed and failed if a pipe on a controller action `onSuccess` event failed
* doubled failed requests counter
* possibly negative ongoing requests counter

# Solved issue

#942 
