### PR TITLE
increase default ping timeout

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -253,7 +253,7 @@
       "host": "localhost",
       "port": 7331,
       "pingInterval": 60000,
-      "pingTimeout": 50,
+      "pingTimeout": 500,
       "resendClientListDelay": 1000,
       "retryInterval": 1000
     },
@@ -440,7 +440,7 @@
       "aliases": ["broker"],
       "host": "localhost",
       "pingInterval": 60000,
-      "pingTimeout": 50,
+      "pingTimeout": 500,
       "port": 7911,
       "retryInterval": 1000
     },

--- a/default.config.js
+++ b/default.config.js
@@ -227,7 +227,6 @@ module.exports = {
         scrollTTL: '15s'
       }
     },
-
     garbageCollector: {
       cleanInterval: 86400000,
       maxDelete: 1000

--- a/lib/services/broker/wsBrokerClient.js
+++ b/lib/services/broker/wsBrokerClient.js
@@ -43,7 +43,7 @@ class WSBrokerClient {
     this.eventName = brokerType;
     this.notifyOnListen = notifyOnListen;
 
-    this._pingTimeout = options.pingTimeout || 50;
+    this._pingTimeout = options.pingTimeout || 500;
     this._pingInterval = options.pingInterval || 1000 * 60;
     this._pingRequestTimeoutId = null;
     this._pingRequestIntervalId = null;

--- a/test/services/implementations/broker.test.js
+++ b/test/services/implementations/broker.test.js
@@ -608,7 +608,7 @@ describe('Test: Internal broker', () => {
             should(client._pingRequestTimeoutId)
               .be.not.equal(null, 'ping response timeout should be registered');
 
-            clock.tick(51);
+            clock.tick(501);
 
             should(client.retryConnection)
               .be.calledOnce();


### PR DESCRIPTION
Increase default WebSocket ping timeout.

Too-low values can cause some issues when using Kuzzle proxy with some network latency and prevent in extreme cases Kuzzle to connect the proxy.