### PR TITLE
ServerInfo: list all http routes

### DIFF
--- a/lib/api/controllers/serverController.js
+++ b/lib/api/controllers/serverController.js
@@ -211,7 +211,7 @@ class ServerController {
             });
 
             actionList[action].nproutes = routeDescriptionList.length;
-            routeDescriptionList.forEach( routeDescription => {
+            routeDescriptionList.forEach(routeDescription => {
               if (actionList[action].http === undefined) {
                 actionList[action].http = [];
               }
@@ -220,7 +220,7 @@ class ServerController {
                 verb: routeDescription.verb.toUpperCase()
               });
             });
-           }
+          }
         });
 
         if (Object.keys(actionList).length > 0) {

--- a/lib/api/controllers/serverController.js
+++ b/lib/api/controllers/serverController.js
@@ -203,20 +203,24 @@ class ServerController {
             actionList[action] = {controller, action};
 
             // resolve associated http route for each actions
-            const routeDescription = httpRoutes.find(route => {
+            const routeDescriptionList = httpRoutes.filter(route => {
               return (
                 (route.controller === controller || controller === 'memoryStorage' && route.controller === 'ms') &&
                 route.action === action
               );
             });
 
-            if (routeDescription) {
-              actionList[action].http = {
+            actionList[action].nproutes = routeDescriptionList.length;
+            routeDescriptionList.forEach( routeDescription => {
+              if (actionList[action].http === undefined) {
+                actionList[action].http = [];
+              }
+              actionList[action].http.push({
                 url: (urlPrefix + routeDescription.url).replace(/\/\//g, '/'),
                 verb: routeDescription.verb.toUpperCase()
-              };
-            }
-          }
+              });
+            });
+           }
         });
 
         if (Object.keys(actionList).length > 0) {

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -35,6 +35,8 @@ module.exports = [
   {verb: 'get', url: '/:index/:collection/_specifications', controller: 'collection', action: 'getSpecifications'},
   {verb: 'get', url: '/validations/_scroll/:scrollId', controller: 'collection', action: 'scrollSpecifications'},
   {verb: 'get', url: '/:index/_list', controller: 'collection', action: 'list'},
+
+  /* DEPRECATED - will be removed in v2 */ 
   {verb: 'get', url: '/:index/_list/:type', controller: 'collection', action: 'list'},
 
   {verb: 'get', url: '/:index/:collection/:_id', controller: 'document', action: 'get'},

--- a/test/api/controllers/serverController.test.js
+++ b/test/api/controllers/serverController.test.js
@@ -217,6 +217,7 @@ describe('Test: server controller', () => {
       };
 
       kuzzle.config.http.routes.push({verb: 'foo', action: 'publicMethod', controller: 'foo', url: '/u/r/l'});
+      kuzzle.config.http.routes.push({verb: 'foo', action: 'publicMethod', controller: 'foo', url: '/u/r/l/:foobar'});
       kuzzle.pluginsManager.routes = [{verb: 'bar', action: 'publicMethod', controller: 'foobar', url: '/foobar'}];
 
       return serverController.info()
@@ -232,28 +233,32 @@ describe('Test: server controller', () => {
               publicMethod: {
                 action: 'publicMethod',
                 controller: 'foo',
-                http: {
-                  url: '/u/r/l',
-                  verb: 'FOO'
-                }
+                nproutes: 2,
+                http: [
+                  {url: '/u/r/l', verb: 'FOO'},
+                  {url: '/u/r/l/:foobar', verb: 'FOO'}
+                ]
               },
               baz: {
                 action: 'baz',
-                controller: 'foo'
+                controller: 'foo',
+                nproutes: 0
               }
             },
             foobar: {
               publicMethod: {
                 action: 'publicMethod',
                 controller: 'foobar',
-                http: {
+                nproutes: 1,
+                http: [{
                   url: '_plugin/foobar',
                   verb: 'BAR'
-                }
+                }]
               },
               anotherMethod: {
                 action: 'anotherMethod',
-                controller: 'foobar'
+                controller: 'foobar',
+                nproutes: 0
               }
             }
           });


### PR DESCRIPTION
Some actions can be handled by more than one HTTP routes (examples: `user/login`, `server/info`, `document/create`...)
Until now, the `server/info` method put arbitrary only one route for each action in `kuzzle.api.routes`.

This PR returns for each action an array of routes instead of a single one, to let the client now all the available HTTP routes.

* also mark `:index/_list/:type` as deprecated, as `type` argument should be passed through a query_string argument.