### PR TITLE
Remove kuzzle from security object methods signatures

### DIFF
--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -318,7 +318,7 @@ class FunnelController {
       .then(user => {
         request.context.user = user;
 
-        return user.isActionAllowed(request, this.kuzzle);
+        return user.isActionAllowed(request);
       })
       .then(isAllowed => {
         if (!isAllowed) {

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -27,7 +27,6 @@ const
   Bluebird = require('bluebird'),
   formatProcessing = require('../core/auth/formatProcessing'),
   Request = require('kuzzle-common-objects').Request,
-  User = require('../core/models/security/user'),
   Role = require('../core/models/security/role'),
   Profile = require('../core/models/security/profile'),
   {
@@ -99,7 +98,7 @@ const persistUser = Bluebird.coroutine(function* persistUserGenerator (kuzzle, r
   }
 
   // Add metadata
-  pojoUser._kuzzle_info= {
+  pojoUser._kuzzle_info = {
     author: request.context.user ? String(request.context.user._id) : null,
     createdAt: Date.now(),
     updatedAt: null,
@@ -113,7 +112,7 @@ const persistUser = Bluebird.coroutine(function* persistUserGenerator (kuzzle, r
     }
   };
   // Throw in case of failure with the right KuzzleError object
-  const createdUser = yield kuzzle.repositories.user.hydrate(new User(), pojoUser)
+  const createdUser = yield kuzzle.repositories.user.fromDTO(pojoUser)
     .then(modifiedUser => kuzzle.repositories.user.persist(modifiedUser, options))
     .then(modifiedUser => formatProcessing.formatUserForSerialization(kuzzle, modifiedUser));
 
@@ -288,7 +287,7 @@ class SecurityController {
   getRole(request) {
     assertHasId(request);
 
-    return this.kuzzle.repositories.role.loadRole(request.input.resource._id)
+    return this.kuzzle.repositories.role.load(request.input.resource._id)
       .then(role => {
         if (!role) {
           return Bluebird.reject(new NotFoundError(`Role with id ${request.input.resource._id} not found`));
@@ -376,9 +375,8 @@ class SecurityController {
   deleteRole(request) {
     assertHasId(request);
 
-    const role = this.kuzzle.repositories.role.getRoleFromRequest(request);
-
-    return this.kuzzle.repositories.role.deleteRole(role, {refresh: request.input.args.refresh});
+    return this.kuzzle.repositories.role.getRoleFromRequest(request)
+      .then(role => this.kuzzle.repositories.role.deleteRole(role, {refresh: request.input.args.refresh}));
   }
 
   /**
@@ -390,7 +388,7 @@ class SecurityController {
   getProfile(request) {
     assertHasId(request);
 
-    return this.kuzzle.repositories.profile.loadProfile(request.input.resource._id)
+    return this.kuzzle.repositories.profile.load(request.input.resource._id)
       .then(profile => {
         if (!profile) {
           return Bluebird.reject(new NotFoundError(`Profile with id ${request.input.resource._id} not found`));
@@ -515,13 +513,13 @@ class SecurityController {
   getProfileRights(request) {
     assertHasId(request);
 
-    return this.kuzzle.repositories.profile.loadProfile(request.input.resource._id)
+    return this.kuzzle.repositories.profile.load(request.input.resource._id)
       .then(profile => {
         if (!profile) {
           return Bluebird.reject(new NotFoundError(`Profile with id ${request.input.resource._id} not found`));
         }
 
-        return profile.getRights(this.kuzzle);
+        return profile.getRights();
       })
       .then(rights => Object.keys(rights).reduce((array, item) => array.concat(rights[item]), []))
       .then(rights => ({hits: rights, total: rights.length}));
@@ -650,7 +648,9 @@ class SecurityController {
       .then(user => {
         const pojo = request.input.body;
         pojo._id = request.input.resource._id;
-        return this.kuzzle.repositories.user.hydrate(user, pojo);
+
+        const currentUserPojo = this.kuzzle.repositories.user.toDTO(user);
+        return this.kuzzle.repositories.user.fromDTO(Object.assign(currentUserPojo, pojo));
       })
       .then(user => this.kuzzle.repositories.user.persist(user, options))
       .then(updatedUser => formatProcessing.formatUserForSerialization(this.kuzzle, updatedUser));
@@ -663,7 +663,6 @@ class SecurityController {
    * @returns {Promise<Object>}
    */
   replaceUser(request) {
-    const user = new User();
     let pojoUser;
 
     assertHasBody(request);
@@ -690,7 +689,7 @@ class SecurityController {
 
     return this.kuzzle.repositories.user.load(request.input.resource._id)
       .then(loadedUser => (!loadedUser) ? Bluebird.reject(new NotFoundError(`User with id ${request.input.resource._id} not found`)) : Bluebird.resolve())
-      .then(() => this.kuzzle.repositories.user.hydrate(user, pojoUser))
+      .then(() => this.kuzzle.repositories.user.fromDTO(pojoUser))
       .then(updatedUser => this.kuzzle.repositories.user.persist(updatedUser, options))
       .then(createdUser => formatProcessing.formatUserForSerialization(this.kuzzle, createdUser));
   }
@@ -711,7 +710,7 @@ class SecurityController {
       retryOnConflict: request.input.args.retryOnConflict
     };
 
-    return this.kuzzle.repositories.profile.loadProfile(request.input.resource._id)
+    return this.kuzzle.repositories.profile.load(request.input.resource._id)
       .then(profile => updateMetadata(profile, request))
       .then(profile => this.kuzzle.repositories.profile.validateAndSaveProfile(_.extend(profile, request.input.body), options))
       .then(updatedProfile => formatProcessing.formatProfileForSerialization(updatedProfile));
@@ -733,7 +732,7 @@ class SecurityController {
       retryOnConflict: request.input.args.retryOnConflict
     };
 
-    return this.kuzzle.repositories.role.loadRole(request.input.resource._id)
+    return this.kuzzle.repositories.role.load(request.input.resource._id)
       .then(role => updateMetadata(role, request))
       .then(role => this.kuzzle.repositories.role.validateAndSaveRole(_.extend(role, request.input.body), options))
       .then(updatedRole => formatProcessing.formatRoleForSerialization(updatedRole));
@@ -1012,9 +1011,8 @@ module.exports = SecurityController;
  * @returns {Promise<Role>}
  */
 function createOrReplaceRole (roleRepository, request, opts) {
-  const role = roleRepository.getRoleFromRequest(request);
-
-  return roleRepository.validateAndSaveRole(role, opts);
+  return roleRepository.getRoleFromRequest(request)
+    .then(role => roleRepository.validateAndSaveRole(role, opts));
 }
 
 /**
@@ -1025,7 +1023,6 @@ function createOrReplaceRole (roleRepository, request, opts) {
  */
 function createOrReplaceProfile (profileRepository, request, opts) {
   return profileRepository.buildProfileFromRequest(request)
-    .then(profile => profileRepository.hydrate(profile, request.input.body))
     .then(hydratedProfile => profileRepository.validateAndSaveProfile(hydratedProfile, opts));
 }
 

--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -189,7 +189,7 @@ class HotelClerk {
           collection
         }, request.context);
 
-        promises.push(request.context.user.isActionAllowed(isAllowedRequest, this.kuzzle)
+        promises.push(request.context.user.isActionAllowed(isAllowedRequest)
           .then(isAllowed => {
             if (!isAllowed) {
               return;

--- a/lib/api/core/models/repositories/profileRepository.js
+++ b/lib/api/core/models/repositories/profileRepository.js
@@ -58,31 +58,26 @@ class ProfileRepository extends Repository {
   /**
    * Loads a Profile object given its id.
    *
-   * @param {string} profileId
+   * @param {string} id
    * @returns {Promise} Resolves to the matching Profile object if found, null if not.
    */
-  loadProfile (profileId) {
-    if (!profileId) {
+  load (id) {
+    if (!id) {
       return Bluebird.reject(new BadRequestError('Missing profileId'));
     }
 
-    if (typeof profileId !== 'string') {
-      return Bluebird.reject(new BadRequestError(`Invalid argument: Expected profile id to be a string, received "${typeof profileId}"`));
+    if (typeof id !== 'string') {
+      return Bluebird.reject(new BadRequestError(`Invalid argument: Expected profile id to be a string, received "${typeof id}"`));
     }
 
-    if (this.profiles[profileId]) {
-      return Bluebird.resolve(this.profiles[profileId]);
+    if (this.profiles[id]) {
+      return Bluebird.resolve(this.profiles[id]);
     }
 
-    return this.load(profileId)
-      .then(result => {
-        if (result) {
-          this.profiles[profileId] = result;
-          return result;
-        }
-
-        // no profile found
-        return null;
+    return super.load(id)
+      .then(profile => {
+        this.profiles[id] = profile;
+        return profile;
       });
   }
 
@@ -93,13 +88,11 @@ class ProfileRepository extends Repository {
    * @returns {Promise} Resolves to the matching Profile object if found, null if not.
    */
   loadProfiles (profileIds) {
-    let promises;
-
     if (!profileIds) {
       return Bluebird.reject(new BadRequestError('Missing profileIds'));
     }
 
-    if (!_.isArray(profileIds) || profileIds.reduce((prev, profile) => (prev || typeof profile !== 'string'), false)) {
+    if (!Array.isArray(profileIds) || profileIds.reduce((prev, profile) => (prev || typeof profile !== 'string'), false)) {
       return Bluebird.reject(new BadRequestError('An array of strings must be provided as profileIds'));
     }
 
@@ -107,19 +100,32 @@ class ProfileRepository extends Repository {
       return Bluebird.resolve([]);
     }
 
-    promises = profileIds.map(profileId => this.loadProfile(profileId));
+    const missing = [];
+    const promises = [];
+
+    for (const id of profileIds) {
+      if (this.profiles[id]) {
+        promises.push(Bluebird.resolve(this.profiles[id]));
+      }
+      else {
+        missing.push(id);
+      }
+    }
+
+    if (missing.length > 0) {
+      promises.push(this.loadMultiFromDatabase(missing)
+        .then(profiles => {
+          for (const profile of profiles) {
+            this.profiles[profile.id] = profile;
+          }
+
+          return profiles;
+        })
+      );
+    }
 
     return Bluebird.all(promises)
-      .then(results => {
-        const profiles = [];
-        results.forEach(profile => {
-          if (profile !== null) {
-            profiles.push(profile);
-          }
-        });
-
-        return profiles;
-      });
+      .then(results => results.reduce((acc, curr) => acc.concat(curr), []));
   }
 
   /**
@@ -129,22 +135,21 @@ class ProfileRepository extends Repository {
    * @returns Promise Resolves to the built Profile object.
    */
   buildProfileFromRequest (request) {
-    const profile = new Profile();
+    const dto = {};
 
     if (request.input.body) {
-      Object.assign(profile, request.input.body);
+      Object.assign(dto, request.input.body);
     }
+    dto._id = request.input.resource._id;
 
-    profile._kuzzle_info = {
+    dto._kuzzle_info = {
       author: request.context.user ? String(request.context.user._id) : null,
       createdAt: Date.now(),
       updatedAt: null,
       updater: null
     };
 
-    profile._id = request.input.resource._id;
-
-    return Bluebird.resolve(profile);
+    return this.fromDTO(dto);
   }
 
   /**
@@ -164,45 +169,6 @@ class ProfileRepository extends Repository {
     }
 
     return this.search(query, options);
-  }
-
-  /**
-   * Populates a Profile object with the values contained in the data object.
-   *
-   * @param {Profile} profile
-   * @param {object} data
-   * @returns {Promise<Profile>} Resolves to the hydrated Profile object.
-   */
-  hydrate (profile, data) {
-    if (data._source) {
-      const source = data._source;
-      delete data._index;
-      delete data._type;
-      delete data._version;
-      delete data.found;
-      delete data._source;
-      Object.assign(data, source);
-    }
-
-    // force "default" role/policy if the profile does not have any role in it
-    if (!profile.policies || profile.policies.length === 0) {
-      profile.policies = [ {roleId: 'default'} ];
-    }
-
-    _.assignIn(profile, data);
-    const policiesRoles = extractRoleIds(profile.policies);
-
-    return this.kuzzle.repositories.role.loadRoles(policiesRoles)
-      .then(roles => {
-        const rolesNotFound = _.difference(policiesRoles, extractRoleIds(roles));
-
-        // Fail if not all roles are found
-        if (rolesNotFound.length) {
-          return Bluebird.reject(new NotFoundError(`Unable to hydrate the profile ${data._id}. The following role(s) don't exist: ${rolesNotFound}`));
-        }
-
-        return profile;
-      });
   }
 
   /**
@@ -292,7 +258,40 @@ class ProfileRepository extends Repository {
       })
       .then(() => profile);
   }
+
+  /**
+   * @param {object} dto
+   * @returns {Promise<Promise>}
+   */
+  fromDTO (dto) {
+    return super.fromDTO(dto)
+      .then(profile => {
+        // force "default" role/policy if the profile does not have any role in it
+        if (!profile.policies || profile.policies.length === 0) {
+          profile.policies = [ {roleId: 'default'} ];
+        }
+
+        if (profile.constructor._hash('') === false) {
+          profile.constructor._hash = this.kuzzle.constructor.hash;
+        }
+
+        const policiesRoles = extractRoleIds(profile.policies);
+        return this.kuzzle.repositories.role.loadRoles(policiesRoles)
+          .then(roles => {
+            const rolesNotFound = _.difference(policiesRoles, extractRoleIds(roles));
+
+            // Fail if not all roles are found
+            if (rolesNotFound.length) {
+              return Bluebird.reject(new NotFoundError(`Unable to hydrate the profile ${profile._id}. The following role(s) don't exist: ${rolesNotFound}`));
+            }
+
+            return profile;
+          });
+
+      });
+  }
 }
+
 
 module.exports = ProfileRepository;
 

--- a/lib/api/core/models/repositories/profileRepository.js
+++ b/lib/api/core/models/repositories/profileRepository.js
@@ -76,7 +76,9 @@ class ProfileRepository extends Repository {
 
     return super.load(id)
       .then(profile => {
-        this.profiles[id] = profile;
+        if (profile) {
+          this.profiles[id] = profile;
+        }
         return profile;
       });
   }

--- a/lib/api/core/models/repositories/repository.js
+++ b/lib/api/core/models/repositories/repository.js
@@ -22,9 +22,10 @@
 'use strict';
 
 const
-  _ = require('lodash'),
   Bluebird = require('bluebird'),
   KuzzleInternalError = require('kuzzle-common-objects').errors.InternalError;
+
+const _kuzzle = Symbol.for('_kuzzle');
 
 /**
  * @class Repository
@@ -82,11 +83,14 @@ class Repository {
     return this.databaseEngine.get(this.collection, id)
       .then(response => {
         if (response._id) {
-          const result = new this.ObjectConstructor();
+          const dto = {};
+
           if (response._source) {
-            return _.assignIn(result, response._source, {_id: response._id});
+            Object.assign(dto, response._source, {_id: response._id});
           }
-          return _.assignIn(result, response);
+          Object.assign(dto, response);
+
+          return this.fromDTO(dto);
         }
         return null;
       })
@@ -105,20 +109,10 @@ class Repository {
    * @param {string[]|object[]} _ids
    * @returns {Promise<object>}
    */
-  loadMultiFromDatabase (_ids) {
-    const ids = [];
-
-    if (!_.isArray(_ids)) {
-      return Bluebird.reject(new KuzzleInternalError(`Bad argument: ${_ids.toString()} is not an array.`));
+  loadMultiFromDatabase (ids) {
+    if (!Array.isArray(ids)) {
+      return Bluebird.reject(new KuzzleInternalError(`Bad argument: ${ids.toString()} is not an array.`));
     }
-    _ids.forEach(element => {
-      if (!_.isObject(element)) {
-        ids.push(element);
-      }
-      else {
-        ids.push(element._id);
-      }
-    });
 
     return this.databaseEngine.mget(this.collection, ids)
       .then(response => {
@@ -126,13 +120,10 @@ class Repository {
           return Bluebird.resolve([]);
         }
 
-        return response.hits
-          .filter(document => document.found)
-          .map(document => {
-            const object = new this.ObjectConstructor();
-
-            return _.assignIn(object, document._source, {_id: document._id});
-          });
+        return Bluebird.all(response.hits
+          .filter(doc => doc.found)
+          .map(doc => this.fromDTO(Object.assign({}, doc._source, {_id: doc._id})))
+        );
       });
   }
 
@@ -145,7 +136,7 @@ class Repository {
    */
   search (query, options = {}) {
     return this.databaseEngine.search(this.collection, query, options)
-      .then(response => formatSearchResults(response));
+      .then(response => this._formatSearchResults(response));
   }
 
   /**
@@ -155,7 +146,7 @@ class Repository {
    */
   scroll (scrollId, ttl) {
     return this.databaseEngine.scroll(this.collection, scrollId, ttl)
-      .then(response => formatSearchResults(response));
+      .then(response => this._formatSearchResults(response));
   }
 
   /**
@@ -176,15 +167,11 @@ class Repository {
 
     return this.cacheEngine.get(key)
       .then(response => {
-        let object;
-
         if (response === null) {
           return null;
         }
 
-        object = new this.ObjectConstructor();
-
-        return _.assignIn(object, JSON.parse(response));
+        return this.fromDTO(Object.assign({}, JSON.parse(response)));
       })
       .catch(err => Bluebird.reject(new KuzzleInternalError(err)));
   }
@@ -265,7 +252,6 @@ class Repository {
 
     return Bluebird.all(promises);
   }
-
 
   /**
    * Delete repository from database according to its id
@@ -354,7 +340,7 @@ class Repository {
    * @returns {object}
    */
   serializeToCache (object) {
-    return _.assign({}, object);
+    return this.toDTO(object);
   }
 
   /**
@@ -364,7 +350,9 @@ class Repository {
    * @returns {object}
    */
   serializeToDatabase (object) {
-    return object;
+    const dto = this.toDTO(object);
+    delete dto._id;
+    return dto;
   }
 
   /**
@@ -374,29 +362,55 @@ class Repository {
 
     return `repos/${this.index}/${this.collection}/${id}`;
   }
+
+  /**
+   * @param {object} dto
+   * @returns {Promise<ObjectConstructor>}
+   */
+  fromDTO (dto) {
+    const o = new this.ObjectConstructor();
+    o[_kuzzle] = this.kuzzle;
+    Object.assign(o, dto);
+
+    return Bluebird.resolve(o);
+  }
+
+  /**
+   * @param {ObjectConstructor} o
+   * @returns {object}
+   */
+  toDTO (o) {
+    return Object.assign({}, o);
+  }
+
+  /**
+   * Given a raw search response from ES, returns a {total: int, hits: []} object
+   * @param {object} raw
+   * @returns {Promise<object>}
+   * @private
+   */
+  _formatSearchResults (raw) {
+    const result = {
+      total: 0,
+      hits: []
+    };
+
+    if (raw.scrollId) {
+      result.scrollId = raw.scrollId;
+    }
+
+    if (raw.hits && raw.hits.length > 0) {
+      result.total = raw.total;
+      return Bluebird.all(raw.hits.map(doc => this.fromDTO(Object.assign({}, doc._source, {_id: doc._id}))))
+        .then(hits => {
+          result.hits = hits;
+          return result;
+        });
+    }
+
+    return Bluebird.resolve(result);
+  }
+
 }
 
 module.exports = Repository;
-
-/**
- * Returns a normalized search results
- * @param {object} raw - raw results from the db engine
- * @returns {object} normalized results
- */
-function formatSearchResults(raw) {
-  const result = {
-    total: 0,
-    hits: []
-  };
-
-  if (raw.scrollId) {
-    result.scrollId = raw.scrollId;
-  }
-
-  if (raw.hits && raw.hits.length > 0) {
-    result.total = raw.total;
-    result.hits = raw.hits.map(document => _.assignIn({}, document._source, {_id: document._id}));
-  }
-
-  return result;
-}

--- a/lib/api/core/models/repositories/repository.js
+++ b/lib/api/core/models/repositories/repository.js
@@ -88,7 +88,9 @@ class Repository {
           if (response._source) {
             Object.assign(dto, response._source, {_id: response._id});
           }
-          Object.assign(dto, response);
+          else {
+            Object.assign(dto, response);
+          }
 
           return this.fromDTO(dto);
         }

--- a/lib/api/core/models/repositories/roleRepository.js
+++ b/lib/api/core/models/repositories/roleRepository.js
@@ -22,11 +22,12 @@
 'use strict';
 
 const
-  _ = require('lodash'),
   Bluebird = require('bluebird'),
-  BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
   Repository = require('./repository'),
-  Role = require('../security/role');
+  Role = require('../security/role'),
+  {
+    BadRequestError
+  } = require('kuzzle-common-objects').errors;
 
 /**
  * @class RoleRepository
@@ -54,49 +55,35 @@ class RoleRepository extends Repository {
   /**
    * From a list of role ids, retrieves the matching Role objects.
    *
-   * @param {Array} roleKeys The role ids to load
+   * @param {Array} ids The role ids to load
    * @returns {Promise} Resolves to an array containing the matching found Role objects.
    */
-  loadRoles (roleKeys) {
-    const
-      keys = [],
-      buffer = {},
-      result = [];
+  loadRoles (ids) {
+    const missingIds = [];
+    const promises = [];
 
-    roleKeys.forEach(roleKey => {
-      if (this.roles[roleKey]) {
-        buffer[roleKey] = this.roles[roleKey];
-      }
-      else if (this.kuzzle.config.security.standard.roles[roleKey]) {
-        const role = new Role();
-        role._id = roleKey;
-        buffer[roleKey] = _.assignIn(role, this.kuzzle.config.security.standard.roles[roleKey]);
-        this.roles[roleKey] = role;
+    for (const id of ids) {
+      if (this.roles[id]) {
+        promises.push(Bluebird.resolve(this.roles[id]));
       }
       else {
-        keys.push(roleKey);
+        missingIds.push(id);
       }
-    });
-
-    if (keys.length === 0) {
-      Object.keys(buffer).forEach(key => {
-        result.push(buffer[key]);
-      });
-
-      return Bluebird.resolve(result);
     }
 
-    return this.loadMultiFromDatabase(keys)
-      .then(roles => {
-        roles.forEach(r => {
-          buffer[r._id] = r;
-          this.roles[r._id] = r;
-        });
+    if (missingIds.length > 0) {
+      promises.push(this.loadMultiFromDatabase(missingIds)
+        .then(roles => {
+          for (const role of roles) {
+            this.roles[role._id] = role;
+          }
+          return roles;
+        })
+      );
+    }
 
-        Object.keys(buffer).forEach(key => result.push(buffer[key]));
-
-        return result;
-      });
+    // flatten [r1, r2, [r3, r4]] to [r1, r2, r3, r4]
+    return Bluebird.reduce(promises, (acc, result) => acc.concat(result), []);
   }
 
   /**
@@ -106,54 +93,53 @@ class RoleRepository extends Repository {
    * @returns {Role}
    */
   getRoleFromRequest (request) {
-    const role = new Role();
+    const dto = {};
 
     if (request.input.resource._id) {
-      role._id = request.input.resource._id;
+      dto._id = request.input.resource._id;
     }
 
-    Object.keys(request.input.body || {}).forEach(key => {
-      if (key !== '_id' && key !== 'closures') {
-        role[key] = request.input.body[key];
-      }
-    });
+    for (const key of Object.keys(request.input.body || {})
+      .filter(k => ['_id', 'closures'].indexOf(k) === -1)
+    ) {
+      dto[key] = request.input.body[key];
+    }
 
-    role._kuzzle_info = {
-      author: request.context.user ? String(request.context.user._id) : null,
+    dto._kuzzle_info = {
+      author: request.context.user ? String(request.context.user._id): null,
       createdAt: Date.now(),
       updatedAt: null,
       updater: null
     };
 
-    return role;
+    return this.fromDTO(dto);
   }
 
   /**
    * Get from database the document that represent the role given in parameter
    *
-   * @param {string} roleId
+   * @param {string} id
    * @returns Promise
    */
-  loadRole (roleId) {
-    if (!roleId) {
+  load (id) {
+    if (!id) {
       return Bluebird.reject(new BadRequestError('Missing role id'));
     }
 
-    if (typeof roleId !== 'string') {
+    if (typeof id !== 'string') {
       return Bluebird.reject(new BadRequestError('A role ID must be provided'));
     }
 
-    if (this.roles[roleId]) {
-      return Bluebird.resolve(this.roles[roleId]);
+    if (this.roles[id]) {
+      return Bluebird.resolve(this.roles[id]);
     }
 
-    return this.loadOneFromDatabase(roleId)
-      .then(loadedRole => {
-        if (loadedRole) {
-          this.roles[loadedRole._id] = loadedRole;
+    return this.loadOneFromDatabase(id)
+      .then(role => {
+        if (role) {
+          this.roles[role._id] = role;
         }
-
-        return loadedRole;
+        return role;
       });
   }
 
@@ -249,7 +235,6 @@ class RoleRepository extends Repository {
 
     return serializedRole;
   }
-
 }
 
 module.exports = RoleRepository;

--- a/lib/api/core/models/repositories/userRepository.js
+++ b/lib/api/core/models/repositories/userRepository.js
@@ -62,13 +62,7 @@ class UserRepository extends Repository {
       return Bluebird.resolve(this.anonymous());
     }
 
-    return super.load(id)
-      .then(user => {
-        if (user === null) {
-          return null;
-        }
-        return this.hydrate(new User(), user);
-      });
+    return super.load(id);
   }
 
   persist (user, options = {}) {
@@ -80,11 +74,13 @@ class UserRepository extends Repository {
       user._id = uuid();
     }
 
-    if (user._id === this.anonymous()._id && user.profileIds.indexOf('anonymous') === -1) {
-      return Bluebird.reject(new BadRequestError('Anonymous user must be assigned the anonymous profile'));
-    }
-
-    return this.persistToDatabase(user, databaseOptions)
+    return this.anonymous()
+      .then(anonymous => {
+        if (user._id === anonymous._id && user.profileIds.indexOf('anonymous') === -1) {
+          return Bluebird.reject(new BadRequestError('Anonymous user must be assigned the anonymous profile'));
+        }
+        return this.persistToDatabase(user, databaseOptions);
+      })
       .then(() => this.persistToCache(user, cacheOptions))
       .then(() => user);
   }
@@ -93,76 +89,49 @@ class UserRepository extends Repository {
    * @returns User
    */
   anonymous () {
-    const user = new User();
-
-    return Object.assign(user, {
+    return this.fromDTO({
       _id: '-1',
       name: 'Anonymous',
       profileIds: ['anonymous']
     });
   }
 
-  hydrate (user, data) {
-    let dataprofileIds;
-
-    if (!data || typeof data !== 'object') {
-      return Bluebird.resolve(user);
+  /**
+   * @param dto
+   * @returns {Promise<User>}
+   */
+  fromDTO (dto) {
+    if (dto.profileIds && !Array.isArray(dto.profileIds)) {
+      dto.profileIds = [dto.profileIds];
     }
 
-    if (data._source) {
-      const source = data._source;
-      delete data._source;
-      Object.assign(data, source);
-    }
-
-    if (data.profileIds) {
-      if (!Array.isArray(data.profileIds)) {
-        data.profileIds = [data.profileIds];
-      }
-
-      dataprofileIds = data.profileIds;
-      delete data.profileIds;
-    }
-
-    Object.assign(user, data);
-    Object.assign(user.profileIds, dataprofileIds);
-
-    if (user._id === undefined || user._id === null) {
-      return Bluebird.resolve(this.anonymous());
-    }
-
-    // if the user exists (have an _id) but no profile
-    // set it to default
-    if (user.profileIds.length === 0) {
-      user.profileIds = this.kuzzle.config.security.restrictedProfileIds;
-    }
-
-    return this.kuzzle.repositories.profile.loadProfiles(user.profileIds)
-      .then(profiles => {
-        const
-          profileIds = profiles.map(profile => profile._id),
-          profilesNotFound = _.difference(user.profileIds, profileIds);
-
-        // Fail if not all roles are found
-        if (profilesNotFound.length) {
-          return Bluebird.reject(new NotFoundError(`Unable to hydrate the user ${data._id}. The following profiles don't exist: ${profilesNotFound}`));
+    return super.fromDTO(dto)
+      .then(user => {
+        if (user._id === undefined || user._id === null) {
+          return Bluebird.resolve(this.anonymous());
         }
 
-        return user;
+        // if the user exists (have an _id) but no profile
+        // set it to default
+        if (user.profileIds.length === 0) {
+          user.profileIds = this.kuzzle.config.security.restrictedProfileIds;
+        }
+
+        return this.kuzzle.repositories.profile.loadProfiles(user.profileIds)
+          .then(profiles => {
+            const
+              profileIds = profiles.map(profile => profile._id),
+              profilesNotFound = _.difference(user.profileIds, profileIds);
+
+            // Fail if not all profiles are found
+            if (profilesNotFound.length) {
+              return Bluebird.reject(new NotFoundError(`Unable to hydrate the user ${dto._id}. The following profiles don't exist: ${profilesNotFound}`));
+            }
+
+            return user;
+          });
       });
-  }
 
-  serializeToCache (user) {
-    // avoid to mutate the user object
-    return Object.assign({}, user);
-  }
-
-  serializeToDatabase (user) {
-    const result = this.serializeToCache(user);
-
-    delete result._id;
-
-    return result;
   }
 }
 

--- a/lib/api/core/models/security/profile.js
+++ b/lib/api/core/models/security/profile.js
@@ -20,12 +20,16 @@
  */
 
 const
-  BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
-  Role = require('./role'),
+  _ = require('lodash'),
   Policies = require('./policies'),
   Bluebird = require('bluebird'),
-  _ = require('lodash'),
-  async = require('async');
+  {
+    BadRequestError,
+    PreconditionError
+  } = require('kuzzle-common-objects').errors;
+
+const
+  _kuzzle = Symbol.for('_kuzzle');
 
 /**
  * @class Profile
@@ -41,13 +45,20 @@ class Profile {
    *
    * @return {Promise}
    */
-  getRoles(kuzzle) {
-    const promises = this.policies.map(policy => {
-      return kuzzle.repositories.role.loadRole(policy.roleId)
-        .then(loadedRole => _.assignIn(new Role(), loadedRole, policy));
-    });
+  getRoles() {
+    if (!this[_kuzzle]) {
+      throw new PreconditionError(`Cannot get roles for uninitialized profile ${this._id}`);
+    }
 
-    return Bluebird.all(promises);
+    return Bluebird.all(this.policies.map(policy => {
+      return this[_kuzzle].repositories.role.load(policy.roleId)
+        .then(role => {
+          if (policy.restrictedTo) {
+            role.restrictedTo = policy.restrictedTo;
+          }
+          return role;
+        });
+    }));
   }
 
   /**
@@ -55,20 +66,23 @@ class Profile {
    * @param {Kuzzle} kuzzle
    * @return {Promise<boolean>}
    */
-  isActionAllowed(request, kuzzle) {
+  isActionAllowed(request) {
     if (this.policies === undefined || this.policies.length === 0) {
       return Bluebird.resolve(false);
     }
 
-    return this.getRoles(kuzzle)
-      .then(roles => {
-        return new Bluebird(resolve => {
-          async.some(roles, (role, callback) => {
-            role.isActionAllowed(request, kuzzle)
-              .then(isAllowed => callback(null, isAllowed));
-          }, (error, result) => resolve(result));
-        });
-      });
+    return this.getRoles()
+      .then(roles => new Bluebird((resolve, reject) => {
+        Bluebird.all(roles.map(role => role.isActionAllowed(request)
+          .then(isAllowed => {
+            if (isAllowed) {
+              resolve(true);
+            }
+          })
+          .catch(reject)
+        ))
+          .then(results => resolve(results.some(r => r)));
+      }));
   }
 
   /**
@@ -77,7 +91,7 @@ class Profile {
    * @return {Promise<boolean>}
    */
   validateDefinition() {
-    if (!_.isArray(this.policies)) {
+    if (!Array.isArray(this.policies)) {
       return Bluebird.reject(new BadRequestError('The roles member must be an array'));
     }
 
@@ -93,28 +107,28 @@ class Profile {
    *
    * @return {Promise}
    */
-  getRights(kuzzle) {
+  getRights() {
     const profileRights = {};
 
-    return this.getRoles(kuzzle)
+    return this.getRoles()
       .then(roles => {
-        roles.forEach(role => {
+        for (const role of roles) {
           let restrictedTo = _.cloneDeep(role.restrictedTo);
 
           if (restrictedTo === undefined || restrictedTo.length === 0) {
             restrictedTo = [{index: '*', collections: ['*']}];
           }
 
-          Object.keys(role.controllers).forEach(controller => {
-            Object.keys(role.controllers[controller].actions).forEach(action => {
+          for (const controller of Object.keys(role.controllers)) {
+            for (const action of Object.keys(role.controllers[controller].actions)) {
               const actionRights = role.controllers[controller].actions[action];
 
-              restrictedTo.forEach(restriction => {
+              for (const restriction of restrictedTo) {
                 if (restriction.collections === undefined || restriction.collections.length === 0) {
                   restriction.collections = ['*'];
                 }
 
-                restriction.collections.forEach(collection => {
+                for (const collection of restriction.collections) {
                   const
                     rightsObject = {},
                     rightsItem = {
@@ -123,18 +137,23 @@ class Profile {
                       collection,
                       index: restriction.index
                     },
-                    rightsKey = kuzzle.constructor.hash(rightsItem);
+                    rightsKey = this.constructor._hash(rightsItem);
 
                   rightsItem.value = actionRights;
                   rightsObject[rightsKey] = rightsItem;
                   _.assignWith(profileRights, rightsObject, Policies.merge);
-                });
-              });
-            });
-          });
-        });
-      })
-      .then(() => profileRights);
+                }
+              }
+            }
+          }
+        }
+
+        return profileRights;
+      });
+  }
+
+  static _hash () {
+    return false;
   }
 }
 

--- a/lib/api/core/models/security/role.js
+++ b/lib/api/core/models/security/role.js
@@ -24,21 +24,23 @@
 const
   _ = require('lodash'),
   Bluebird = require('bluebird'),
-  async = require('async'),
-  vm = require('vm'),
-  ParseError = require('kuzzle-common-objects').errors.ParseError,
   Request = require('kuzzle-common-objects').Request,
   Sandbox = require('../../sandbox'),
+  vm = require('vm'),
   {
     BadRequestError,
     InternalError: KuzzleInternalError,
+    ParseError,
+    PreconditionError
   } = require('kuzzle-common-objects').errors;
+
+const
+  _kuzzle = Symbol.for('_kuzzle');
 
 /**
  * @class Role
  */
 class Role {
-
   constructor () {
     this.controllers = {};
 
@@ -51,10 +53,13 @@ class Role {
 
   /**
    * @param {Request} request
-   * @param {Kuzzle} kuzzle
    * @return {Promise.<boolean>}
    */
-  isActionAllowed (request, kuzzle) {
+  isActionAllowed (request) {
+    if (!this[_kuzzle]) {
+      throw new PreconditionError(`Cannot check permissions on uninitialized role ${this._id}`);
+    }
+
     let
       controllerRights,
       actionRights;
@@ -98,7 +103,7 @@ class Role {
       promises.push(Bluebird.resolve(actionRights));
     }
     else if (typeof actionRights === 'object' && actionRights !== null) {
-      promises.push(executeClosure(this, kuzzle, path, actionRights, request));
+      promises.push(executeClosure(this, this[_kuzzle], path, actionRights, request));
     }
     else {
       return Bluebird.reject(new KuzzleInternalError(`Invalid rights given for role ${this._id}(${path.join('/')}) : ${actionRights}`));
@@ -225,32 +230,34 @@ class Role {
   }
 }
 
-module.exports = Role;
-
 
 /**
- * @param {Role} role
- * @param {Request} request
- * @returns {Promise<Boolean>} resolves to a Boolean value
+ * @param {Kuzzle} kuzzle
+ * @param {object} argsDefinitions
+ * @returns {Promise}
  */
-function checkRestrictions(role, request) {
-  // If no restrictions, we allow the action:
-  if (role.restrictedTo.length === 0) {
-    return Bluebird.resolve(true);
+function buildArgsForContext (kuzzle, argsDefinitions) {
+  if (Object.keys(argsDefinitions).length > 0) {
+    return buildClosureArgs(kuzzle, argsDefinitions);
   }
 
-  // If the request's action does not refer to an index, restrictions are useless for this action (=> ignore them):
-  if (!request.input.resource.index || request.input.resource.index === null || typeof request.input.resource.index === 'undefined') {
-    return Bluebird.resolve(true);
-  }
+  return Bluebird.resolve({});
+}
 
-  return new Bluebird(resolve => {
-    async.some(role.restrictedTo, (restriction, callback) => {
-      callback(null, checkIndexRestriction(request, restriction));
-    }, (error, result) => {
-      resolve(result);
-    });
-  });
+/**
+ * @param {Kuzzle} kuzzle
+ * @param {object} argsDefinitions
+ * @returns {Promise}
+ */
+function buildClosureArgs (kuzzle, argsDefinitions) {
+  const result = {};
+
+  return Bluebird.all(Object.keys(argsDefinitions).map(arg => factoryFunctionClosure(kuzzle, arg, argsDefinitions[arg])
+    .then(val => {
+      result[arg] = val;
+    })
+  ))
+    .then(() => result);
 }
 
 /**
@@ -273,7 +280,28 @@ function checkIndexRestriction(request, restriction) {
     return true;
   }
 
-  return _.includes(restriction.collections, request.input.resource.collection);
+  return restriction.collections.indexOf(request.input.resource.collection) > -1;
+}
+
+/**
+ * @param {Role} role
+ * @param {Request} request
+ * @returns {Promise<Boolean>} resolves to a Boolean value
+ */
+function checkRestrictions(role, request) {
+  // If no restrictions, we allow the action:
+  if (role.restrictedTo.length === 0) {
+    return Bluebird.resolve(true);
+  }
+
+  // If the request's action does not refer to an index, restrictions are useless for this action (=> ignore them):
+  if (!request.input.resource.index) {
+    return Bluebird.resolve(true);
+  }
+
+  return Bluebird.resolve(
+    role.restrictedTo.some(restriction => checkIndexRestriction(request, restriction))
+  );
 }
 
 /**
@@ -325,6 +353,7 @@ function executeClosure (role, kuzzle, path, actionRights, request) {
     .then(args => {
       const sandboxContextObject = {
         args,
+        console,
         $request: request,
         $currentUserId: request.context.userId
       };
@@ -333,12 +362,10 @@ function executeClosure (role, kuzzle, path, actionRights, request) {
 
       if (!role.closures[path].test) {
         try {
-          const sandboxScript = new vm.Script(`(function ($request, $currentUserId, args) {
-  ${actionRights.test};
-  return false;
-})($request, $currentUserId, args)`);
-
-          role.closures[path].test = sandboxScript;
+          role.closures[path].test = new vm.Script(`(function ($request, $currentUserId, args) {
+            ${actionRights.test};
+            return false;
+          })($request, $currentUserId, args)`);
         }
         catch (err) {
           message = `Error parsing closure rights for role ${role._id} (${path.join('/')}): ${actionRights.test}`;
@@ -354,7 +381,7 @@ function executeClosure (role, kuzzle, path, actionRights, request) {
       return role.closures[path].test.runInContext(sandboxContext);
     })
     .then(result => {
-      if (! _.isBoolean(result)) {
+      if (typeof result !== 'boolean') {
         message = `Error during rights action closure execution (${path.join('/')}): ${actionRights.test}`;
 
         kuzzle.pluginsManager.trigger('log:error', message);
@@ -378,44 +405,6 @@ function executeClosure (role, kuzzle, path, actionRights, request) {
 }
 
 /**
- * @param {Kuzzle} kuzzle
- * @param {object} argsDefinitions
- * @returns {Promise}
- */
-function buildArgsForContext (kuzzle, argsDefinitions) {
-  if (Object.keys(argsDefinitions).length > 0) {
-    return buildClosureArgs(kuzzle, argsDefinitions);
-  }
-
-  return Bluebird.resolve({});
-}
-
-/**
- * @param {Kuzzle} kuzzle
- * @param {object} argsDefinitions
- * @returns {Promise}
- */
-function buildClosureArgs (kuzzle, argsDefinitions) {
-  const argsFunctions = {};
-
-  // Build the object that will be passed to parallel
-  _.forEach(argsDefinitions, (argDefinition, argName) => {
-    argsFunctions[argName] = factoryFunctionClosure(kuzzle, argName, argDefinition);
-  });
-
-  return new Bluebird(resolve => {
-    async.parallel(argsFunctions, (error, results) => {
-      if (error) {
-        // In case we have an error we want to return an empty object because the error can come from storageEngine
-        return resolve({});
-      }
-
-      resolve(results);
-    });
-  });
-}
-
-/**
  * Returns a function built for async.parallel with the right action on storageEngine
  *
  * @param {Kuzzle} kuzzle
@@ -426,48 +415,54 @@ function buildClosureArgs (kuzzle, argsDefinitions) {
 function factoryFunctionClosure (kuzzle, argName, argDefinition) {
   if (!argDefinition.collection || !argDefinition.index || !argDefinition.action || Object.keys(argDefinition.action).length === 0) {
     kuzzle.pluginsManager.trigger('log:error', `Bad format in closure rights for ${argName}`);
-    return callback => callback(null, {});
+    return Bluebird.resolve({});
   }
 
   const methodName = Object.keys(argDefinition.action)[0];
 
   if (['get', 'mget', 'search'].indexOf(methodName) === -1) {
     kuzzle.pluginsManager.trigger('log:error', `Try to use an unauthorized function (${methodName}) in closure rights check`);
-    return callback => callback(null, {});
+    return Bluebird.resolve({});
   }
 
-  return callback => {
-    const request = new Request({
-      action: methodName,
-      collection: argDefinition.collection,
-      index: argDefinition.index
-    });
+  const request = new Request({
+    action: methodName,
+    collection: argDefinition.collection,
+    index: argDefinition.index
+  });
 
-    if (methodName === 'mget') {
-      request.input.body = {
-        ids: argDefinition.action[methodName]
+  if (methodName === 'mget') {
+    request.input.body = {
+      ids: argDefinition.action[methodName]
+    };
+  }
+  else if (methodName === 'search') {
+    request.input.body = argDefinition.action[methodName];
+  }
+  else if (methodName === 'get') {
+    request.input.resource._id = argDefinition.action[methodName];
+  }
+
+  return kuzzle.services.list.storageEngine[methodName](request)
+    .then(response => {
+      if (response.hits) {
+        return response.hits.map(document => ({
+          content: document._source,
+          id: document._id
+        }));
+      }
+
+      return {
+        content: response._source,
+        id: response._id
       };
-    }
-    else if (methodName === 'search') {
-      request.input.body = argDefinition.action[methodName];
-    }
-    else if (methodName === 'get') {
-      request.input.resource._id = argDefinition.action[methodName];
-    }
-
-    kuzzle.services.list.storageEngine[methodName](request)
-      .then(response => {
-        if (response.hits) {
-          return callback(null, response.hits.map(document => {
-            return {content: document._source, id: document._id};
-          }));
-        }
-
-        callback(null, {content: response._source, id: response._id});
-      })
-      .catch(e => {
-        kuzzle.pluginsManager.trigger('log:error', `Error during storageEngine execution for ${methodName} with ${JSON.stringify(argDefinition)}: ${e.message}`);
-        return callback(null, {});
-      });
-  };
+    })
+    .catch(e => {
+      kuzzle.pluginsManager.trigger('log:error', `Error during storageEngine execution for ${methodName} with ${JSON.stringify(argDefinition)}: ${e.message}`);
+      return {};
+    });
 }
+
+module.exports = Role;
+
+

--- a/lib/api/core/models/security/user.js
+++ b/lib/api/core/models/security/user.js
@@ -24,8 +24,13 @@
 const
   Policies = require('./policies'),
   Bluebird = require('bluebird'),
-  async = require('async'),
-  _ = require('lodash');
+  _ = require('lodash'),
+  {
+    PreconditionError
+  } = require('kuzzle-common-objects').errors;
+
+const
+  _kuzzle = Symbol.for('_kuzzle');
 
 /**
  * @class User
@@ -37,21 +42,23 @@ class User {
   }
 
   /**
-   * @param {Kuzzle} kuzzle
-   *
-   * @return {Promise}
+   * @return {Promise<Profile[]>}
    */
-  getProfiles(kuzzle) {
-    return kuzzle.repositories.profile.loadProfiles(this.profileIds);
+  getProfiles() {
+    if (!this[_kuzzle]) {
+      throw new PreconditionError(`Cannot get profiles for non-initialized user ${this._id}`);
+    }
+
+    return this[_kuzzle].repositories.profile.loadProfiles(this.profileIds);
   }
 
   /**
    * @return {Promise}
    */
-  getRights(kuzzle) {
-    return this.getProfiles(kuzzle)
+  getRights() {
+    return this.getProfiles()
       .then(profiles => {
-        const promises = profiles.map(profile => profile.getRights(kuzzle));
+        const promises = profiles.map(profile => profile.getRights());
 
         return Bluebird.all(promises)
           .then(results => {
@@ -66,28 +73,25 @@ class User {
 
   /**
    * @param {Request} request
-   * @param {Kuzzle} kuzzle
    * @returns {*}
    */
-  isActionAllowed(request, kuzzle) {
+  isActionAllowed(request) {
     if (this.profileIds === undefined || this.profileIds.length === 0) {
       return Bluebird.resolve(false);
     }
 
-    return this.getProfiles(kuzzle)
-      .then(profiles => {
-        return new Bluebird((resolve, reject) => {
-          async.some(profiles, (profile, callback) => {
-            profile.isActionAllowed(request, kuzzle).asCallback(callback);
-          }, (error, result) => {
-            if (error) {
-              return reject(error);
+    return this.getProfiles()
+      .then(profiles => new Bluebird((resolve, reject) => {
+        Bluebird.all(profiles.map(profile => profile.isActionAllowed(request)
+          .then(isAllowed => {
+            if (isAllowed) {
+              resolve(true);
             }
-
-            resolve(result);
-          });
-        });
-      });
+          })
+          .catch(reject)
+        ))
+          .then(results => resolve(results.some(r => r)));
+      }));
   }
 }
 

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -37,6 +37,40 @@ function loadConfig () {
   config.internal = {
     hash: {
       seed: Buffer.from('^m&mOISKBvb1xpl1mRsrylaQXpjb&IJX')
+    },
+    mapping: {
+      internal: {
+        _kuzzle_info: {
+          properties: {
+            author: {
+              type: 'text',
+              fields: {
+                keyword: {type: 'keyword'}
+              }
+            },
+            createdAt: {type: 'long'},
+            updatedAt: {type: 'long'},
+            updater: {
+              type: 'text',
+              fields: {
+                keyword: {type: 'keyword'}
+              }
+            }
+          }
+        }
+      },
+      engine: {
+        _kuzzle_info: {
+          properties: {
+            active: {type: 'boolean'},
+            author: {type: 'keyword'},
+            createdAt: {type: 'date'},
+            updatedAt: {type: 'date'},
+            updater: {type: 'keyword'},
+            deletedAt: {type: 'date'}
+          }
+        }
+      }
     }
   };
 

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -38,18 +38,6 @@ const
   } = require('kuzzle-common-objects').errors;
 
 const scrollCachePrefix = '_docscroll_';
-const kuzzleInfoMapping = {
-  _kuzzle_info: {
-    properties: {
-      active: {type: 'boolean'},
-      author: {type: 'keyword'},
-      createdAt: {type: 'date'},
-      updatedAt: {type: 'date'},
-      updater: {type: 'keyword'},
-      deletedAt: {type: 'date'}
-    }
-  }
-};
 
 /**
  * @property {Kuzzle} kuzzle
@@ -577,7 +565,7 @@ class ElasticSearch extends Service {
 
     esRequest.body = {
       [esRequest.type]: {
-        properties: kuzzleInfoMapping
+        properties: this.kuzzle.config.internal.mapping.engine
       }
     };
 
@@ -710,7 +698,7 @@ class ElasticSearch extends Service {
     if (!esRequest.body.properties) {
       esRequest.body.properties = {};
     }
-    esRequest.body.properties._kuzzle_info = kuzzleInfoMapping._kuzzle_info;
+    esRequest.body.properties._kuzzle_info = this.kuzzle.config.internal.mapping.engine._kuzzle_info;
 
     return this.client.indices.putMapping(esRequest)
       .catch(error => Bluebird.reject(this.esWrapper.formatESError(error)));

--- a/lib/services/internalEngine/bootstrap.js
+++ b/lib/services/internalEngine/bootstrap.js
@@ -78,13 +78,16 @@ class InternalEngineBootstrap {
       return Bluebird.resolve();
     }
 
-    return this.db.updateMapping('roles', {
+    const mapping = {
       properties: {
         controllers: {
           enabled: false
-        }
+        },
+        _kuzzle_info: this.kuzzle.config.internal.mapping.internal._kuzzle_info
       }
-    })
+    };
+
+    return this.db.updateMapping('roles', mapping)
       .then(() => {
         const promises = ['anonymous', 'default', 'admin']
           .map(roleId => this.db.createOrReplace('roles', roleId, this.kuzzle.config.security.default.role));
@@ -114,7 +117,7 @@ class InternalEngineBootstrap {
       return Bluebird.resolve();
     }
 
-    return this.db.updateMapping('profiles', {
+    const mapping = {
       properties: {
         policies: {
           properties: {
@@ -122,9 +125,12 @@ class InternalEngineBootstrap {
               type: 'keyword'
             }
           }
-        }
+        },
+        _kuzzle_info: this.kuzzle.config.internal.mapping.internal._kuzzle_info
       }
-    })
+    };
+
+    return this.db.updateMapping('profiles', mapping)
       .then(() => {
         this.kuzzle.indexCache.add(this.db.index, 'profiles');
 
@@ -143,13 +149,15 @@ class InternalEngineBootstrap {
       return Bluebird.resolve();
     }
 
-    return this.db.updateMapping('users', {
+    const mapping = {
       properties: {
         profileIds: {
           type: 'keyword'
-        }
+        },
+        _kuzzle_info: this.kuzzle.config.internal.mapping.internal._kuzzle_info
       }
-    })
+    };
+    return this.db.updateMapping('users', mapping)
       .then(() => {
         this.kuzzle.indexCache.add(this.db.index, 'users');
       });

--- a/test/api/controllers/funnelController/checkRights.test.js
+++ b/test/api/controllers/funnelController/checkRights.test.js
@@ -2,7 +2,6 @@
 
 const
   should = require('should'),
-  Bluebird = require('bluebird'),
   sinon = require('sinon'),
   Request = require('kuzzle-common-objects').Request,
   ForbiddenError = require('kuzzle-common-objects').errors.ForbiddenError,
@@ -22,8 +21,11 @@ describe('funnelController.processRequest', () => {
 
   it('should reject the promise with UnauthorizedError if an anonymous user is not allowed to execute the action', done => {
     let request = new Request({controller: 'document', index: '@test', action: 'get'});
-    kuzzle.repositories.user.load.returns(Bluebird.resolve({_id: -1, isActionAllowed: sinon.stub().returns(Bluebird.resolve(false))}));
-    kuzzle.repositories.token.verifyToken.returns(Bluebird.resolve({userId: -1}));
+    kuzzle.repositories.user.load.resolves({
+      _id: -1,
+      isActionAllowed: sinon.stub().resolves(false)
+    });
+    kuzzle.repositories.token.verifyToken.resolves({userId: -1});
 
     funnel.checkRights(request)
       .then(() => should.fail('fulfilled promise', 'rejected promise'))
@@ -37,8 +39,11 @@ describe('funnelController.processRequest', () => {
 
   it('should reject the promise with UnauthorizedError if an authenticated user is not allowed to execute the action', done => {
     let request = new Request({controller: 'document', index: '@test', action: 'get'});
-    kuzzle.repositories.user.load.returns(Bluebird.resolve({_id: 'user', isActionAllowed: sinon.stub().returns(Bluebird.resolve(false))}));
-    kuzzle.repositories.token.verifyToken.returns(Bluebird.resolve({user: 'user'}));
+    kuzzle.repositories.user.load.resolves({
+      _id: 'user',
+      isActionAllowed: sinon.stub().resolves(false)
+    });
+    kuzzle.repositories.token.verifyToken.resolves({user: 'user'});
 
     funnel.checkRights(request)
       .then(() => should.fail('fulfilled promise', 'rejected promise'))
@@ -57,8 +62,11 @@ describe('funnelController.processRequest', () => {
       action: 'list'
     });
 
-    kuzzle.repositories.user.load.returns(Bluebird.resolve({_id: 'user', isActionAllowed: sinon.stub().returns(Bluebird.resolve(true))}));
-    kuzzle.repositories.token.verifyToken.returns(Bluebird.resolve({user: 'user'}));
+    kuzzle.repositories.user.load.resolves({
+      _id: 'user',
+      isActionAllowed: sinon.stub().resolves(true)
+    });
+    kuzzle.repositories.token.verifyToken.resolves({user: 'user'});
 
     return funnel.checkRights(request)
       .then(() => {

--- a/test/api/controllers/securityController/roles.test.js
+++ b/test/api/controllers/securityController/roles.test.js
@@ -116,7 +116,9 @@ describe('Test: security controller - roles', () => {
 
   describe('#getRole', () => {
     it('should resolve to an object on a getRole call', () => {
-      kuzzle.repositories.role.loadRole = sandbox.stub().returns(Bluebird.resolve({_id: 'test'}));
+      kuzzle.repositories.role.load.resolves({
+        _id: 'test'
+      });
 
       return securityController.getRole(new Request({_id: 'test'}))
         .then(response => {
@@ -126,7 +128,7 @@ describe('Test: security controller - roles', () => {
     });
 
     it('should reject NotFoundError on a getRole call with a bad id', () => {
-      kuzzle.repositories.role.loadRole = sandbox.stub().returns(Bluebird.resolve(null));
+      kuzzle.repositories.role.load.resolves(null);
       return should(securityController.getRole(new Request({_id: 'badId'}))).be.rejected();
     });
   });
@@ -196,7 +198,7 @@ describe('Test: security controller - roles', () => {
 
   describe('#updateRole', () => {
     it('should return a valid response', () => {
-      kuzzle.repositories.role.loadRole = sandbox.stub().returns(Bluebird.resolve({_id: 'test'}));
+      kuzzle.repositories.role.load.resolves({_id: 'test'});
       kuzzle.repositories.role.roles = [];
 
       kuzzle.repositories.role.validateAndSaveRole = role => {
@@ -221,12 +223,12 @@ describe('Test: security controller - roles', () => {
     });
 
     it('should reject the promise if the role cannot be found in the database', () => {
-      kuzzle.repositories.role.loadRole = sandbox.stub().returns(Bluebird.resolve(null));
+      kuzzle.repositories.role.load.resolves(null);
       return should(securityController.updateRole(new Request({_id: 'badId', body: {}, context: {action: 'updateRole'}}))).be.rejected();
     });
 
     it('should forward refresh option', () => {
-      kuzzle.repositories.role.loadRole = sandbox.stub().returns(Bluebird.resolve({_id: 'test'}));
+      kuzzle.repositories.role.load.resolves({_id: 'test'});
       kuzzle.repositories.role.roles = [];
 
       kuzzle.repositories.role.validateAndSaveRole = sinon.stub().returnsArg(0);
@@ -251,7 +253,7 @@ describe('Test: security controller - roles', () => {
     it('should return response with on deleteRole call', done => {
       const role = {my: 'role'};
 
-      kuzzle.repositories.role.getRoleFromRequest = sandbox.stub().returns(role);
+      kuzzle.repositories.role.getRoleFromRequest.resolves(role);
       kuzzle.repositories.role.deleteRole = sandbox.stub().returns(Bluebird.resolve());
 
       securityController.deleteRole(new Request({_id: 'test',body: {}}))
@@ -270,7 +272,7 @@ describe('Test: security controller - roles', () => {
     it('should forward refresh option', () => {
       const role = {my: 'role'};
 
-      kuzzle.repositories.role.getRoleFromRequest = sandbox.stub().returns(role);
+      kuzzle.repositories.role.getRoleFromRequest.resolves(role);
       kuzzle.repositories.role.deleteRole = sandbox.stub().returns(Bluebird.resolve());
 
       return securityController.deleteRole(new Request({

--- a/test/api/controllers/securityController/users.test.js
+++ b/test/api/controllers/securityController/users.test.js
@@ -264,9 +264,9 @@ describe('Test: security controller - users', () => {
     });
 
     it('should compute a user id if none is provided', () => {
-      kuzzle.repositories.user.load = sandbox.stub().returns(Bluebird.resolve(null));
-      kuzzle.repositories.user.persist = sandbox.stub().returns(Bluebird.resolve({_id: 'test'}));
-      kuzzle.repositories.user.hydrate = sandbox.stub().returns(Bluebird.resolve());
+      kuzzle.repositories.user.load.resolves(null);
+      kuzzle.repositories.user.fromDTO.callsFake((...args) => Bluebird.resolve(args[0]));
+      kuzzle.repositories.user.persist.resolves({_id: 'test'});
 
       return securityController.createUser(new Request({
         body: {
@@ -277,12 +277,14 @@ describe('Test: security controller - users', () => {
         }
       }))
         .then(response => {
-          should(kuzzle.repositories.user.persist).be.calledOnce();
-          should(kuzzle.repositories.user.hydrate).be.calledOnce();
+          should(kuzzle.repositories.user.persist)
+            .be.calledOnce();
+          should(kuzzle.repositories.user.persist.firstCall.args[0]._id)
+            .match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+
           should(response).be.instanceof(Object);
           should(response).be.match({_id: 'test', _source: {}, _meta: {}});
           should(kuzzle.repositories.user.persist.firstCall.args[1]).match({database: {method: 'create'}});
-          should(kuzzle.repositories.user.hydrate.firstCall.args[1]._id).match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
         });
     });
 
@@ -363,7 +365,7 @@ describe('Test: security controller - users', () => {
 
       kuzzle.pluginsManager.getStrategyMethod
         .withArgs('someStrategy', 'validate')
-        .rejects(new Error('error'));
+        .returns(sinon.stub().rejects(new Error('error')));
 
       return should(securityController.createUser(request)).be.rejectedWith(BadRequestError);
     });
@@ -481,18 +483,17 @@ describe('Test: security controller - users', () => {
     });
 
     it('should compute a user id if none is provided', () => {
-      kuzzle.repositories.user.load = sandbox.stub().returns(Bluebird.resolve(null));
-      kuzzle.repositories.user.persist = sandbox.stub().returns(Bluebird.resolve({_id: 'test'}));
-      kuzzle.repositories.user.hydrate = sandbox.stub().returns(Bluebird.resolve());
+      kuzzle.repositories.user.load.resolves(null);
+      kuzzle.repositories.user.persist.resolves({_id: 'test'});
+      kuzzle.repositories.user.fromDTO.callsFake((...args) => Bluebird.resolve(args[0]));
 
       return securityController.createRestrictedUser(new Request({body: {content: {name: 'John Doe'}}}))
         .then(response => {
           should(kuzzle.repositories.user.persist).be.calledOnce();
-          should(kuzzle.repositories.user.hydrate).be.calledOnce();
           should(response).be.instanceof(Object);
           should(response).be.match({_id: 'test', _source: {}, _meta: {}});
+          should(kuzzle.repositories.user.persist.firstCall.args[0]._id).match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
           should(kuzzle.repositories.user.persist.firstCall.args[1]).match({database: {method: 'create'}});
-          should(kuzzle.repositories.user.hydrate.firstCall.args[1]._id).match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
         });
     });
 
@@ -524,6 +525,7 @@ describe('Test: security controller - users', () => {
 
   describe('#updateUser', () => {
     it('should return a valid response', () => {
+      kuzzle.repositories.user.toDTO.returns({_id: 'test'});
       kuzzle.repositories.user.persist = sandbox.stub().returns(Bluebird.resolve({_id: 'test'}));
       kuzzle.repositories.profile.loadProfile = sandbox.stub().returns(Bluebird.resolve({_id: 'anonymous', _source: {}, _meta: {}}));
 
@@ -543,7 +545,14 @@ describe('Test: security controller - users', () => {
     });
 
     it('should update the profile correctly', () => {
-      kuzzle.repositories.user.persist = sandbox.stub().returns(Bluebird.resolve({_id: 'test', profileIds: ['anonymous'], foo: 'bar'}));
+      kuzzle.repositories.user.fromDTO.callsFake((...args) => Bluebird.resolve(args[0]));
+      kuzzle.repositories.user.toDTO.returns({
+        _id: 'test',
+        profileIds: ['anonymous'],
+        foo: 'bar',
+        bar: 'baz'
+      });
+      kuzzle.repositories.user.persist.callsFake((...args) => Bluebird.resolve(args[0]));
       kuzzle.repositories.profile.loadProfile = sandbox.stub().returns(Bluebird.resolve({_id: 'default', _source: {}, _meta: {}}));
 
       return securityController.updateUser(new Request({
@@ -555,6 +564,7 @@ describe('Test: security controller - users', () => {
           should(response._id).be.exactly('test');
           should(response._source.profile).be.an.instanceOf(Object);
           should(response._source.foo).be.exactly('bar');
+          should(response._source.bar).be.exactly('baz');
           should(response._meta).be.an.instanceOf(Object);
         });
     });
@@ -574,8 +584,14 @@ describe('Test: security controller - users', () => {
     });
 
     it('should forward refresh option', () => {
-      kuzzle.repositories.user.persist = sandbox.stub().returns(Bluebird.resolve({_id: 'test'}));
-      kuzzle.repositories.profile.loadProfile = sandbox.stub().returns(Bluebird.resolve({_id: 'anonymous', _source: {}, _meta: {}}));
+      kuzzle.repositories.user.fromDTO.callsFake((...args) => Bluebird.resolve(args[0]));
+      kuzzle.repositories.user.toDTO.returns({});
+      kuzzle.repositories.user.persist.resolves({_id: 'test'});
+      kuzzle.repositories.profile.load.resolves({
+        _id: 'anonymous',
+        _source: {},
+        _meta: {}
+      });
 
       return securityController.updateUser(new Request({_id: 'test', body: {foo: 'bar'}, refresh: 'wait_for'}))
         .then(() => {

--- a/test/api/core/models/repositories/roleRepository.test.js
+++ b/test/api/core/models/repositories/roleRepository.test.js
@@ -43,42 +43,6 @@ describe('Test: repositories/roleRepository', () => {
         });
     });
 
-    it('should complete unfetched default roles from config', () => {
-      const role = {foo: 'bar'};
-
-      roleRepository.roles.foo = role;
-      roleRepository.loadMultiFromDatabase = sinon.stub();
-
-      return roleRepository.loadRoles(['foo', 'admin', 'anonymous'])
-        .then(result => {
-          should(result)
-            .be.an.Array()
-            .have.length(3);
-
-          should(result[0])
-            .be.exactly(role);
-
-          should(result[1])
-            .be.an.instanceOf(Role)
-            .match({
-              _id: 'admin',
-              controllers: {
-                '*': {
-                  actions: {
-                    '*': true
-                  }
-                }
-              }
-            });
-
-          should(result[2])
-            .be.an.instanceOf(Role)
-            .match({
-              _id: 'anonymous'
-            });
-        });
-    });
-
     it('should load roles from memory & database', () => {
       const
         role1 = new Role(),
@@ -114,7 +78,7 @@ describe('Test: repositories/roleRepository', () => {
 
   describe('#loadRole', () => {
     it('should return a bad request error when no _id is provided', () => {
-      return should(roleRepository.loadRole({})).rejectedWith(BadRequestError);
+      return should(roleRepository.load({})).rejectedWith(BadRequestError);
     });
 
     it('should load the role directly from memory if it\'s in memory', () => {
@@ -122,7 +86,7 @@ describe('Test: repositories/roleRepository', () => {
 
       roleRepository.roles.foo = role;
 
-      return roleRepository.loadRole('foo')
+      return roleRepository.load('foo')
         .then(result => {
           should(result)
             .be.exactly(role);
@@ -134,7 +98,7 @@ describe('Test: repositories/roleRepository', () => {
 
       roleRepository.loadOneFromDatabase = sinon.stub().returns(Bluebird.resolve(role));
 
-      return roleRepository.loadRole('foo')
+      return roleRepository.load('foo')
         .then(result => {
           should(result)
             .be.exactly(role);
@@ -366,11 +330,14 @@ describe('Test: repositories/roleRepository', () => {
           body: {
             controllers: controllers
           }
-        }),
-        role = roleRepository.getRoleFromRequest(request);
+        });
 
-      should(role._id).be.exactly('roleId');
-      should(role.controllers).be.eql(controllers);
+      return roleRepository.getRoleFromRequest(request)
+        .then(role => {
+          should(role._id).be.exactly('roleId');
+          should(role.controllers).be.eql(controllers);
+        });
+
     });
   });
 

--- a/test/api/core/models/security/role.test.js
+++ b/test/api/core/models/security/role.test.js
@@ -12,6 +12,9 @@ const
   ParseError = require('kuzzle-common-objects').errors.ParseError,
   Role = require(ROLE_MODULE_PATH);
 
+const
+  _kuzzle = Symbol.for('_kuzzle');
+
 describe('Test: security/roleTest', () => {
   let
     kuzzle,
@@ -67,24 +70,26 @@ describe('Test: security/roleTest', () => {
         }
       };
 
-      return role.isActionAllowed(request, kuzzle)
+      role[_kuzzle] = kuzzle;
+
+      return role.isActionAllowed(request)
         .then(isAllowed => {
           should(isAllowed).be.false();
 
           delete role.controllers.controller.actions;
-          return role.isActionAllowed(request, kuzzle);
+          return role.isActionAllowed(request);
         })
         .then(isAllowed => {
           should(isAllowed).be.false();
 
           delete role.controllers.controller;
-          return role.isActionAllowed(request, kuzzle);
+          return role.isActionAllowed(request);
         })
         .then(isAllowed => {
           should(isAllowed).be.false();
 
           delete role.controllers;
-          return role.isActionAllowed(request, kuzzle);
+          return role.isActionAllowed(request);
         })
         .then(isAllowed => {
           should(isAllowed).be.false();
@@ -103,7 +108,9 @@ describe('Test: security/roleTest', () => {
         }
       };
 
-      return should(role.isActionAllowed(request, kuzzle)).be.fulfilledWith(true);
+      role[_kuzzle] = kuzzle;
+      return should(role.isActionAllowed(request))
+        .be.fulfilledWith(true);
     });
 
     it('should allow a wildcard action', () => {
@@ -116,7 +123,9 @@ describe('Test: security/roleTest', () => {
         }
       };
 
-      return should(role.isActionAllowed(request, kuzzle)).be.fulfilledWith(true);
+      role[_kuzzle] = kuzzle;
+      return should(role.isActionAllowed(request))
+        .be.fulfilledWith(true);
     });
 
     it('should properly handle restrictions', () => {
@@ -140,46 +149,47 @@ describe('Test: security/roleTest', () => {
         }
       };
 
-      return role.isActionAllowed(req, kuzzle)
+      role[_kuzzle] = kuzzle;
+      return role.isActionAllowed(req)
         .then(isAllowed => {
           should(isAllowed).be.true();
           role.restrictedTo = restrictions;
-          return role.isActionAllowed(req, kuzzle);
+          return role.isActionAllowed(req);
         })
         .then(isAllowed => {
           should(isAllowed).be.true();
           req.input.resource.index = 'index';
-          return role.isActionAllowed(req, kuzzle);
+          return role.isActionAllowed(req);
         })
         .then(isAllowed => {
           should(isAllowed).be.false();
           req.input.resource.index = 'index1';
-          return role.isActionAllowed(req, kuzzle);
+          return role.isActionAllowed(req);
         })
         .then(isAllowed => {
           should(isAllowed).be.true();
           req.input.resource.index = 'index2';
-          return role.isActionAllowed(req, kuzzle);
+          return role.isActionAllowed(req);
         })
         .then(isAllowed => {
           should(isAllowed).be.true();
           req.input.resource.collection = 'collection';
-          return role.isActionAllowed(req, kuzzle);
+          return role.isActionAllowed(req);
         })
         .then(isAllowed => {
           should(isAllowed).be.false();
           req.input.resource.collection = 'collection1';
-          return role.isActionAllowed(req, kuzzle);
+          return role.isActionAllowed(req);
         })
         .then(isAllowed => {
           should(isAllowed).be.true();
           req.input.resource.collection = 'collection2';
-          return role.isActionAllowed(req, kuzzle);
+          return role.isActionAllowed(req);
         })
         .then(isAllowed => {
           should(isAllowed).be.false();
           req.input.resource.index = 'index3';
-          return role.isActionAllowed(req, kuzzle);
+          return role.isActionAllowed(req);
         })
         .then(isAllowed => {
           should(isAllowed).be.true();
@@ -201,16 +211,17 @@ describe('Test: security/roleTest', () => {
         }
       };
 
-      return role.isActionAllowed(request, kuzzle)
+      role[_kuzzle] = kuzzle;
+      return role.isActionAllowed(request)
         .then(isAllowed => {
           should(isAllowed).be.false();
           role.controllers.controller.actions.action = true;
-          return role.isActionAllowed(request, kuzzle);
+          return role.isActionAllowed(request);
         })
         .then(isAllowed => {
           should(isAllowed).be.true();
           role.controllers.controller.actions.action = false;
-          return role.isActionAllowed(request, kuzzle);
+          return role.isActionAllowed(request);
         })
         .then(isAllowed => {
           should(isAllowed).be.false();
@@ -227,7 +238,9 @@ describe('Test: security/roleTest', () => {
         }
       };
 
-      return should(role.isActionAllowed(request, kuzzle)).be.rejected();
+      role[_kuzzle] = kuzzle;
+      return should(role.isActionAllowed(request))
+        .be.rejected();
     });
 
     it('should reject if the closure function return a non boolean value', () => {
@@ -241,7 +254,9 @@ describe('Test: security/roleTest', () => {
         }
       };
 
-      return should(role.isActionAllowed(request, kuzzle)).be.rejected();
+      role[_kuzzle] = kuzzle;
+      return should(role.isActionAllowed(request))
+        .be.rejected();
     });
 
     it('should reject if an invalid function is given', () => {
@@ -258,7 +273,9 @@ describe('Test: security/roleTest', () => {
         }
       };
 
-      return should(role.isActionAllowed(request, kuzzle)).be.rejectedWith(ParseError);
+      role[_kuzzle] = kuzzle;
+      return should(role.isActionAllowed(request))
+        .be.rejectedWith(ParseError);
     });
 
     it('should reject if an invalid argument is given', () => {
@@ -279,7 +296,9 @@ describe('Test: security/roleTest', () => {
         }
       };
 
-      return should(role.isActionAllowed(request, kuzzle)).be.rejectedWith(ParseError);
+      role[_kuzzle] = kuzzle;
+      return should(role.isActionAllowed(request))
+        .be.rejectedWith(ParseError);
     });
 
     it('should handle a custom right function', () => {
@@ -302,11 +321,12 @@ describe('Test: security/roleTest', () => {
         }
       };
 
-      return role.isActionAllowed(request, kuzzle)
+      role[_kuzzle] = kuzzle;
+      return role.isActionAllowed(request)
         .then(isAllowed => {
           should(isAllowed).be.true();
 
-          return role.isActionAllowed(noMatchRequest, kuzzle);
+          return role.isActionAllowed(noMatchRequest);
         })
         .then(isAllowed => {
           should(isAllowed).be.false();
@@ -316,7 +336,7 @@ describe('Test: security/roleTest', () => {
             test: 'return $request.input.action !== \'action\'; '
           };
 
-          return role.isActionAllowed(request, kuzzle);
+          return role.isActionAllowed(request);
         })
         .then(isAllowed => {
           should(isAllowed).be.false();
@@ -366,11 +386,12 @@ describe('Test: security/roleTest', () => {
 
       kuzzle.services.list.storageEngine.get.returns(Bluebird.resolve(documentAda));
 
-      return role.isActionAllowed(allowed, kuzzle)
+      role[_kuzzle] = kuzzle;
+      return role.isActionAllowed(allowed)
         .then(isAllowed => {
           should(isAllowed).be.true();
 
-          return role.isActionAllowed(denied, kuzzle);
+          return role.isActionAllowed(denied);
         })
         .then(isAllowed => should(isAllowed).be.false());
     });
@@ -416,13 +437,14 @@ describe('Test: security/roleTest', () => {
         }
       };
 
-      kuzzle.services.list.storageEngine.mget.returns(Bluebird.resolve({hits: [documentAda]}));
+      kuzzle.services.list.storageEngine.mget.resolves({hits: [documentAda]});
 
-      return role.isActionAllowed(allowed, kuzzle)
+      role[_kuzzle] = kuzzle;
+      return role.isActionAllowed(allowed)
         .then(isAllowed => {
           should(isAllowed).be.true();
 
-          return role.isActionAllowed(denied, kuzzle);
+          return role.isActionAllowed(denied);
         })
         .then(isAllowed => should(isAllowed).be.false());
     });
@@ -478,11 +500,12 @@ describe('Test: security/roleTest', () => {
 
       kuzzle.services.list.storageEngine.search.returns(Bluebird.resolve({hits: [documentAda]}));
 
-      return role.isActionAllowed(allowed, kuzzle)
+      role[_kuzzle] = kuzzle;
+      return role.isActionAllowed(allowed)
         .then(isAllowed => {
           should(isAllowed).be.true();
 
-          return role.isActionAllowed(denied, kuzzle);
+          return role.isActionAllowed(denied);
         })
         .then(isAllowed => should(isAllowed).be.false());
     });
@@ -519,7 +542,8 @@ describe('Test: security/roleTest', () => {
         }
       };
 
-      return role.isActionAllowed(req, kuzzle)
+      role[_kuzzle] = kuzzle;
+      return role.isActionAllowed(req)
         .then(isAllowed => should(isAllowed).be.false());
     });
 
@@ -555,7 +579,9 @@ describe('Test: security/roleTest', () => {
         }
       };
 
-      return should(role.isActionAllowed(req, kuzzle)).be.fulfilledWith(false);
+      role[_kuzzle] = kuzzle;
+      return should(role.isActionAllowed(req))
+        .be.fulfilledWith(false);
     });
 
     it('should not allow if collection is not specified', () => {
@@ -589,7 +615,9 @@ describe('Test: security/roleTest', () => {
         }
       };
 
-      return should(role.isActionAllowed(req, kuzzle)).be.fulfilledWith(false);
+      role[_kuzzle] = kuzzle;
+      return should(role.isActionAllowed(req))
+        .be.fulfilledWith(false);
     });
   });
 

--- a/test/api/core/models/security/user.test.js
+++ b/test/api/core/models/security/user.test.js
@@ -7,8 +7,11 @@ const
   User = require('../../../../../lib/api/core/models/security/user'),
   Request = require('kuzzle-common-objects').Request;
 
+const
+  _kuzzle = Symbol.for('_kuzzle');
+
 describe('Test: security/userTest', () => {
-  var
+  let
     kuzzle,
     sandbox,
     profile,
@@ -113,7 +116,9 @@ describe('Test: security/userTest', () => {
   });
 
   it('should retrieve the profile', () => {
-    return user.getProfiles(kuzzle)
+    user[_kuzzle] = kuzzle;
+
+    return user.getProfiles()
       .then(p => {
         should(p).be.an.Array();
         should(p[0]).be.an.Object();
@@ -121,8 +126,9 @@ describe('Test: security/userTest', () => {
       });
   });
 
-  it('should use the isActionAlloed method from its profile', () => {
-    return user.isActionAllowed(new Request({}), kuzzle)
+  it('should use the isActionAllowed method from its profile', () => {
+    user[_kuzzle] = kuzzle;
+    return user.isActionAllowed(new Request({}))
       .then(isActionAllowed => {
         should(isActionAllowed).be.a.Boolean();
         should(isActionAllowed).be.true();
@@ -132,7 +138,7 @@ describe('Test: security/userTest', () => {
 
   it('should respond false if the user have no profileIds', () => {
     user.profileIds = [];
-    return user.isActionAllowed(new Request({}), kuzzle)
+    return user.isActionAllowed(new Request({}))
       .then(isActionAllowed => {
         should(isActionAllowed).be.a.Boolean();
         should(isActionAllowed).be.false();
@@ -141,8 +147,7 @@ describe('Test: security/userTest', () => {
   });
 
   it('should rejects if the loadProfiles throws an error', () => {
-    sandbox.stub(user, 'getProfiles')
-      .rejects(new Error('error'));
-    return should(user.isActionAllowed(new Request({}), kuzzle)).be.rejectedWith('error');
+    sandbox.stub(user, 'getProfiles').returns(Promise.reject(new Error('error')));
+    return should(user.isActionAllowed(new Request({}))).be.rejectedWith('error');
   });
 });

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -186,6 +186,8 @@ class KuzzleMock extends Kuzzle {
     this.repositories = {
       init: sinon.stub().resolves(),
       profile: {
+        fromDTO: sinon.stub().resolves(),
+        initialize: sinon.stub().resolves(),
         load: sinon.stub().resolves(),
         loadMultiFromDatabase: sinon.stub().resolves(),
         loadProfiles: sinon.stub().resolves(),
@@ -193,22 +195,25 @@ class KuzzleMock extends Kuzzle {
       },
       role: {
         deleteRole: sinon.stub().resolves(),
+        fromDTO: sinon.stub().resolves(),
         getRoleFromRequest: sinon.stub().callsFake((...args) => Bluebird.resolve(args[0])),
+        load: sinon.stub().resolves(),
         loadMultiFromDatabase: sinon.stub().resolves(),
-        loadRole: sinon.stub().resolves(),
         loadRoles: sinon.stub().resolves(),
         searchRole: sinon.stub().resolves(),
         validateAndSaveRole: sinon.stub().callsFake((...args) => Bluebird.resolve(args[0]))
       },
       user: {
+        anonymous: sinon.stub().returns({_id: '-1'}),
+        delete: sinon.stub().usingPromise(Bluebird).resolves(),
+        fromDTO: sinon.stub().resolves(),
         load: sinon.stub().resolves(foo),
-        search: sinon.stub().resolves(),
-        scroll: sinon.stub().resolves(),
         ObjectConstructor: sinon.stub().returns({}),
         hydrate: sinon.stub().resolves(),
         persist: sinon.stub().resolves({}),
-        anonymous: sinon.stub().returns({_id: '-1'}),
-        delete: sinon.stub().usingPromise(Bluebird).resolves()
+        search: sinon.stub().resolves(),
+        scroll: sinon.stub().resolves(),
+        toDTO: sinon.stub()
       },
       token: {
         anonymous: sinon.stub().returns({_id: 'anonymous'}),


### PR DESCRIPTION
Fixes #997 
NB: while the signature of security methods changes, this can be considered as **not** being a breaking change as the removed parameter will simply be ignored.

The only drawback is if the end user calls these methods on a bare newly constructed object, which has not been initialized, in which case, he will receive a `PreconditionError`.

I do not believe this is  a problem though as the current implementation would make this scenario very unlikely to happen anywhere else than in kuzzle core code itself. Non-privileged plugins had till this pr simply no way to call these methods.

~~## Implementation~~

~~Security objects (`user`, `profile`, `role`) are now injected a hidden reference to `kuzzle` during hydratation/init.~~

[EDIT] Repositories are updated to use a slightly different mechanism.
We introduce a new data layer (DTO) between the storage engines (cache and db) and the business layer (`user`, `profile`, `role` objects).

Low-level storage layers return a unified dto object, `{ _id: 'id', foo: 'bar' }` and pass it to a new `Repository.fromDTO` method, which resolves to a fully initalized business object.

This new method injects kuzzle as a hidden property, thus enabling the initial fix.

As a side-effects, no `hydrate` method is needed anymore. Object merges can be done easilly on the DTO level (cf ̀`securityController.updateUser` as an example).

**Boyscouting**

Meta data have been enabled back for security objects. Soft deletion is not handled but these information can still be valuable to the end-users.
NB: The mapping for _kuzzle_info is slightly different between kuzzle internal engine and the main storage to avoid breaking changes.
