### PR TITLE
fixes #1036 `callback is not a function`

### DIFF
--- a/default.config.js
+++ b/default.config.js
@@ -42,7 +42,7 @@ module.exports = {
   },
 
   limits: {
-    concurrentRequests: 50,
+    concurrentRequests: 100,
     documentsFetchCount: 1000,
     documentsWriteCount: 200,
     requestsHistorySize: 50,
@@ -56,8 +56,8 @@ module.exports = {
   plugins: {
     common: {
       bootstrapLockTimeout: 5000,
-      pipeWarnTime: 40,
-      pipeTimeout: 250,
+      pipeWarnTime: 500,
+      pipeTimeout: 5000,
       initTimeout: 10000,
     }
   },

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -394,10 +394,10 @@ class FunnelController {
    * @param {Function} callback
    * @returns {Number} -1: delayed, 0: processing, 1: error
    */
-  executePluginRequest(request, overloadProtect, callback) {
+  executePluginRequest(request, callback) {
     request.clearError();
     request.status = 102;
-    
+
     let controllers;
 
     try {
@@ -406,19 +406,6 @@ class FunnelController {
     catch(e) {
       callback(e);
       return 1;
-    }
-
-    if (overloadProtect) {
-      const processNow = this.getRequestSlot('executePluginRequest', request, callback);
-
-      if (request.error) {
-        callback(request.error);
-        return 1;
-      }
-
-      if (!processNow) {
-        return -1;
-      }
     }
 
     this._historize(request);
@@ -570,6 +557,7 @@ class FunnelController {
       let i; // perf cf https://jsperf.com/bvidis-for-oddities - NOSONAR
       for (i = 0; i < quantityToInject; i++) {
         const cachedItem = this.requestsCacheById[this.requestsCacheQueue.peekFront()];
+
         if (this[cachedItem.executor](cachedItem.request, cachedItem.callback) === -1) {
           // no slot found again. We stop here and try next time
           break;

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -164,6 +164,12 @@ function execute (kuzzle, request, callback) {
     reject,
     deferred;
 
+  if (callback && typeof callback !== 'function') {
+    error = new PluginImplementationError(`Invalid argument: Expected callback to be a function, received "${typeof callback}"`);
+    kuzzle.pluginsManager.trigger('log:error', error);
+    return Bluebird.reject(error);
+  }
+
   if (!callback) {
     deferred = new Bluebird((res, rej) => {
       resolve = res;

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -157,48 +157,37 @@ class PluginContext {
  * @param {boolean} [overloadProtect]
  * @param {Function} [callback]
  */
-function execute (kuzzle, request, overloadProtect = true, callback = null) {
-  let resolve = null,
-    reject = null, 
-    deferred = null,
-    _callback = callback,
-    _overloadProtect = overloadProtect;
+function execute (kuzzle, request, callback) {
+  let
+    error,
+    resolve,
+    reject,
+    deferred;
 
-  let error = null;
-  const overloadProtectType = typeof _overloadProtect;
-
-  if (overloadProtectType === 'function') {
-    _callback = _overloadProtect;
-    _overloadProtect = true;
-  }
-  else if (overloadProtectType !== 'boolean') {
-    error = new PluginImplementationError('Invalid argument: the overload protection flag must be a boolean');
-  }
-
-  if (!_callback) {
+  if (!callback) {
     deferred = new Bluebird((res, rej) => {
       resolve = res;
       reject = rej;
     });
   }
 
-  if (!error && (!request || !(request instanceof Request))) {
+  if (!request || !(request instanceof Request)) {
     error = new PluginImplementationError('Invalid argument: a Request object must be supplied');
   }
 
   if (error) {
-    if (_callback) {
-      return _callback(error);
+    if (callback) {
+      return callback(error);
     }
 
     reject(error);
     return deferred;
   }
 
-  kuzzle.funnel.executePluginRequest(request, _overloadProtect, (err, response) => {
-    if (_callback) {
+  kuzzle.funnel.executePluginRequest(request, (err, response) => {
+    if (callback) {
       try {
-        _callback(err, response);
+        callback(err, response);
       }
       catch (e) {
         kuzzle.pluginsManager.trigger('log:error', new PluginImplementationError(e));
@@ -217,7 +206,7 @@ function execute (kuzzle, request, overloadProtect = true, callback = null) {
     }
   });
 
-  if (!_callback) {
+  if (!callback) {
     return deferred;
   }
 }

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -179,9 +179,6 @@ function execute (kuzzle, request, callback) {
 
   if (!request || !(request instanceof Request)) {
     error = new PluginImplementationError('Invalid argument: a Request object must be supplied');
-  }
-
-  if (error) {
     if (callback) {
       return callback(error);
     }

--- a/test/api/controllers/funnelController/executePluginRequest.test.js
+++ b/test/api/controllers/funnelController/executePluginRequest.test.js
@@ -17,7 +17,6 @@ describe('funnelController.executePluginRequest', () => {
     kuzzle = new KuzzleMock();
     funnel = new FunnelController(kuzzle);
     funnel.controllers.testme = {action: sinon.stub()};
-    funnel.getRequestSlot = sinon.stub();
     funnel._historize = sinon.stub();
     funnel.handleErrorDump = sinon.stub();
   });
@@ -25,12 +24,11 @@ describe('funnelController.executePluginRequest', () => {
   it('should fail if an unknown controller is invoked', done => {
     const rq = new Request({controller: 'foo', action: 'bar'});
 
-    const ret = funnel.executePluginRequest(rq, true, (err, res) => {
+    const ret = funnel.executePluginRequest(rq, (err, res) => {
       try {
         should(res).be.undefined();
         should(err).be.instanceOf(BadRequestError);
         should(err.message).be.eql('Unknown controller foo');
-        should(funnel.getRequestSlot.called).be.false();
         should(kuzzle.pluginsManager.trigger.called).be.false();
         done();
       }
@@ -42,43 +40,18 @@ describe('funnelController.executePluginRequest', () => {
     should(ret).be.eql(1);
   });
 
-  it('should execute without requesting a slot if asked to', done => {
-    const rq = new Request({controller: 'testme', action: 'action'});
-
-    funnel.controllers.testme.action.resolves(rq);
-
-    const ret = funnel.executePluginRequest(rq, false, (err, res) => {
-      try {
-        should(err).be.null();
-        should(res).be.eql(rq);
-        should(funnel.getRequestSlot.called).be.false();
-        should(funnel._historize).calledOnce().calledWith(rq);
-        should(rq.status).be.eql(200);
-        should(kuzzle.pluginsManager.trigger.called).be.false();
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
-
-    should(ret).be.eql(0);
-  });
-
-  it('should execute the request if a slot is immediately available', done => {
+  it('should execute the request', done => {
     const rq = new Request({controller: 'testme', action: 'action'});
 
     funnel.controllers.testme.action.callsFake(() => {
       rq.status = 333;
       return Promise.resolve(rq);
     });
-    funnel.getRequestSlot.returns(true);
 
     const callback = (err, res) => {
       try {
         should(err).be.null();
         should(res).be.eql(rq);
-        should(funnel.getRequestSlot).calledOnce().calledWith('executePluginRequest', rq, callback);
         should(funnel._historize).calledOnce().calledWith(rq);
         should(rq.status).be.eql(333);
         should(kuzzle.pluginsManager.trigger.called).be.false();
@@ -89,43 +62,7 @@ describe('funnelController.executePluginRequest', () => {
       }
     };
 
-    should(funnel.executePluginRequest(rq, true, callback)).be.eql(0);
-  });
-
-  it('should delay the request if a slot is not yet available', () => {
-    const 
-      rq = new Request({controller: 'testme', action: 'action'}),
-      callback = sinon.stub();
-
-    funnel.getRequestSlot.returns(false);
-
-    should(funnel.executePluginRequest(rq, true, callback)).be.eql(-1);
-    should(funnel.getRequestSlot).calledOnce().calledWith('executePluginRequest', rq, callback);
-    should(funnel.controllers.testme.action.called).be.false();
-    should(funnel._historize.called).be.false();
-    should(rq.status).be.eql(102);
-    should(callback.called).be.false();
-    should(kuzzle.pluginsManager.trigger.called).be.false();
-  });
-
-  it('should reject the request if unable to get a slot', () => {
-    const 
-      rq = new Request({controller: 'testme', action: 'action'}),
-      callback = sinon.stub(),
-      error = new BadRequestError('foobar');
-
-    funnel.getRequestSlot.callsFake(() => {
-      rq.setError(error);
-      return false;
-    });
-
-    should(funnel.executePluginRequest(rq, true, callback)).be.eql(1);
-    should(funnel.getRequestSlot).calledOnce().calledWith('executePluginRequest', rq, callback);
-    should(funnel.controllers.testme.action.called).be.false();
-    should(funnel._historize.called).be.false();
-    should(rq.status).be.eql(error.status);
-    should(callback).calledOnce().calledWith(error);
-    should(kuzzle.pluginsManager.trigger.called).be.false();
+    should(funnel.executePluginRequest(rq, callback)).be.eql(0);
   });
 
   it('should forward a controller error to the callback', done => {
@@ -134,13 +71,11 @@ describe('funnelController.executePluginRequest', () => {
       error = new Error('foobar');
 
     funnel.controllers.testme.action.rejects(error);
-    funnel.getRequestSlot.returns(true);
 
     const callback = (err, res) => {
       try {
         should(err).be.eql(error);
         should(res).be.undefined();
-        should(funnel.getRequestSlot).calledOnce().calledWith('executePluginRequest', rq, callback);
         should(funnel._historize).calledOnce().calledWith(rq);
         should(rq.status).be.eql(500);
         should(funnel.handleErrorDump.called).be.true();
@@ -152,7 +87,7 @@ describe('funnelController.executePluginRequest', () => {
       }
     };
 
-    should(funnel.executePluginRequest(rq, true, callback)).be.eql(0);
+    should(funnel.executePluginRequest(rq, callback)).be.eql(0);
   });
 
 });

--- a/test/api/core/pluginContext/pluginContext.test.js
+++ b/test/api/core/pluginContext/pluginContext.test.js
@@ -352,6 +352,12 @@ describe('Plugin Context', () => {
         /Invalid argument: a Request object must be supplied/
       );
     });
+
+    it('should reject if callback argument is not a function', () => {
+      return should(context.accessors.execute({requestId: 'request'}, 'foo'))
+        .be.rejectedWith({message: /^Invalid argument: Expected callback to be a function, received "string"/});
+
+    });
   });
 
   describe('#strategies', () => {

--- a/test/api/core/pluginContext/pluginContext.test.js
+++ b/test/api/core/pluginContext/pluginContext.test.js
@@ -261,7 +261,7 @@ describe('Plugin Context', () => {
             should(callback).be.calledOnce();
             should(err).be.null();
             should(res).match(request);
-            should(kuzzle.funnel.executePluginRequest).calledWithMatch(request, true, sinon.match.func);
+            should(kuzzle.funnel.executePluginRequest).calledWithMatch(request, sinon.match.func);
             done();
           }
           catch(e) {
@@ -286,7 +286,7 @@ describe('Plugin Context', () => {
       return ret
         .then(res => {
           should(res).match(request);
-          should(kuzzle.funnel.executePluginRequest).calledWithMatch(request, true, sinon.match.func);
+          should(kuzzle.funnel.executePluginRequest).calledWithMatch(request, sinon.match.func);
         });
     });
 
@@ -297,7 +297,7 @@ describe('Plugin Context', () => {
         callback = sinon.spy(
           (err, res) => {
             try {
-              should(kuzzle.funnel.executePluginRequest).calledWithMatch(request, true, sinon.match.func);
+              should(kuzzle.funnel.executePluginRequest).calledWithMatch(request, sinon.match.func);
               should(callback).be.calledOnce();
               should(err).match(error);
               should(res).be.undefined();
@@ -322,7 +322,7 @@ describe('Plugin Context', () => {
 
       return context.accessors.execute(request)
         .catch(err => {
-          should(kuzzle.funnel.executePluginRequest).calledWithMatch(request, true, sinon.match.func);
+          should(kuzzle.funnel.executePluginRequest).calledWithMatch(request, sinon.match.func);
           should(err).match(error);
         });
     });
@@ -350,35 +350,6 @@ describe('Plugin Context', () => {
     it('should reject if no Request object is provided', () => {
       return should(context.accessors.execute({})).be.rejectedWith(
         /Invalid argument: a Request object must be supplied/
-      );
-    });
-
-    it('should resolve to an error if an improper overloadProtect flag is supplied', done => {
-      const
-        request = new Request({body: {some: 'request'}}, {connectionId: 'connectionid'}),
-        callback = sinon.spy(
-          (err, res) => {
-            try {
-              should(kuzzle.funnel.executePluginRequest.called).be.false();
-              should(callback).be.calledOnce();
-              should(err).be.instanceOf(PluginImplementationError);
-              should(err.message).startWith('Invalid argument: the overload protection flag must be a boolean');
-              should(res).be.undefined();
-              done();
-            }
-            catch(e) {
-              done(e);
-            }
-          });
-
-      context.accessors.execute(request, 'foobar', callback);
-    });
-
-    it('should reject if an invalid overloadProtect flag is provided', () => {
-      const request = new Request({body: {some: 'request'}}, {connectionId: 'connectionid'});
-
-      return should(context.accessors.execute(request, 'foobar')).be.rejectedWith(
-        /Invalid argument: the overload protection flag must be a boolean/
       );
     });
   });


### PR DESCRIPTION
cf #1036 for further explanation on the issue.

This PR takes a quite radical approach by excluding any plugin:execute action from the overload protection.
The reasons behind this decision are:

* the overload is a complex part of Kuzzle code and any additional complexity makes it more difficult to maintain
* plugin controllers already go through the "regular" overload mechanism. 

### Boyscouting

* increased default overload trigger (a simple kuzzle installation on my laptop can handle more than 200 req/s)
* increased default pipe timers, which tend to pollute logs on production systems.
