### PR TITLE
limit message size for websocket and socket.io

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -293,7 +293,7 @@
     },
     // (embedded only)
     //   * maxRequestSize:
-    //     The maxium size of an incoming request. Units can be expressed in
+    //     The maximum size of an incoming request. Units can be expressed in
     //     bytes ("b" or none), kilobytes ("kb"), megabytes ("mb"), gigabytes
     //     ("gb") or terabytes ("tb")
     //   * port:

--- a/lib/api/core/entrypoints/embedded/protocols/http.js
+++ b/lib/api/core/entrypoints/embedded/protocols/http.js
@@ -43,7 +43,6 @@ class HttpProtocol extends Protocol {
   constructor() {
     super();
 
-    this.maxRequestSize = null;
     this.maxFormFileSize = null;
     this.server = null;
   }
@@ -54,18 +53,14 @@ class HttpProtocol extends Protocol {
    * @param {EmbeddedEntryPoint} entryPoint
    */
   init(entryPoint) {
+    super.init(entryPoint);
     this.entryPoint = entryPoint;
 
     debug('initializing http Server with config: %a', entryPoint.config);
 
-    this.maxRequestSize = bytes.parse(entryPoint.config.maxRequestSize);
     this.maxFormFileSize = bytes.parse(entryPoint.config.protocols.http.maxFormFileSize);
 
     this.server = entryPoint.httpServer;
-
-    if (this.maxRequestSize === null || isNaN(this.maxRequestSize)) {
-      throw new Error('Invalid HTTP "maxRequestSize" parameter');
-    }
 
     if (this.maxFormFileSize === null || isNaN(this.maxFormFileSize)) {
       throw new Error('Invalid HTTP "maxFormFileSize" parameter');

--- a/lib/api/core/entrypoints/embedded/protocols/protocol.js
+++ b/lib/api/core/entrypoints/embedded/protocols/protocol.js
@@ -18,8 +18,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const bytes = require('bytes');
 
 class Protocol {
+  constructor() {
+    this.maxRequestSize = null;
+  }
+
+  init(entryPoint) {
+    this.maxRequestSize = bytes.parse(entryPoint.config.maxRequestSize);
+
+    if (this.maxRequestSize === null || isNaN(this.maxRequestSize)) {
+      throw new Error('Invalid "maxRequestSize" parameter');
+    }
+  }
 
   broadcast () {
     // do nothing by default

--- a/lib/api/core/entrypoints/embedded/protocols/socketio.js
+++ b/lib/api/core/entrypoints/embedded/protocols/socketio.js
@@ -46,6 +46,7 @@ class SocketIoProtocol extends Protocol {
   }
 
   init(entryPoint) {
+    super.init(entryPoint);
     debug('initializing socketIo Server with config: %a', entryPoint.config.socketio);
 
     if (!entryPoint.config.protocols.socketio.enabled) {
@@ -57,7 +58,11 @@ class SocketIoProtocol extends Protocol {
 
     // SocketIo server listens by default to "/socket.io" path
     // (see (http://socket.io/docs/server-api/#server#path(v:string):server))
-    this.io = require('socket.io')(entryPoint.httpServer);
+    this.io = require('socket.io')(entryPoint.httpServer, {
+      // maxHttpBufferSize is passed to the ws library as the maxPayload option
+      // see https://github.com/socketio/socket.io/issues/2326#issuecomment-292146468
+      maxHttpBufferSize: this.maxRequestSize
+    });
 
     this.io.set('origins', entryPoint.config.protocols.socketio.origins);
 

--- a/lib/api/core/entrypoints/embedded/protocols/socketio.js
+++ b/lib/api/core/entrypoints/embedded/protocols/socketio.js
@@ -134,15 +134,6 @@ class SocketIoProtocol extends Protocol {
       return;
     }
 
-    // socket.io parses the content by itself and does not expose the original message :\..
-    if (JSON.stringify(data).length > this.entryPoint.httpServer.maxRequestSize) {
-      this.kuzzle.pluginsManager.trigger('log:error', `[socketio] Input message length(${data.length}) exceeds maxRequestSize: ${this.entryPoint.httpServer.maxRequestSize}`);
-      return this.io.to(socket.id).emit(data.requestId, {
-        status: 413,
-        error: {message: 'Error: maximum input request size exceeded'}
-      });
-    }
-
     debug('[%s] onClientMessage: %a', connection.id, data);
 
     try {

--- a/lib/api/core/entrypoints/embedded/protocols/websocket.js
+++ b/lib/api/core/entrypoints/embedded/protocols/websocket.js
@@ -29,8 +29,7 @@ const
   ClientConnection = require('../clientConnection'),
   {
     BadRequestError,
-    InternalError: KuzzleInternalError,
-    SizeLimitError
+    InternalError: KuzzleInternalError
   } = require('kuzzle-common-objects').errors;
 
 /**
@@ -159,11 +158,6 @@ class WebsocketProtocol extends Protocol {
     }
 
     let parsed;
-
-    if (data.length > this.entryPoint.httpServer.maxRequestSize) {
-      this.kuzzle.pluginsManager.trigger('log:error', `[websocket] Input message length(${data.length}) exceed maxRequestSize: ${this.entryPoint.httpServer.maxRequestSize}`);
-      return this._send(connection.id, JSON.stringify(new SizeLimitError('Error: maximum input request size exceeded')));
-    }
 
     debug('[%s] onClientMessage: %a', connection.id, data);
 

--- a/lib/api/core/entrypoints/embedded/protocols/websocket.js
+++ b/lib/api/core/entrypoints/embedded/protocols/websocket.js
@@ -51,6 +51,7 @@ class WebsocketProtocol extends Protocol {
    * @param {EmbeddedEntryPoint} entryPoint
    */
   init (entryPoint) {
+    super.init(entryPoint);
     debug('initializing WebSocket Server with config: %a', entryPoint.config.websocket);
 
     if (!entryPoint.config.protocols.websocket.enabled) {
@@ -60,7 +61,11 @@ class WebsocketProtocol extends Protocol {
     this.entryPoint = entryPoint;
     this.kuzzle = this.entryPoint.kuzzle;
 
-    this.server = new WebSocketServer({server: entryPoint.httpServer}, {perMessageDeflate: false});
+    this.server = new WebSocketServer({
+      server: entryPoint.httpServer,
+      maxPayload: this.maxRequestSize,
+      perMessageDeflate: false
+    });
 
     this.server.on('connection', socket => this.onConnection(socket));
     this.server.on('error', error => this.onServerError(error));

--- a/test/api/core/entrypoints/embedded/protocols/http.test.js
+++ b/test/api/core/entrypoints/embedded/protocols/http.test.js
@@ -39,7 +39,7 @@ describe('/lib/api/core/entrypoints/embedded/protocols/http', () => {
       entrypoint.config.maxRequestSize = 'invalid';
 
       return should(() => protocol.init(entrypoint))
-        .throw('Invalid HTTP "maxRequestSize" parameter');
+        .throw('Invalid "maxRequestSize" parameter');
     });
 
     it('should throw if an invalid maxFormFileSize is given', () => {

--- a/test/api/core/entrypoints/embedded/protocols/socketio.test.js
+++ b/test/api/core/entrypoints/embedded/protocols/socketio.test.js
@@ -171,9 +171,6 @@ describe('/lib/api/core/entrypoints/embedded/protocols/socketio', () => {
       socket = {
 
       };
-      entrypoint.httpServer = {
-        maxRequestSize: Infinity
-      };
       entrypoint.execute = sinon.spy();
 
       protocol.init(entrypoint);
@@ -187,30 +184,6 @@ describe('/lib/api/core/entrypoints/embedded/protocols/socketio', () => {
 
       should(entrypoint.execute)
         .have.callCount(0);
-    });
-
-    it('should complain if the message is too big', () => {
-      entrypoint.httpServer.maxRequestSize = 3;
-      const data = {
-        requestId: 'requestId'
-      };
-
-      protocol.onClientMessage(socket, {id: 'connectionId'}, data);
-
-      should(socketEmitStub)
-        .be.calledOnce()
-        .be.calledWith('requestId');
-
-      {
-        const emitted = socketEmitStub.firstCall.args[1];
-        should(emitted)
-          .match({
-            status: 413,
-            error: {
-              message: 'Error: maximum input request size exceeded'
-            }
-          });
-      }
     });
 
     it('should pass the message to the entry point', () => {

--- a/test/api/core/entrypoints/embedded/protocols/websocket.test.js
+++ b/test/api/core/entrypoints/embedded/protocols/websocket.test.js
@@ -239,20 +239,6 @@ describe('/lib/api/core/entrypoints/embedded/protocols/websocket', () => {
         .have.callCount(0);
     });
 
-    it ('should complain if the size exceeds the max authorized one', () => {
-      entrypoint.httpServer.maxRequestSize = 3;
-      const data = {
-        length: 4
-      };
-
-      protocol.onClientMessage(connection, data);
-
-      should(protocol._send)
-        .be.calledOnce();
-      should(protocol._send.firstCall.args[1])
-        .startWith('{"message":"Error: maximum input request size exceeded');
-    });
-
     it('should call entrypoint execute', () => {
       const data = JSON.stringify({foo: 'bar'});
 


### PR DESCRIPTION
# Description

To avoid denial of services, a maximum message size parameter is set in the configuration file (see the `server.maxRequestSize` parameter, defaulted to 1MB).

So far, only the HTTP protocol enforced that limit (see why below) , making anyone able to crash Kuzzle easily by sending very large messages over websocket or socket.io

This PR fixes that problem by making the websocket layer close connections if messages bypassing the configured limit are received.

# Why did I remove the existing size limit checks?

First of all, they didn't work. Existing tests (for [socket.io](https://github.com/kuzzleio/kuzzle/pull/1059/files#diff-9a67ca481237a887ba9bba2b6f3c4af7L133) and for [websocket](https://github.com/kuzzleio/kuzzle/pull/1059/files#diff-0a15a933eefee16d6be9f79ac421774fL158)) relied on the `entryPoint.httpServer.maxRequestSize` parameter, which does not exist (the correct path is `entryPoint.server.maxRequestSize`).
Since in JS, comparing any number to undefined always returns `false`, then these tests never validate.

Second, I prefer letting the protocol itself handle the maximum message size. This ends up in connections being abruptly closed with a 1006 error code, but it's a lot safer than testing the message while it's already being held in memory. And, in the case of socket.io, this prevents having to re-serializing the JSON data to check its approximate size

# Why did I remove the unit tests?

Because since the maximum request size is now being handled by protocols themselves at a lower level, I do not think I can mock sockets being closed in unit tests...