### PR TITLE
catch any exception thrown inside an HTTP request scenario

### DIFF
--- a/lib/api/core/httpRouter/index.js
+++ b/lib/api/core/httpRouter/index.js
@@ -178,7 +178,7 @@ class Router {
         request = new Request({requestId: httpRequest.requestId}, {}, 'rest');
         request.response.setHeaders(this.defaultHeaders);
       }
-      const e = (err instanceof KuzzleError) && err || new InternalError(err);
+      const e = (err instanceof KuzzleError) && err || new KuzzleInternalError(err);
       replyWithError(cb, request, e);
     }
   }

--- a/lib/api/core/httpRouter/index.js
+++ b/lib/api/core/httpRouter/index.js
@@ -173,14 +173,12 @@ class Router {
       routeHandler.addContent(httpRequest.content);
       routeHandler.invokeHandler(cb);
     }
-    catch (e) {
+    catch (err) {
       if (request === undefined) {
         request = new Request({requestId: httpRequest.requestId}, {}, 'rest');
         request.response.setHeaders(this.defaultHeaders);
       }
-      if (! e instanceof KuzzleError) {
-        e = new InternalError(e);
-      }
+      const e = (err instanceof KuzzleError) && err || new InternalError(err);
       replyWithError(cb, request, e);
     }
   }

