### PR TITLE
Do not inject http headers into request's input args

### DIFF
--- a/lib/api/core/httpRouter/index.js
+++ b/lib/api/core/httpRouter/index.js
@@ -178,7 +178,7 @@ class Router {
         request = new Request({requestId: httpRequest.requestId}, {}, 'rest');
         request.response.setHeaders(this.defaultHeaders);
       }
-      const e = (err instanceof KuzzleError) && err || new InternalError(err);
+      const e = (err instanceof KuzzleError) && err || new KuzzleInternalError(err);
       replyWithError(cb, request, e);
     }
   }

--- a/lib/api/core/httpRouter/index.js
+++ b/lib/api/core/httpRouter/index.js
@@ -173,14 +173,12 @@ class Router {
       routeHandler.addContent(httpRequest.content);
       routeHandler.invokeHandler(cb);
     }
-    catch (e) {
+    catch (err) {
       if (request === undefined) {
         request = new Request({requestId: httpRequest.requestId}, {}, 'rest');
         request.response.setHeaders(this.defaultHeaders);
       }
-      if (! e instanceof KuzzleError) {
-        e = new InternalError(e);
-      }
+      const e = (err instanceof KuzzleError) && err || new InternalError(err);
       replyWithError(cb, request, e);
     }
   }

--- a/lib/api/core/httpRouter/index.js
+++ b/lib/api/core/httpRouter/index.js
@@ -25,6 +25,7 @@ const
   RoutePart = require('./routePart'),
   Request = require('kuzzle-common-objects').Request,
   {
+    KuzzleError,
     InternalError: KuzzleInternalError,
     BadRequestError,
     NotFoundError
@@ -119,8 +120,10 @@ class Router {
    * @param {function} cb
    */
   route(httpRequest, cb) {
+    let request;
+
     if (!this.routes[httpRequest.method]) {
-      const request = new Request({requestId: httpRequest.requestId}, {}, 'rest');
+      request = new Request({requestId: httpRequest.requestId}, {}, 'rest');
       request.response.setHeaders(this.defaultHeaders);
 
       if (httpRequest.method.toUpperCase() === 'OPTIONS') {
@@ -140,36 +143,45 @@ class Router {
 
     httpRequest.url = httpRequest.url.replace(LeadingSlashRegex, '');
 
-    const routeHandler = this.routes[httpRequest.method].getHandler(httpRequest);
-    routeHandler.getRequest().response.setHeaders(this.defaultHeaders);
-
-    if (routeHandler.handler === null) {
-      return replyWithError(cb, routeHandler.getRequest(), new NotFoundError(`API URL not found: ${routeHandler.url}`));
-    }
-
-    if (httpRequest.content.length <= 0) {
-      return routeHandler.invokeHandler(cb);
-    }
-
-    if (httpRequest.headers['content-type']
-      && !httpRequest.headers['content-type'].startsWith('application/json')) {
-      return replyWithError(cb, routeHandler.getRequest(), new BadRequestError(`Invalid request content-type. Expected "application/json", got: "${httpRequest.headers['content-type']}"`));
-    }
-
-    {
-      const encoding = CharsetRegex.exec(httpRequest.headers['content-type']);
-
-      if (encoding !== null && encoding[1].toLowerCase() !== 'utf-8') {
-        return replyWithError(cb, routeHandler.getRequest(), new BadRequestError(`Invalid request charset. Expected "utf-8", got: "${encoding[1].toLowerCase()}"`));
-      }
-    }
-
     try {
+      const routeHandler = this.routes[httpRequest.method].getHandler(httpRequest);
+
+      request = routeHandler.getRequest();
+      request.response.setHeaders(this.defaultHeaders);
+
+      if (routeHandler.handler === null) {
+        return replyWithError(cb, request, new NotFoundError(`API URL not found: ${routeHandler.url}`));
+      }
+
+      if (httpRequest.content.length <= 0) {
+        return routeHandler.invokeHandler(cb);
+      }
+
+      if (httpRequest.headers['content-type']
+        && !httpRequest.headers['content-type'].startsWith('application/json')) {
+        return replyWithError(cb, request, new BadRequestError(`Invalid request content-type. Expected "application/json", got: "${httpRequest.headers['content-type']}"`));
+      }
+
+      {
+        const encoding = CharsetRegex.exec(httpRequest.headers['content-type']);
+
+        if (encoding !== null && encoding[1].toLowerCase() !== 'utf-8') {
+          return replyWithError(cb, request, new BadRequestError(`Invalid request charset. Expected "utf-8", got: "${encoding[1].toLowerCase()}"`));
+        }
+      }
+
       routeHandler.addContent(httpRequest.content);
       routeHandler.invokeHandler(cb);
     }
     catch (e) {
-      replyWithError(cb, routeHandler.getRequest(), new BadRequestError('Unable to convert HTTP body to JSON'));
+      if (request === undefined) {
+        request = new Request({requestId: httpRequest.requestId}, {}, 'rest');
+        request.response.setHeaders(this.defaultHeaders);
+      }
+      if (! e instanceof KuzzleError) {
+        e = new InternalError(e);
+      }
+      replyWithError(cb, request, e);
     }
   }
 }

--- a/lib/api/core/httpRouter/routeHandler.js
+++ b/lib/api/core/httpRouter/routeHandler.js
@@ -55,7 +55,7 @@ class RouteHandler {
         try {
           this.data.volatile = JSON.parse(headers[k]);
         } catch (e) {
-          throw new BadRequestError('Unable to convert HTTP x-kuzzle-volatile header to JSON')
+          throw new BadRequestError('Unable to convert HTTP x-kuzzle-volatile header to JSON');
         }
       }
     });

--- a/lib/api/core/httpRouter/routeHandler.js
+++ b/lib/api/core/httpRouter/routeHandler.js
@@ -21,7 +21,11 @@
 
 'use strict';
 
-const Request = require('kuzzle-common-objects').Request;
+const
+  Request = require('kuzzle-common-objects').Request,
+  {
+    BadRequestError,
+  } = require('kuzzle-common-objects').errors;
 
 /**
  * Object returned by routePart.getHandler(),
@@ -48,7 +52,11 @@ class RouteHandler {
         this.data.jwt = headers[k].substring('Bearer '.length);
       }
       else if (k.toLowerCase() === 'x-kuzzle-volatile') {
-        this.data.volatile = JSON.parse(headers[k]);
+        try {
+          this.data.volatile = JSON.parse(headers[k]);
+        } catch (e) {
+          throw new BadRequestError('Unable to convert HTTP x-kuzzle-volatile header to JSON')
+        }
       }
       else {
         this.data[k] = headers[k];
@@ -73,7 +81,11 @@ class RouteHandler {
    * @param {string} content
    */
   addContent(content) {
-    this.getRequest().input.body = JSON.parse(content);
+    try {
+      this.getRequest().input.body = JSON.parse(content);
+    } catch (e) {
+      throw new BadRequestError('Unable to convert HTTP body to JSON');
+    }
   }
 
   /**

--- a/lib/api/core/httpRouter/routeHandler.js
+++ b/lib/api/core/httpRouter/routeHandler.js
@@ -23,9 +23,7 @@
 
 const
   Request = require('kuzzle-common-objects').Request,
-  {
-    BadRequestError,
-  } = require('kuzzle-common-objects').errors;
+  BadRequestError = require('kuzzle-common-objects').errors.BadRequestError;
 
 /**
  * Object returned by routePart.getHandler(),
@@ -38,6 +36,7 @@ const
  * @param {string} requestId
  * @param {object} query - HTTP request query parameters
  * @param {object} headers
+ * @throws {BadRequestError} If x-kuzzle-volatile HTTP header can not be parsed in JSON format
  */
 class RouteHandler {
   constructor(url, query, requestId, headers) {
@@ -74,8 +73,8 @@ class RouteHandler {
   /**
    * Parse a string content and adds it to the right request object place
    *
-   * @throws
    * @param {string} content
+   * @throws {BadRequestError} If the HTTP body can not be parsed in JSON format
    */
   addContent(content) {
     try {

--- a/lib/api/core/httpRouter/routeHandler.js
+++ b/lib/api/core/httpRouter/routeHandler.js
@@ -55,7 +55,7 @@ class RouteHandler {
         try {
           this.data.volatile = JSON.parse(headers[k]);
         } catch (e) {
-          throw new BadRequestError('Unable to convert HTTP x-kuzzle-volatile header to JSON')
+          throw new BadRequestError('Unable to convert HTTP x-kuzzle-volatile header to JSON');
         }
       }
       else {

--- a/lib/api/core/httpRouter/routeHandler.js
+++ b/lib/api/core/httpRouter/routeHandler.js
@@ -55,11 +55,8 @@ class RouteHandler {
         try {
           this.data.volatile = JSON.parse(headers[k]);
         } catch (e) {
-          throw new BadRequestError('Unable to convert HTTP x-kuzzle-volatile header to JSON');
+          throw new BadRequestError('Unable to convert HTTP x-kuzzle-volatile header to JSON')
         }
-      }
-      else {
-        this.data[k] = headers[k];
       }
     });
     Object.assign(this.data, query);

--- a/test/api/core/httpRouter/httpRouter.test.js
+++ b/test/api/core/httpRouter/httpRouter.test.js
@@ -81,8 +81,8 @@ describe('core/httpRouter', () => {
       rq.headers.foo = 'bar';
       rq.headers.Authorization = 'Bearer jwtFoobar';
       rq.headers['X-Kuzzle-Volatile'] = '{"modifiedBy": "John Doe", "reason": "foobar"}';
-      rq.headers['volatile'] = 'volatile-header';
-      rq.headers['jwt'] = 'jwt-header';
+      rq.headers.volatile = 'volatile-header';
+      rq.headers.jwt = 'jwt-header';
       rq.method = 'POST';
 
       router.route(rq, callback);
@@ -276,7 +276,7 @@ describe('core/httpRouter', () => {
       rq.url = '/foo/bar';
       rq.method = 'GET';
       rq.headers['content-type'] = 'application/json';
-      rq.headers['x-kuzzle-volatile'] = '{bad JSON syntax}'
+      rq.headers['x-kuzzle-volatile'] = '{bad JSON syntax}';
 
       router.route(rq, result => {
         should(handler.called).be.false();

--- a/test/api/core/httpRouter/httpRouter.test.js
+++ b/test/api/core/httpRouter/httpRouter.test.js
@@ -81,19 +81,25 @@ describe('core/httpRouter', () => {
       rq.headers.foo = 'bar';
       rq.headers.Authorization = 'Bearer jwtFoobar';
       rq.headers['X-Kuzzle-Volatile'] = '{"modifiedBy": "John Doe", "reason": "foobar"}';
+      rq.headers['volatile'] = 'volatile-header';
+      rq.headers['jwt'] = 'jwt-header';
       rq.method = 'POST';
 
       router.route(rq, callback);
-      should(handler.calledOnce).be.true();
+      should(handler).be.calledOnce();
       should(handler.firstCall.args[0]).be.instanceOf(Request);
       should(handler.firstCall.args[0].context.protocol).be.exactly('http');
       should(handler.firstCall.args[0].context.connectionId).be.exactly('requestId');
       should(handler.firstCall.args[0].input.headers).be.eql({
         foo: 'bar',
         Authorization: 'Bearer jwtFoobar',
-        'X-Kuzzle-Volatile': '{"modifiedBy": "John Doe", "reason": "foobar"}'});
+        'X-Kuzzle-Volatile': '{"modifiedBy": "John Doe", "reason": "foobar"}',
+        volatile: 'volatile-header',
+        jwt: 'jwt-header'
+      });
       should(handler.firstCall.args[0].input.jwt).be.exactly('jwtFoobar');
       should(handler.firstCall.args[0].input.volatile).be.eql({modifiedBy: 'John Doe', reason: 'foobar'});
+      should(handler.firstCall.args[0].input.args.foo).be.undefined();
     });
 
     it('should amend the request object if a body is found in the content', () => {
@@ -108,7 +114,7 @@ describe('core/httpRouter', () => {
       should(handler.calledOnce).be.true();
       should(handler.firstCall.args[0].id).match(rq.requestId);
       should(handler.firstCall.args[0].input.body).match({foo: 'bar'});
-      should(handler.firstCall.args[0].input.args['content-type']).eql('application/json');
+      should(handler.firstCall.args[0].input.headers['content-type']).eql('application/json');
     });
 
     it('should return dynamic values for parametric routes', () => {
@@ -123,7 +129,7 @@ describe('core/httpRouter', () => {
       should(handler.calledOnce).be.true();
       should(handler.firstCall.args[0].id).match(rq.requestId);
       should(handler.firstCall.args[0].input.body).match({foo: 'bar'});
-      should(handler.firstCall.args[0].input.args['content-type']).eql('application/json');
+      should(handler.firstCall.args[0].input.headers['content-type']).eql('application/json');
       should(handler.firstCall.args[0].input.args.bar).eql('hello');
       should(handler.firstCall.args[0].input.args.baz).eql('world');
     });
@@ -140,7 +146,7 @@ describe('core/httpRouter', () => {
       should(handler.calledOnce).be.true();
       should(handler.firstCall.args[0].id).match(rq.requestId);
       should(handler.firstCall.args[0].input.body).match({foo: 'bar'});
-      should(handler.firstCall.args[0].input.args['content-type']).eql('application/json; charset=utf-8');
+      should(handler.firstCall.args[0].input.headers['content-type']).eql('application/json; charset=utf-8');
       should(handler.firstCall.args[0].input.args.bar).eql('hello');
       should(handler.firstCall.args[0].input.args.baz).eql('%world');
     });
@@ -270,7 +276,7 @@ describe('core/httpRouter', () => {
       rq.url = '/foo/bar';
       rq.method = 'GET';
       rq.headers['content-type'] = 'application/json';
-      rq.headers['x-kuzzle-volatile'] = '{bad JSON syntax}';
+      rq.headers['x-kuzzle-volatile'] = '{bad JSON syntax}'
 
       router.route(rq, result => {
         should(handler.called).be.false();

--- a/test/api/core/httpRouter/httpRouter.test.js
+++ b/test/api/core/httpRouter/httpRouter.test.js
@@ -270,7 +270,7 @@ describe('core/httpRouter', () => {
       rq.url = '/foo/bar';
       rq.method = 'GET';
       rq.headers['content-type'] = 'application/json';
-      rq.headers['x-kuzzle-volatile'] = '{bad JSON syntax}'
+      rq.headers['x-kuzzle-volatile'] = '{bad JSON syntax}';
 
       router.route(rq, result => {
         should(handler.called).be.false();


### PR DESCRIPTION
# Bugfix
#1030: catch any exception thrown inside an HTTP request scenario, and send back a response with errors

# Other improvements
 #1031 : do not inject HTTP headers to request's input args. (they are already accessible via `request.input.headers`)