### PR TITLE
fix unexpected "out" notifications being sent

### DIFF
--- a/lib/api/core/notifier.js
+++ b/lib/api/core/notifier.js
@@ -36,7 +36,6 @@ const
 class NotifierController {
   constructor(kuzzle) {
     this.kuzzle = kuzzle;
-    this.cacheKeyPrefix = 'notif/';
   }
 
   /**
@@ -141,8 +140,8 @@ class NotifierController {
          since we have the complete document, we use the cache to avoid performing another test when
          notifying about document creations
          */
-        this.kuzzle.services.list.internalCache.add(this.cacheKeyPrefix + request.id, rooms)
-          .then(() => this.kuzzle.services.list.internalCache.expire(this.cacheKeyPrefix + request.id, 10));
+        this.kuzzle.services.list.internalCache.add(this._getDocumentKeyPrefix(request) + request.id, rooms)
+          .then(() => this.kuzzle.services.list.internalCache.expire(this._getDocumentKeyPrefix(request) + request.id, 10));
       }
 
       this.notifyDocument(rooms, request, scope, state, request.input.action, {
@@ -161,7 +160,7 @@ class NotifierController {
    * @param {object} newDocument - the newly created document
    */
   notifyDocumentCreate (request, newDocument) {
-    return this.kuzzle.services.list.internalCache.search(this.cacheKeyPrefix + request.id)
+    return this.kuzzle.services.list.internalCache.search(this._getDocumentKeyPrefix(request) + request.id)
       .then(rooms => {
         this.notifyDocument(rooms, request, 'in', 'done', 'create', {
           _meta: newDocument._meta || {},
@@ -169,7 +168,7 @@ class NotifierController {
           _id: newDocument._id
         });
 
-        return this.kuzzle.services.list.internalCache.add(this.cacheKeyPrefix + newDocument._id, rooms);
+        return this.kuzzle.services.list.internalCache.add(this._getDocumentKeyPrefix(request) + newDocument._id, rooms);
       })
       .catch(error => this.kuzzle.pluginsManager.trigger('log:error', error));
   }
@@ -185,7 +184,7 @@ class NotifierController {
   notifyDocumentReplace (request) {
     let matchedRooms;
 
-    return this.kuzzle.services.list.internalCache.search(this.cacheKeyPrefix + request.id)
+    return this.kuzzle.services.list.internalCache.search(this._getDocumentKeyPrefix(request) + request.id)
       .then(rooms => {
         const _meta = request.input.body._kuzzle_info;
         delete request.input.body._kuzzle_info;
@@ -197,7 +196,7 @@ class NotifierController {
           _id: request.input.resource._id
         });
 
-        return this.kuzzle.services.list.internalCache.search(this.cacheKeyPrefix + request.input.resource._id);
+        return this.kuzzle.services.list.internalCache.search(this._getDocumentKeyPrefix(request) + request.input.resource._id);
       })
       .then(cachedRooms => {
         const stopListening = _.difference(cachedRooms, matchedRooms);
@@ -206,9 +205,9 @@ class NotifierController {
           _id: request.input.resource._id
         });
 
-        return this.kuzzle.services.list.internalCache.remove(this.cacheKeyPrefix + request.input.resource._id, stopListening);
+        return this.kuzzle.services.list.internalCache.remove(this._getDocumentKeyPrefix(request) + request.input.resource._id, stopListening);
       })
-      .then(() => this.kuzzle.services.list.internalCache.add(this.cacheKeyPrefix + request.input.resource._id, matchedRooms))
+      .then(() => this.kuzzle.services.list.internalCache.add(this._getDocumentKeyPrefix(request) + request.input.resource._id, matchedRooms))
       .catch(error => this.kuzzle.pluginsManager.trigger('log:error', error));
   }
 
@@ -250,7 +249,7 @@ class NotifierController {
           _source: updatedDocument._source
         });
 
-        return this.kuzzle.services.list.internalCache.search(this.cacheKeyPrefix + updatedDocument._id);
+        return this.kuzzle.services.list.internalCache.search(this._getDocumentKeyPrefix(request) + updatedDocument._id);
       })
       .then(cachedRooms => {
         const
@@ -260,9 +259,9 @@ class NotifierController {
           _id: updatedDocument._id
         });
 
-        return this.kuzzle.services.list.internalCache.remove(this.cacheKeyPrefix + updatedDocument._id, stopListening);
+        return this.kuzzle.services.list.internalCache.remove(this._getDocumentKeyPrefix(request) + updatedDocument._id, stopListening);
       })
