### PR TITLE
DB layer configuration - remove deprecated traces from pre-1.0 versions

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -453,25 +453,6 @@
         "scrollTTL": "15s"
       }
     }
-    // 2. using a Elasticsearch cluster:
-    //   * hosts:
-    //         Array of nodes of the cluster.
-    //         Each item can be a string representing the hostname,
-    //         or an object with any options allowed by ES client
-    //         (see https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/host-reference.html)
-    //"db": {
-    //  "backend": "elasticsearch",
-    //  "aliases": ["storageEngine"],
-    //  "hosts": [
-    //    "http://elastic1:9200",
-    //    {"host": "elastic2", port: 9300}
-    //  ],
-    //  "apiVersion": "5.0",
-    //  "defaults": {
-    //    // Time to live of a paginated search
-    //    "scrollTTL": "15s"
-    //  }
-    //}
   },
 
   // Configuration of the Kuzzle's internal statistics module

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -1046,9 +1046,7 @@ function prepareMetadata(response) {
  * @returns {object}
  */
 function buildClient(config) {
-  let options;
-
-  // Passed to Elasticsearch's client to make it use 
+  // Passed to Elasticsearch's client to make it use
   // Bluebird instead of ES6 promises
   const defer = function defer () {
     let resolve, reject;
@@ -1061,20 +1059,7 @@ function buildClient(config) {
     return {resolve, reject, promise};
   };
 
-  if (config.client) {
-    options = Object.assign({defer}, config.client);
-  }
-  else {
-    // keep compatibility layer for the time being
-    // @todo: once the install base is clean, remove this
-    options = {
-      defer,
-      hosts: config.hosts || config.host + ':' + config.port,
-      apiVersion: config.apiVersion
-    };
-  }
-
-  return new es.Client(options);
+  return new es.Client(Object.assign({defer}, config.client));
 }
 
 /**


### PR DESCRIPTION
Removes some pseudo-compatibility layer code meant to support some older configuration formats of elasticsearch.
The new format was marked as a breaking change and the compatibility layer never worked anyway.

cf #926 