### PR TITLE
Make plugins bootstrap cluster-friendly

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -66,6 +66,9 @@
   // (see http://kuzzle.io/guide/#plugins)
   "plugins": {
     // [Common]
+    //   * bootstrapLockTimeout
+    //        Maximum amount of time (in milliseconds)
+    //        to wait for a concurrent plugin bootstrap
     //   * pipeWarnTime:
     //        Warning time threshold (in milliseconds)
     //        on a pipe plugin action
@@ -76,6 +79,7 @@
     //        Maximum execution time (in milliseconds)
     //        of a plugin initialization
     "common": {
+      "bootstrapLockTimeout": 5000,
       "pipeWarnTime": 40,
       "pipeTimeout": 250,
       "initTimeout": 2000
@@ -350,6 +354,14 @@
         "host": "localhost",
         "port": 6379
       }
+    },
+    // [internalEngine]
+    // The database layer used internally by Kuzzle
+    //   * bootstrapLockTimeout:
+    //       Maximum amount of time (in milliseconds)
+    //       to wait for a concurrent database bootstrap
+    "internalEngine": {
+      "bootstrapLockTimeout": 5000
     },
     // 2. using a master/slaves Redis instance with Redis sentinels
     //    (cf. http://redis.io/topics/sentinel):

--- a/default.config.js
+++ b/default.config.js
@@ -55,6 +55,7 @@ module.exports = {
 
   plugins: {
     common: {
+      bootstrapLockTimeout: 5000,
       pipeWarnTime: 40,
       pipeTimeout: 250,
       initTimeout: 10000,
@@ -214,6 +215,9 @@ module.exports = {
       aliases: ['broker'],
       socket: './run/broker.sock',
       retryInterval: 1000
+    },
+    internalEngine: {
+      bootstrapLockTimeout: 5000
     },
     db: {
       aliases: ['storageEngine'],

--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -385,7 +385,7 @@ class HotelClerk {
         if (this.kuzzle.config.limits.subscriptionMinterms > 0
           && normalized.normalized.length > this.kuzzle.config.limits.subscriptionMinterms
         ) {
-          throw new SizeLimitError(`Unable to subscribe: maximum of minterms exceeded (max ${this.kuzzle.config.limits.subscriptionMinterms}, received ${normalized.normalized.length})`);
+          throw new SizeLimitError(`Unable to subscribe: maximum number of minterms exceeded (max ${this.kuzzle.config.limits.subscriptionMinterms}, received ${normalized.normalized.length})`);
         }
 
         if (this.kuzzle.config.limits.subscriptionRooms > 0 && this.roomsCount >= this.kuzzle.config.limits.subscriptionRooms) {

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -66,7 +66,7 @@ class PluginContext {
         internalEngineIndex = `%plugin:${pluginName}`.toLowerCase(),
         pluginInternalEngine = new InternalEngine(kuzzle, internalEngineIndex);
 
-      pluginInternalEngine.init(new PluginInternalEngineBootstrap(kuzzle, pluginInternalEngine));
+      pluginInternalEngine.init(new PluginInternalEngineBootstrap(pluginName, kuzzle, pluginInternalEngine));
 
       Object.defineProperty(this, 'log', {
         enumerable: true,

--- a/lib/services/internalEngine/bootstrap.js
+++ b/lib/services/internalEngine/bootstrap.js
@@ -23,6 +23,7 @@
 
 const
   Bluebird = require('bluebird'),
+  KuzzleInternalError = require('kuzzle-common-objects').errors.InternalError,
   crypto = require('crypto');
 
 const
@@ -49,7 +50,7 @@ class InternalEngineBootstrap {
 
     if (isLocked) {
       yield this.getJWTSecret();
-      return Bluebird.resolve();
+      return this._waitTillUnlocked();
     }
 
     yield this.db.createInternalIndex();
@@ -330,6 +331,23 @@ class InternalEngineBootstrap {
 
   unLock () {
     return this.db.delete('config', lockId);
+  }
+
+  _waitTillUnlocked (attempts = 0) {
+    return this.db.exists('config', lockId)
+      .then(isLocked => {
+        if (!isLocked) {
+          return;
+        }
+
+        if (attempts > 10) {
+          throw new KuzzleInternalError('Internal engine bootstrap - lock wait timeout exceeded');
+        }
+
+        return Bluebird.delay(Math.round(this.kuzzle.config.services.internalEngine.bootstrapLockTimeout / 10))
+          .then(() => this._waitTillUnlocked(attempts + 1));
+      });
+
   }
 }
 

--- a/lib/services/internalEngine/pluginBootstrap.js
+++ b/lib/services/internalEngine/pluginBootstrap.js
@@ -19,7 +19,9 @@
  * limitations under the License.
  */
 
-const Bluebird = require('bluebird');
+const
+  Bluebird = require('bluebird'),
+  PluginImplementationError = require('kuzzle-common-objects').errors.PluginImplementationError;
 
 /**
  *
@@ -28,26 +30,28 @@ const Bluebird = require('bluebird');
  * @constructor
  */
 class PluginInternalEngineBootstrap {
-  constructor(kuzzle, engine) {
+  constructor(pluginName, kuzzle, engine) {
     this.kuzzle = kuzzle;
     this.db = engine;
+    this.pluginName = pluginName;
+
+    this._lockId = `bootstrap-lock-${kuzzle.constructor.hash(this.pluginName)}`;
   }
 
-  /**
-   * Bootstraps Plugin storage engine
-   * Creates the internal index and collections if needed
-   *
-   * @returns {Promise.<T>}
-   */
   all (collections) {
-    return this.db.createInternalIndex()
-      .then(() => this.createCollections(collections))
-      .then(() => this.db.refresh())
-      .then(() => Bluebird.resolve(this.kuzzle.indexCache.add(this.db.index)))
-      .catch(error => {
-        // plugin manager is initializing, cannot use the logger
-        console.error(error, error.stack); // eslint-disable-line no-console
-        throw error;
+    return this.lock()
+      .then(isLocked => {
+        if (isLocked) {
+          return this._waitTillUnlocked();
+        }
+
+        return this.db.createInternalIndex()
+          .then(() => this.createCollections(collections))
+          .then(() => this.db.refresh())
+          .then(() => {
+            this.kuzzle.indexCache.add(this.db.index);
+            return this.unlock();
+          });
       });
   }
 
@@ -56,14 +60,48 @@ class PluginInternalEngineBootstrap {
   }
 
   createCollections (collections) {
-    const promises = [Bluebird.resolve()];
+    return Bluebird.all(Object.keys(collections).map(collection => this.createCollection(collection, collections[collection])));
+  }
 
-    Object.keys(collections).forEach(collection => {
-      promises.push(this.createCollection(collection, collections[collection]));
-    });
+  unlock () {
+    return this.kuzzle.internalEngine.delete('config', this._lockId);
+  }
 
-    return Bluebird.all(promises);
+  * _lockGen () {
+    try {
+      yield this.kuzzle.internalEngine.create('config', this._lockId, {timestamp: Date.now()});
+      return false;
+    }
+    catch (e) {
+      // lock found - check if not obsolete
+    }
+
+    const lock = yield this.kuzzle.internalEngine.get('config', this._lockId);
+    if (lock._source.timestamp < Date.now() - this.kuzzle.config.plugins.common.bootstrapLockTimeout * 2) {
+      yield this.kuzzle.internalEngine.createOrReplace('config', this._lockId, {timestamp: Date.now()});
+      return false;
+    }
+
+    return true;
+  }
+
+  _waitTillUnlocked (attempts = 0) {
+    return this.kuzzle.internalEngine.exists('config', this._lockId)
+      .then(isLocked => {
+        if (!isLocked) {
+          return;
+        }
+
+        if (attempts > 10) {
+          throw new PluginImplementationError(`Plugin ${this.pluginName} bootstrap - lock wait timeout exceeded`);
+        }
+
+        return Bluebird.delay(Math.round(this.kuzzle.config.plugins.common.bootstrapLockTimeout / 10))
+          .then(() => this._waitTillUnlocked(attempts + 1));
+      });
   }
 }
+
+PluginInternalEngineBootstrap.prototype.lock = Bluebird.coroutine(PluginInternalEngineBootstrap.prototype._lockGen);
 
 module.exports = PluginInternalEngineBootstrap;

--- a/test/api/core/hotelClerk/addSubscription.test.js
+++ b/test/api/core/hotelClerk/addSubscription.test.js
@@ -213,7 +213,7 @@ describe('Test: hotelClerk.addSubscription', () => {
         should(error)
           .be.an.instanceof(SizeLimitError);
         should(error.message)
-          .eql('Unable to subscribe: maximum of minterms exceeded (max 8, received 9)');
+          .eql('Unable to subscribe: maximum number of minterms exceeded (max 8, received 9)');
       });
   });
 

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -131,6 +131,7 @@ class KuzzleMock extends Kuzzle {
       createOrReplace: sinon.stub().resolves(),
       delete: sinon.stub().resolves(),
       deleteIndex: sinon.stub().resolves(),
+      exists: sinon.stub().resolves(),
       expire: sinon.stub().resolves(),
       get: sinon.stub().resolves(foo),
       mget: sinon.stub().resolves({hits: [foo]}),


### PR DESCRIPTION
This PR implements a mutex system for plugins bootstrap to avoid collisions during multiple Kuzzle instances starting up at the same time.
