### PR TITLE
Embedded entry point - graceful shutdown

### DIFF
--- a/lib/api/core/entrypoints/embedded/index.js
+++ b/lib/api/core/entrypoints/embedded/index.js
@@ -30,7 +30,8 @@ const
   http = require('http'),
   HttpProtocol = require('./protocols/http'),
   {
-    InternalError: KuzzleInternalError
+    InternalError: KuzzleInternalError,
+    ServiceUnavailableError
   } = require('kuzzle-common-objects').errors,
   WebSocketProtocol = require('./protocols/websocket'),
   SocketIoProtocol = require('./protocols/socketio'),
@@ -54,6 +55,8 @@ class EmbeddedEntryPoint extends EntryPoint {
     this.clients = {};
 
     this.logger = null;
+
+    this.isShuttingDown = false;
   }
 
   dispatch (event, data) {
@@ -64,7 +67,7 @@ class EmbeddedEntryPoint extends EntryPoint {
       return this._broadcast(data);
     }
     else if (event === 'shutdown') {
-      // do nothing (already handled by kuzzle, kept for backward compatiblity).
+      this.isShuttingDown = true;
       return;
     }
 
@@ -371,6 +374,10 @@ class EmbeddedEntryPoint extends EntryPoint {
    * @param cb
    */
   execute (request, cb) {
+    if (this.isShuttingDown) {
+      return this._isShuttingDownError(request, cb);
+    }
+
     this.kuzzle.funnel.execute(request, (error, result) => {
       if (error && !result.error) {
         result.setError(error);
@@ -428,6 +435,13 @@ class EmbeddedEntryPoint extends EntryPoint {
         this.kuzzle.pluginsManager.trigger('log:error', `[broadcast] protocol ${protoKey} failed: ${e.message}`);
       }
     }
+  }
+
+  _isShuttingDownError (request, cb) {
+    request.setError(new ServiceUnavailableError('Kuzzle is shutting down'));
+    this.logAccess(request);
+
+    cb(this.constructor._removeErrorStack(request.response.toJSON()));
   }
 
   _notify (data) {

--- a/test/api/core/entrypoints/embedded/index.test.js
+++ b/test/api/core/entrypoints/embedded/index.test.js
@@ -3,7 +3,8 @@
 const
   Bluebird = require('bluebird'),
   {
-    InternalError: KuzzleInternalError
+    InternalError: KuzzleInternalError,
+    ServiceUnavailableError
   } = require('kuzzle-common-objects').errors,
   KuzzleMock = require('../../../../mocks/kuzzle.mock'),
   mockrequire = require('mock-require'),
@@ -123,7 +124,7 @@ describe('lib/core/api/core/entrypoints/embedded/index', () => {
       });
     });
 
-    it('should try to return an error if one recieved without any response', (done) => {
+    it('should try to return an error if one received without any response', (done) => {
       const error = new KuzzleInternalError('test');
       kuzzle.funnel.execute = (request, cb) => cb(error, request);
 
@@ -134,7 +135,19 @@ describe('lib/core/api/core/entrypoints/embedded/index', () => {
 
         done();
       });
+    });
 
+    it('should refuse incoming requests if shutting down', (done) => {
+      entrypoint.dispatch('shutdown');
+
+      const request = new Request({});
+      entrypoint.execute(request, response => {
+        should(response.status).eql(503);
+        should(response.content.error)
+          .be.an.instanceof(ServiceUnavailableError);
+
+        done();
+      });
     });
   });
 


### PR DESCRIPTION
This PR enables the ability to gracefully shut kuzzle down while using embedded entrypoints (=without proxy).

Related issue: #923 