### PR TITLE
Log protocols init failures

### DIFF
--- a/lib/api/core/entrypoints/embedded/index.js
+++ b/lib/api/core/entrypoints/embedded/index.js
@@ -164,6 +164,10 @@ class EmbeddedEntryPoint extends EntryPoint {
 
       promises.push(Bluebird.resolve()
         .then(() => protocol.init(this, new Context(this.kuzzle)))
+        .catch(error => {
+          this.kuzzle.pluginsManager.trigger('log:error', `Error during "${name}" protocol init:`);
+          throw error;
+        })
         .timeout(this.kuzzle.config.services.common.defaultInitTimeout)
         .then(() => {
           this.protocols[name] = protocol;

--- a/test/api/core/entrypoints/embedded/index.test.js
+++ b/test/api/core/entrypoints/embedded/index.test.js
@@ -134,7 +134,6 @@ describe('lib/core/api/core/entrypoints/embedded/index', () => {
 
         done();
       });
-
     });
   });
 
@@ -440,6 +439,30 @@ describe('lib/core/api/core/entrypoints/embedded/index', () => {
         should(requireStub)
           .be.calledTwice();
 
+      });
+    });
+
+    it('should log and reject if an error occured', () => {
+      mockrequire('fs', {
+        existsSync: sinon.stub().returns(true),
+        readdirSync: sinon.stub().returns(['protocol']),
+        statSync: sinon.stub().returns({isDirectory: () => true})
+      });
+
+      mockrequire.reRequire('../../../../../lib/api/core/entrypoints/embedded');
+      const Rewired = rewire('../../../../../lib/api/core/entrypoints/embedded');
+
+      const requireStub = sinon.stub().returns(function () {
+        this.init = sinon.stub().throws(Error('test'));
+      });
+
+      return Rewired.__with__({
+        require: requireStub
+      })(() => {
+        const ep = new Rewired(kuzzle);
+
+        should(ep.loadMoreProtocols())
+          .be.rejectedWith('test');
       });
     });
   });


### PR DESCRIPTION
This PR adds a log message that identify protocols that might fail to init.

Related issue: #989 