### PR TITLE
Identify requests using their immutable identifier

### DIFF
--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -138,8 +138,8 @@ class FunnelController {
 
     // resolves the callback immediately if a slot is available
     if (this.concurrentRequests < this.kuzzle.config.limits.concurrentRequests) {
-      if (this.requestsCacheById[request.id]) {
-        delete this.requestsCacheById[request.id];
+      if (this.requestsCacheById[request.internalId]) {
+        delete this.requestsCacheById[request.internalId];
       }
       return true;
     }
@@ -163,9 +163,9 @@ class FunnelController {
       return false;
     }
 
-    if (!this.requestsCacheById[request.id]) {
-      this.requestsCacheById[request.id] = new CacheItem(executor, request, executeCallback);
-      this.requestsCacheQueue.push(request.id);
+    if (!this.requestsCacheById[request.internalId]) {
+      this.requestsCacheById[request.internalId] = new CacheItem(executor, request, executeCallback);
+      this.requestsCacheQueue.push(request.internalId);
 
       if (!this.overloaded) {
         this.overloaded = true;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "json2yaml": "^1.1.0",
     "jsonwebtoken": "^7.4.3",
     "koncorde": "^1.1.3",
-    "kuzzle-common-objects": "^3.0.6",
+    "kuzzle-common-objects": "^3.0.7",
     "lodash": "4.17.4",
     "moment": "2.18.1",
     "ms": "^2.0.0",

--- a/test/api/controllers/funnelController/execute.test.js
+++ b/test/api/controllers/funnelController/execute.test.js
@@ -127,11 +127,9 @@ describe('funnelController.execute', () => {
       should(funnel.overloaded).be.true();
       should(funnel.processRequest.called).be.false();
       should(funnel.requestsCacheQueue.length).be.eql(1);
-      should(funnel.requestsCacheQueue.shift())
-        .eql(request.id);
-      should(funnel.requestsCacheById[request.id]).eql(new (FunnelController.__get__('CacheItem'))('execute', request, callback));
-      should(funnel._playCachedRequests)
-        .be.calledOnce();
+      should(funnel.requestsCacheQueue.shift()).eql(request.internalId);
+      should(funnel.requestsCacheById[request.internalId]).eql(new (FunnelController.__get__('CacheItem'))('execute', request, callback));
+      should(funnel._playCachedRequests).be.calledOnce();
     });
 
     it('should not execute a cached request', () => {
@@ -159,12 +157,9 @@ describe('funnelController.execute', () => {
       should(funnel.overloaded).be.true();
       should(funnel.processRequest.called).be.false();
       should(funnel.requestsCacheQueue.length).be.eql(1);
-      should(funnel.requestsCacheQueue.shift())
-        .be.eql(request.id);
-      should(funnel.requestsCacheById[request.id])
-        .match({request, callback});
-      should(funnel._playCachedRequests)
-        .have.callCount(0);
+      should(funnel.requestsCacheQueue.shift()).be.eql(request.internalId);
+      should(funnel.requestsCacheById[request.internalId]).match({request, callback});
+      should(funnel._playCachedRequests).have.callCount(0);
     });
 
     it('should not play a cached request multiple times', () => {
@@ -177,8 +172,7 @@ describe('funnelController.execute', () => {
         funnel.execute(request, callback);
       }
 
-      should(funnel.requestsCacheQueue.length)
-        .eql(1);
+      should(funnel.requestsCacheQueue.length).eql(1);
     });
 
     it('should discard the request if the requestsBufferSize property is reached', done => {
@@ -224,13 +218,13 @@ describe('funnelController.execute', () => {
     });
 
     it('should play cached request in order', (done) => {
-      const
-        secondRequest = Object.assign({}, request, {id: 'req-2'}),
+      const 
+        serialized = request.serialize(),
+        secondRequest = new Request(Object.assign(serialized.data, {id: 'req-2'})),
         firstCallback = sinon.spy(),
         secondCallback = () => {
           should(firstCallback).be.calledOnce();
-          should(funnel.overloaded)
-            .be.false();
+          should(funnel.overloaded).be.false();
           done();
         };
 


### PR DESCRIPTION
(1.x equivalent of the following hotfix: https://github.com/kuzzleio/kuzzle/pull/1043)

The overload-protection mechanism relied on the request's `requestId` property, which is a mutable, client-defined identifier, intended to help clients linking Kuzzle responses to the corresponding requests they emitted.

This means that if a malicious party floods a Kuzzle server with requests using the same `requestId` value,  this forces the overload-protection mechanism to intervene, and it tries to buffer these new requests. Since a request with the same identifier is already buffered, then the new ones are discarded.
This leads to an unrecoverable memory leak in Kuzzle's entry point system, as long as in protocol plugins, eventually saturating a Kuzzle processus memory, forcing it to shut down.

This pull request fixes that issue by relying on the new `kuzzle-common-object` module version, which adds an immutable, internal identifier when a request object is created server-side. This identifier is now used by the overload-protection mechanism in place of the mutable `requestId` one.
