### PR TITLE
Fix the documents garbage collector service

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -407,6 +407,19 @@
       }
     },
 
+    // [garbageCollector]
+    // The document garbage collector service: permanently delete
+    // documents in the trashcan area
+    //
+    //   * cleanInterval:
+    //      Delay between each garbage collection, in milliseconds
+    //    * maxDelete:
+    //      Maximum number of documents to delete **per data collection**
+    "garbageCollector": {
+      "cleanInterval": 86400000,
+      "maxDelete": 1000
+    },
+
     // [internalBroker]
     // The internalBroker is used for internal Kuzzle communication,
     // notably to transport messages between the CLI and the server.

--- a/lib/api/core/indexCache.js
+++ b/lib/api/core/indexCache.js
@@ -20,6 +20,8 @@
  */
 'use strict';
 
+const Bluebird = require('bluebird');
+
 /**
  * Index/collection cache management
  */
@@ -42,16 +44,19 @@ class IndexCache {
   init () {
     return this.kuzzle.internalEngine.listIndexes()
       .then(indexes => {
-        indexes.forEach(index => {
+        const promises = [];
+
+        for (const index of indexes) {
           this.indexes[index] = [];
 
-          this.kuzzle.internalEngine.listCollections(index)
+          promises.push(this.kuzzle.internalEngine.listCollections(index)
             .then(collections => {
               this.indexes[index] = collections;
-            });
-        });
+            })
+          );
+        }
 
-        return null;
+        return Bluebird.all(promises);
       });
   }
 

--- a/lib/api/kuzzle.js
+++ b/lib/api/kuzzle.js
@@ -34,7 +34,6 @@ const
   HotelClerk = require('./core/hotelClerk'),
   IndexCache = require('./core/indexCache'),
   InternalEngine = require('../services/internalEngine'),
-  GarbageCollector = require('../services/garbageCollector'),
   Notifier = require('./core/notifier'),
   PassportWrapper = require('./core/auth/passportWrapper'),
   PluginsManager = require('./core/plugins/pluginsManager'),
