### PR TITLE
Make kuzzle immune to non-thenable return values from plugins

### DIFF
--- a/lib/api/controllers/collectionController.js
+++ b/lib/api/controllers/collectionController.js
@@ -282,7 +282,7 @@ class CollectionController {
       .then(response => {
         this.kuzzle.indexCache.add(request.input.resource.index, request.input.resource.collection);
 
-        return Bluebird.resolve(response);
+        return response;
       });
   }
 }

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -371,7 +371,7 @@ class FunnelController {
       .then(newRequest => {
         modifiedRequest = newRequest;
 
-        return controllers[request.input.controller][request.input.action](newRequest);
+        return callController(controllers, newRequest);
       })
       .then(responseData => {
         modifiedRequest.setResult(responseData, {status: request.status === 102 ? 200 : request.status});
@@ -431,7 +431,8 @@ class FunnelController {
 
     this._historize(request);
 
-    controllers[request.input.controller][request.input.action](request)
+    Bluebird.resolve()
+      .then(() => callController(controllers, request))
       .then(response => {
         request.setResult(response, {status: request.status === 102 ? 200 : request.status});
         callback(null, request);
@@ -620,13 +621,33 @@ class FunnelController {
   }
 }
 
-
 /**
  * @param {string} string
  * @returns {string}
  */
 function capitalizeFirstLetter(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+/**
+ * Invoke a controller function, checking that its return
+ * value is a Promise. If not, wraps the returned value
+ * in a rejected Promise and returns it.
+ * 
+ * Used to make Kuzzle safe from badly implemented plugins
+ * 
+ * @param  {Object} controllers
+ * @param  {Request} request 
+ * @return {Promise}
+ */
+function callController(controllers, request) {
+  const ret = controllers[request.input.controller][request.input.action](request);
+
+  if (!ret || typeof ret.then !== 'function') {
+    return Bluebird.reject(new PluginImplementationError(`Unexpected return value from action ${request.input.controller}/${request.input.action}: expected a Promise`));
+  }
+
+  return ret;
 }
 
 module.exports = FunnelController;

--- a/lib/api/controllers/indexController.js
+++ b/lib/api/controllers/indexController.js
@@ -96,7 +96,7 @@ class IndexController {
       .then(response => {
         this.kuzzle.indexCache.add(request.input.resource.index);
 
-        return Bluebird.resolve(response);
+        return response;
       });
   }
 
@@ -113,7 +113,7 @@ class IndexController {
       .then(response => {
         this.kuzzle.indexCache.remove(request.input.resource.index);
 
-        return Bluebird.resolve(response);
+        return response;
       });
   }
 
@@ -147,7 +147,7 @@ class IndexController {
    */
   refreshInternal() {
     return this.kuzzle.internalEngine.refresh()
-      .then(() => Bluebird.resolve({acknowledged: true}));
+      .then(() => ({acknowledged: true}));
   }
 
   /**
@@ -176,7 +176,7 @@ class IndexController {
     assertBodyAttributeType(request, 'autoRefresh', 'boolean');
 
     return this.engine.setAutoRefresh(request)
-      .then(response => Bluebird.resolve({response}));
+      .then(response => ({response}));
   }
 
   /**

--- a/lib/api/controllers/realtimeController.js
+++ b/lib/api/controllers/realtimeController.js
@@ -26,7 +26,8 @@ const
     assertHasBody,
     assertBodyHasAttribute,
     assertHasIndexAndCollection
-  } = require('../../util/requestAssertions');
+  } = require('../../util/requestAssertions'),
+  Bluebird = require('bluebird');
 
 /**
  * @class RealtimeController
@@ -57,7 +58,7 @@ class RealtimeController {
     assertHasBody(request);
     assertBodyHasAttribute(request, 'roomId');
 
-    return this.kuzzle.hotelClerk.join(request);
+    return Bluebird.resolve(this.kuzzle.hotelClerk.join(request));
   }
 
   /**
@@ -68,7 +69,7 @@ class RealtimeController {
     assertHasBody(request);
     assertBodyHasAttribute(request, 'roomId');
 
-    return this.kuzzle.hotelClerk.removeSubscription(request);
+    return Bluebird.resolve(this.kuzzle.hotelClerk.removeSubscription(request));
   }
 
   /**
@@ -79,7 +80,7 @@ class RealtimeController {
     assertHasBody(request);
     assertBodyHasAttribute(request, 'roomId');
 
-    return this.kuzzle.hotelClerk.countSubscription(request);
+    return Bluebird.resolve(this.kuzzle.hotelClerk.countSubscription(request));
   }
 
   /**

--- a/lib/api/controllers/serverController.js
+++ b/lib/api/controllers/serverController.js
@@ -109,6 +109,7 @@ class ServerController {
       status: 'green',
       services: {}
     };
+
     return this.kuzzle.services.list.internalCache.getInfos()
       .then(() => {
         result.services.internalCache = 'green';
@@ -139,7 +140,7 @@ class ServerController {
         result.services.storageEngine = 'red';
         result.status = 'red';
       })
-      .then(() => Bluebird.resolve(result));
+      .then(() => result);
   }
 
   /**

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -427,7 +427,14 @@ class PluginsManager {
       verifyAdapter = (...args) => {
         const callback = args[args.length - 1];
 
-        return plugin.object[strategy.methods.verify](...args.slice(0, -1))
+        const ret = plugin.object[strategy.methods.verify](...args.slice(0, -1));
+
+        // catching plugins returning non-thenable content
+        if (!ret || typeof ret.then !== 'function') {
+          return callback(new PluginImplementationError(`Unexpected response from strategy "${strategyName}": expected a Promise`));
+        }
+
+        return ret
           .then(result => {
             if (result && typeof result === 'object') {
               if (result.kuid && typeof result.kuid === 'string') {

--- a/test/api/controllers/funnelController/executePluginRequest.test.js
+++ b/test/api/controllers/funnelController/executePluginRequest.test.js
@@ -154,4 +154,5 @@ describe('funnelController.executePluginRequest', () => {
 
     should(funnel.executePluginRequest(rq, true, callback)).be.eql(0);
   });
+
 });


### PR DESCRIPTION
# Description

According to the documentation, authentication and controller plugins are required to return promise objects, but no check is ever performed to make sure that this is the case: Kuzzle just assume that plugins are returning promises.

This makes Kuzzle crashes whenever a plugin returns a non-Promise object.

# Other changes

The `realtime` controller contained a few methods returning non-Promise objects. This worked with Kuzzle's API because they were called from within a promise chain, but a crash would have occured if those method were called by plugins through the `pluginContext.execute` method.