-      .then(() => this.kuzzle.services.list.internalCache.add(this.cacheKeyPrefix + updatedDocument._id, matchedRooms))
+      .then(() => this.kuzzle.services.list.internalCache.add(this._getDocumentKeyPrefix(request) + updatedDocument._id, matchedRooms))
       .catch(error => this.kuzzle.pluginsManager.trigger('log:error', error));
   }
 
@@ -396,6 +395,12 @@ class NotifierController {
           this._dispatch(channels, updatedNotification);
         });
     }
+  }
+
+  _getDocumentKeyPrefix(request) {
+    return 'notif/'
+      + request.input.resource.index + '/' 
+      + request.input.resource.collection + '/';
   }
 }
 

--- a/lib/api/core/notifier.js
+++ b/lib/api/core/notifier.js
@@ -140,8 +140,8 @@ class NotifierController {
          since we have the complete document, we use the cache to avoid performing another test when
          notifying about document creations
          */
-        this.kuzzle.services.list.internalCache.add(this._getDocumentKeyPrefix(request) + request.id, rooms)
-          .then(() => this.kuzzle.services.list.internalCache.expire(this._getDocumentKeyPrefix(request) + request.id, 10));
+        this.kuzzle.services.list.internalCache.add(this._getKeyPrefix(request) + request.id, rooms)
+          .then(() => this.kuzzle.services.list.internalCache.expire(this._getKeyPrefix(request) + request.id, 10));
       }
 
       this.notifyDocument(rooms, request, scope, state, request.input.action, {
@@ -160,7 +160,7 @@ class NotifierController {
    * @param {object} newDocument - the newly created document
    */
   notifyDocumentCreate (request, newDocument) {
-    return this.kuzzle.services.list.internalCache.search(this._getDocumentKeyPrefix(request) + request.id)
+    return this.kuzzle.services.list.internalCache.search(this._getKeyPrefix(request) + request.id)
       .then(rooms => {
         this.notifyDocument(rooms, request, 'in', 'done', 'create', {
           _meta: newDocument._meta || {},
@@ -168,7 +168,7 @@ class NotifierController {
           _id: newDocument._id
         });
 
-        return this.kuzzle.services.list.internalCache.add(this._getDocumentKeyPrefix(request) + newDocument._id, rooms);
+        return this.kuzzle.services.list.internalCache.add(this._getKeyPrefix(request) + newDocument._id, rooms);
       })
       .catch(error => this.kuzzle.pluginsManager.trigger('log:error', error));
   }
@@ -184,7 +184,7 @@ class NotifierController {
   notifyDocumentReplace (request) {
     let matchedRooms;
 
-    return this.kuzzle.services.list.internalCache.search(this._getDocumentKeyPrefix(request) + request.id)
+    return this.kuzzle.services.list.internalCache.search(this._getKeyPrefix(request) + request.id)
       .then(rooms => {
         const _meta = request.input.body._kuzzle_info;
         delete request.input.body._kuzzle_info;
@@ -196,7 +196,7 @@ class NotifierController {
           _id: request.input.resource._id
         });
 
-        return this.kuzzle.services.list.internalCache.search(this._getDocumentKeyPrefix(request) + request.input.resource._id);
+        return this.kuzzle.services.list.internalCache.search(this._getKeyPrefix(request) + request.input.resource._id);
       })
       .then(cachedRooms => {
         const stopListening = _.difference(cachedRooms, matchedRooms);
@@ -205,9 +205,9 @@ class NotifierController {
           _id: request.input.resource._id
         });
 
-        return this.kuzzle.services.list.internalCache.remove(this._getDocumentKeyPrefix(request) + request.input.resource._id, stopListening);
+        return this.kuzzle.services.list.internalCache.remove(this._getKeyPrefix(request) + request.input.resource._id, stopListening);
       })
-      .then(() => this.kuzzle.services.list.internalCache.add(this._getDocumentKeyPrefix(request) + request.input.resource._id, matchedRooms))
+      .then(() => this.kuzzle.services.list.internalCache.add(this._getKeyPrefix(request) + request.input.resource._id, matchedRooms))
       .catch(error => this.kuzzle.pluginsManager.trigger('log:error', error));
   }
 
@@ -249,7 +249,7 @@ class NotifierController {
           _source: updatedDocument._source
         });
 
-        return this.kuzzle.services.list.internalCache.search(this._getDocumentKeyPrefix(request) + updatedDocument._id);
+        return this.kuzzle.services.list.internalCache.search(this._getKeyPrefix(request) + updatedDocument._id);
       })
       .then(cachedRooms => {
         const
@@ -259,9 +259,9 @@ class NotifierController {
           _id: updatedDocument._id
         });
 
-        return this.kuzzle.services.list.internalCache.remove(this._getDocumentKeyPrefix(request) + updatedDocument._id, stopListening);
+        return this.kuzzle.services.list.internalCache.remove(this._getKeyPrefix(request) + updatedDocument._id, stopListening);
       })
