### PR TITLE
server/info: remove useless `nproutes` attribute

### DIFF
--- a/lib/api/controllers/serverController.js
+++ b/lib/api/controllers/serverController.js
@@ -210,7 +210,6 @@ class ServerController {
               );
             });
 
-            actionList[action].nproutes = routeDescriptionList.length;
             routeDescriptionList.forEach(routeDescription => {
               if (actionList[action].http === undefined) {
                 actionList[action].http = [];

--- a/test/api/controllers/serverController.test.js
+++ b/test/api/controllers/serverController.test.js
@@ -233,7 +233,6 @@ describe('Test: server controller', () => {
               publicMethod: {
                 action: 'publicMethod',
                 controller: 'foo',
-                nproutes: 2,
                 http: [
                   {url: '/u/r/l', verb: 'FOO'},
                   {url: '/u/r/l/:foobar', verb: 'FOO'}
@@ -241,15 +240,13 @@ describe('Test: server controller', () => {
               },
               baz: {
                 action: 'baz',
-                controller: 'foo',
-                nproutes: 0
+                controller: 'foo'
               }
             },
             foobar: {
               publicMethod: {
                 action: 'publicMethod',
                 controller: 'foobar',
-                nproutes: 1,
                 http: [{
                   url: '_plugin/foobar',
                   verb: 'BAR'
@@ -257,8 +254,7 @@ describe('Test: server controller', () => {
               },
               anotherMethod: {
                 action: 'anotherMethod',
-                controller: 'foobar',
-                nproutes: 0
+                controller: 'foobar'
               }
             }
           });


### PR DESCRIPTION
Pointed from https://github.com/kuzzleio/documentation/pull/415#pullrequestreview-81861521:
`server/info` action returned for each action an attribute `nproutes` (which should have been called `nbroutes` anyway), that is useless (and has never been documented), as the number of HTTP routes can easily be deduced from the `http` attribute.
