### PR TITLE
Hotfix: head and options http headers

### DIFF
--- a/lib/api/core/httpRouter/index.js
+++ b/lib/api/core/httpRouter/index.js
@@ -68,7 +68,6 @@ class Router {
 
     // Add an automatic HEAD route on the '/' url, answering with default headers
     attach('/', (request, cb) => {
-      Object.assign(request.input.args, this.defaultHeaders);
       request.setResult({}, 200);
       cb(request);
     }, this.routes.HEAD);
@@ -148,7 +147,7 @@ class Router {
       request.response.setHeaders(this.defaultHeaders);
 
       if (httpRequest.method.toUpperCase() === 'OPTIONS') {
-        Object.assign(request.input.args, httpRequest.headers);
+        request.input.headers = httpRequest.headers;
         request.setResult({}, 200);
 
         return this.kuzzle.pluginsManager.trigger('http:options', request)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {

--- a/test/api/core/httpRouter/httpRouter.test.js
+++ b/test/api/core/httpRouter/httpRouter.test.js
@@ -178,9 +178,10 @@ describe('core/httpRouter', () => {
           headers: router.defaultHeaders
         });
 
+        should(result.input.headers).match(rq.headers);
         should(kuzzleMock.pluginsManager.trigger.calledOnce).be.true();
         should(kuzzleMock.pluginsManager.trigger.calledWith('http:options', sinon.match.instanceOf(Request))).be.true();
-        should(kuzzleMock.pluginsManager.trigger.firstCall.args[1].input.args.foo).eql('bar');
+        should(kuzzleMock.pluginsManager.trigger.firstCall.args[1].input.headers.foo).eql('bar');
         done();
       });
     });
@@ -208,6 +209,7 @@ describe('core/httpRouter', () => {
           headers: router.defaultHeaders
         });
 
+        should(result.input.headers).match(rq.headers);
         done();
       });
     });


### PR DESCRIPTION
https://github.com/kuzzleio/kuzzle/pull/1034 fixes HTTP headers being incorrectly assigned to the `args` section of the `RequestInput` object, instead of the `headers` one.

But the default HEAD and OPTIONS HTTP requests were left out of these changes, so this PR fixes that.