### PR TITLE
Allow plugins to attach PATCH verbs to their HTTP routes

### DIFF
--- a/lib/api/core/entrypoints/embedded/protocols/http.js
+++ b/lib/api/core/entrypoints/embedded/protocols/http.js
@@ -240,7 +240,7 @@ class HttpProtocol extends Protocol {
     response.writeHead(error.status, {
       'Content-Type': 'application/json',
       'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods' : 'GET,POST,PUT,DELETE,OPTIONS',
+      'Access-Control-Allow-Methods' : 'GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS',
       'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
     });
 

--- a/lib/api/core/httpRouter/index.js
+++ b/lib/api/core/httpRouter/index.js
@@ -60,6 +60,7 @@ class Router {
       GET: new RoutePart(),
       POST: new RoutePart(),
       PUT: new RoutePart(),
+      PATCH: new RoutePart(),
       DELETE: new RoutePart(),
       HEAD: new RoutePart()
     };
@@ -103,6 +104,16 @@ class Router {
   }
 
   /**
+   * Attach a handler to a PATCH HTTP route
+   *
+   * @param {string} url
+   * @param {Function} handler
+   */
+  patch(url, handler) {
+    attach(url, handler, this.routes.PATCH);
+  }
+
+  /**
    * Attach a handler to a DELETE HTTP route
    *
    * @param {string} url
@@ -110,6 +121,16 @@ class Router {
    */
   delete(url, handler) {
     attach(url, handler, this.routes.DELETE);
+  }
+
+  /**
+   * Attach a handler to a HEAD HTTP route
+   *
+   * @param {string} url
+   * @param {Function} handler
+   */
+  head(url, handler) {
+    attach(url, handler, this.routes.HEAD);
   }
 
   /**

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -588,7 +588,7 @@ class PluginsManager {
       });
     });
 
-    const allowedVerbs = ['get', 'head', 'post', 'put', 'delete'];
+    const allowedVerbs = ['get', 'head', 'post', 'put', 'delete', 'patch'];
 
     if (plugin.object.routes) {
       plugin.object.routes.forEach(route => {

--- a/test/api/core/entrypoints/embedded/protocols/http.test.js
+++ b/test/api/core/entrypoints/embedded/protocols/http.test.js
@@ -394,7 +394,7 @@ describe('/lib/api/core/entrypoints/embedded/protocols/http', () => {
         .be.calledWith(123, {
           'Content-Type': 'application/json',
           'Access-Control-Allow-Origin': '*',
-          'Access-Control-Allow-Methods' : 'GET,POST,PUT,DELETE,OPTIONS',
+          'Access-Control-Allow-Methods' : 'GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS',
           'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
         });
     });

--- a/test/api/core/httpRouter/httpRouter.test.js
+++ b/test/api/core/httpRouter/httpRouter.test.js
@@ -31,14 +31,14 @@ describe('core/httpRouter', () => {
   });
 
   describe('#adding routes', () => {
-    it('should add a POST route when asked to', () => {
-      router.post('/foo/bar', handler);
-      should(router.routes.POST.subparts.foo.subparts.bar.handler).be.eql(handler);
-    });
-
     it('should add a GET route when asked to', () => {
       router.get('/foo/bar', handler);
       should(router.routes.GET.subparts.foo.subparts.bar.handler).be.eql(handler);
+    });
+
+    it('should add a POST route when asked to', () => {
+      router.post('/foo/bar', handler);
+      should(router.routes.POST.subparts.foo.subparts.bar.handler).be.eql(handler);
     });
 
     it('should add a PUT route when asked to', () => {
@@ -46,9 +46,19 @@ describe('core/httpRouter', () => {
       should(router.routes.PUT.subparts.foo.subparts.bar.handler).be.eql(handler);
     });
 
+    it('should add a PATCH route when asked to', () => {
+      router.patch('/foo/bar', handler);
+      should(router.routes.PATCH.subparts.foo.subparts.bar.handler).be.eql(handler);
+    });
+
     it('should add a DELETE route when asked to', () => {
       router.delete('/foo/bar', handler);
       should(router.routes.DELETE.subparts.foo.subparts.bar.handler).be.eql(handler);
+    });
+
+    it('should add a HEAD route when asked to', () => {
+      router.head('/foo/bar', handler);
+      should(router.routes.HEAD.subparts.foo.subparts.bar.handler).be.eql(handler);
     });
 
     it('should raise an internal error when trying to add a duplicate', () => {

--- a/test/api/core/pluginsManager/run.test.js
+++ b/test/api/core/pluginsManager/run.test.js
@@ -25,7 +25,7 @@ describe('Test plugins manager run', () => {
 
   before(() => {
     PluginsManager = rewire('../../../../lib/api/core/plugins/pluginsManager');
-    
+
     // making it quiet
     PluginsManager.__set__({
       console: {
@@ -280,7 +280,11 @@ describe('Test plugins manager run', () => {
   it('should attach controller routes on kuzzle object', () => {
     plugin.object.routes = [
       {verb: 'get', url: '/bar/:name', controller: 'foo', action: 'bar'},
-      {verb: 'post', url: '/bar', controller: 'foo', action: 'bar'}
+      {verb: 'head', url: '/bar/:name', controller: 'foo', action: 'bar'},
+      {verb: 'post', url: '/bar', controller: 'foo', action: 'bar'},
+      {verb: 'put', url: '/bar', controller: 'foo', action: 'bar'},
+      {verb: 'delete', url: '/bar', controller: 'foo', action: 'bar'},
+      {verb: 'patch', url: '/bar', controller: 'foo', action: 'bar'}
     ];
 
     plugin.object.controllers = {
@@ -293,17 +297,37 @@ describe('Test plugins manager run', () => {
 
     return pluginsManager.run()
       .then(() => {
-        should(pluginsManager.routes).be.an.Array().and.length(2);
+        should(pluginsManager.routes).be.an.Array().and.length(6);
+
         should(pluginsManager.routes[0].verb).be.equal('get');
         should(pluginsManager.routes[0].url).be.equal('/testPlugin/bar/:name');
-        should(pluginsManager.routes[1].verb).be.equal('post');
-        should(pluginsManager.routes[1].url).be.equal('/testPlugin/bar');
-        should(pluginsManager.routes[0].controller)
-          .be.equal(pluginsManager.routes[0].controller)
-          .and.be.equal('testPlugin/foo');
-        should(pluginsManager.routes[0].action)
-          .be.equal(pluginsManager.routes[0].action)
-          .and.be.equal('bar');
+        should(pluginsManager.routes[0].controller).be.equal('testPlugin/foo');
+        should(pluginsManager.routes[0].action).be.equal('bar');
+
+        should(pluginsManager.routes[1].verb).be.equal('head');
+        should(pluginsManager.routes[1].url).be.equal('/testPlugin/bar/:name');
+        should(pluginsManager.routes[1].controller).be.equal('testPlugin/foo');
+        should(pluginsManager.routes[1].action).be.equal('bar');
+
+        should(pluginsManager.routes[2].verb).be.equal('post');
+        should(pluginsManager.routes[2].url).be.equal('/testPlugin/bar');
+        should(pluginsManager.routes[2].controller).be.equal('testPlugin/foo');
+        should(pluginsManager.routes[2].action).be.equal('bar');
+
+        should(pluginsManager.routes[3].verb).be.equal('put');
+        should(pluginsManager.routes[3].url).be.equal('/testPlugin/bar');
+        should(pluginsManager.routes[3].controller).be.equal('testPlugin/foo');
+        should(pluginsManager.routes[3].action).be.equal('bar');
+
+        should(pluginsManager.routes[4].verb).be.equal('delete');
+        should(pluginsManager.routes[4].url).be.equal('/testPlugin/bar');
+        should(pluginsManager.routes[4].controller).be.equal('testPlugin/foo');
+        should(pluginsManager.routes[4].action).be.equal('bar');
+
+        should(pluginsManager.routes[5].verb).be.equal('patch');
+        should(pluginsManager.routes[5].url).be.equal('/testPlugin/bar');
+        should(pluginsManager.routes[5].controller).be.equal('testPlugin/foo');
+        should(pluginsManager.routes[5].action).be.equal('bar');
       });
   });
 
@@ -339,14 +363,6 @@ describe('Test plugins manager run', () => {
   });
 
   it('should not add an invalid route to the API', () => {
-    plugin.object.routes = [
-      {invalid: 'get', url: '/bar/:name', controller: 'foo', action: 'bar'},
-      {verb: 'post', url: ['/bar'], controller: 'foo', action: 'bar'},
-      {verb: 'invalid', url: '/bar', controller: 'foo', action: 'bar'},
-      {verb: 'get', url: '/bar/:name', controller: 'foo', action: 'invalid'},
-      {verb: 'get', url: '/bar/:name', controller: 'invalid', action: 'bar'},
-    ];
-
     plugin.object.controllers = {
       'foo': {
         'bar': 'functionName'
@@ -355,6 +371,30 @@ describe('Test plugins manager run', () => {
 
     plugin.object.functionName = () => {};
 
-    should(pluginsManager.run()).be.rejected();
+    plugin.object.routes = [
+      {invalid: 'get', url: '/bar/:name', controller: 'foo', action: 'bar'}
+    ];
+    should(pluginsManager.run()).be.rejectedWith(PluginImplementationError);
+
+    plugin.object.routes = [
+      {verb: 'post', url: ['/bar'], controller: 'foo', action: 'bar'}
+    ];
+    should(pluginsManager.run()).be.rejectedWith(PluginImplementationError);
+
+    plugin.object.routes = [
+      {verb: 'invalid', url: '/bar', controller: 'foo', action: 'bar'}
+    ];
+    should(pluginsManager.run()).be.rejectedWith(PluginImplementationError);
+
+    plugin.object.routes = [
+      {verb: 'get', url: '/bar/:name', controller: 'foo', action: 'invalid'}
+    ];
+    should(pluginsManager.run()).be.rejectedWith(PluginImplementationError);
+
+    plugin.object.routes = [
+      {verb: 'get', url: '/bar/:name', controller: 'invalid', action: 'bar'}
+    ];
+    should(pluginsManager.run()).be.rejectedWith(PluginImplementationError);
+
   });
 });


### PR DESCRIPTION
Fix also HEAD routes (that were allowed, but did not work).
fix #1018 