### PR TITLE
Allow createOrReplace to create a new document with auto generated id

### DIFF
--- a/lib/api/controllers/documentController.js
+++ b/lib/api/controllers/documentController.js
@@ -195,7 +195,6 @@ class DocumentController {
 
     assertHasBody(request);
     assertHasIndexAndCollection(request);
-    //assertHasId(request);
     assertIdStartsNotUnderscore(request);
 
     return this.kuzzle.validation.validationPromise(request, false)

--- a/lib/api/controllers/documentController.js
+++ b/lib/api/controllers/documentController.js
@@ -195,7 +195,7 @@ class DocumentController {
 
     assertHasBody(request);
     assertHasIndexAndCollection(request);
-    assertHasId(request);
+    //assertHasId(request);
     assertIdStartsNotUnderscore(request);
 
     return this.kuzzle.validation.validationPromise(request, false)


### PR DESCRIPTION
Allow createOrReplace to create a new Document without specifying an id.
In case we do not specify any id then the document will simply be created with an auto generated id by Kuzzle.
In case an id is provided then the document will be replaced if it already exists otherwise it will be created with this same id.