### PR TITLE
raise an error if the document is not active

### DIFF
--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -474,28 +474,28 @@ class ElasticSearch extends Service {
 
     return this.client.get({index: esRequest.index, type: esRequest.type, id: esRequest.id})
       .then(result => {
-        if (result._source._kuzzle_info && result._source._kuzzle_info.active) {
-          // injecting retryOnConflict default configuration
-          if (!esRequest.hasOwnProperty('retryOnConflict') && this.config.defaults.onUpdateConflictRetries > 0) {
-            esRequest.retryOnConflict = this.config.defaults.onUpdateConflictRetries;
-          }
-
-          // Add metadata
-          esRequest.body = {
-            doc: {
-              _kuzzle_info: {
-                active: false,
-                deletedAt: Date.now(),
-                updater: request.context.user._id ? String(request.context.user._id) : null
-              }
-            }
-          };
-
-          return this.client.update(esRequest)
-            .then(r => this.refreshIndexIfNeeded(esRequest, r))
-            .catch(error => Bluebird.reject(this.esWrapper.formatESError(error)));
+        if (result._source._kuzzle_info && !result._source._kuzzle_info.active) {
+          return Bluebird.reject(new NotFoundError(`Document ${esRequest.id} does not exist`));
         }
-        return Bluebird.reject(new NotFoundError(`Document ${esRequest.id} does not exist`));
+        // injecting retryOnConflict default configuration
+        if (!esRequest.hasOwnProperty('retryOnConflict') && this.config.defaults.onUpdateConflictRetries > 0) {
+          esRequest.retryOnConflict = this.config.defaults.onUpdateConflictRetries;
+        }
+
+        // Add metadata
+        esRequest.body = {
+          doc: {
+            _kuzzle_info: {
+              active: false,
+              deletedAt: Date.now(),
+              updater: request.context.user._id ? String(request.context.user._id) : null
+            }
+          }
+        };
+
+        return this.client.update(esRequest)
+          .then(r => this.refreshIndexIfNeeded(esRequest, r))
+          .catch(error => Bluebird.reject(this.esWrapper.formatESError(error)));
       })
       .catch(error => Bluebird.reject(this.esWrapper.formatESError(error)));
   }

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -472,24 +472,31 @@ class ElasticSearch extends Service {
 
     assertWellFormedRefresh(esRequest);
 
-    // injecting retryOnConflict default configuration
-    if (!esRequest.hasOwnProperty('retryOnConflict') && this.config.defaults.onUpdateConflictRetries > 0) {
-      esRequest.retryOnConflict = this.config.defaults.onUpdateConflictRetries;
-    }
+    return this.client.get({index: esRequest.index, type: esRequest.type, id: esRequest.id})
+      .then(result => {
+        if (result._source._kuzzle_info && result._source._kuzzle_info.active) {
+          // injecting retryOnConflict default configuration
+          if (!esRequest.hasOwnProperty('retryOnConflict') && this.config.defaults.onUpdateConflictRetries > 0) {
+            esRequest.retryOnConflict = this.config.defaults.onUpdateConflictRetries;
+          }
 
-    // Add metadata
-    esRequest.body = {
-      doc: {
-        _kuzzle_info: {
-          active: false,
-          deletedAt: Date.now(),
-          updater: request.context.user._id ? String(request.context.user._id) : null
+          // Add metadata
+          esRequest.body = {
+            doc: {
+              _kuzzle_info: {
+                active: false,
+                deletedAt: Date.now(),
+                updater: request.context.user._id ? String(request.context.user._id) : null
+              }
+            }
+          };
+
+          return this.client.update(esRequest)
+            .then(r => this.refreshIndexIfNeeded(esRequest, r))
+            .catch(error => Bluebird.reject(this.esWrapper.formatESError(error)));
         }
-      }
-    };
-
-    return this.client.update(esRequest)
-      .then(result => this.refreshIndexIfNeeded(esRequest, result))
+        return Bluebird.reject(new NotFoundError(`Document ${esRequest.id} does not exist`));
+      })
       .catch(error => Bluebird.reject(this.esWrapper.formatESError(error)));
   }
 

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -754,6 +754,13 @@ describe('Test: ElasticSearch service', () => {
       const refreshIndexSpy = sandbox.spy(elasticsearch, 'refreshIndexIfNeeded');
 
       elasticsearch.client.update.returns(Bluebird.resolve({}));
+      elasticsearch.client.get.returns(Bluebird.resolve({
+        _source: {
+          _kuzzle_info: {
+            active: true
+          }
+        }
+      }));
 
       request.input.body = null;
       request.input.resource._id = createdDocumentId;


### PR DESCRIPTION
We now raise an error if we try to delete a document which is already deleted and has the _kuzzle_info.active attribute to false
  