### PR TITLE
Improve docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM kuzzleio/base
-MAINTAINER Kuzzle <support@kuzzle.io>
+
+LABEL io.kuzzle.vendor="Kuzzle <support@kuzzle.io>"
+LABEL description="Power your web, mobile & iot apps with the Kuzzle backend"
 
 COPY ./ /var/app/
-COPY ./docker-compose/scripts/run.sh /run.sh
-COPY ./docker-compose/scripts/install-plugins.sh /install-plugins.sh
-COPY ./docker-compose/config/pm2.json /config/pm2.json
+COPY ./docker-compose/scripts/run.sh /usr/local/bin/kuzzle
 
 WORKDIR /var/app
 
@@ -16,15 +16,20 @@ RUN  apt-get update \
     g++ \
     gdb \
     python \
+  \
   && npm install \
-  && sh /install-plugins.sh \
+  && for plugin in plugins/enabled/*; do cd "$plugin"; npm install; cd /var/app; done \
+  \
+  && chmod a+x /usr/local/bin/kuzzle \
+  && chmod a+x /var/app/docker-compose/scripts/docker-entrypoint.sh \
+  \
   && apt-get clean \
   && apt-get remove -y \
     build-essential \
     g++ \
     python \
   && apt-get autoremove -y \
-  && chmod 755 /run.sh \
   && rm -rf /var/lib/apt/lists/*
 
-CMD ["/run.sh"]
+ENTRYPOINT ["/var/app/docker-compose/scripts/docker-entrypoint.sh"]
+CMD ["kuzzle", "start"]

--- a/docker-compose/scripts/docker-entrypoint.sh
+++ b/docker-compose/scripts/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+exec "$@"

--- a/docker-compose/scripts/run.sh
+++ b/docker-compose/scripts/run.sh
@@ -2,26 +2,29 @@
 
 set -e
 
+log () {
+  echo "[$(date --rfc-3339 seconds)] - $1"
+}
+
 elastic_host=${kuzzle_services__db__client__host:-http://elasticsearch:9200}
 
-echo "[$(date --rfc-3339 seconds)] - Waiting for elasticsearch to be available"
+log "Waiting for elasticsearch"
 while ! curl -f -s -o /dev/null "$elastic_host"
 do
-    echo "[$(date --rfc-3339 seconds)] - Still trying to connect to $elastic_host"
+    log "Still trying to connect to $elastic_host"
     sleep 1
 done
 # create a tmp index just to force the shards to init
 curl -XPUT -s -o /dev/null "$elastic_host/%25___tmp"
-echo "[$(date --rfc-3339 seconds)] - Elasticsearch is up. Waiting for shards to be active (can take a while)"
+log "Elasticsearch is up. Waiting for shards..."
 E=$(curl -s "$elastic_host/_cluster/health?wait_for_status=yellow&wait_for_active_shards=1&timeout=60s")
 curl -XDELETE -s -o /dev/null "$elastic_host/%25___tmp"
 
 if ! (echo ${E} | grep -E '"status":"(yellow|green)"' > /dev/null); then
-    echo "[$(date --rfc-3339 seconds)] - Could not connect to elasticsearch in time. Aborting..."
+    log "Could not connect to elasticsearch in time. Aborting..."
     exit 1
 fi
 
-echo "[$(date --rfc-3339 seconds)] - Starting Kuzzle..."
+log "Starting Kuzzle..."
 
-pm2 start --silent /config/pm2.json
-pm2 logs --lines 0 --raw
+exec ./bin/kuzzle "$@"


### PR DESCRIPTION
This PR brings the following new abilities:

* do not use pm2 anymore
* allow to pass options to kuzzle binary directly from command
* boyscouting: replace deprecated MAINTAINER directive with LABELs