### PR TITLE
Allow strict mapping definition

### DIFF
--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -38,6 +38,18 @@ const
   } = require('kuzzle-common-objects').errors;
 
 const scrollCachePrefix = '_docscroll_';
+const kuzzleInfoMapping = {
+  _kuzzle_info: {
+    properties: {
+      active: {type: 'boolean'},
+      author: {type: 'keyword'},
+      createdAt: {type: 'date'},
+      updatedAt: {type: 'date'},
+      updater: {type: 'keyword'},
+      deletedAt: {type: 'date'}
+    }
+  }
+};
 
 /**
  * @property {Kuzzle} kuzzle
@@ -564,7 +576,9 @@ class ElasticSearch extends Service {
     const esRequest = initESRequest(request);
 
     esRequest.body = {
-      [esRequest.type]: {}
+      [esRequest.type]: {
+        properties: kuzzleInfoMapping
+      }
     };
 
     if (!this.kuzzle.indexCache.exists(esRequest.index)) {
@@ -693,6 +707,10 @@ class ElasticSearch extends Service {
     const esRequest = initESRequest(request);
 
     esRequest.body = request.input.body;
+    if (!esRequest.body.properties) {
+      esRequest.body.properties = {};
+    }
+    esRequest.body.properties._kuzzle_info = kuzzleInfoMapping._kuzzle_info;
 
     return this.client.indices.putMapping(esRequest)
       .catch(error => Bluebird.reject(this.esWrapper.formatESError(error)));

--- a/lib/services/internalEngine/bootstrap.js
+++ b/lib/services/internalEngine/bootstrap.js
@@ -82,32 +82,6 @@ class InternalEngineBootstrap {
       properties: {
         controllers: {
           enabled: false
-        },
-        _kuzzle_info: {
-          properties: {
-            author: {
-              type: 'text',
-              fields: {
-                keyword: {
-                  type: 'keyword'
-                }
-              }
-            },
-            createdAt: {
-              type: 'long'
-            },
-            updatedAt: {
-              type: 'long'
-            },
-            updater: {
-              type: 'text',
-              fields: {
-                keyword: {
-                  type: 'keyword'
-                }
-              }
-            }
-          }
         }
       }
     })
@@ -148,32 +122,6 @@ class InternalEngineBootstrap {
               type: 'keyword'
             }
           }
-        },
-        _kuzzle_info: {
-          properties: {
-            author: {
-              type: 'text',
-              fields: {
-                keyword: {
-                  type: 'keyword'
-                }
-              }
-            },
-            createdAt: {
-              type: 'long'
-            },
-            updatedAt: {
-              type: 'long'
-            },
-            updater: {
-              type: 'text',
-              fields: {
-                keyword: {
-                  type: 'keyword'
-                }
-              }
-            }
-          }
         }
       }
     })
@@ -199,32 +147,6 @@ class InternalEngineBootstrap {
       properties: {
         profileIds: {
           type: 'keyword'
-        },
-        _kuzzle_info: {
-          properties: {
-            author: {
-              type: 'text',
-              fields: {
-                keyword: {
-                  type: 'keyword'
-                }
-              }
-            },
-            createdAt: {
-              type: 'long'
-            },
-            updatedAt: {
-              type: 'long'
-            },
-            updater: {
-              type: 'text',
-              fields: {
-                keyword: {
-                  type: 'keyword'
-                }
-              }
-            }
-          }
         }
       }
     })

--- a/test/api/cli/index.test.js
+++ b/test/api/cli/index.test.js
@@ -120,7 +120,7 @@ describe('Tests: api/cli/index.js', () => {
           }
         };
 
-      kuzzle.internalEngine.init.returns(Bluebird.reject(error));
+      kuzzle.internalEngine.init.rejects(error);
 
       return should(cli.doAction.call(context, 'action', 'data', {debug: true})).be.rejectedWith(error);
     });

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -120,7 +120,7 @@ describe('Test the auth controller', () => {
     });
 
     it('should reject if authentication fails', () => {
-      kuzzle.passport.authenticate.returns(Bluebird.reject(new Error('error')));
+      kuzzle.passport.authenticate.rejects(new Error('error'));
 
       return should(authController.login(request)).be.rejected();
     });
@@ -154,7 +154,7 @@ describe('Test the auth controller', () => {
     it('should emit an error if the token cannot be expired', () => {
       const error = new Error('Mocked error');
 
-      kuzzle.repositories.token.expire.returns(Bluebird.reject(error));
+      kuzzle.repositories.token.expire.rejects(error);
 
       return should(authController.logout(request)).be.rejectedWith(KuzzleInternalError);
     });
@@ -209,7 +209,7 @@ describe('Test the auth controller', () => {
     });
 
     it('should return a valid response if the token is not valid', () => {
-      kuzzle.repositories.token.verifyToken.returns(Bluebird.reject(new UnauthorizedError('foobar')));
+      kuzzle.repositories.token.verifyToken.rejects(new UnauthorizedError('foobar'));
 
       return authController.checkToken(request)
         .then(response => {
@@ -223,7 +223,7 @@ describe('Test the auth controller', () => {
 
     it('should return a rejected promise if an error occurs', () => {
       const error = new KuzzleInternalError('Foobar');
-      kuzzle.repositories.token.verifyToken.returns(Bluebird.reject(error));
+      kuzzle.repositories.token.verifyToken.rejects(error);
 
       return should(authController.checkToken(request)).be.rejectedWith(error);
     });

--- a/test/api/controllers/cliController.test.js
+++ b/test/api/controllers/cliController.test.js
@@ -1,4 +1,5 @@
 const
+  Bluebird = require('bluebird'),
   rewire = require('rewire'),
   should = require('should'),
   sinon = require('sinon'),
@@ -120,7 +121,7 @@ describe('lib/api/controllers/cliController', () => {
         error = new BadRequestError('test');
 
       cli.init();
-      cli.actions.dump.returns(Promise.reject(error));
+      cli.actions.dump.rejects(error);
 
       return cli.onListenCB(rawRequest)
         .then(() => {

--- a/test/api/controllers/cliController.test.js
+++ b/test/api/controllers/cliController.test.js
@@ -1,5 +1,4 @@
 const
-  Bluebird = require('bluebird'),
   rewire = require('rewire'),
   should = require('should'),
   sinon = require('sinon'),

--- a/test/api/controllers/collectionController.test.js
+++ b/test/api/controllers/collectionController.test.js
@@ -1,5 +1,5 @@
 const
-  Promise = require('bluebird'),
+  Bluebird = require('bluebird'),
   should = require('should'),
   sinon = require('sinon'),
   rewire = require('rewire'),
@@ -91,7 +91,7 @@ describe('Test: collection controller', () => {
 
   describe('#getSpecifications', () => {
     it('should call internalEngine with the right id', () => {
-      kuzzle.internalEngine.get = sandbox.stub().returns(Promise.resolve({_source: {foo: 'bar'}}));
+      kuzzle.internalEngine.get = sandbox.stub().returns(Bluebird.resolve({_source: {foo: 'bar'}}));
 
       return collectionController.getSpecifications(request)
         .then(response => {
@@ -99,10 +99,10 @@ describe('Test: collection controller', () => {
             should(kuzzle.internalEngine.get).be.calledOnce();
             should(kuzzle.internalEngine.get).be.calledWithMatch('validations', `${index}#${collection}`);
             should(response).match(foo);
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch (error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
@@ -120,7 +120,7 @@ describe('Test: collection controller', () => {
     });
 
     it('should call internalEngine with the right data', () => {
-      kuzzle.internalEngine.search = sandbox.stub().returns(Promise.resolve({
+      kuzzle.internalEngine.search = sandbox.stub().returns(Bluebird.resolve({
         hits: [{_id: 'bar'}],
         scrollId: 'foobar',
         total: 123
@@ -149,7 +149,7 @@ describe('Test: collection controller', () => {
             should(response).match({total: 123, scrollId: 'foobar', hits: [{_id: 'bar'}]});
           }
           catch (error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
@@ -162,7 +162,7 @@ describe('Test: collection controller', () => {
     });
 
     it('should call internalEngine with the right data', () => {
-      kuzzle.internalEngine.scroll = sandbox.stub().returns(Promise.resolve({
+      kuzzle.internalEngine.scroll = sandbox.stub().returns(Bluebird.resolve({
         hits: [{_id: 'bar'}],
         scrollId: 'foobar',
         total: 123
@@ -178,13 +178,13 @@ describe('Test: collection controller', () => {
             should(response).match({total: 123, scrollId: 'foobar', hits: [{_id: 'bar'}]});
           }
           catch (error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
 
     it('should handle the optional scroll argument', () => {
-      kuzzle.internalEngine.scroll = sandbox.stub().returns(Promise.resolve({
+      kuzzle.internalEngine.scroll = sandbox.stub().returns(Bluebird.resolve({
         hits: [{_id: 'bar'}],
         scrollId: 'foobar',
         total: 123
@@ -200,7 +200,7 @@ describe('Test: collection controller', () => {
             should(response).match({total: 123, scrollId: 'foobar', hits: [{_id: 'bar'}]});
           }
           catch (error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
@@ -225,8 +225,8 @@ describe('Test: collection controller', () => {
         }
       };
 
-      kuzzle.validation.isValidSpecification = sandbox.stub().returns(Promise.resolve({isValid: true}));
-      kuzzle.validation.curateSpecification = sandbox.stub().returns(Promise.resolve());
+      kuzzle.validation.isValidSpecification = sandbox.stub().returns(Bluebird.resolve({isValid: true}));
+      kuzzle.validation.curateSpecification = sandbox.stub().returns(Bluebird.resolve());
 
       return collectionController.updateSpecifications(request)
         .then(response => {
@@ -237,10 +237,10 @@ describe('Test: collection controller', () => {
             should(kuzzle.internalEngine.createOrReplace).be.calledWithMatch('validations', `${index}#${collection}`);
             should(response).match(request.input.body);
 
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch (error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
@@ -263,7 +263,7 @@ describe('Test: collection controller', () => {
         }
       };
 
-      kuzzle.validation.isValidSpecification = sandbox.stub().returns(Promise.resolve({
+      kuzzle.validation.isValidSpecification = sandbox.stub().returns(Bluebird.resolve({
         isValid: false,
         errors: ['bad bad is a bad type !']
       }));
@@ -282,10 +282,10 @@ describe('Test: collection controller', () => {
             should(error.message).be.exactly('Some errors with provided specifications.');
             should(error.details).match([ 'bad bad is a bad type !' ]);
 
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch (er) {
-            return Promise.reject(er);
+            return Bluebird.reject(er);
           }
         });
     });
@@ -309,7 +309,7 @@ describe('Test: collection controller', () => {
       };
 
       CollectionController.__set__({
-        createSpecificationList: sandbox.stub().returns(Promise.resolve({
+        createSpecificationList: sandbox.stub().returns(Bluebird.resolve({
           _id: 'indexcollection',
           _source: {
             validation: 'validation',
@@ -317,14 +317,14 @@ describe('Test: collection controller', () => {
             collection: 'collection'
           }
         })),
-        validateSpecificationList: sandbox.stub().returns(Promise.resolve({valid: true}))
+        validateSpecificationList: sandbox.stub().returns(Bluebird.resolve({valid: true}))
       });
 
       return collectionController.validateSpecifications(request)
         .then(response => {
           should(response).match({valid: true});
 
-          return Promise.resolve();
+          return Bluebird.resolve();
         });
     });
 
@@ -351,7 +351,7 @@ describe('Test: collection controller', () => {
       };
 
       CollectionController.__set__({
-        createSpecificationList: sandbox.stub().returns(Promise.resolve({
+        createSpecificationList: sandbox.stub().returns(Bluebird.resolve({
           _id: 'indexcollection',
           _source: {
             validation: 'validation',
@@ -359,7 +359,7 @@ describe('Test: collection controller', () => {
             collection: 'collection'
           }
         })),
-        validateSpecificationList: sandbox.stub().returns(Promise.resolve(errorResponse))
+        validateSpecificationList: sandbox.stub().returns(Bluebird.resolve(errorResponse))
       });
 
       return collectionController.validateSpecifications(request)
@@ -371,7 +371,7 @@ describe('Test: collection controller', () => {
 
   describe('#deleteSpecifications', () => {
     it('should call the right functions and respond with the right response if the validation specification exists', () => {
-      kuzzle.internalEngine.delete = sandbox.stub().returns(Promise.resolve());
+      kuzzle.internalEngine.delete = sandbox.stub().returns(Bluebird.resolve());
 
       kuzzle.validation.specification = {};
       kuzzle.validation.specification[index] = {};
@@ -384,10 +384,10 @@ describe('Test: collection controller', () => {
             should(kuzzle.internalEngine.delete).be.calledOnce();
             should(response).match({acknowledged: true});
 
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch (error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
@@ -402,10 +402,10 @@ describe('Test: collection controller', () => {
             should(kuzzle.internalEngine.delete).not.be.called();
             should(response).match({acknowledged: true});
 
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch (error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
@@ -413,7 +413,7 @@ describe('Test: collection controller', () => {
 
   describe('#list', () => {
     beforeEach(() => {
-      kuzzle.services.list.storageEngine.listCollections.returns(Promise.resolve({collections: {stored: ['foo']}}));
+      kuzzle.services.list.storageEngine.listCollections.returns(Bluebird.resolve({collections: {stored: ['foo']}}));
       kuzzle.hotelClerk.getRealtimeCollections.returns(['foo', 'bar']);
     });
 
@@ -465,7 +465,7 @@ describe('Test: collection controller', () => {
 
     it('should return a portion of the collection list if from and size are specified', () => {
       request = new Request({index: 'index', type: 'all', from: 2, size: 3});
-      kuzzle.services.list.storageEngine.listCollections.returns(Promise.resolve({collections: {stored: ['astored', 'bstored', 'cstored', 'dstored', 'estored']}}));
+      kuzzle.services.list.storageEngine.listCollections.returns(Bluebird.resolve({collections: {stored: ['astored', 'bstored', 'cstored', 'dstored', 'estored']}}));
       kuzzle.hotelClerk.getRealtimeCollections.returns(['arealtime', 'brealtime', 'crealtime', 'drealtime', 'erealtime']);
 
       return collectionController.list(request)
@@ -484,7 +484,7 @@ describe('Test: collection controller', () => {
 
     it('should return a portion of the collection list if from is specified', () => {
       request = new Request({index: 'index', type: 'all', from: 8});
-      kuzzle.services.list.storageEngine.listCollections.returns(Promise.resolve({collections: {stored: ['astored', 'bstored', 'cstored', 'dstored', 'estored']}}));
+      kuzzle.services.list.storageEngine.listCollections.returns(Bluebird.resolve({collections: {stored: ['astored', 'bstored', 'cstored', 'dstored', 'estored']}}));
       kuzzle.hotelClerk.getRealtimeCollections.returns(['arealtime', 'brealtime', 'crealtime', 'drealtime', 'erealtime']);
 
       return collectionController.list(request)
@@ -502,7 +502,7 @@ describe('Test: collection controller', () => {
 
     it('should return a portion of the collection list if size is specified', () => {
       request = new Request({index: 'index', type: 'all', size: 2});
-      kuzzle.services.list.storageEngine.listCollections.returns(Promise.resolve({
+      kuzzle.services.list.storageEngine.listCollections.returns(Bluebird.resolve({
         collections: {stored: ['astored', 'bstored', 'cstored', 'dstored', 'estored']}
       }));
       kuzzle.hotelClerk.getRealtimeCollections.returns(['arealtime', 'brealtime', 'crealtime', 'drealtime', 'erealtime']);
@@ -522,13 +522,13 @@ describe('Test: collection controller', () => {
 
 
     it('should reject an error if getting stored collections fails', () => {
-      kuzzle.services.list.storageEngine.listCollections.returns(Promise.reject(new Error('foobar')));
+      kuzzle.services.list.storageEngine.listCollections.rejects(new Error('foobar'));
       request = new Request({index: 'index', type: 'stored'});
       return should(collectionController.list(request)).be.rejected();
     });
 
     it('should reject an error if getting all collections fails', () => {
-      kuzzle.services.list.storageEngine.listCollections.returns(Promise.reject(new Error('foobar')));
+      kuzzle.services.list.storageEngine.listCollections.rejects(new Error('foobar'));
       request = new Request({index: 'index', type: 'all'});
       return should(collectionController.list(request)).be.rejected();
     });
@@ -536,7 +536,7 @@ describe('Test: collection controller', () => {
 
   describe('#exists', () => {
     it('should call the storageEngine', () => {
-      kuzzle.services.list.storageEngine.collectionExists.returns(Promise.resolve(foo));
+      kuzzle.services.list.storageEngine.collectionExists.returns(Bluebird.resolve(foo));
       return collectionController.exists(request)
         .then(response => {
           should(response).match(foo);
@@ -567,10 +567,10 @@ describe('Test: collection controller', () => {
             should(response).be.instanceof(Object);
             should(response).match(foo);
 
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch(error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });

--- a/test/api/controllers/documentController.test.js
+++ b/test/api/controllers/documentController.test.js
@@ -68,7 +68,7 @@ describe('Test: document controller', () => {
     });
 
     it('should reject an error in case of error', () => {
-      kuzzle.services.list.storageEngine.search.returns(Bluebird.reject(new Error('foobar')));
+      kuzzle.services.list.storageEngine.search.rejects(new Error('foobar'));
 
       return should(documentController.search(request)).be.rejectedWith('foobar');
     });
@@ -90,7 +90,7 @@ describe('Test: document controller', () => {
       request.input.args.scroll = '1m';
       request.input.args.scrollId = 'SomeScrollIdentifier';
 
-      kuzzle.services.list.storageEngine.scroll.returns(Bluebird.reject(new Error('foobar')));
+      kuzzle.services.list.storageEngine.scroll.rejects(new Error('foobar'));
 
       return should(documentController.scroll(request)).be.rejectedWith('foobar');
     });
@@ -114,7 +114,7 @@ describe('Test: document controller', () => {
     it('should return false if the document doesn\'t exist', () => {
       request.input.resource._id = 'ghost';
 
-      engine.get.returns(Bluebird.reject(new NotFoundError('foobar')));
+      engine.get.rejects(new NotFoundError('foobar'));
 
       return documentController.exists(request)
         .then(response => {
@@ -124,7 +124,7 @@ describe('Test: document controller', () => {
     });
 
     it('should reject with an error in case of error', () => {
-      engine.get.returns(Bluebird.reject(new Error('foobar')));
+      engine.get.rejects(new Error('foobar'));
 
       return should(documentController.exists(request)).be.rejected();
     });
@@ -144,7 +144,7 @@ describe('Test: document controller', () => {
     });
 
     it('should reject an error in case of error', () => {
-      kuzzle.services.list.storageEngine.get.returns(Bluebird.reject(new Error('foobar')));
+      kuzzle.services.list.storageEngine.get.rejects(new Error('foobar'));
       return should(documentController.get(request)).be.rejected();
     });
   });
@@ -199,7 +199,7 @@ describe('Test: document controller', () => {
     });
 
     it('should reject an error in case of error', () => {
-      kuzzle.services.list.storageEngine.count.returns(Bluebird.reject(new Error('foobar')));
+      kuzzle.services.list.storageEngine.count.rejects(new Error('foobar'));
       return should(documentController.count(request)).be.rejected();
     });
   });

--- a/test/api/controllers/funnelController/execute.test.js
+++ b/test/api/controllers/funnelController/execute.test.js
@@ -41,7 +41,7 @@ describe('funnelController.execute', () => {
     sinon.stub(funnel, '_playCachedRequests');
   });
 
-  after(() => {
+  afterEach(() => {
     if (clock) {
       clock.restore();
     }
@@ -66,7 +66,7 @@ describe('funnelController.execute', () => {
 
     it('should forward any error occurring during the request execution', done => {
       const error = new ServiceUnavailableError('test');
-      funnel.checkRights = sinon.stub().returns(Bluebird.reject(error));
+      funnel.checkRights.rejects(error);
 
       funnel.execute(request, (err, res) => {
         should(err).be.instanceOf(Error);

--- a/test/api/controllers/funnelController/processRequest.test.js
+++ b/test/api/controllers/funnelController/processRequest.test.js
@@ -127,7 +127,7 @@ describe('funnelController.processRequest', () => {
       action: 'fail',
     });
 
-    funnel.controllers.fakeController.fail.returns(Bluebird.reject(new Error('rejected')));
+    funnel.controllers.fakeController.fail.rejects(new Error('rejected'));
 
     funnel.processRequest(request)
       .then(() => done('Expected test to fail'))
@@ -158,7 +158,7 @@ describe('funnelController.processRequest', () => {
       action: 'fail',
     });
 
-    funnel.pluginsControllers['fakePlugin/controller'].fail.returns(Bluebird.reject(new Error('rejected')));
+    funnel.pluginsControllers['fakePlugin/controller'].fail.rejects(new Error('rejected'));
 
     funnel.processRequest(request)
       .then(() => done('Expected test to fail'))

--- a/test/api/controllers/indexController.test.js
+++ b/test/api/controllers/indexController.test.js
@@ -211,7 +211,7 @@ describe('Test: index controller', () => {
     });
 
     it('should reject an error in case of error', () => {
-      kuzzle.services.list.storageEngine.listIndexes.returns(Bluebird.reject(new Error('foobar')));
+      kuzzle.services.list.storageEngine.listIndexes.rejects(new Error('foobar'));
       return should(indexController.list(request)).be.rejected();
     });
   });

--- a/test/api/controllers/securityController/users.test.js
+++ b/test/api/controllers/securityController/users.test.js
@@ -138,7 +138,7 @@ describe('Test: security controller - users', () => {
 
     it('should reject an error in case of error', () => {
       const error = new Error('Mocked error');
-      kuzzle.repositories.user.search = sandbox.stub().returns(Bluebird.reject(error));
+      kuzzle.repositories.user.search.rejects(error);
 
       return should(securityController.searchUsers(new Request({body: {hydrate: false}})))
         .be.rejectedWith(error);
@@ -205,8 +205,7 @@ describe('Test: security controller - users', () => {
 
     it('should reject an error in case of error', () => {
       const error = new Error('Mocked error');
-
-      kuzzle.repositories.user.delete = sandbox.stub().returns(Bluebird.reject(error));
+      kuzzle.repositories.user.delete.rejects(error);
 
       return should(securityController.deleteUser(new Request({_id: 'test'}))).be.rejectedWith(error);
     });
@@ -364,7 +363,7 @@ describe('Test: security controller - users', () => {
 
       kuzzle.pluginsManager.getStrategyMethod
         .withArgs('someStrategy', 'validate')
-        .returns(sinon.stub().returns(Bluebird.reject(new Error('error'))));
+        .rejects(new Error('error'));
 
       return should(securityController.createUser(request)).be.rejectedWith(BadRequestError);
     });

--- a/test/api/controllers/serverController.test.js
+++ b/test/api/controllers/serverController.test.js
@@ -150,7 +150,7 @@ describe('Test: server controller', () => {
     });
 
     it('should return a 503 response with status "red" if storageEngine is KO', () => {
-      kuzzle.services.list.storageEngine.getInfos.returns(Bluebird.reject(new Error()));
+      kuzzle.services.list.storageEngine.getInfos.rejects(new Error());
 
       return serverController.healthCheck(request)
         .then(response => {
@@ -164,7 +164,7 @@ describe('Test: server controller', () => {
     });
 
     it('should return a 503 response with status "red" if memoryStorage is KO', () => {
-      kuzzle.services.list.memoryStorage.getInfos.returns(Bluebird.reject(new Error()));
+      kuzzle.services.list.memoryStorage.getInfos.rejects(new Error());
 
       return serverController.healthCheck(request)
         .then(response => {
@@ -178,7 +178,7 @@ describe('Test: server controller', () => {
     });
 
     it('should return a 503 response with status "red" if internalCache is KO', () => {
-      kuzzle.services.list.internalCache.getInfos.returns(Bluebird.reject(new Error()));
+      kuzzle.services.list.internalCache.getInfos.rejects(new Error());
 
       return serverController.healthCheck(request)
         .then(response => {
@@ -264,7 +264,7 @@ describe('Test: server controller', () => {
     });
 
     it('should reject an error in case of error', () => {
-      kuzzle.services.list.broker.getInfos.returns(Bluebird.reject(new Error('foobar')));
+      kuzzle.services.list.broker.getInfos.rejects(new Error('foobar'));
       return should(serverController.info()).be.rejected();
     });
   });

--- a/test/api/core/hotelClerk/addSubscription.test.js
+++ b/test/api/core/hotelClerk/addSubscription.test.js
@@ -104,7 +104,7 @@ describe('Test: hotelClerk.addSubscription', () => {
   });
 
   it('should reject when Koncorde throws an error', () => {
-    kuzzle.realtime.normalize.returns(Bluebird.reject(new Error('test')));
+    kuzzle.realtime.normalize.rejects(new Error('test'));
 
     return should(hotelClerk.addSubscription(request)).be.rejected();
   });

--- a/test/api/core/models/repositories/profileRepository.test.js
+++ b/test/api/core/models/repositories/profileRepository.test.js
@@ -67,7 +67,8 @@ describe('Test: repositories/profileRepository', () => {
     });
 
     it('should return null if the profile does not exist', () => {
-      kuzzle.internalEngine.get.returns(Bluebird.reject(new NotFoundError('Not found')));
+      kuzzle.internalEngine.get
+        .rejects(new NotFoundError('Not found'));
 
       return profileRepository.loadProfile('idontexist')
         .then(result => {

--- a/test/api/core/models/repositories/tokenRepository.test.js
+++ b/test/api/core/models/repositories/tokenRepository.test.js
@@ -107,7 +107,8 @@ describe('Test: repositories/tokenRepository', () => {
     it('should reject the promise if an error occurred while fetching the user from the cache', () => {
       const token = jwt.sign({_id: 'auser'}, kuzzle.config.security.jwt.secret, {algorithm: kuzzle.config.security.jwt.algorithm});
 
-      sandbox.stub(tokenRepository, 'loadFromCache').returns(Bluebird.reject(new KuzzleInternalError('Error')));
+      sandbox.stub(tokenRepository, 'loadFromCache')
+        .rejects(new KuzzleInternalError('Error'));
 
       return should(tokenRepository.verifyToken(token)).be.rejectedWith(KuzzleInternalError);
     });
@@ -174,7 +175,7 @@ describe('Test: repositories/tokenRepository', () => {
         user
       });
 
-      kuzzle.services.list.internalCache.volatileSet.returns(Promise.reject(new Error('error')));
+      kuzzle.services.list.internalCache.volatileSet.rejects(new Error('error'));
 
       return should(tokenRepository.generateToken(user, request))
         .be.rejectedWith(KuzzleInternalError, {message: 'Unable to generate token for unknown user'});

--- a/test/api/core/models/security/user.test.js
+++ b/test/api/core/models/security/user.test.js
@@ -1,6 +1,6 @@
-var
+const
   should = require('should'),
-  Promise = require('bluebird'),
+  Bluebird = require('bluebird'),
   sinon = require('sinon'),
   Kuzzle = require('../../../../../lib/api/kuzzle'),
   Profile = require('../../../../../lib/api/core/models/security/profile'),
@@ -21,19 +21,19 @@ describe('Test: security/userTest', () => {
 
     profile = new Profile();
     profile._id = 'profile';
-    profile.isActionAllowed = sinon.stub().returns(Promise.resolve(true));
+    profile.isActionAllowed = sinon.stub().returns(Bluebird.resolve(true));
 
     profile2 = new Profile();
     profile2._id = 'profile2';
-    profile2.isActionAllowed = sinon.stub().returns(Promise.resolve(false));
+    profile2.isActionAllowed = sinon.stub().returns(Bluebird.resolve(false));
 
     user = new User();
     user.profileIds = ['profile', 'profile2'];
 
     kuzzle.repositories = {
       profile: {
-        loadProfile: sinon.stub().returns(Promise.resolve(profile)),
-        loadProfiles: sinon.stub().returns(Promise.resolve([profile, profile2]))
+        loadProfile: sinon.stub().returns(Bluebird.resolve(profile)),
+        loadProfiles: sinon.stub().returns(Bluebird.resolve([profile, profile2]))
       }
     };
   });
@@ -65,9 +65,9 @@ describe('Test: security/userTest', () => {
         }
       };
 
-    sandbox.stub(user, 'getProfiles').returns(Promise.resolve([profile, profile2]));
-    sandbox.stub(profile, 'getRights').returns(Promise.resolve(profileRights));
-    sandbox.stub(profile2, 'getRights').returns(Promise.resolve(profileRights2));
+    sandbox.stub(user, 'getProfiles').returns(Bluebird.resolve([profile, profile2]));
+    sandbox.stub(profile, 'getRights').returns(Bluebird.resolve(profileRights));
+    sandbox.stub(profile2, 'getRights').returns(Bluebird.resolve(profileRights2));
 
     return user.getRights(kuzzle)
       .then(rights => {
@@ -141,7 +141,8 @@ describe('Test: security/userTest', () => {
   });
 
   it('should rejects if the loadProfiles throws an error', () => {
-    sandbox.stub(user, 'getProfiles').returns(Promise.reject(new Error('error')));
+    sandbox.stub(user, 'getProfiles')
+      .rejects(new Error('error'));
     return should(user.isActionAllowed(new Request({}), kuzzle)).be.rejectedWith('error');
   });
 });

--- a/test/api/core/statistics.test.js
+++ b/test/api/core/statistics.test.js
@@ -1,7 +1,7 @@
-var
+const
   _ = require('lodash'),
   should = require('should'),
-  Promise = require('bluebird'),
+  Bluebird = require('bluebird'),
   rewire = require('rewire'),
   sinon = require('sinon'),
   sandbox = sinon.sandbox.create(),
@@ -160,8 +160,8 @@ describe('Test: statistics core component', () => {
     request.input.args.startTime = lastFrame - 1000;
     request.input.args.stopTime = new Date(new Date().getTime() + 100000);
 
-    sandbox.stub(kuzzle.services.list.internalCache, 'searchKeys').returns(Promise.resolve(['stats/' + lastFrame, 'stats/'.concat(lastFrame + 100)]));
-    sandbox.stub(kuzzle.services.list.internalCache, 'mget').returns(Promise.resolve([JSON.stringify(fakeStats), JSON.stringify(fakeStats)]));
+    sandbox.stub(kuzzle.services.list.internalCache, 'searchKeys').returns(Bluebird.resolve(['stats/' + lastFrame, 'stats/'.concat(lastFrame + 100)]));
+    sandbox.stub(kuzzle.services.list.internalCache, 'mget').returns(Bluebird.resolve([JSON.stringify(fakeStats), JSON.stringify(fakeStats)]));
 
     return stats.getStats(request)
       .then(response => {
@@ -191,8 +191,8 @@ describe('Test: statistics core component', () => {
     stats.lastFrame = lastFrame;
     request.input.args.stopTime = lastFrame + 1000;
 
-    sandbox.stub(kuzzle.services.list.internalCache, 'searchKeys').returns(Promise.resolve(['stats/' + lastFrame, 'stats/'.concat(lastFrame + 100)]));
-    sandbox.stub(kuzzle.services.list.internalCache, 'mget').returns(Promise.resolve([JSON.stringify(fakeStats), JSON.stringify(fakeStats)]));
+    sandbox.stub(kuzzle.services.list.internalCache, 'searchKeys').returns(Bluebird.resolve(['stats/' + lastFrame, 'stats/'.concat(lastFrame + 100)]));
+    sandbox.stub(kuzzle.services.list.internalCache, 'mget').returns(Bluebird.resolve([JSON.stringify(fakeStats), JSON.stringify(fakeStats)]));
 
     return stats.getStats(request)
       .then(response => {
@@ -212,7 +212,7 @@ describe('Test: statistics core component', () => {
 
   it('should get the last frame from the cache when statistics snapshots have been taken', () => {
     stats.lastFrame = lastFrame;
-    sandbox.stub(kuzzle.services.list.internalCache, 'get').returns(Promise.resolve(JSON.stringify(fakeStats)));
+    sandbox.stub(kuzzle.services.list.internalCache, 'get').returns(Bluebird.resolve(JSON.stringify(fakeStats)));
 
     stats.getLastStats()
       .then(response => {
@@ -241,8 +241,8 @@ describe('Test: statistics core component', () => {
   it('should return all saved statistics', () => {
     stats.lastFrame = lastFrame;
 
-    sandbox.stub(kuzzle.services.list.internalCache, 'searchKeys').returns(Promise.resolve(['stats/' + lastFrame, 'stats/'.concat(lastFrame + 100)]));
-    sandbox.stub(kuzzle.services.list.internalCache, 'mget').returns(Promise.resolve([JSON.stringify(fakeStats), JSON.stringify(fakeStats)]));
+    sandbox.stub(kuzzle.services.list.internalCache, 'searchKeys').returns(Bluebird.resolve(['stats/' + lastFrame, 'stats/'.concat(lastFrame + 100)]));
+    sandbox.stub(kuzzle.services.list.internalCache, 'mget').returns(Bluebird.resolve([JSON.stringify(fakeStats), JSON.stringify(fakeStats)]));
 
     return stats.getAllStats()
       .then(response => {
@@ -263,7 +263,7 @@ describe('Test: statistics core component', () => {
   it('should write statistics frames in cache', () => {
     var
       writeStats = Statistics.__get__('writeStats'),
-      spy = sandbox.stub(kuzzle.services.list.internalCache, 'volatileSet').returns(Promise.resolve());
+      spy = sandbox.stub(kuzzle.services.list.internalCache, 'volatileSet').returns(Bluebird.resolve());
 
     stats.currentStats = _.extend({}, fakeStats);
 
@@ -278,7 +278,8 @@ describe('Test: statistics core component', () => {
   it('should reject the promise if the cache returns an error', () => {
     stats.lastFrame = Date.now();
 
-    sandbox.stub(kuzzle.services.list.internalCache, 'get').returns(Promise.reject(new Error()));
+    sandbox.stub(kuzzle.services.list.internalCache, 'get')
+      .rejects(new Error());
 
     return should(stats.getLastStats(request)).be.rejected();
   });

--- a/test/api/core/validation/init.test.js
+++ b/test/api/core/validation/init.test.js
@@ -154,7 +154,8 @@ describe('Test: validation initialization', () => {
 
     it('should resolve false if the specification is not correct', () => {
       const
-        curateCollectionSpecificationStub = sandbox.stub(validation, 'curateCollectionSpecification').returns(Bluebird.reject(new Error('Mocked error')));
+        curateCollectionSpecificationStub = sandbox.stub(validation, 'curateCollectionSpecification')
+          .rejects(new Error('Mocked Error'));
 
       return validation.isValidSpecification('anIndex', 'aCollection', {a: 'bad specification'})
         .then(result => {

--- a/test/api/kuzzle.test.js
+++ b/test/api/kuzzle.test.js
@@ -1,6 +1,5 @@
 const
   sinon = require('sinon'),
-  Bluebird = require('bluebird'),
   should = require('should'),
   rewire = require('rewire'),
   Kuzzle = rewire('../../lib/api/kuzzle'),

--- a/test/api/kuzzle.test.js
+++ b/test/api/kuzzle.test.js
@@ -132,7 +132,7 @@ describe('/lib/api/kuzzle.js', () => {
     it('does not really test anything but increases coverage', () => {
       const error = new Error('error');
 
-      kuzzle.internalEngine.init.returns(Bluebird.reject(error));
+      kuzzle.internalEngine.init.rejects(error);
 
       return should(kuzzle.start()).be.rejectedWith(error);
     });

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -142,6 +142,7 @@ class KuzzleMock extends Kuzzle {
       persist: sinon.stub().resolves(),
       refresh: sinon.stub().resolves(),
       replace: sinon.stub().resolves(),
+      scroll: sinon.stub().resolves(),
       search: sinon.stub().resolves(),
       update: sinon.stub().resolves(),
       updateMapping: sinon.stub().resolves(foo),
@@ -186,13 +187,17 @@ class KuzzleMock extends Kuzzle {
       init: sinon.stub().resolves(),
       profile: {
         load: sinon.stub().resolves(),
+        loadMultiFromDatabase: sinon.stub().resolves(),
         loadProfiles: sinon.stub().resolves(),
         searchProfiles: sinon.stub().resolves()
       },
       role: {
+        deleteRole: sinon.stub().resolves(),
         getRoleFromRequest: sinon.stub().callsFake((...args) => Bluebird.resolve(args[0])),
+        loadMultiFromDatabase: sinon.stub().resolves(),
         loadRole: sinon.stub().resolves(),
         loadRoles: sinon.stub().resolves(),
+        searchRole: sinon.stub().resolves(),
         validateAndSaveRole: sinon.stub().callsFake((...args) => Bluebird.resolve(args[0]))
       },
       user: {

--- a/test/services/garbageCollector.test.js
+++ b/test/services/garbageCollector.test.js
@@ -54,7 +54,6 @@ describe('Test: GarbageCollector service', () => {
 
   describe('#run', () => {
     it('if kuzzle is overloaded, it should delay the process in one hour', () => {
-      kuzzle.pluginsManager.trigger.onCall(0).returns(Bluebird.reject(new Error('foobar')));
       kuzzle.funnel.overloaded = true;
 
       return gc.run()

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -209,7 +209,7 @@ describe('Test: ElasticSearch service', () => {
     });
 
     it('should return a rejected promise if a search fails', done => {
-      elasticsearch.client.search.returns(Bluebird.reject(new Error('Mocked error')));
+      elasticsearch.client.search.rejects(new Error('Mocked error'));
 
       elasticsearch.search(request)
         .then(() => done('should have been rejected'))
@@ -240,7 +240,7 @@ describe('Test: ElasticSearch service', () => {
     });
 
     it('should return a rejected promise if a scroll fails', () => {
-      elasticsearch.client.scroll.returns(Bluebird.reject(new Error('error')));
+      elasticsearch.client.scroll.rejects(new Error('error'));
 
       request.input.args.scrollId = 'foobar';
       return should(elasticsearch.scroll(request)).be.rejectedWith(Error, {message: 'error'});
@@ -301,7 +301,7 @@ describe('Test: ElasticSearch service', () => {
       elasticsearch.client.create.returns(Bluebird.resolve({}));
       error.displayName = 'NotFound';
 
-      elasticsearch.client.get.returns(Bluebird.reject(error));
+      elasticsearch.client.get.rejects(error);
       request.input.resource._id = '42';
 
       return elasticsearch.create(request)
@@ -318,7 +318,7 @@ describe('Test: ElasticSearch service', () => {
 
     it('should reject the create promise if elasticsearch throws an error', () => {
       const error = new Error('Mocked create error');
-      elasticsearch.client.get.returns(Bluebird.reject(new Error('Mocked get error')));
+      elasticsearch.client.get.rejects(new Error('Mocked get error'));
       elasticsearch.kuzzle.indexCache.exists.returns(true);
 
       request.input.resource._id = 'foobar';
@@ -330,7 +330,7 @@ describe('Test: ElasticSearch service', () => {
       const error = new Error('Mocked index error');
       elasticsearch.kuzzle.indexCache.exists.returns(true);
       elasticsearch.client.get.returns(Bluebird.resolve({_source: {_kuzzle_info: {active: false}}}));
-      elasticsearch.client.index.returns(Bluebird.reject(error));
+      elasticsearch.client.index.rejects(error);
       request.input.resource._id = '42';
 
       return should(elasticsearch.create(request)).be.rejectedWith(error);
@@ -377,7 +377,7 @@ describe('Test: ElasticSearch service', () => {
       const error = new Error('Mocked error');
 
       elasticsearch.kuzzle.indexCache.exists.returns(true);
-      elasticsearch.client.index.returns(Bluebird.reject(error));
+      elasticsearch.client.index.rejects(error);
 
       request.input.resource._id = createdDocumentId;
       return should(elasticsearch.createOrReplace(request)).be.rejectedWith(error);
@@ -420,7 +420,7 @@ describe('Test: ElasticSearch service', () => {
       const error = new Error('Mocked error');
 
       elasticsearch.client.exists.returns(Bluebird.resolve(true));
-      elasticsearch.client.index.returns(Bluebird.reject(error));
+      elasticsearch.client.index.rejects(error);
       elasticsearch.kuzzle.indexCache.exists.returns(true);
 
       request.input.resource._id = createdDocumentId;
@@ -517,7 +517,7 @@ describe('Test: ElasticSearch service', () => {
 
   describe('#mget', () => {
     it('should return a rejected promise if getting a single document fails', done => {
-      elasticsearch.client.mget.returns(Bluebird.reject(new Error('Mocked error')));
+      elasticsearch.client.mget.rejects(new Error('Mocked error'));
 
       elasticsearch.mget(request)
         .catch(() => {
@@ -542,7 +542,7 @@ describe('Test: ElasticSearch service', () => {
     });
 
     it('should return a rejected promise if getting some multiple documents fails', done => {
-      elasticsearch.client.mget.returns(Bluebird.reject(new Error('Mocked error')));
+      elasticsearch.client.mget.rejects(new Error('Mocked error'));
 
       request.input.body = {};
 
@@ -587,7 +587,7 @@ describe('Test: ElasticSearch service', () => {
 
     it('should return a rejected promise if the count fails', () => {
       const error = new Error('Mocked error');
-      elasticsearch.client.count.returns(Bluebird.reject(error));
+      elasticsearch.client.count.rejects(error);
 
       request.input.body = {query: {foo: 'bar'}};
 
@@ -695,7 +695,7 @@ describe('Test: ElasticSearch service', () => {
       };
 
       esError.body.error['resource.id'] = 'bar';
-      elasticsearch.client.update.returns(Bluebird.reject(esError));
+      elasticsearch.client.update.rejects(esError);
       elasticsearch.kuzzle.indexCache.exists.returns(true);
 
       elasticsearch.update(request)
@@ -722,8 +722,7 @@ describe('Test: ElasticSearch service', () => {
       };
 
       elasticsearch.kuzzle.indexCache.exists.returns(true);
-      elasticsearch.client.update.returns(Bluebird.reject(esError));
-
+      elasticsearch.client.update.rejects(esError);
 
       elasticsearch.update(request)
         .catch((error) => {
@@ -743,7 +742,7 @@ describe('Test: ElasticSearch service', () => {
       const
         esError = new Error('banana error');
 
-      elasticsearch.client.update.returns(Bluebird.reject(esError));
+      elasticsearch.client.update.rejects(esError);
       elasticsearch.kuzzle.indexCache.exists.returns(true);
 
       return should(elasticsearch.update(request)).be.rejected();
@@ -767,7 +766,7 @@ describe('Test: ElasticSearch service', () => {
     });
 
     it('should return a rejected promise if a delete fails', () => {
-      elasticsearch.client.update.returns(Bluebird.reject(new Error('Mocked error')));
+      elasticsearch.client.update.rejects(new Error('Mocked error'));
 
       return should(elasticsearch.delete(request)).be.rejected();
     });
@@ -849,7 +848,7 @@ describe('Test: ElasticSearch service', () => {
 
     it('should return a rejected promise if the delete by query fails because of a bulk failure', () => {
       const error = new KuzzleError('Mocked error');
-      elasticsearch.client.bulk.returns(Bluebird.reject(error));
+      elasticsearch.client.bulk.rejects(error);
 
       request.input.body.query = {some: 'query'};
 
@@ -932,7 +931,7 @@ describe('Test: ElasticSearch service', () => {
 
     it('should reject the promise if the delete by query fails because of a bulk failure', () => {
       const error = new KuzzleError('Mocked error');
-      elasticsearch.client.bulk.returns(Bluebird.reject(error));
+      elasticsearch.client.bulk.rejects(error);
 
       request.input.body.query = {some: 'query'};
 
@@ -1097,7 +1096,7 @@ describe('Test: ElasticSearch service', () => {
         ]
       };
 
-      elasticsearch.client.bulk.returns(Bluebird.reject(error));
+      elasticsearch.client.bulk.rejects(error);
 
       return should(elasticsearch.import(request)).be.rejectedWith(error);
     });
@@ -1215,7 +1214,7 @@ describe('Test: ElasticSearch service', () => {
         }
       };
 
-      elasticsearch.client.indices.putMapping.returns(Bluebird.reject(error));
+      elasticsearch.client.indices.putMapping.rejects(error);
 
       elasticsearch.updateMapping(request)
         .catch((err) => {
@@ -1317,7 +1316,7 @@ describe('Test: ElasticSearch service', () => {
 
     it('should reject the listCollections promise if elasticsearch throws an error', () => {
       const error = new Error('Mocked error');
-      elasticsearch.client.indices.getMapping.returns(Bluebird.reject(error));
+      elasticsearch.client.indices.getMapping.rejects(error);
 
       request.input.resource.index = 'kuzzle-unit-tests-fakeindex';
       request.input.body = null;
@@ -1336,7 +1335,7 @@ describe('Test: ElasticSearch service', () => {
 
     it('should reject the createCollection promise if elasticsearch throws an error', () => {
       const error = new Error('Mocked error');
-      elasticsearch.client.indices.putMapping.returns(Bluebird.reject(error));
+      elasticsearch.client.indices.putMapping.rejects(error);
       elasticsearch.kuzzle.indexCache.exists.returns(true);
 
       return should(elasticsearch.createCollection(request)).be.rejectedWith(error);
@@ -1388,7 +1387,7 @@ describe('Test: ElasticSearch service', () => {
       indexes[kuzzle.config.internalIndex] = [];
 
       elasticsearch.client.indices.getMapping.returns(Bluebird.resolve(indexes));
-      elasticsearch.client.indices.delete.returns(Bluebird.reject(error));
+      elasticsearch.client.indices.delete.rejects(error);
 
       return should(elasticsearch.deleteIndexes(request)).be.rejectedWith(error);
     });
@@ -1406,7 +1405,7 @@ describe('Test: ElasticSearch service', () => {
 
     it('should reject the createIndex promise if elasticsearch throws an error', () => {
       const error = new Error('Mocked error');
-      elasticsearch.client.indices.create.returns(Bluebird.reject(error));
+      elasticsearch.client.indices.create.rejects(error);
 
       return should(elasticsearch.createIndex(request)).be.rejectedWith(error);
     });
@@ -1429,7 +1428,7 @@ describe('Test: ElasticSearch service', () => {
     });
 
     it('should reject the deleteIndex promise if elasticsearch throws an error', () => {
-      elasticsearch.client.indices.delete.returns(Bluebird.reject(new Error()));
+      elasticsearch.client.indices.delete.rejects(new Error());
 
       return should(elasticsearch.deleteIndex(request)).be.rejected();
     });
@@ -1450,7 +1449,7 @@ describe('Test: ElasticSearch service', () => {
 
     it('should reject the listIndexes promise if elasticsearch throws an error', () => {
       const error = new Error('Mocked error');
-      elasticsearch.client.indices.getMapping.returns(Bluebird.reject(error));
+      elasticsearch.client.indices.getMapping.rejects(error);
 
       return should(elasticsearch.listIndexes(request)).be.rejectedWith(error);
     });
@@ -1565,7 +1564,7 @@ describe('Test: ElasticSearch service', () => {
         error = new Error('Mocked error'),
         pluginSpy = kuzzle.pluginsManager.trigger;
 
-      elasticsearch.client.indices.refresh.returns(Bluebird.reject(error));
+      elasticsearch.client.indices.refresh.rejects(error);
       elasticsearch.settings.autoRefresh[request.input.resource.index] = true;
 
       return elasticsearch.refreshIndexIfNeeded({index: request.input.resource.index}, {foo: 'bar'})
@@ -1606,7 +1605,7 @@ describe('Test: ElasticSearch service', () => {
         error = new Error('test'),
         spy = sandbox.spy(elasticsearch.esWrapper, 'formatESError');
 
-      elasticsearch.client.indices.exists.returns(Bluebird.reject(error));
+      elasticsearch.client.indices.exists.rejects(error);
 
       return elasticsearch.indexExists(request)
         .then(() => {
@@ -1648,7 +1647,7 @@ describe('Test: ElasticSearch service', () => {
         error = new Error('test'),
         spy = sinon.spy(elasticsearch.esWrapper, 'formatESError');
 
-      elasticsearch.client.indices.existsType.returns(Bluebird.reject(error));
+      elasticsearch.client.indices.existsType.rejects(error);
 
       return elasticsearch.collectionExists(request)
         .then(() => {

--- a/test/services/init.test.js
+++ b/test/services/init.test.js
@@ -78,7 +78,7 @@ describe('Test: lib/services/', () => {
       const error = new Error('test');
       error.status = 404;
 
-      kuzzle.internalEngine.get.onCall(0).returns(Bluebird.reject(error));
+      kuzzle.internalEngine.get.onCall(0).rejects(error);
       kuzzle.internalEngine.get.returns(Bluebird.resolve({_source: {foo: 'bar'}}));
 
       return services.init()
@@ -103,7 +103,7 @@ describe('Test: lib/services/', () => {
 
     it('should return a rejected promise if something wrong occurred while fetching the configuration from the db', () => {
       const error = new Error('test');
-      kuzzle.internalEngine.get.returns(Bluebird.reject(error));
+      kuzzle.internalEngine.get.rejects(error);
 
       return should(services.init()).be.rejectedWith(error);
     });

--- a/test/services/internalEngine/index.test.js
+++ b/test/services/internalEngine/index.test.js
@@ -7,6 +7,7 @@ const
   KuzzleMock = require('../../mocks/kuzzle.mock'),
   ESClientMock = require('../../mocks/services/elasticsearchClient.mock'),
   NotFoundError = require('kuzzle-common-objects').errors.NotFoundError,
+  Bluebird = require('bluebird'),
   ms = require('ms');
 
 describe('InternalEngine', () => {
@@ -48,7 +49,7 @@ describe('InternalEngine', () => {
         collection = 'collection',
         query = { 'some': 'filters' };
 
-      kuzzle.internalEngine.client.search.returns(Promise.resolve({hits: { hits: ['foo', 'bar'], total: 123}}));
+      kuzzle.internalEngine.client.search.returns(Bluebird.resolve({hits: { hits: ['foo', 'bar'], total: 123}}));
 
       return kuzzle.internalEngine.search(collection, query, {from: 0, size: 20, scroll: 'foo'})
         .then(result => {
@@ -70,10 +71,10 @@ describe('InternalEngine', () => {
             should(result).be.an.Object().and.not.be.empty();
             should(result.total).be.eql(123);
             should(result.hits).be.an.Array().and.match(['foo', 'bar']);
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch(error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
@@ -83,7 +84,7 @@ describe('InternalEngine', () => {
         collection = 'collection',
         query = { query: {'some': 'filters' }};
 
-      kuzzle.internalEngine.client.search.returns(Promise.resolve({hits: { hits: ['foo', 'bar'], total: 123}}));
+      kuzzle.internalEngine.client.search.returns(Bluebird.resolve({hits: { hits: ['foo', 'bar'], total: 123}}));
 
       return kuzzle.internalEngine.search(collection, query, {from: 0, size: 20, scroll: 'foo'})
         .then(result => {
@@ -105,10 +106,10 @@ describe('InternalEngine', () => {
             should(result).be.an.Object().and.not.be.empty();
             should(result.total).be.eql(123);
             should(result.hits).be.an.Array().and.match(['foo', 'bar']);
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch(error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
@@ -116,7 +117,7 @@ describe('InternalEngine', () => {
     it('should perform a search on an empty filter if the filters argument is missing', () => {
       const collection = 'collection';
 
-      kuzzle.internalEngine.client.search.returns(Promise.resolve({hits: {hits: ['foo', 'bar'], total: 123}}));
+      kuzzle.internalEngine.client.search.returns(Bluebird.resolve({hits: {hits: ['foo', 'bar'], total: 123}}));
 
       return kuzzle.internalEngine.search(collection)
         .then(result => {
@@ -135,7 +136,7 @@ describe('InternalEngine', () => {
             should(result.hits).be.an.Array().and.match(['foo', 'bar']);
           }
           catch(error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
@@ -145,7 +146,7 @@ describe('InternalEngine', () => {
         collection = 'collection',
         query = {};
 
-      kuzzle.internalEngine.client.search.returns(Promise.resolve({
+      kuzzle.internalEngine.client.search.returns(Bluebird.resolve({
         hits: {
           total: 123,
           hits: ['foo', 'bar']
@@ -174,10 +175,10 @@ describe('InternalEngine', () => {
             should(result.total).be.eql(123);
             should(result.hits).be.an.Array().and.match(['foo', 'bar']);
             should(result.scrollId).be.eql('foobar');
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch(error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
@@ -187,7 +188,7 @@ describe('InternalEngine', () => {
         collection = 'collection',
         query = {};
 
-      kuzzle.internalEngine.client.search.returns(Promise.resolve({
+      kuzzle.internalEngine.client.search.returns(Bluebird.resolve({
         hits: {
           total: 123,
           hits: ['foo', 'bar']
@@ -220,17 +221,17 @@ describe('InternalEngine', () => {
             should(result.total).be.eql(123);
             should(result.hits).be.an.Array().and.match(['foo', 'bar']);
             should(result.scrollId).be.eql('foobar');
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch(error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
 
     it('should rejects the promise if the search fails', () => {
       const error = new Error('Mocked error');
-      kuzzle.internalEngine.client.search.returns(Promise.reject(error));
+      kuzzle.internalEngine.client.search.rejects(error);
 
       return should(kuzzle.internalEngine.search('foo')).be.rejectedWith(error);
     });
@@ -241,7 +242,7 @@ describe('InternalEngine', () => {
       const
         collection = 'collection';
 
-      kuzzle.internalEngine.client.scroll.returns(Promise.resolve({
+      kuzzle.internalEngine.client.scroll.returns(Bluebird.resolve({
         hits: {
           total: 123,
           hits: ['foo', 'bar']
@@ -249,7 +250,7 @@ describe('InternalEngine', () => {
         _scroll_id: 'foobar'
       }));
 
-      kuzzle.services.list.internalCache.exists.returns(Promise.resolve(1));
+      kuzzle.services.list.internalCache.exists.returns(Bluebird.resolve(1));
 
       return kuzzle.internalEngine.scroll(collection, 'foobar', '45s')
         .then(result => {
@@ -269,10 +270,10 @@ describe('InternalEngine', () => {
             should(result.total).be.eql(123);
             should(result.hits).be.an.Array().and.match(['foo', 'bar']);
             should(result.scrollId).be.eql('foobar');
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch(error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
@@ -281,7 +282,7 @@ describe('InternalEngine', () => {
       const
         collection = 'collection';
 
-      kuzzle.internalEngine.client.scroll.returns(Promise.resolve({
+      kuzzle.internalEngine.client.scroll.returns(Bluebird.resolve({
         hits: {
           hits: ['foo', 'bar'],
           total: 123
@@ -289,7 +290,7 @@ describe('InternalEngine', () => {
         _scroll_id: 'foobar'
       }));
 
-      kuzzle.services.list.internalCache.exists.returns(Promise.resolve(1));
+      kuzzle.services.list.internalCache.exists.returns(Bluebird.resolve(1));
 
       return kuzzle.internalEngine.scroll(collection, 'foobar')
         .then(result => {
@@ -309,10 +310,10 @@ describe('InternalEngine', () => {
             should(result.total).be.eql(123);
             should(result.hits).be.an.Array().and.match(['foo', 'bar']);
             should(result.scrollId).be.eql('foobar');
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch(error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
@@ -321,7 +322,7 @@ describe('InternalEngine', () => {
       const
         collection = 'collection';
 
-      kuzzle.internalEngine.client.scroll.returns(Promise.resolve({
+      kuzzle.internalEngine.client.scroll.returns(Bluebird.resolve({
         hits: {
           hits: ['foo', 'bar'],
           total: 123
@@ -329,7 +330,7 @@ describe('InternalEngine', () => {
         _scroll_id: 'foobar'
       }));
 
-      kuzzle.services.list.internalCache.exists.returns(Promise.resolve(1));
+      kuzzle.services.list.internalCache.exists.returns(Bluebird.resolve(1));
 
       return kuzzle.internalEngine.scroll(collection, 'foobar', 'foo')
         .then(result => {
@@ -349,10 +350,10 @@ describe('InternalEngine', () => {
             should(result.total).be.eql(123);
             should(result.hits).be.an.Array().and.match(['foo', 'bar']);
             should(result.scrollId).be.eql('foobar');
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch(error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
@@ -361,7 +362,7 @@ describe('InternalEngine', () => {
       const
         collection = 'collection';
 
-      kuzzle.internalEngine.client.scroll.returns(Promise.resolve({
+      kuzzle.internalEngine.client.scroll.returns(Bluebird.resolve({
         hits: {
           total: 123,
           hits: ['foo', 'bar']
@@ -369,7 +370,7 @@ describe('InternalEngine', () => {
         _scroll_id: 'foobar'
       }));
 
-      kuzzle.services.list.internalCache.exists.returns(Promise.resolve(0));
+      kuzzle.services.list.internalCache.exists.returns(Bluebird.resolve(0));
 
       return should(kuzzle.internalEngine.scroll(collection, 'foobar')).be.rejectedWith(NotFoundError, {message: 'Non-existing or expired scroll identifier'});
     });
@@ -381,7 +382,7 @@ describe('InternalEngine', () => {
         collection = 'foo',
         id = 'bar';
 
-      kuzzle.internalEngine.client.get.returns(Promise.resolve({foo: 'bar'}));
+      kuzzle.internalEngine.client.get.returns(Bluebird.resolve({foo: 'bar'}));
 
       return kuzzle.internalEngine.get(collection, id)
         .then(result => {
@@ -395,17 +396,17 @@ describe('InternalEngine', () => {
               });
 
             should(result).be.an.Object().and.match({'foo': 'bar'});
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch(error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
 
     it('should reject the promise if getting the document fails', () => {
       const error = new Error('Mocked error');
-      kuzzle.internalEngine.client.get.returns(Promise.reject(error));
+      kuzzle.internalEngine.client.get.rejects(error);
       return should(kuzzle.internalEngine.get('foo', 'bar')).be.rejectedWith(error);
     });
   });
@@ -416,7 +417,7 @@ describe('InternalEngine', () => {
         collection = 'foo',
         ids = ['bar', 'qux'];
 
-      kuzzle.internalEngine.client.mget.returns(Promise.resolve({docs: ['foo', 'bar']}));
+      kuzzle.internalEngine.client.mget.returns(Bluebird.resolve({docs: ['foo', 'bar']}));
 
       return kuzzle.internalEngine.mget(collection, ids)
         .then(result => {
@@ -433,17 +434,17 @@ describe('InternalEngine', () => {
             should(result).be.an.Object().and.not.be.empty();
             should(result).not.have.property('docs');
             should(result).match({hits: ['foo', 'bar']});
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch(error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
 
     it('should reject the promise if getting the document fails', () => {
       const error = new Error('Mocked error');
-      kuzzle.internalEngine.client.mget.returns(Promise.reject(error));
+      kuzzle.internalEngine.client.mget.rejects(error);
       return should(kuzzle.internalEngine.mget('foo', ['bar'])).be.rejectedWith(error);
     });
   });
@@ -455,7 +456,7 @@ describe('InternalEngine', () => {
         id = 'bar',
         content = {'foo': 'bar'};
 
-      kuzzle.internalEngine.client.create.returns(Promise.resolve({id}));
+      kuzzle.internalEngine.client.create.returns(Bluebird.resolve({id}));
 
       return kuzzle.internalEngine.create(collection, id, content)
         .then(result => {
@@ -472,17 +473,17 @@ describe('InternalEngine', () => {
             should(result).be.an.Object().and.not.be.empty();
             should(result).match({id, _source: content});
 
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch(error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
 
     it('should reject the promise if creating the document fails', () => {
       const error = new Error('Mocked error');
-      kuzzle.internalEngine.client.create.returns(Promise.reject(error));
+      kuzzle.internalEngine.client.create.rejects(error);
       return should(kuzzle.internalEngine.create('foo', 'bar', {'baz': 'qux'})).be.rejectedWith(error);
     });
   });
@@ -494,7 +495,7 @@ describe('InternalEngine', () => {
         id = 'bar',
         content = {'foo': 'bar'};
 
-      kuzzle.internalEngine.client.index.returns(Promise.resolve({id}));
+      kuzzle.internalEngine.client.index.returns(Bluebird.resolve({id}));
 
       return kuzzle.internalEngine.createOrReplace(collection, id, content)
         .then(result => {
@@ -510,17 +511,17 @@ describe('InternalEngine', () => {
 
             should(result).be.an.Object().and.not.be.empty();
             should(result).match({id, _source: content});
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch(error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
 
     it('should reject the promise if creating the document fails', () => {
       const error = new Error('Mocked error');
-      kuzzle.internalEngine.client.index.returns(Promise.reject(error));
+      kuzzle.internalEngine.client.index.rejects(error);
       return should(kuzzle.internalEngine.createOrReplace('foo', 'bar', {'baz': 'qux'})).be.rejectedWith(error);
     });
   });
@@ -532,7 +533,7 @@ describe('InternalEngine', () => {
         id = 'bar',
         content = {'foo': 'bar'};
 
-      kuzzle.internalEngine.client.update.returns(Promise.resolve({id}));
+      kuzzle.internalEngine.client.update.returns(Bluebird.resolve({id}));
 
       return kuzzle.internalEngine.update(collection, id, content)
         .then(result => {
@@ -551,17 +552,17 @@ describe('InternalEngine', () => {
 
             should(result).be.an.Object().and.not.be.empty();
 
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch(error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
 
     it('should reject the promise if creating the document fails', () => {
       const error = new Error('Mocked error');
-      kuzzle.internalEngine.client.update.returns(Promise.reject(error));
+      kuzzle.internalEngine.client.update.rejects(error);
       return should(kuzzle.internalEngine.update('foo', 'bar', {'baz': 'qux'})).be.rejectedWith(error);
     });
   });
@@ -573,8 +574,8 @@ describe('InternalEngine', () => {
         id = 'bar',
         content = {'foo': 'bar'};
 
-      kuzzle.internalEngine.client.index.returns(Promise.resolve({id}));
-      kuzzle.internalEngine.client.exists.returns(Promise.resolve(true));
+      kuzzle.internalEngine.client.index.returns(Bluebird.resolve({id}));
+      kuzzle.internalEngine.client.exists.returns(Bluebird.resolve(true));
 
       return kuzzle.internalEngine.replace(collection, id, content)
         .then(result => {
@@ -590,23 +591,23 @@ describe('InternalEngine', () => {
 
             should(result).be.an.Object().and.not.be.empty();
             should(result).match({id, _source: content});
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch(error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
 
     it('should rejects the promise if the document does not exist', () => {
-      kuzzle.internalEngine.client.exists.returns(Promise.resolve(false));
+      kuzzle.internalEngine.client.exists.returns(Bluebird.resolve(false));
       return should(kuzzle.internalEngine.replace('foo', 'bar', {'baz': 'qux'})).be.rejectedWith(NotFoundError);
     });
 
     it('should rejects the promise if the replace action fails', () => {
       const error = new Error('Mocked error');
-      kuzzle.internalEngine.client.exists.returns(Promise.resolve(true));
-      kuzzle.internalEngine.client.index.returns(Promise.reject(error));
+      kuzzle.internalEngine.client.exists.returns(Bluebird.resolve(true));
+      kuzzle.internalEngine.client.index.rejects(error);
       return should(kuzzle.internalEngine.replace('foo', 'bar', {'baz': 'qux'})).be.rejectedWith(error);
     });
   });
@@ -617,7 +618,7 @@ describe('InternalEngine', () => {
         collection = 'foo',
         id = 'bar';
 
-      kuzzle.internalEngine.client.delete.returns(Promise.resolve());
+      kuzzle.internalEngine.client.delete.returns(Bluebird.resolve());
 
       return kuzzle.internalEngine.delete(collection, id)
         .then(() => {
@@ -630,17 +631,17 @@ describe('InternalEngine', () => {
                 id
               });
 
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch(error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
 
     it('should reject the promise if deleting the document fails', () => {
       const error = new Error('Mocked error');
-      kuzzle.internalEngine.client.delete.returns(Promise.reject(error));
+      kuzzle.internalEngine.client.delete.rejects(error);
       return should(kuzzle.internalEngine.delete('foo', 'bar')).be.rejectedWith(error);
     });
   });
@@ -649,7 +650,7 @@ describe('InternalEngine', () => {
     it('should forward the request to elasticsearch', () => {
       const
         createStub = kuzzle.internalEngine.client.indices.create,
-        existsStub = kuzzle.internalEngine.client.indices.exists.returns(Promise.resolve(false));
+        existsStub = kuzzle.internalEngine.client.indices.exists.returns(Bluebird.resolve(false));
 
       return kuzzle.internalEngine.createInternalIndex()
         .then(() => {
@@ -659,10 +660,10 @@ describe('InternalEngine', () => {
             should(createStub).be.calledOnce();
             should(createStub).be.calledWith({index: kuzzle.internalEngine.index});
 
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch(error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
@@ -670,7 +671,7 @@ describe('InternalEngine', () => {
     it('should not try to create an existing index', () => {
       const
         createStub = kuzzle.internalEngine.client.indices.create,
-        existsStub = kuzzle.internalEngine.client.indices.exists.returns(Promise.resolve(true));
+        existsStub = kuzzle.internalEngine.client.indices.exists.returns(Bluebird.resolve(true));
 
       return kuzzle.internalEngine.createInternalIndex()
         .then(() => {
@@ -679,18 +680,18 @@ describe('InternalEngine', () => {
             should(existsStub).be.calledWith({index: kuzzle.internalEngine.index});
             should(createStub).have.callCount(0);
 
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch(error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
 
     it('should reject the promise if creating the internal index fails', () => {
       const error = new Error('Mocked error');
-      kuzzle.internalEngine.client.indices.exists.returns(Promise.resolve(false));
-      kuzzle.internalEngine.client.indices.create.returns(Promise.reject(error));
+      kuzzle.internalEngine.client.indices.exists.returns(Bluebird.resolve(false));
+      kuzzle.internalEngine.client.indices.create.rejects(error);
 
       return should(kuzzle.internalEngine.createInternalIndex()).be.rejectedWith(error);
     });
@@ -698,7 +699,7 @@ describe('InternalEngine', () => {
 
   describe('#listIndexes', () => {
     it('should forward the request to elasticsearch', () => {
-      kuzzle.internalEngine.client.indices.getMapping.returns(Promise.resolve({
+      kuzzle.internalEngine.client.indices.getMapping.returns(Bluebird.resolve({
         index1: {mappings: {foo: 'bar'}},
         index2: {mappings: {foo: 'bar'}}
       }));
@@ -715,10 +716,10 @@ describe('InternalEngine', () => {
             should(result).match(['index1', 'index2']);
 
 
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch(error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
 
         });
@@ -728,7 +729,7 @@ describe('InternalEngine', () => {
 
   describe('#listCollections', () => {
     it('should forward the request to elasticsearch', () => {
-      kuzzle.internalEngine.client.indices.getMapping.returns(Promise.resolve({
+      kuzzle.internalEngine.client.indices.getMapping.returns(Bluebird.resolve({
         index1: {mappings: {foo: 'bar', baz: 'qux'}},
         index2: {mappings: {foo: 'bar'}}
       }));
@@ -747,10 +748,10 @@ describe('InternalEngine', () => {
 
             should(result).match(['foo', 'baz']);
 
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch(error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
 
         });
@@ -786,10 +787,10 @@ describe('InternalEngine', () => {
               .be.calledWithMatch({
                 index: kuzzle.internalEngine.index
               });
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch(error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
@@ -812,10 +813,10 @@ describe('InternalEngine', () => {
                 body: mapping
               });
 
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch(error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });
@@ -832,10 +833,10 @@ describe('InternalEngine', () => {
                 index: kuzzle.internalEngine.index
               });
 
-            return Promise.resolve();
+            return Bluebird.resolve();
           }
           catch(error) {
-            return Promise.reject(error);
+            return Bluebird.reject(error);
           }
         });
     });

--- a/test/services/internalEngine/pluginBootstrap.test.js
+++ b/test/services/internalEngine/pluginBootstrap.test.js
@@ -81,7 +81,7 @@ describe('services/internalEngine/pluginBootstrap.js', () => {
 
   describe('#lock', () => {
     it('should create a new lock if some old one is found', () => {
-      kuzzle.internalEngine.create.returns(Bluebird.reject());
+      kuzzle.internalEngine.create.rejects();
       kuzzle.internalEngine.get.returns(Bluebird.resolve({_source: {timestamp: 0}}));
 
       return bootstrap.lock()

--- a/test/util/esWrapper.test.js
+++ b/test/util/esWrapper.test.js
@@ -98,7 +98,7 @@ describe('Test: ElasticSearch Wrapper', () => {
 
     it('should reject the getMapping promise if elasticsearch throws an error', () => {
       const error = new Error('Mocked error');
-      client.indices.getMapping.returns(Bluebird.reject(error));
+      client.indices.getMapping.rejects(error);
 
       return should(esWrapper.getMapping(mappingRequest)).be.rejectedWith(error);
     });


### PR DESCRIPTION
Fixes #1002 by auto-injecting `_kuzzle_info` internal propery mapping.

## Boyscouting 

(big one, sorry -_-;...)
Modified all tests that would use patterns like `mock.returns(Bluebird.rejects())` to avoid premature escalation of UnhandledRejection before the test promise is checked.
