### PR TITLE
Plugin instantiated requests should propagate volatile data

### DIFF
--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -300,8 +300,14 @@ function instantiateRequest(request, data, options = {}) {
       }
     }
 
-    if (_data.jwt === undefined) {
+    if (!_data || _data.jwt === undefined) {
       target.input.jwt = _request.input.jwt;
+    }
+
+    if (_data) {
+      target.input.volatile = Object.assign({}, _request.input.volatile, _data.volatile);
+    } else {
+      target.input.volatile = _request.input.volatile;
     }
   }
 

--- a/test/api/controllers/securityController/users.test.js
+++ b/test/api/controllers/securityController/users.test.js
@@ -344,7 +344,7 @@ describe('Test: security controller - users', () => {
     });
 
     it('should reject an error if a strategy is unknown', () => {
-      kuzzle.repositories.user.load = sandbox.stub().returns(Bluebird.resolve(null));
+      kuzzle.repositories.user.load = sandbox.stub().resolves(null);
       kuzzle.pluginsManager.listStrategies = sandbox.stub().returns(['someStrategy']);
 
       request.input.body.credentials = {unknownStrategy: {some: 'credentials'}};
@@ -353,17 +353,17 @@ describe('Test: security controller - users', () => {
     });
 
     it('should reject an error if credentials don\'t validate the strategy', () => {
-      kuzzle.repositories.user.load = sandbox.stub().returns(Bluebird.resolve(null));
+      kuzzle.repositories.user.load = sandbox.stub().resolves(null);
       kuzzle.pluginsManager.listStrategies = sandbox.stub().returns(['someStrategy']);
       kuzzle.pluginsManager.getStrategyMethod = sandbox.stub();
 
       kuzzle.pluginsManager.getStrategyMethod
         .withArgs('someStrategy', 'exists')
-        .returns(sinon.stub().returns(Bluebird.resolve(false)));
+        .returns(sinon.stub().resolves(false));
 
       kuzzle.pluginsManager.getStrategyMethod
         .withArgs('someStrategy', 'validate')
-        .rejects(new Error('error'));
+        .returns(sinon.stub().rejects(new Error('error')));
 
       return should(securityController.createUser(request)).be.rejectedWith(BadRequestError);
     });

--- a/test/api/core/pluginContext/pluginContext.test.js
+++ b/test/api/core/pluginContext/pluginContext.test.js
@@ -65,7 +65,6 @@ describe('Plugin Context', () => {
     });
 
     describe('#Request', () => {
-
       it('should throw when trying to instantiate a Request object without providing any data', () => {
         should(function () { new context.constructors.Request(); }).throw(PluginImplementationError);
       });
@@ -82,7 +81,8 @@ describe('Plugin Context', () => {
             result: 'result',
             error: new Error('error'),
             status: 666,
-            jwt: 'jwt'
+            jwt: 'jwt',
+            volatile: {foo: 'bar'}
           }, {
             protocol: 'protocol',
             connectionId: 'connectionId'
@@ -101,6 +101,7 @@ describe('Plugin Context', () => {
         should(pluginRequest.input.resource._id).be.eql(request.input.resource._id);
         should(pluginRequest.input.resource.index).be.eql(request.input.resource.index);
         should(pluginRequest.input.resource.collection).be.eql(request.input.resource.collection);
+        should(pluginRequest.input.volatile).match({foo: 'bar'});
       });
 
       it('should override origin request data with provided ones', () => {
@@ -116,7 +117,8 @@ describe('Plugin Context', () => {
             result: 'result',
             error: new Error('error'),
             status: 666,
-            jwt: 'jwt'
+            jwt: 'jwt',
+            volatile: {foo: 'bar'}
           }, {
             protocol: 'protocol',
             connectionId: 'connectionId'
@@ -129,6 +131,7 @@ describe('Plugin Context', () => {
             size: 99,
             collection: 'pluginCollection',
             jwt: null,
+            volatile: {foo: 'overridden', bar: 'baz'}
           });
 
         should(pluginRequest.context.protocol).be.eql('protocol');
@@ -146,6 +149,7 @@ describe('Plugin Context', () => {
         should(pluginRequest.input.resource._id).be.eql('_id');
         should(pluginRequest.input.resource.index).be.eql('index');
         should(pluginRequest.input.resource.collection).be.eql('pluginCollection');
+        should(pluginRequest.input.volatile).match({foo: 'overridden', bar: 'baz'});
       });
 
       it('should allow building a request without providing another one', () => {


### PR DESCRIPTION
# Description

Volatile data should always be propagated to requests derivated from API requests by plugins.
This also allows notifications to be traceable to an origin request by SDKs.

# Boyscout

Fix an unhandled promise rejection in an unrelated unit test.
