### PR TITLE
use HTTP `GET` method instead of `POST` for server/getStats

### DIFF
--- a/features/run.sh
+++ b/features/run.sh
@@ -6,14 +6,18 @@ set -e
 
 proxy_host="${CUCUMBER_PROXY_HOST:-localhost}"
 embedded_host="${CUCUMBER_EMBEDDED_HOST:-localhost}"
+proxy_port="${CUCUMBER_PROXY_PORT:-7513}"
+embedded_port="${CUCUMBER_EMBEDDED_PORT:-7512}"
 
 for endpoint in Embedded Proxy; do
   for protocol in websocket http socketio; do
     if [ "$endpoint" == "Proxy" ]; then
       host="$proxy_host"
+      port="$proxy_port"
     else
       host="$embedded_host"
+      port="$embedded_port"
     fi
-    ./node_modules/.bin/cucumberjs --format progress-bar -p "${protocol}${endpoint}" --world-parameters "{\"host\": \"${host}\"}"
+    ./node_modules/.bin/cucumberjs --format progress-bar -p "${protocol}${endpoint}" --world-parameters "{\"host\": \"${host}\", \"port\": \"${port}\"}"
   done
 done

--- a/features/support/api/http.js
+++ b/features/support/api/http.js
@@ -1,4 +1,5 @@
 const
+  _ = require('lodash'),
   rp = require('request-promise'),
   routes = require('../../../lib/config/httpRoutes');
 

--- a/features/support/api/http.js
+++ b/features/support/api/http.js
@@ -83,11 +83,13 @@ class HttpApi {
             _.difference(Object.keys(args.body), hits).forEach(key => {
               const value = args.body[key];
 
-              if (_.isArray(value)) {
-                queryString.push(...value.map(v => `${key}=${v}`));
-              }
-              else {
-                queryString.push(`${key}=${value}`);
+              if (value !== undefined) {
+                if (_.isArray(value)) {
+                  queryString.push(...value.map(v => `${key}=${v}`));
+                }
+                else {
+                  queryString.push(`${key}=${value}`);
+                }
               }
             });
 
@@ -607,13 +609,7 @@ class HttpApi {
   }
 
   getStats (dates) {
-    const options = {
-      url: this.apiPath('_getStats'),
-      method: 'POST',
-      body: dates
-    };
-
-    return this.callApi(options);
+    return this.callApi(this._getRequest(null, null, 'server', 'getStats', {body: dates}));
   }
 
   getUser (id) {

--- a/features/support/api/http.js
+++ b/features/support/api/http.js
@@ -1,5 +1,4 @@
 const
-  _ = require('lodash'),
   rp = require('request-promise'),
   routes = require('../../../lib/config/httpRoutes');
 
@@ -84,7 +83,7 @@ class HttpApi {
               const value = args.body[key];
 
               if (value !== undefined) {
-                if (_.isArray(value)) {
+                if (Array.isArray(value)) {
                   queryString.push(...value.map(v => `${key}=${v}`));
                 }
                 else {

--- a/lib/api/core/statistics.js
+++ b/lib/api/core/statistics.js
@@ -174,11 +174,11 @@ class StatisticsController {
 
 
     if (request && request.input.args && request.input.args.startTime) {
-      startTime = new Date(request.input.args.startTime).getTime();
+      startTime = isNaN(request.input.args.startTime) ? new Date(request.input.args.startTime).getTime() : request.input.args.startTime;
     }
 
     if (request && request.input.args && request.input.args.stopTime) {
-      stopTime = new Date(request.input.args.stopTime).getTime();
+      stopTime = isNaN(request.input.args.stopTime) ? new Date(request.input.args.stopTime).getTime() : request.input.args.stopTime;
     }
 
     if ((startTime !== undefined && isNaN(startTime)) || (stopTime !== undefined && isNaN(stopTime))) {

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -67,6 +67,7 @@ module.exports = [
   {verb: 'get', url: '/_getAllStats', controller: 'server', action: 'getAllStats'},
   {verb: 'get', url: '/_getConfig', controller: 'server', action: 'getConfig'},
   {verb: 'get', url: '/_getLastStats', controller: 'server', action: 'getLastStats'},
+  {verb: 'get', url: '/_getStats', controller: 'server', action: 'getStats'},
   {verb: 'get', url: '/', controller: 'server', action: 'info'},
   {verb: 'get', url: '/_healthCheck', controller: 'server', action: 'healthCheck'},
   {verb: 'get', url: '/_serverInfo', controller: 'server', action: 'info'},
@@ -145,6 +146,7 @@ module.exports = [
   {verb: 'post', url: '/:index/_bulk', controller: 'bulk', action: 'import'},
   {verb: 'post', url: '/:index/:collection/_bulk', controller: 'bulk', action: 'import'},
 
+  /* DEPRECATED - will be removed in v2 */
   {verb: 'post', url: '/_getStats', controller: 'server', action: 'getStats'},
 
   {verb: 'post', url: '/:index/_create', controller: 'index', action: 'create'},


### PR DESCRIPTION
Also do not parse `date` arguments if they are in a timestamp format.

## Deprecation
old `POST` method is maintained to avoid breaking change, but is now marked as deprecated.
It has to be removed in next major release.

## Boyscout 
Add the possibility to override default ports while running feature tests