--- a/lib/api/core/httpRouter/index.js
+++ b/lib/api/core/httpRouter/index.js
@@ -25,6 +25,7 @@ const
   RoutePart = require('./routePart'),
   Request = require('kuzzle-common-objects').Request,
   {
+    KuzzleError,
     InternalError: KuzzleInternalError,
     BadRequestError,
     NotFoundError
@@ -119,8 +120,10 @@ class Router {
    * @param {function} cb
    */
   route(httpRequest, cb) {
+    let request;
+
     if (!this.routes[httpRequest.method]) {
-      const request = new Request({requestId: httpRequest.requestId}, {}, 'rest');
+      request = new Request({requestId: httpRequest.requestId}, {}, 'rest');
       request.response.setHeaders(this.defaultHeaders);
 
       if (httpRequest.method.toUpperCase() === 'OPTIONS') {
@@ -140,36 +143,45 @@ class Router {
 
     httpRequest.url = httpRequest.url.replace(LeadingSlashRegex, '');
 
-    const routeHandler = this.routes[httpRequest.method].getHandler(httpRequest);
-    routeHandler.getRequest().response.setHeaders(this.defaultHeaders);
-
-    if (routeHandler.handler === null) {
-      return replyWithError(cb, routeHandler.getRequest(), new NotFoundError(`API URL not found: ${routeHandler.url}`));
-    }
-
-    if (httpRequest.content.length <= 0) {
-      return routeHandler.invokeHandler(cb);
-    }
-
-    if (httpRequest.headers['content-type']
-      && !httpRequest.headers['content-type'].startsWith('application/json')) {
-      return replyWithError(cb, routeHandler.getRequest(), new BadRequestError(`Invalid request content-type. Expected "application/json", got: "${httpRequest.headers['content-type']}"`));
-    }
-
-    {
-      const encoding = CharsetRegex.exec(httpRequest.headers['content-type']);
-
-      if (encoding !== null && encoding[1].toLowerCase() !== 'utf-8') {
-        return replyWithError(cb, routeHandler.getRequest(), new BadRequestError(`Invalid request charset. Expected "utf-8", got: "${encoding[1].toLowerCase()}"`));
-      }
-    }
-
     try {
+      const routeHandler = this.routes[httpRequest.method].getHandler(httpRequest);
+
+      request = routeHandler.getRequest();
+      request.response.setHeaders(this.defaultHeaders);
+
+      if (routeHandler.handler === null) {
+        return replyWithError(cb, request, new NotFoundError(`API URL not found: ${routeHandler.url}`));
+      }
+
+      if (httpRequest.content.length <= 0) {
+        return routeHandler.invokeHandler(cb);
+      }
+
+      if (httpRequest.headers['content-type']
+        && !httpRequest.headers['content-type'].startsWith('application/json')) {
+        return replyWithError(cb, request, new BadRequestError(`Invalid request content-type. Expected "application/json", got: "${httpRequest.headers['content-type']}"`));
+      }
+
+      {
+        const encoding = CharsetRegex.exec(httpRequest.headers['content-type']);
+
+        if (encoding !== null && encoding[1].toLowerCase() !== 'utf-8') {
+          return replyWithError(cb, request, new BadRequestError(`Invalid request charset. Expected "utf-8", got: "${encoding[1].toLowerCase()}"`));
+        }
+      }
+
       routeHandler.addContent(httpRequest.content);
       routeHandler.invokeHandler(cb);
     }
     catch (e) {
-      replyWithError(cb, routeHandler.getRequest(), new BadRequestError('Unable to convert HTTP body to JSON'));
+      if (request === undefined) {
+        request = new Request({requestId: httpRequest.requestId}, {}, 'rest');
+        request.response.setHeaders(this.defaultHeaders);
+      }
+      if (! e instanceof KuzzleError) {
+        e = new InternalError(e);
+      }
+      replyWithError(cb, request, e);
     }
   }
 }

--- a/lib/api/core/httpRouter/routeHandler.js
+++ b/lib/api/core/httpRouter/routeHandler.js
@@ -21,7 +21,11 @@
 
 'use strict';
 
-const Request = require('kuzzle-common-objects').Request;
+const
+  Request = require('kuzzle-common-objects').Request,
+  {
+    BadRequestError,
+  } = require('kuzzle-common-objects').errors;
 
 /**
  * Object returned by routePart.getHandler(),
@@ -48,7 +52,11 @@ class RouteHandler {
         this.data.jwt = headers[k].substring('Bearer '.length);
       }
       else if (k.toLowerCase() === 'x-kuzzle-volatile') {
-        this.data.volatile = JSON.parse(headers[k]);
+        try {
+          this.data.volatile = JSON.parse(headers[k]);
+        } catch (e) {
+          throw new BadRequestError('Unable to convert HTTP x-kuzzle-volatile header to JSON')
+        }
       }
       else {
         this.data[k] = headers[k];
@@ -73,7 +81,11 @@ class RouteHandler {
    * @param {string} content
    */
   addContent(content) {
-    this.getRequest().input.body = JSON.parse(content);
+    try {
+      this.getRequest().input.body = JSON.parse(content);
+    } catch (e) {
+      throw new BadRequestError('Unable to convert HTTP body to JSON');
+    }
   }
 
   /**

--- a/lib/api/core/httpRouter/routeHandler.js
+++ b/lib/api/core/httpRouter/routeHandler.js
@@ -23,9 +23,7 @@
 
 const
   Request = require('kuzzle-common-objects').Request,
-  {
-    BadRequestError,
-  } = require('kuzzle-common-objects').errors;
+  BadRequestError = require('kuzzle-common-objects').errors.BadRequestError;
 
 /**
  * Object returned by routePart.getHandler(),
@@ -38,6 +36,7 @@ const
  * @param {string} requestId
  * @param {object} query - HTTP request query parameters
  * @param {object} headers
+ * @throws {BadRequestError} If x-kuzzle-volatile HTTP header can not be parsed in JSON format
  */
 class RouteHandler {
   constructor(url, query, requestId, headers) {
@@ -77,8 +76,8 @@ class RouteHandler {
   /**
    * Parse a string content and adds it to the right request object place
    *
-   * @throws
    * @param {string} content
+   * @throws {BadRequestError} If the HTTP body can not be parsed in JSON format
    */
   addContent(content) {
     try {

--- a/lib/api/core/httpRouter/routeHandler.js
+++ b/lib/api/core/httpRouter/routeHandler.js
@@ -55,7 +55,7 @@ class RouteHandler {
         try {
           this.data.volatile = JSON.parse(headers[k]);
         } catch (e) {
-          throw new BadRequestError('Unable to convert HTTP x-kuzzle-volatile header to JSON')
+          throw new BadRequestError('Unable to convert HTTP x-kuzzle-volatile header to JSON');
         }
       }
       else {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {

--- a/test/api/core/httpRouter/httpRouter.test.js
+++ b/test/api/core/httpRouter/httpRouter.test.js
@@ -270,7 +270,7 @@ describe('core/httpRouter', () => {
       rq.url = '/foo/bar';
       rq.method = 'GET';
       rq.headers['content-type'] = 'application/json';
-      rq.headers['x-kuzzle-volatile'] = '{bad JSON syntax}'
+      rq.headers['x-kuzzle-volatile'] = '{bad JSON syntax}';
 
       router.route(rq, result => {
         should(handler.called).be.false();


### PR DESCRIPTION
catch any exception thrown inside an HTTP request scenario, and send back a response with errors


If the exception thrown is a KuzzleError, returns the given error with its status code
If not, returns a 500 error with the error message.

Also catch JSON parsing error for x-kuzzle-volatile header

fix #1030 