@@ -76,8 +75,6 @@ class Kuzzle extends EventEmitter {
     this.tokenManager = new TokenManager(this);
     this.indexCache = new IndexCache(this);
     this.repositories = new Repositories(this);
-
-    this.gc = new GarbageCollector(this);
 
     this.passport = new PassportWrapper();
 
@@ -127,7 +124,6 @@ class Kuzzle extends EventEmitter {
       .then(() => this.services.init())
       .then(() => this.validation.init())
       .then(() => this.indexCache.init())
-      .then(() => this.gc.init())
       .then(() => this.funnel.init())
       .then(() => this.pluginsManager.init())
       .then(() => this.pluginsManager.run())

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -522,7 +522,7 @@ class ElasticSearch extends Service {
   /**
    * Delete all document that match the given filter from the trash
    * @param {Request} request
-   * @returns {Promise}
+   * @returns {Promise} resolve the list of deleted ids
    */
   deleteByQueryFromTrash(request) {
     const
@@ -533,7 +533,6 @@ class ElasticSearch extends Service {
 
     esRequestSearch.body = request.input.body;
     esRequestSearch.scroll = '30s';
-    esRequestBulk.body = [];
 
     if (esRequestSearch.body.query === null) {
       return Bluebird.reject(new BadRequestError('null is not a valid document ID'));
@@ -542,13 +541,12 @@ class ElasticSearch extends Service {
     return getAllIdsFromQuery(this.client, esRequestSearch)
       .then(ids => {
         return new Bluebird((resolve, reject) => {
-          ids.forEach(id => {
-            esRequestBulk.body.push({delete: {_index: esRequestBulk.index, _type: esRequestBulk.type, _id: id}});
-          });
+          esRequestBulk.body = ids.map(id => ({delete: {_index: esRequestBulk.index, _type: esRequestBulk.type, _id: id}}));
 
           if (esRequestBulk.body.length === 0) {
             return resolve({ids: []});
           }
+
           return this.client.bulk(esRequestBulk)
             .then(() => this.refreshIndexIfNeeded(esRequestBulk, {ids}))
             .catch(error => reject(this.esWrapper.formatESError(error)));

--- a/lib/services/garbageCollector.js
+++ b/lib/services/garbageCollector.js
@@ -22,120 +22,123 @@
 'use strict';
 
 const
-  OneHour = 3600000,
-  OneDay = OneHour * 24,
   Bluebird = require('bluebird'),
   Request = require('kuzzle-common-objects').Request;
 
-function GarbageCollector(kuzzle) {
-  this.timer = null;
+// Time constants
+const 
+  oneHour = 3600000,
+  oneDay = oneHour * 24;
 
-  this.init = function garbageCollectorInit() {
-    this.run();
+// There can be only one
+let _highlander = null;
+
+class GarbageCollector {
+  constructor(kuzzle) {
+    this.kuzzle = kuzzle;
+  }
+
+  init () {
+    // We do not want to trigger the garbage collector right away:
+    // if for whatever reason Kuzzle is (re)started on a production
+    // environment (after a crash, because of autoscaling, etc),
+    // the last thing a client needs is to clean up trashcans
+    setTimeout(() => this.run(), oneHour);
+
     return Bluebird.resolve(this);
-  };
+  }
 
-  this.run = function garbageCollectorRun () {
+  run () {
     let ids = [];
-    const
-      body = {
-        from: 0,
-        size: kuzzle.config.services.garbageCollector.maxDelete || 10000,
-        sort: [{ '_kuzzle_info.deletedAt': { unmapped_type: 'date'} }],
-        query: {
-          bool: {
-            should: [
-              {
-                term: {
-                  '_kuzzle_info.active': false
-                }
-              }
-            ]
-          }
-        }
-      };
 
-    if (this.timer) {
-      clearTimeout(this.timer);
+    if (this.kuzzle.funnel.overloaded) {
+      // Reschedule the task to be run in 1 hour
+      setTimeout(() => this.run(), oneHour);
+
+      return Bluebird.resolve();
     }
 
-    if (kuzzle.funnel.overloaded) {
-      // Reschedule the task to run in 1 hour
-      this.timer = setTimeout(() => this.run(), OneHour);
-
-      return Bluebird.resolve({ids});
-    }
-
-    // Reschedule the task to be executed every 24 hours by default
-    this.timer = setTimeout(() => this.run(), kuzzle.config.services.garbageCollector.cleanInterval || OneDay);
-
-    return kuzzle.pluginsManager.trigger('gc:start')
+    return this.kuzzle.pluginsManager.trigger('gc:start')
       .then(() => {
-        kuzzle.pluginsManager.trigger('log:info', '[GC] Started');
+        this.kuzzle.pluginsManager.trigger('log:info', '[GC] Started');
 
-        return kuzzle.services.list.storageEngine.listIndexes()
-          .then(res => {
-            const indexesPromises = [];
+        // Builds an array of {index, collection} pairs
+        const indexes = Object.keys(this.kuzzle.indexCache.indexes)
+          .filter(index => index[0] !== '%'); // skipping reserved indexes
 
-            res.indexes.forEach(index => {
-              if (index === kuzzle.internalEngine.index) {
-                return;
-              }
+        const collections = [];
 
-              indexesPromises.push(
-                kuzzle.services.list.storageEngine.listCollections(new Request({index}))
-                  .then(collections => {
-                    const collectionsPromises = [];
+        for (const index of indexes) {
+          collections.push(...this.kuzzle.indexCache.indexes[index].map(collection => ({index, collection})));
+        }
 
-                    collections.collections.stored.forEach(collection => {
-                      const request = new Request({index, collection, body});
+        return Bluebird.resolve(collections)
+          .each(icpair => {
+            return this.clearCollection(icpair.index, icpair.collection)
+              .then(deletedIds => {
+                if (deletedIds.length) {
+                  // using concat instead of push + spread operator because the list
+                  // of deleted IDs may be large
+                  ids = ids.concat(deletedIds);
+                  this.kuzzle.pluginsManager.trigger('log:info', `[GC] ${icpair.index}/${icpair.collection}: trashcan emptied (${deletedIds.length} documents deleted)`);
+                }
 
-                      collectionsPromises.push(
-                        kuzzle.services.list.storageEngine.deleteByQueryFromTrash(request)
-                          .then(deletedDocs => {
-
-                            ids = ids.concat(deletedDocs.ids);
-
-                            kuzzle.pluginsManager.trigger('log:info', `[GC] Deleted ${deletedDocs.ids.length} documents on collection ${collection} of index ${index}`);
-                            return null;
-                          })
-                          .catch(deleteByQueryFromTrashError => {
-                            kuzzle.pluginsManager.trigger('log:error', deleteByQueryFromTrashError);
-                            return null;
-                          })
-                          // always resolve the promise, we don't want to break the GC when an error occurs
-                          .finally(() => Bluebird.resolve())
-                      );
-                    });
-
-                    return Bluebird.all(collectionsPromises);
-                  })
-                  .catch(listCollectionsError => {
-                    kuzzle.pluginsManager.trigger('log:error', listCollectionsError);
-                    return null;
-                  })
-                  // always resolve the promise, we don't want to break the GC when an error occurs
-                  .finally(() => Bluebird.resolve())
-              );
-            });
-
-            return Bluebird.all(indexesPromises);
-          })
-          .then(() => {
-            kuzzle.pluginsManager.trigger('log:info', `[GC] Finished. Deleted ${ids.length} documents`);
-            kuzzle.pluginsManager.trigger('gc:end', {ids});
-
-            return {ids};
-          })
-          .catch(listIndexesError => {
-            kuzzle.pluginsManager.trigger('log:error', listIndexesError);
-            return null;
+                return null;
+              });
           });
       })
-      .catch(pipeError => {
-        kuzzle.pluginsManager.trigger('log:error', pipeError);
+      .then(() => {
+        if (ids.length) {
+          this.kuzzle.pluginsManager.trigger('log:info', `[GC] Finished: ${ids.length} documents deleted in all trashcans`);
+        }
+
+        this.kuzzle.pluginsManager.trigger('gc:end', {ids});
+        return {ids};
+      })
+      .catch(error => {
+        this.kuzzle.pluginsManager.trigger('log:error', error);
         return null;
+      })
+      .finally(() => {
+        // Reschedule the task to be executed every 24 hours by default
+        setTimeout(
+          () => this.run(), 
+          this.kuzzle.config.services.garbageCollector.cleanInterval || oneDay
+        );
       });
-  };
+  }
+
+  clearCollection(index, collection) {
+    const body = {
+      from: 0,
+      size: this.kuzzle.config.services.garbageCollector.maxDelete || 10000,
+      sort: [{ '_kuzzle_info.deletedAt': { unmapped_type: 'date'} }],
+      query: {
+        bool: {
+          should: [
+            {
+              term: {
+                '_kuzzle_info.active': false
+              }
+            }
+          ]
+        }
+      }
+    };
+
+    const request = new Request({index, collection, body});
+
+    return this.kuzzle.services.list.storageEngine.deleteByQueryFromTrash(request)
+      .then(deletedDocs => deletedDocs.ids)
+      .catch(error => {
+        this.kuzzle.pluginsManager.trigger('log:error', error);
+        // always resolve the promise, we don't want to break the GC when an error occurs
+        return [];
+      });
+  }
 }
-module.exports = GarbageCollector;
+
+module.exports = function singleton (kuzzle) {
+  _highlander = _highlander || new GarbageCollector(kuzzle);
+  return _highlander;
+};

--- a/lib/services/garbageCollector.js
+++ b/lib/services/garbageCollector.js
@@ -109,6 +109,11 @@ class GarbageCollector {
   }
 
   clearCollection(index, collection) {
+    if (this.kuzzle.funnel.overloaded) {
+      // skip
+      return Bluebird.resolve([]);
+    }
+
     const body = {
       from: 0,
       size: this.kuzzle.config.services.garbageCollector.maxDelete || 10000,

--- a/lib/services/garbageCollector.js
+++ b/lib/services/garbageCollector.js
@@ -66,10 +66,10 @@ class GarbageCollector {
         const indexes = Object.keys(this.kuzzle.indexCache.indexes)
           .filter(index => index[0] !== '%'); // skipping reserved indexes
 
-        const collections = [];
+        let collections = [];
 
         for (const index of indexes) {
-          collections.push(...this.kuzzle.indexCache.indexes[index].map(collection => ({index, collection})));
+          collections = collections.concat(this.kuzzle.indexCache.indexes[index].map(collection => ({index, collection})));
         }
 
         return Bluebird.resolve(collections)

--- a/lib/services/garbageCollector.js
+++ b/lib/services/garbageCollector.js
@@ -43,7 +43,7 @@ class GarbageCollector {
     // if for whatever reason Kuzzle is (re)started on a production
     // environment (after a crash, because of autoscaling, etc),
     // the last thing a client needs is to clean up trashcans
-    setTimeout(() => this.run(), oneHour);
+    setTimeout(() => this.run(), this.kuzzle.config.services.garbageCollector.cleanInterval || oneDay);
 
     return Bluebird.resolve(this);
   }

--- a/test/api/controllers/securityController/users.test.js
+++ b/test/api/controllers/securityController/users.test.js
@@ -348,12 +348,12 @@ describe('Test: security controller - users', () => {
 
     it('should throw an error and rollback if credentials don\'t create properly', done => {
       const
-        validateStub = sandbox.stub().returns(Bluebird.resolve()),
-        existsStub = sandbox.stub().returns(Bluebird.resolve(false)),
-        createStub = sandbox.stub().returns(Bluebird.reject(new Error('some error'))),
-        deleteStub = sandbox.stub().returns(Bluebird.resolve());
+        validateStub = sandbox.stub().resolves(),
+        existsStub = sandbox.stub().resolves(false),
+        createStub = sandbox.stub().rejects(new Error('some error')),
+        deleteStub = sandbox.stub().resolves();
 
-      kuzzle.repositories.user.load = sandbox.stub().returns(Bluebird.resolve(null));
+      kuzzle.repositories.user.load = sandbox.stub().resolves(null);
       kuzzle.pluginsManager.listStrategies = sandbox.stub().returns(['someStrategy']);
       kuzzle.pluginsManager.getStrategyMethod = sandbox.stub();
 
@@ -376,10 +376,10 @@ describe('Test: security controller - users', () => {
 
     it('should intercept errors during deletion of a recovery phase', done => {
       const
-        validateStub = sandbox.stub().returns(Bluebird.resolve()),
-        existsStub = sandbox.stub().returns(Bluebird.resolve(false)),
-        createStub = sandbox.stub().returns(Bluebird.reject(new Error('some error'))),
-        deleteStub = sandbox.stub().returns(Bluebird.reject(new Error('some error')));
+        validateStub = sandbox.stub().resolves(),
+        existsStub = sandbox.stub().resolves(false),
+        createStub = sandbox.stub().rejects(new Error('some error')),
+        deleteStub = sandbox.stub().rejects(new Error('some error'));
 
       kuzzle.repositories.user.load = sandbox.stub().returns(Bluebird.resolve(null));
       kuzzle.pluginsManager.listStrategies = sandbox.stub().returns(['someStrategy']);
@@ -405,14 +405,14 @@ describe('Test: security controller - users', () => {
     it('should not create credentials if user creation fails', done => {
       const
         error = new Error('foobar'),
-        validateStub = sandbox.stub().returns(Bluebird.resolve()),
-        existsStub = sandbox.stub().returns(Bluebird.resolve(false)),
-        createStub = sandbox.stub().returns(Bluebird.resolve());
+        validateStub = sandbox.stub().resolves(),
+        existsStub = sandbox.stub().resolves(false),
+        createStub = sandbox.stub().resolves();
 
-      kuzzle.repositories.user.load = sandbox.stub().returns(Bluebird.resolve(null));
+      kuzzle.repositories.user.load = sandbox.stub().resolves(null);
       kuzzle.pluginsManager.listStrategies = sandbox.stub().returns(['someStrategy']);
       kuzzle.pluginsManager.getStrategyMethod = sandbox.stub();
-      kuzzle.repositories.user.persist = sandbox.stub().returns(Bluebird.reject(error));
+      kuzzle.repositories.user.persist = sandbox.stub().rejects(error);
 
       kuzzle.pluginsManager.getStrategyMethod.withArgs('someStrategy', 'validate').returns(validateStub);
       kuzzle.pluginsManager.getStrategyMethod.withArgs('someStrategy', 'exists').returns(existsStub);

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -106,6 +106,7 @@ class KuzzleMock extends Kuzzle {
     };
 
     this.indexCache = {
+      indexes: {},
       add: sinon.stub(),
       exists: sinon.stub(),
       init: sinon.stub().returns(Bluebird.resolve()),
@@ -172,7 +173,7 @@ class KuzzleMock extends Kuzzle {
       plugins: {},
       run: sinon.stub().returns(Bluebird.resolve()),
       getPluginsDescription: sinon.stub().returns({}),
-      trigger: sinon.spy((...args) => Bluebird.resolve(args[1])),
+      trigger: sinon.stub().callsFake((...args) => Bluebird.resolve(args[1])),
       listStrategies: sinon.stub().returns([]),
       getStrategyMethod: sinon.stub().returns(sinon.stub()),
       strategies: {},

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -17,23 +17,23 @@ class KuzzleMock extends Kuzzle {
     this.config.server.entryPoints.proxy = true;
 
     this.cliController = {
-      init: sinon.stub().returns(Bluebird.resolve()),
+      init: sinon.stub().resolves(),
       actions: {
-        adminExists: sinon.stub().returns(Bluebird.resolve()),
-        createFirstAdmin: sinon.stub().returns(Bluebird.resolve()),
-        cleanAndPrepare: sinon.stub().returns(Bluebird.resolve()),
-        cleanDb: sinon.stub().returns(Bluebird.resolve()),
-        managePlugins: sinon.stub().returns(Bluebird.resolve()),
-        data: sinon.stub().returns(Bluebird.resolve()),
-        dump: sinon.stub().returns(Bluebird.resolve())
+        adminExists: sinon.stub().resolves(),
+        createFirstAdmin: sinon.stub().resolves(),
+        cleanAndPrepare: sinon.stub().resolves(),
+        cleanDb: sinon.stub().resolves(),
+        managePlugins: sinon.stub().resolves(),
+        data: sinon.stub().resolves(),
+        dump: sinon.stub().usingPromise(Bluebird).resolves()
       }
     };
 
     this.realtime = {
       test: sinon.stub().returns([]),
-      register: sinon.stub().returns(Bluebird.resolve()),
-      remove: sinon.stub().returns(Bluebird.resolve()),
-      normalize: sinon.stub().returns(Bluebird.resolve({id: 'foobar'})),
+      register: sinon.stub().resolves(),
+      remove: sinon.stub().resolves(),
+      normalize: sinon.stub().resolves({id: 'foobar'}),
       store: sinon.stub().returns({id: 'foobar'})
     };
 
@@ -43,14 +43,14 @@ class KuzzleMock extends Kuzzle {
       entryPoints: [
         {
           dispatch: sinon.spy(),
-          init: sinon.stub().returns(Bluebird.resolve()),
+          init: sinon.stub().resolves(),
           joinChannel: sinon.spy(),
           leaveChannel: sinon.spy(),
           send: sinon.spy()
         },
         {
           dispatch: sinon.spy(),
-          init: sinon.stub().returns(Bluebird.resolve()),
+          init: sinon.stub().resolves(),
           joinChannel: sinon.spy(),
           leaveChannel: sinon.spy(),
           send: sinon.spy()
@@ -79,7 +79,7 @@ class KuzzleMock extends Kuzzle {
       handleErrorDump: sinon.spy(),
       execute: sinon.spy(),
       mExecute: sinon.stub(),
-      processRequest: sinon.stub().returns(Bluebird.resolve()),
+      processRequest: sinon.stub().resolves(),
       checkRights: sinon.stub(),
       getEventName: sinon.spy(),
       executePluginRequest: sinon.stub()
@@ -98,52 +98,52 @@ class KuzzleMock extends Kuzzle {
     this.hotelClerk = {
       getRealtimeCollections: sinon.stub(),
       removeCustomerFromAllRooms: sinon.stub(),
-      addSubscription: sinon.stub().returns(Bluebird.resolve(foo)),
-      join: sinon.stub().returns(Bluebird.resolve(foo)),
-      removeSubscription: sinon.stub().returns(Bluebird.resolve(foo)),
-      countSubscription: sinon.stub().returns(Bluebird.resolve(foo)),
-      listSubscriptions: sinon.stub().returns(Bluebird.resolve(foo)),
+      addSubscription: sinon.stub().resolves(foo),
+      join: sinon.stub().resolves(foo),
+      removeSubscription: sinon.stub().resolves(foo),
+      countSubscription: sinon.stub().resolves(foo),
+      listSubscriptions: sinon.stub().resolves(foo),
     };
 
     this.indexCache = {
       indexes: {},
       add: sinon.stub(),
       exists: sinon.stub(),
-      init: sinon.stub().returns(Bluebird.resolve()),
-      initInternal: sinon.stub().returns(Bluebird.resolve()),
+      init: sinon.stub().resolves(),
+      initInternal: sinon.stub().resolves(),
       remove: sinon.stub(),
       reset: sinon.stub()
     };
 
     this.internalEngine = {
       bootstrap: {
-        adminExists: sinon.stub().returns(Bluebird.resolve(true)),
-        all: sinon.stub().returns(Bluebird.resolve()),
-        createCollections: sinon.stub().returns(Bluebird.resolve()),
-        createRolesCollection: sinon.stub().returns(Bluebird.resolve()),
-        createProfilesCollection: sinon.stub().returns(Bluebird.resolve()),
-        createUsersCollection: sinon.stub().returns(Bluebird.resolve()),
-        createPluginsCollection: sinon.stub().returns(Bluebird.resolve()),
-        delete: sinon.stub().returns(Bluebird.resolve())
+        adminExists: sinon.stub().resolves(true),
+        all: sinon.stub().resolves(),
+        createCollections: sinon.stub().resolves(),
+        createRolesCollection: sinon.stub().resolves(),
+        createProfilesCollection: sinon.stub().resolves(),
+        createUsersCollection: sinon.stub().resolves(),
+        createPluginsCollection: sinon.stub().resolves(),
+        delete: sinon.stub().resolves()
       },
-      create: sinon.stub().returns(Bluebird.resolve()),
-      createInternalIndex: sinon.stub().returns(Bluebird.resolve()),
-      createOrReplace: sinon.stub().returns(Bluebird.resolve()),
-      delete: sinon.stub().returns(Bluebird.resolve()),
-      deleteIndex: sinon.stub().returns(Bluebird.resolve()),
-      expire: sinon.stub().returns(Bluebird.resolve()),
-      get: sinon.stub().returns(Bluebird.resolve(foo)),
-      mget: sinon.stub().returns(Bluebird.resolve({hits: [foo]})),
+      create: sinon.stub().resolves(),
+      createInternalIndex: sinon.stub().resolves(),
+      createOrReplace: sinon.stub().resolves(),
+      delete: sinon.stub().resolves(),
+      deleteIndex: sinon.stub().resolves(),
+      expire: sinon.stub().resolves(),
+      get: sinon.stub().resolves(foo),
+      mget: sinon.stub().resolves({hits: [foo]}),
       index: 'internalIndex',
-      init: sinon.stub().returns(Bluebird.resolve()),
+      init: sinon.stub().resolves(),
       listCollections: sinon.stub(),
       listIndexes: sinon.stub(),
-      persist: sinon.stub().returns(Bluebird.resolve()),
-      refresh: sinon.stub().returns(Bluebird.resolve()),
-      replace: sinon.stub().returns(Bluebird.resolve()),
-      search: sinon.stub().returns(Bluebird.resolve()),
-      update: sinon.stub().returns(Bluebird.resolve()),
-      updateMapping: sinon.stub().returns(Bluebird.resolve(foo)),
+      persist: sinon.stub().resolves(),
+      refresh: sinon.stub().resolves(),
+      replace: sinon.stub().resolves(),
+      search: sinon.stub().resolves(),
+      update: sinon.stub().resolves(),
+      updateMapping: sinon.stub().resolves(foo),
       getMapping: sinon.stub()
     };
 
@@ -158,20 +158,20 @@ class KuzzleMock extends Kuzzle {
       notifyDocumentDelete: sinon.spy(),
       notifyDocumentReplace: sinon.spy(),
       notifyDocumentUpdate: sinon.spy(),
-      publish: sinon.stub().returns(Bluebird.resolve(foo))
+      publish: sinon.stub().resolves(foo)
     };
 
     this.passport = {
       use: sinon.stub(),
       unuse: sinon.stub(),
-      authenticate: sinon.stub().returns(Bluebird.resolve({})),
+      authenticate: sinon.stub().resolves({}),
       injectAuthenticateOptions: sinon.stub()
     };
 
     this.pluginsManager = {
-      init: sinon.stub().returns(Bluebird.resolve()),
+      init: sinon.stub().resolves(),
       plugins: {},
-      run: sinon.stub().returns(Bluebird.resolve()),
+      run: sinon.stub().resolves(),
       getPluginsDescription: sinon.stub().returns({}),
       trigger: sinon.stub().callsFake((...args) => Bluebird.resolve(args[1])),
       listStrategies: sinon.stub().returns([]),
@@ -182,44 +182,44 @@ class KuzzleMock extends Kuzzle {
     };
 
     this.repositories = {
-      init: sinon.stub().returns(Bluebird.resolve()),
+      init: sinon.stub().resolves(),
       profile: {
-        load: sinon.stub().returns(Bluebird.resolve()),
-        loadProfiles: sinon.stub().returns(Bluebird.resolve()),
-        searchProfiles: sinon.stub().returns(Bluebird.resolve())
+        load: sinon.stub().resolves(),
+        loadProfiles: sinon.stub().resolves(),
+        searchProfiles: sinon.stub().resolves()
       },
       role: {
-        getRoleFromRequest: sinon.spy(function () {return Bluebird.resolve(arguments[0]);}),
-        loadRole: sinon.stub().returns(Bluebird.resolve()),
-        loadRoles: sinon.stub().returns(Bluebird.resolve()),
-        validateAndSaveRole: sinon.spy(function () {return Bluebird.resolve(arguments[0]);})
+        getRoleFromRequest: sinon.stub().callsFake((...args) => Bluebird.resolve(args[0])),
+        loadRole: sinon.stub().resolves(),
+        loadRoles: sinon.stub().resolves(),
+        validateAndSaveRole: sinon.stub().callsFake((...args) => Bluebird.resolve(args[0]))
       },
       user: {
-        load: sinon.stub().returns(Bluebird.resolve(foo)),
-        search: sinon.stub().returns(Bluebird.resolve()),
-        scroll: sinon.stub().returns(Bluebird.resolve()),
+        load: sinon.stub().resolves(foo),
+        search: sinon.stub().resolves(),
+        scroll: sinon.stub().resolves(),
         ObjectConstructor: sinon.stub().returns({}),
-        hydrate: sinon.stub().returns(Bluebird.resolve()),
-        persist: sinon.stub().returns(Bluebird.resolve({})),
+        hydrate: sinon.stub().resolves(),
+        persist: sinon.stub().resolves({}),
         anonymous: sinon.stub().returns({_id: '-1'}),
-        delete: sinon.stub().returns(Bluebird.resolve())
+        delete: sinon.stub().usingPromise(Bluebird).resolves()
       },
       token: {
         anonymous: sinon.stub().returns({_id: 'anonymous'}),
-        verifyToken: sinon.stub().returns(Bluebird.resolve()),
-        generateToken: sinon.stub().returns(Bluebird.resolve({})),
-        expire: sinon.stub().returns(Bluebird.resolve()),
-        deleteByUserId: sinon.stub().returns(Bluebird.resolve())
+        verifyToken: sinon.stub().resolves(),
+        generateToken: sinon.stub().resolves({}),
+        expire: sinon.stub().resolves(),
+        deleteByUserId: sinon.stub().resolves()
       }
     };
 
     this.rootPath = '/kuzzle';
 
     this.router = {
-      execute: sinon.stub().returns(Bluebird.resolve(foo)),
+      execute: sinon.stub().resolves(foo),
       isConnectionAlive: sinon.stub().returns(true),
       init: sinon.spy(),
-      newConnection: sinon.stub().returns(Bluebird.resolve(foo)),
+      newConnection: sinon.stub().resolves(foo),
       removeConnection: sinon.spy(),
       http: {
         route: sinon.stub()
@@ -227,70 +227,68 @@ class KuzzleMock extends Kuzzle {
     };
 
     this.services = {
-      init: sinon.stub().returns(Bluebird.resolve()),
+      init: sinon.stub().resolves(),
       list: {
         broker: {
-          getInfos: sinon.stub().returns(Bluebird.resolve()),
+          getInfos: sinon.stub().resolves(),
           listen: sinon.spy(),
-          send: sinon.stub().returns(Bluebird.resolve())
+          send: sinon.stub().resolves()
         },
         gc: {
           init: sinon.spy(),
-          run: sinon.stub().returns(Bluebird.resolve({ids: []}))
+          run: sinon.stub().resolves({ids: []})
         },
         internalCache: {
-          add: sinon.stub().returns(Bluebird.resolve()),
-          del: sinon.stub().returns(Bluebird.resolve()),
-          exists: sinon.stub().returns(Bluebird.resolve()),
-          expire: sinon.stub().returns(Bluebird.resolve()),
-          flushdb: sinon.stub().returns(Bluebird.resolve()),
-          get: sinon.stub().returns(Bluebird.resolve(null)),
-          getInfos: sinon.stub().returns(Bluebird.resolve()),
-          persist: sinon.stub().returns(Bluebird.resolve()),
-          pexpire: sinon.stub().returns(Bluebird.resolve()),
-          psetex: sinon.stub().returns(Bluebird.resolve()),
-          remove: sinon.stub().returns(Bluebird.resolve()),
-          search: sinon.stub().returns(Bluebird.resolve()),
-          searchKeys: sinon.stub().returns(Bluebird.resolve([])),
-          set: sinon.stub().returns(Bluebird.resolve()),
-          setnx: sinon.stub().returns(Bluebird.resolve()),
-          volatileSet: sinon.stub().returns(Bluebird.resolve())
+          add: sinon.stub().resolves(),
+          del: sinon.stub().resolves(),
+          exists: sinon.stub().resolves(),
+          expire: sinon.stub().resolves(),
+          flushdb: sinon.stub().resolves(),
+          get: sinon.stub().resolves(null),
+          getInfos: sinon.stub().resolves(),
+          persist: sinon.stub().resolves(),
+          pexpire: sinon.stub().resolves(),
+          psetex: sinon.stub().resolves(),
+          remove: sinon.stub().resolves(),
+          search: sinon.stub().resolves(),
+          searchKeys: sinon.stub().resolves([]),
+          set: sinon.stub().resolves(),
+          setnx: sinon.stub().resolves(),
+          volatileSet: sinon.stub().resolves()
         },
         memoryStorage: {
-          flushdb: sinon.stub().returns(Bluebird.resolve()),
-          getInfos: sinon.stub().returns(Bluebird.resolve())
+          flushdb: sinon.stub().resolves(),
+          getInfos: sinon.stub().resolves()
         },
         storageEngine: {
-          get: sinon.stub().returns(Bluebird.resolve({
-            _source: {foo}
-          })),
+          get: sinon.stub().resolves({_source: {foo}}),
           mget: sinon.stub(),
-          getInfos: sinon.stub().returns(Bluebird.resolve()),
-          getMapping: sinon.stub().returns(Bluebird.resolve(foo)),
-          listIndexes: sinon.stub().returns(Bluebird.resolve({indexes: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']})),
-          collectionExists: sinon.stub().returns(Bluebird.resolve()),
-          count: sinon.stub().returns(Bluebird.resolve(42)),
-          create: sinon.stub().returns(Bluebird.resolve(foo)),
-          createCollection: sinon.stub().returns(Bluebird.resolve(foo)),
-          createIndex: sinon.stub().returns(Bluebird.resolve(foo)),
-          createOrReplace: sinon.stub().returns(Bluebird.resolve(foo)),
-          delete: sinon.stub().returns(Bluebird.resolve(foo)),
-          deleteByQuery: sinon.stub().returns(Bluebird.resolve(Object.assign({}, foo, {ids: 'responseIds'}))),
-          deleteByQueryFromTrash: sinon.stub().returns(Bluebird.resolve(Object.assign({}, foo, {ids: 'responseIds'}))),
-          deleteIndex: sinon.stub().returns(Bluebird.resolve(foo)),
-          deleteIndexes: sinon.stub().returns(Bluebird.resolve({deleted: ['a', 'e', 'i']})),
-          getAutoRefresh: sinon.stub().returns(Bluebird.resolve(false)),
-          import: sinon.stub().returns(Bluebird.resolve(foo)),
-          indexExists: sinon.stub().returns(Bluebird.resolve()),
-          listCollections: sinon.stub().returns(Bluebird.resolve()),
-          refreshIndex: sinon.stub().returns(Bluebird.resolve(foo)),
-          replace: sinon.stub().returns(Bluebird.resolve(foo)),
-          search: sinon.stub().returns(Bluebird.resolve(foo)),
-          scroll: sinon.stub().returns(Bluebird.resolve(foo)),
-          setAutoRefresh: sinon.stub().returns(Bluebird.resolve(true)),
-          truncateCollection: sinon.stub().returns(Bluebird.resolve(foo)),
-          update: sinon.stub().returns(Bluebird.resolve(foo)),
-          updateMapping: sinon.stub().returns(Bluebird.resolve(foo))
+          getInfos: sinon.stub().resolves(),
+          getMapping: sinon.stub().resolves(foo),
+          listIndexes: sinon.stub().resolves({indexes: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']}),
+          collectionExists: sinon.stub().resolves(),
+          count: sinon.stub().resolves(42),
+          create: sinon.stub().resolves(foo),
+          createCollection: sinon.stub().resolves(foo),
+          createIndex: sinon.stub().resolves(foo),
+          createOrReplace: sinon.stub().resolves(foo),
+          delete: sinon.stub().resolves(foo),
+          deleteByQuery: sinon.stub().resolves(Object.assign({}, foo, {ids: 'responseIds'})),
+          deleteByQueryFromTrash: sinon.stub().resolves(Object.assign({}, foo, {ids: 'responseIds'})),
+          deleteIndex: sinon.stub().resolves(foo),
+          deleteIndexes: sinon.stub().resolves({deleted: ['a', 'e', 'i']}),
+          getAutoRefresh: sinon.stub().resolves(false),
+          import: sinon.stub().resolves(foo),
+          indexExists: sinon.stub().resolves(),
+          listCollections: sinon.stub().resolves(),
+          refreshIndex: sinon.stub().resolves(foo),
+          replace: sinon.stub().resolves(foo),
+          search: sinon.stub().resolves(foo),
+          scroll: sinon.stub().resolves(foo),
+          setAutoRefresh: sinon.stub().resolves(true),
+          truncateCollection: sinon.stub().resolves(foo),
+          update: sinon.stub().resolves(foo),
+          updateMapping: sinon.stub().resolves(foo)
         }
       }
     };
@@ -299,9 +297,9 @@ class KuzzleMock extends Kuzzle {
       completedRequest: sinon.spy(),
       newConnection: sinon.stub(),
       failedRequest: sinon.spy(),
-      getAllStats: sinon.stub().returns(Bluebird.resolve(foo)),
-      getLastStats: sinon.stub().returns(Bluebird.resolve(foo)),
-      getStats: sinon.stub().returns(Bluebird.resolve(foo)),
+      getAllStats: sinon.stub().resolves(foo),
+      getLastStats: sinon.stub().resolves(foo),
+      getStats: sinon.stub().resolves(foo),
       init: sinon.spy(),
       dropConnection: sinon.stub(),
       startRequest: sinon.spy()
@@ -309,14 +307,14 @@ class KuzzleMock extends Kuzzle {
 
     this.tokenManager = {
       add: sinon.stub(),
-      expire: sinon.stub().returns(Bluebird.resolve())
+      expire: sinon.stub().resolves()
     };
 
     this.validation = {
       init: sinon.spy(),
-      curateSpecification: sinon.spy(function () {return Bluebird.resolve();}),
-      validate: sinon.spy(function () {return Bluebird.resolve(arguments[0]);}),
-      validationPromise: sinon.spy(function () {return Bluebird.resolve(arguments[0]);}),
+      curateSpecification: sinon.stub().resolves(),
+      validate: sinon.stub().callsFake((...args) => Bluebird.resolve(args[0])),
+      validationPromise: sinon.stub().callsFake((...args) => Bluebird.resolve(args[0])),
       addType: sinon.spy()
     };
 

--- a/test/services/garbageCollector.test.js
+++ b/test/services/garbageCollector.test.js
@@ -46,7 +46,7 @@ describe('Test: GarbageCollector service', () => {
 
       return gc.init()
         .then(() => {
-          clock.tick(oneHour);
+          clock.tick(oneDay);
           should(gc.run).be.calledOnce();
         });
     });

--- a/test/services/internalEngine/bootstrap.test.js
+++ b/test/services/internalEngine/bootstrap.test.js
@@ -365,14 +365,14 @@ describe('services/internalEngine/bootstrap.js', () => {
     it('should take an existing seed from the db', () => {
       kuzzle.internalEngine.create
         .withArgs('config', 'security.jwt.secret')
-        .returns(Bluebird.reject(new Error('test')));
+        .rejects(new Error('test'));
       kuzzle.internalEngine.get
         .withArgs('config', 'security.jwt.secret')
-        .returns(Bluebird.resolve({
+        .resolves({
           _source: {
             seed: '42'
           }
-        }));
+        });
 
       return bootstrap.all()
         .then(() => {


### PR DESCRIPTION
# Description

I'm working on the document metadata documentations, so I had to read the documents garbage collector service, and found a few problems:

* it's started 2 times: once in the Kuzzle startup sequence, and the other instance comes from the service initializer, automatically launching the service `init` method (I don't think this code should be a "service", but requalifying it as a core module would introduce a breaking change in Kuzzle configuration files)
* only 1 timer instance was kept, but this module should really be a singleton, removing the need of keeping track of `setTimeout` calls and cleaning the timer
* it gets the list of indexes and collections from the database layer, instead of using Kuzzle's index cache 
* it tries to clean documents as soon as it is started, and I find that behavior potentially harmful in production environments
* it asks the database layer to clean all collections at once, instead of sequentially, potentially stressing the database layer especially on databases with large number of collections to clean up
* it checks if Kuzzle is overloaded only before starting the cleaning sequence, where it would be more benefical to verify Kuzzle's status before every collection clean-up, to interrupt the GC if Kuzzle becomes overloaded in the middle of the cleaning process
* the garbage collector configuration was missing from the `.kuzzlerc.sample` file

This PR fixes all these issues. Garbage collector unit tests were also converted to today's coding standards.

# Other changes

Kuzzle mock now uses `sinon` new `stub.resolves` and `stub.rejects` method, for more readability.
