### PR TITLE
Plugins bootstrap lock adjustements

### DIFF
--- a/lib/services/internalEngine/pluginBootstrap.js
+++ b/lib/services/internalEngine/pluginBootstrap.js
@@ -43,8 +43,7 @@ class PluginInternalEngineBootstrap {
     // This "outdated delay" should be long enough to still abort Kuzzle's
     // lock sequence, but short enough to not imped a production environment
     // for too long.
-    this.outdatedDelay = this.kuzzle.config.plugins.common.bootstrapLockTimeout + 2*this.attemptDelay;
-
+    this.outdatedDelay = 1.5 * this.kuzzle.config.plugins.common.bootstrapLockTimeout;
     this._lockId = `bootstrap-lock-${kuzzle.constructor.hash(this.pluginName)}`;
   }
 

--- a/lib/services/internalEngine/pluginBootstrap.js
+++ b/lib/services/internalEngine/pluginBootstrap.js
@@ -21,7 +21,7 @@
 
 const
   Bluebird = require('bluebird'),
-  PluginImplementationError = require('kuzzle-common-objects').errors.PluginImplementationError;
+  KuzzleInternalError = require('kuzzle-common-objects').errors.InternalError;
 
 /**
  *
@@ -34,6 +34,16 @@ class PluginInternalEngineBootstrap {
     this.kuzzle = kuzzle;
     this.db = engine;
     this.pluginName = pluginName;
+    this.attemptDelay = Math.round(this.kuzzle.config.plugins.common.bootstrapLockTimeout / 10);
+
+    // We make 10 attempts to check if the db resource is still locked.
+    // After that, we throw an error and abort Kuzzle's start sequence.
+    // But if, for some reason, the lock is never deleted, we have to consider
+    // it as outdated, and renew it.
+    // This "outdated delay" should be long enough to still abort Kuzzle's
+    // lock sequence, but short enough to not imped a production environment
+    // for too long.
+    this.outdatedDelay = this.kuzzle.config.plugins.common.bootstrapLockTimeout + 2*this.attemptDelay;
 
     this._lockId = `bootstrap-lock-${kuzzle.constructor.hash(this.pluginName)}`;
   }
@@ -73,11 +83,14 @@ class PluginInternalEngineBootstrap {
       return false;
     }
     catch (e) {
-      // lock found - check if not obsolete
+      // lock found - check if not obsolete or in the future
     }
 
-    const lock = yield this.kuzzle.internalEngine.get('config', this._lockId);
-    if (lock._source.timestamp < Date.now() - this.kuzzle.config.plugins.common.bootstrapLockTimeout * 2) {
+    const 
+      lock = yield this.kuzzle.internalEngine.get('config', this._lockId),
+      now = Date.now();
+
+    if (lock._source.timestamp < now - this.outdatedDelay || lock._source.timestamp > now) {
       yield this.kuzzle.internalEngine.createOrReplace('config', this._lockId, {timestamp: Date.now()});
       return false;
     }
@@ -93,10 +106,10 @@ class PluginInternalEngineBootstrap {
         }
 
         if (attempts > 10) {
-          throw new PluginImplementationError(`Plugin ${this.pluginName} bootstrap - lock wait timeout exceeded`);
+          throw new KuzzleInternalError(`Plugin ${this.pluginName} bootstrap - lock wait timeout exceeded`);
         }
 
-        return Bluebird.delay(Math.round(this.kuzzle.config.plugins.common.bootstrapLockTimeout / 10))
+        return Bluebird.delay(this.attemptDelay)
           .then(() => this._waitTillUnlocked(attempts + 1));
       });
   }

--- a/lib/services/internalEngine/pluginBootstrap.js
+++ b/lib/services/internalEngine/pluginBootstrap.js
@@ -21,7 +21,7 @@
 
 const
   Bluebird = require('bluebird'),
-  KuzzleInternalError = require('kuzzle-common-objects').errors.InternalError;
+  GatewayTimeoutError = require('kuzzle-common-objects').errors.GatewayTimeoutError;
 
 /**
  *
@@ -105,7 +105,7 @@ class PluginInternalEngineBootstrap {
         }
 
         if (attempts > 10) {
-          throw new KuzzleInternalError(`Plugin ${this.pluginName} bootstrap - lock wait timeout exceeded`);
+          throw new GatewayTimeoutError(`Plugin ${this.pluginName} bootstrap - lock wait timeout exceeded`);
         }
 
         return Bluebird.delay(this.attemptDelay)


### PR DESCRIPTION
# Description

If, for some reason, a bootstrap lock timestamp is set to the future, then unless it is manually removed, it prevents Kuzzle from starting forever (or at least until we reach that point in the future).
Now, locks in the future are considered abnormal and removed automatically

# Other changes

* I found the delay to be slightly too long between the last retry attempt and the time we consider a lock to be outdated
* When the maximum number of attemps was reached, a `PluginImplementationError` error was thrown. I changed it to a `GatewayTimeoutError`, since it is really the communication delay between Elasticsearch and Kuzzle who is at fault when such an error is thrown, and it has little to do with plugins
* Made a bit clearer what are the various delay values and how they are used