### PR TITLE
security* - add refresh option

### DIFF
--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -640,7 +640,8 @@ class SecurityController {
     const options = {
       database: {
         method: 'update',
-        refresh: request.input.args.refresh
+        refresh: request.input.args.refresh,
+        retryOnConflict: request.input.args.retryOnConflict
       }
     };
 
@@ -706,7 +707,8 @@ class SecurityController {
 
     const options = {
       method: 'update',
-      refresh: request.input.args.refresh
+      refresh: request.input.args.refresh,
+      retryOnConflict: request.input.args.retryOnConflict
     };
 
     return this.kuzzle.repositories.profile.loadProfile(request.input.resource._id)
@@ -727,7 +729,8 @@ class SecurityController {
 
     const options = {
       method: 'update',
-      refresh: request.input.args.refresh
+      refresh: request.input.args.refresh,
+      retryOnConflict: request.input.args.retryOnConflict
     };
 
     return this.kuzzle.repositories.role.loadRole(request.input.resource._id)

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -106,9 +106,15 @@ const persistUser = Bluebird.coroutine(function* persistUserGenerator (kuzzle, r
     updater: null
   };
 
+  const options = {
+    database: {
+      method: 'create',
+      refresh: request.input.args.refresh
+    }
+  };
   // Throw in case of failure with the right KuzzleError object
   const createdUser = yield kuzzle.repositories.user.hydrate(new User(), pojoUser)
-    .then(modifiedUser => kuzzle.repositories.user.persist(modifiedUser, {database: {method: 'create'}}))
+    .then(modifiedUser => kuzzle.repositories.user.persist(modifiedUser, options))
     .then(modifiedUser => formatProcessing.formatUserForSerialization(kuzzle, modifiedUser));
 
   // Creating credentials
@@ -151,7 +157,7 @@ const persistUser = Bluebird.coroutine(function* persistUserGenerator (kuzzle, r
       });
   }
 
-  return kuzzle.repositories.user.delete(pojoUser._id)
+  return kuzzle.repositories.user.delete(pojoUser._id, {refresh: request.input.args.refresh})
     .finally(() => {
       throw new PluginImplementationError(
         `An error occurred during the creation of user "${pojoUser._id}":\n` 
@@ -164,7 +170,7 @@ const persistUser = Bluebird.coroutine(function* persistUserGenerator (kuzzle, r
  * @param {Kuzzle} kuzzle 
  * @param {Request} request 
  */
-const removeUser = Bluebird.coroutine(function* removeUserGenerator (kuzzle, request) {
+const removeUserStrategies = Bluebird.coroutine(function* removeUserGenerator (kuzzle, request) {
   const
     availableStrategies = kuzzle.pluginsManager.listStrategies(),
     userStrategies = [],
@@ -342,7 +348,7 @@ class SecurityController {
     assertHasBody(request);
     assertHasId(request);
 
-    return createOrReplaceRole(this.kuzzle.repositories.role, request, {method: 'createOrReplace'})
+    return createOrReplaceRole(this.kuzzle.repositories.role, request, {method: 'createOrReplace', refresh: request.input.args.refresh})
       .then(role => formatProcessing.formatRoleForSerialization(role));
   }
 
@@ -357,7 +363,7 @@ class SecurityController {
     assertHasId(request);
     assertIdStartsNotUnderscore(request);
 
-    return createOrReplaceRole(this.kuzzle.repositories.role, request, {method: 'create'})
+    return createOrReplaceRole(this.kuzzle.repositories.role, request, {method: 'create', refresh: request.input.args.refresh})
       .then(role => formatProcessing.formatRoleForSerialization(role));
   }
 
@@ -425,7 +431,7 @@ class SecurityController {
     assertHasId(request);
     assertIdStartsNotUnderscore(request);
 
-    return createOrReplaceProfile(this.kuzzle.repositories.profile, request, {method: 'createOrReplace'})
+    return createOrReplaceProfile(this.kuzzle.repositories.profile, request, {method: 'createOrReplace', refresh: request.input.args.refresh})
       .then(profile => formatProcessing.formatProfileForSerialization(profile));
   }
 
@@ -442,7 +448,7 @@ class SecurityController {
     assertHasId(request);
     assertIdStartsNotUnderscore(request);
 
-    return createOrReplaceProfile(this.kuzzle.repositories.profile, request, {method: 'create'})
+    return createOrReplaceProfile(this.kuzzle.repositories.profile, request, {method: 'create', refresh: request.input.args.refresh})
       .then(profile => formatProcessing.formatProfileForSerialization(profile));
   }
 
@@ -568,7 +574,7 @@ class SecurityController {
 
     return this.kuzzle.repositories.user.delete(request.input.resource._id, {refresh: request.input.args.refresh})
       .then(() => this.kuzzle.repositories.token.deleteByUserId(request.input.resource._id))
-      .then(() => removeUser(this.kuzzle, request))
+      .then(() => removeUserStrategies(this.kuzzle, request))
       .then(() => ({ _id: request.input.resource._id}));
   }
 
@@ -631,6 +637,13 @@ class SecurityController {
     assertHasBody(request);
     assertHasId(request);
 
+    const options = {
+      database: {
+        method: 'update',
+        refresh: request.input.args.refresh
+      }
+    };
+
     return this.kuzzle.repositories.user.load(request.input.resource._id)
       .then(user => updateMetadata(user, request))
       .then(user => {
@@ -638,7 +651,7 @@ class SecurityController {
         pojo._id = request.input.resource._id;
         return this.kuzzle.repositories.user.hydrate(user, pojo);
       })
-      .then(user => this.kuzzle.repositories.user.persist(user, {database: {method: 'update'}}))
+      .then(user => this.kuzzle.repositories.user.persist(user, options))
       .then(updatedUser => formatProcessing.formatUserForSerialization(this.kuzzle, updatedUser));
   }
 
@@ -667,10 +680,17 @@ class SecurityController {
       updater: null
     };
 
+    const options = {
+      database: {
+        method: 'replace',
+        refresh: request.input.args.refresh
+      }
+    };
+
     return this.kuzzle.repositories.user.load(request.input.resource._id)
       .then(loadedUser => (!loadedUser) ? Bluebird.reject(new NotFoundError(`User with id ${request.input.resource._id} not found`)) : Bluebird.resolve())
       .then(() => this.kuzzle.repositories.user.hydrate(user, pojoUser))
-      .then(updatedUser => this.kuzzle.repositories.user.persist(updatedUser, {database: {method: 'replace'}}))
+      .then(updatedUser => this.kuzzle.repositories.user.persist(updatedUser, options))
       .then(createdUser => formatProcessing.formatUserForSerialization(this.kuzzle, createdUser));
   }
 
@@ -684,9 +704,14 @@ class SecurityController {
     assertHasBody(request);
     assertHasId(request);
 
+    const options = {
+      method: 'update',
+      refresh: request.input.args.refresh
+    };
+
     return this.kuzzle.repositories.profile.loadProfile(request.input.resource._id)
       .then(profile => updateMetadata(profile, request))
-      .then(profile => this.kuzzle.repositories.profile.validateAndSaveProfile(_.extend(profile, request.input.body), {method: 'update'}))
+      .then(profile => this.kuzzle.repositories.profile.validateAndSaveProfile(_.extend(profile, request.input.body), options))
       .then(updatedProfile => formatProcessing.formatProfileForSerialization(updatedProfile));
   }
 
@@ -700,9 +725,14 @@ class SecurityController {
     assertHasBody(request);
     assertHasId(request);
 
+    const options = {
+      method: 'update',
+      refresh: request.input.args.refresh
+    };
+
     return this.kuzzle.repositories.role.loadRole(request.input.resource._id)
       .then(role => updateMetadata(role, request))
-      .then(role => this.kuzzle.repositories.role.validateAndSaveRole(_.extend(role, request.input.body), {method: 'update'}))
+      .then(role => this.kuzzle.repositories.role.validateAndSaveRole(_.extend(role, request.input.body), options))
       .then(updatedRole => formatProcessing.formatRoleForSerialization(updatedRole));
   }
 

--- a/lib/services/internalEngine/index.js
+++ b/lib/services/internalEngine/index.js
@@ -332,6 +332,12 @@ class InternalEngine {
     if (options.refresh === 'wait_for') {
       request.refresh = 'wait_for';
     }
+    if (options.retryOnConflict !== undefined) {
+      request.retryOnConflict = options.retryOnConflict;
+    }
+    else {
+      request.retryOnConflict = this.config.defaults.onUpdateConflictRetries;
+    }
 
     return this.client.update(request)
       .catch(error => Bluebird.reject(this.esWrapper.formatESError(error)));

--- a/test/api/controllers/securityController/profiles.test.js
+++ b/test/api/controllers/securityController/profiles.test.js
@@ -89,6 +89,24 @@ describe('Test: security controller - profiles', () => {
       return should(securityController.createOrReplaceProfile(new Request({_id: 'test', body: {policies: ['role1']}})))
         .be.rejectedWith(error);
     });
+
+    it('should forward refresh option', () => {
+      kuzzle.repositories.profile.validateAndSaveProfile = sandbox.stub().returns(Promise.resolve({_id: 'test', _source: {}, _meta: {}}));
+
+      return securityController.createOrReplaceProfile(new Request({
+        _id: 'test',
+        body: {
+          policies: [{roleId: 'role1'}]
+        },
+        refresh: 'wait_for'
+      }))
+        .then(() => {
+          should(kuzzle.repositories.profile.validateAndSaveProfile.firstCall.args[1])
+            .match({
+              refresh: 'wait_for'
+            });
+        });
+    });
   });
 
   describe('#createProfile', () => {
@@ -111,6 +129,26 @@ describe('Test: security controller - profiles', () => {
       return should(() => {
         securityController.createOrReplaceProfile(new Request({_id: 'badTest', body: {roleId: 'test', policies: 'not-an-array-roleIds'}}));
       }).throw(BadRequestError);
+    });
+
+    it('should forward refresh option', () => {
+      kuzzle.repositories.profile.validateAndSaveProfile = sandbox.stub().returns(Promise.resolve({_id: 'test', _source: {}, _meta: {}}));
+
+      return securityController.createProfile(new Request({
+        _id: 'test',
+        body: {
+          policies: [{roleId:'role1'}]
+        },
+        refresh: 'wait_for'
+      }))
+        .then(() => {
+          const options = kuzzle.repositories.profile.validateAndSaveProfile.firstCall.args[1];
+
+          should(options)
+            .match({
+              refresh: 'wait_for'
+            });
+        });
     });
   });
 
@@ -311,6 +349,27 @@ describe('Test: security controller - profiles', () => {
       return should(() => {
         securityController.updateProfile(new Request({body: {}}));
       }).throw(BadRequestError);
+    });
+
+    it('should forward refresh option', () => {
+      kuzzle.repositories.profile.loadProfile = sandbox.stub().returns(Promise.resolve({}));
+      kuzzle.repositories.profile.validateAndSaveProfile = sandbox.stub().returns(Promise.resolve({_id: 'test'}));
+
+      return securityController.updateProfile(new Request({
+        _id: 'test',
+        body: {
+          foo: 'bar'
+        },
+        refresh: 'wait_for'
+      }))
+        .then(() => {
+          const options = kuzzle.repositories.profile.validateAndSaveProfile.firstCall.args[1];
+
+          should(options)
+            .match({
+              refresh: 'wait_for'
+            });
+        });
     });
   });
 

--- a/test/api/controllers/securityController/roles.test.js
+++ b/test/api/controllers/securityController/roles.test.js
@@ -19,11 +19,12 @@ describe('Test: security controller - roles', () => {
     securityController;
 
   before(() => {
-    kuzzle = new KuzzleMock();
-    securityController = new SecurityController(kuzzle);
   });
 
   beforeEach(() => {
+    kuzzle = new KuzzleMock();
+    securityController = new SecurityController(kuzzle);
+
     request = new Request({controller: 'security'});
     kuzzle.internalEngine.get = sandbox.stub().returns(Promise.resolve({}));
     kuzzle.internalEngine.getMapping = sinon.stub().returns(Promise.resolve({internalIndex: {mappings: {roles: {properties: {}}}}}));
@@ -84,14 +85,28 @@ describe('Test: security controller - roles', () => {
       return should(securityController.createOrReplaceRole(new Request({_id: 'alreadyExists', body: {indexes: {}}})))
         .be.rejectedWith(new Error('Mocked error'));
     });
+
+    it('should forward refresh option', () => {
+      kuzzle.repositories.role.validateAndSaveRole = sandbox.stub().returns(Promise.resolve({_id: 'test'}));
+
+      return securityController.createOrReplaceRole(new Request({
+        _id: 'test',
+        body: {
+          controllers: {}
+        },
+        refresh: 'wait_for'
+      }))
+        .then(() => {
+          const options = kuzzle.repositories.role.validateAndSaveRole.firstCall.args[1];
+
+          should(options).match({
+            refresh: 'wait_for'
+          });
+        });
+    });
   });
 
   describe('#createRole', () => {
-    it('should reject when a role already exists with the id', () => {
-      return should(securityController.createRole(new Request({_id: 'alreadyExists', body: {controllers: {}}})))
-        .be.rejectedWith(new Error('Mocked error'));
-    });
-
     it('should resolve to an object on a createRole call', () => {
       kuzzle.repositories.role.validateAndSaveRole = sandbox.stub().returns(Promise.resolve({_id: 'test'}));
       return should(securityController.createRole(new Request({_id: 'test', body: {controllers: {}}})))
@@ -180,7 +195,7 @@ describe('Test: security controller - roles', () => {
   });
 
   describe('#updateRole', () => {
-    it('should return a valid response', done => {
+    it('should return a valid response', () => {
       kuzzle.repositories.role.loadRole = sandbox.stub().returns(Promise.resolve({_id: 'test'}));
       kuzzle.repositories.role.roles = [];
 
@@ -192,14 +207,11 @@ describe('Test: security controller - roles', () => {
         return Promise.resolve(role);
       };
 
-      securityController.updateRole(new Request({_id: 'test', body: {foo: 'bar'}}))
+      return securityController.updateRole(new Request({_id: 'test', body: {foo: 'bar'}}))
         .then(response => {
           should(response).be.instanceof(Object);
           should(response._id).be.exactly('test');
-
-          done();
-        })
-        .catch(err => { done(err); });
+        });
     });
 
     it('should throw an error if no id is given', () => {
@@ -211,6 +223,27 @@ describe('Test: security controller - roles', () => {
     it('should reject the promise if the role cannot be found in the database', () => {
       kuzzle.repositories.role.loadRole = sandbox.stub().returns(Promise.resolve(null));
       return should(securityController.updateRole(new Request({_id: 'badId', body: {}, context: {action: 'updateRole'}}))).be.rejected();
+    });
+
+    it('should forward refresh option', () => {
+      kuzzle.repositories.role.loadRole = sandbox.stub().returns(Promise.resolve({_id: 'test'}));
+      kuzzle.repositories.role.roles = [];
+
+      kuzzle.repositories.role.validateAndSaveRole = sinon.stub().returnsArg(0);
+
+      return securityController.updateRole(new Request({
+        _id: 'test',
+        body: {
+          foo: 'bar'
+        },
+        refresh: 'wait_for'
+      }))
+        .then(() => {
+          const options = kuzzle.repositories.role.validateAndSaveRole.firstCall.args[1];
+          should(options).match({
+            refresh: 'wait_for'
+          });
+        });
     });
   });
 
@@ -231,6 +264,26 @@ describe('Test: security controller - roles', () => {
     it('should reject the promise if attempting to delete one of the core roles', () => {
       kuzzle.repositories.role.deleteRole = sandbox.stub().returns(Promise.reject(new Error('admin is one of the basic roles of Kuzzle, you cannot delete it, but you can edit it.')));
       return should(securityController.deleteRole(new Request({_id: 'admin',body: {}}))).be.rejected();
+    });
+
+    it('should forward refresh option', () => {
+      const role = {my: 'role'};
+
+      kuzzle.repositories.role.getRoleFromRequest = sandbox.stub().returns(role);
+      kuzzle.repositories.role.deleteRole = sandbox.stub().returns(Promise.resolve());
+
+      return securityController.deleteRole(new Request({
+        _id: 'test',
+        body: {},
+        refresh: 'wait_for'
+      }))
+        .then(() => {
+          const options = kuzzle.repositories.role.deleteRole.firstCall.args[1];
+
+          should(options).match({
+            refresh: 'wait_for'
+          });
+        });
     });
   });
 


### PR DESCRIPTION
Fixes #980

Allows users to use a `refresh` option on the `security` controller actions.