### PR TITLE
compose - es java heap to 512m

### DIFF
--- a/docker-compose/dev.yml
+++ b/docker-compose/dev.yml
@@ -39,12 +39,8 @@ services:
     image: redis:3.2
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.4.1
+    image: kuzzleio/elasticsearch:5.4.1
     environment:
       - cluster.name=kuzzle
-      # disable xpack
-      - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
-      - xpack.graph.enabled=false
-      - xpack.watcher.enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
 

--- a/docker-compose/test.yml
+++ b/docker-compose/test.yml
@@ -42,12 +42,8 @@ services:
     image: redis:3.2
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.4.1
+    image: kuzzleio/elasticsearch:5.4.1
     environment:
       - cluster.name=kuzzle
-      # disable xpack
-      - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
-      - xpack.graph.enabled=false
-      - xpack.watcher.enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
 


### PR DESCRIPTION
By default, reduce elasticsearch java heap space from 2g down to 512m