### PR TITLE
Log the origin stack trace when catching a plugin callback error

### DIFF
--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -201,7 +201,7 @@ function execute (kuzzle, request, overloadProtect = true, callback = null) {
         _callback(err, response);
       }
       catch (e) {
-        kuzzle.pluginsManager.trigger('log:error', new PluginImplementationError(`Uncatched error by a plugin callback: ${e}`));
+        kuzzle.pluginsManager.trigger('log:error', new PluginImplementationError(e));
 
         if (err) {
           kuzzle.pluginsManager.trigger('log:error', `Previous error: ${err}`);


### PR DESCRIPTION
Upon catching an exception from a plugin callback executed at the end of an API call, we embed it in a `PluginImplementationError` error before logging it.

This PR now provides the exception directly to the `PluginImplementationError` constructor, instead of a message string, allowing the exception stack trace to be copied over to the new error instance. 

This allows plugin developers to know where the problem is exactly by simply reading the error message, instead of having to search for it.