-      .then(() => this.kuzzle.services.list.internalCache.add(this._getDocumentKeyPrefix(request) + updatedDocument._id, matchedRooms))
+      .then(() => this.kuzzle.services.list.internalCache.add(this._getKeyPrefix(request) + updatedDocument._id, matchedRooms))
       .catch(error => this.kuzzle.pluginsManager.trigger('log:error', error));
   }
 
@@ -397,7 +397,7 @@ class NotifierController {
     }
   }
 
-  _getDocumentKeyPrefix(request) {
+  _getKeyPrefix(request) {
     return 'notif/'
       + request.input.resource.index + '/' 
       + request.input.resource.collection + '/';

--- a/test/api/core/notifier/notifyDocumentReplace.test.js
+++ b/test/api/core/notifier/notifyDocumentReplace.test.js
@@ -56,14 +56,25 @@ describe('Test: notifier.notifyDocumentReplace', () => {
           });
 
         should(internalCache.search.callCount).be.eql(2);
-        should(internalCache.search.getCall(0)).calledWith(notifier.cacheKeyPrefix + request.id);
-        should(internalCache.search.getCall(1)).calledWith(notifier.cacheKeyPrefix + request.input.resource._id);
+        should(internalCache.search.getCall(0)).calledWith(
+          `notif/${request.input.resource.index}/${request.input.resource.collection}/${request.id}`
+        );
+
+        should(internalCache.search.getCall(1)).calledWith(
+          `notif/${request.input.resource.index}/${request.input.resource.collection}/${request.input.resource._id}`
+        );
 
         should(internalCache.remove).calledOnce();
-        should(internalCache.remove).calledWith(notifier.cacheKeyPrefix + request.input.resource._id, ['bar']);
+        should(internalCache.remove).calledWith(
+          `notif/${request.input.resource.index}/${request.input.resource.collection}/${request.input.resource._id}`, 
+          ['bar']
+        );
 
         should(internalCache.add).calledOnce();
-        should(internalCache.add).calledWith(notifier.cacheKeyPrefix + request.input.resource._id, ['foo']);
+        should(internalCache.add).calledWith(
+          `notif/${request.input.resource.index}/${request.input.resource.collection}/${request.input.resource._id}`, 
+          ['foo']
+        );
       });
   });
 });

--- a/test/api/core/notifier/notifyDocumentUpdate.test.js
+++ b/test/api/core/notifier/notifyDocumentUpdate.test.js
@@ -66,16 +66,16 @@ describe('Test: notifier.notifyDocumentUpdate', () => {
 
         should(kuzzle.services.list.internalCache.search)
           .calledOnce()
-          .calledWith(notifier.cacheKeyPrefix + request.input.resource._id);
+          .calledWith(`notif/${request.input.resource.index}/${request.input.resource.collection}/${request.input.resource._id}`);
 
         should(kuzzle.services.list.internalCache.remove)
           .calledOnce()
-          .calledWith(notifier.cacheKeyPrefix + request.input.resource._id);
+          .calledWith(`notif/${request.input.resource.index}/${request.input.resource.collection}/${request.input.resource._id}`);
 
 
         should(kuzzle.services.list.internalCache.add)
           .calledOnce()
-          .calledWith(notifier.cacheKeyPrefix + request.input.resource._id);
+          .calledWith(`notif/${request.input.resource.index}/${request.input.resource.collection}/${request.input.resource._id}`);
       });
   });
 });


### PR DESCRIPTION
# Description

For any given document having generated a real-time notification, the notifier core component stores the corresponding list of rooms, to make it able to detect whenever that document exits a room's scope after being updated, replaced or deleted.

There is a bug in that mechanism: it is possible for subscribers to receive unexpected `scope: out` notifications after a document in another collection than the subscription has been changed.

To reproduce:
* subscribe to a collection
* create a document with a specific ID in that collection (this correctly generates a `scope: in` notification)
* update **another** document, in a **different** collection, but with the same document unique ID => the previously made subscription receive  a `scope: out` notification (with empty content)

# Why

The problem lies in the generated cache key used to store the `scope: in` notifications: it only contains the document identifier, saying nothing about its parent collection.
So, in the example above, the notifier core component retrieves the list of rooms having previously matched a document with the same identifier than the one currently examined, but in a different collection, and with no way to tell the difference.

# Changes

The cache key is now a composition of the following information:
* document's index
* document's collection
* document unique identifier
