### PR TITLE
Fix a bug preventing user profiles from being cached

### DIFF
--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -1131,14 +1131,10 @@ function checkSearchPageLimit(request, limit) {
  * @returns {Promise<object>}
  */
 function formatUserSearchResult(kuzzle, formatter, raw) {
-  const
-    promises = raw.hits.map(user => formatter(kuzzle, user)),
-    users = raw;
-
-  return Bluebird.all(promises)
+  return Bluebird.map(raw.hits, user => formatter(kuzzle, user))
     .then(formattedUsers => {
-      users.hits = formattedUsers;
-      return users;
+      raw.hits = formattedUsers;
+      return raw;
     });
 }
 

--- a/lib/api/core/auth/formatProcessing.js
+++ b/lib/api/core/auth/formatProcessing.js
@@ -71,12 +71,10 @@ module.exports = {
      * @deprecated This event is deprecated since v1.0.0
      */
     return kuzzle.pluginsManager.trigger('security:formatUserForSerialization', user)
-      .then(triggeredUser => {
-
-        const response = {_id: triggeredUser._id, _source: _.omit(triggeredUser, ['_kuzzle_info']), _meta: triggeredUser._kuzzle_info || {}};
-        delete response._source._id;
-
-        return response;
-      });
+      .then(triggeredUser => ({
+        _id: triggeredUser._id, 
+        _source: _.omit(triggeredUser, ['_kuzzle_info', '_id']), 
+        _meta: triggeredUser._kuzzle_info || {}
+      }));
   }
 };

--- a/lib/api/core/models/repositories/profileRepository.js
+++ b/lib/api/core/models/repositories/profileRepository.js
@@ -102,12 +102,13 @@ class ProfileRepository extends Repository {
       return Bluebird.resolve([]);
     }
 
-    const missing = [];
-    const promises = [];
+    const 
+      missing = [],
+      profiles = [];
 
     for (const id of profileIds) {
       if (this.profiles[id]) {
-        promises.push(Bluebird.resolve(this.profiles[id]));
+        profiles.push(this.profiles[id]);
       }
       else {
         missing.push(id);
@@ -115,26 +116,25 @@ class ProfileRepository extends Repository {
     }
 
     if (missing.length > 0) {
-      promises.push(this.loadMultiFromDatabase(missing)
-        .then(profiles => {
-          for (const profile of profiles) {
-            this.profiles[profile.id] = profile;
+      return this.loadMultiFromDatabase(missing)
+        .then(loaded => {
+          for (const profile of loaded) {
+            this.profiles[profile._id] = profile;
+            profiles.push(profile);
           }
 
           return profiles;
-        })
-      );
+        });
     }
 
-    return Bluebird.all(promises)
-      .then(results => results.reduce((acc, curr) => acc.concat(curr), []));
+    return Bluebird.resolve(profiles);
   }
 
   /**
    * Builds a Profile object from a Request
    *
    * @param {Request} request
-   * @returns Promise Resolves to the built Profile object.
+   * @returns {Promise<Profile>}
    */
   buildProfileFromRequest (request) {
     const dto = {};
@@ -263,7 +263,7 @@ class ProfileRepository extends Repository {
 
   /**
    * @param {object} dto
-   * @returns {Promise<Promise>}
+   * @returns {Promise<Profile>}
    */
   fromDTO (dto) {
     return super.fromDTO(dto)
@@ -284,12 +284,11 @@ class ProfileRepository extends Repository {
 
             // Fail if not all roles are found
             if (rolesNotFound.length) {
-              return Bluebird.reject(new NotFoundError(`Unable to hydrate the profile ${profile._id}. The following role(s) don't exist: ${rolesNotFound}`));
+              throw new NotFoundError(`Unable to hydrate the profile ${profile._id}. The following role(s) don't exist: ${rolesNotFound}`);
             }
 
             return profile;
           });
-
       });
   }
 }

--- a/lib/api/core/models/repositories/repository.js
+++ b/lib/api/core/models/repositories/repository.js
@@ -119,7 +119,7 @@ class Repository {
     return this.databaseEngine.mget(this.collection, ids)
       .then(response => {
         if (!response.hits || response.hits.length === 0) {
-          return Bluebird.resolve([]);
+          return [];
         }
 
         return Bluebird.all(response.hits

--- a/lib/api/core/models/repositories/userRepository.js
+++ b/lib/api/core/models/repositories/userRepository.js
@@ -108,7 +108,7 @@ class UserRepository extends Repository {
     return super.fromDTO(dto)
       .then(user => {
         if (user._id === undefined || user._id === null) {
-          return Bluebird.resolve(this.anonymous());
+          return this.anonymous();
         }
 
         // if the user exists (have an _id) but no profile
@@ -125,7 +125,7 @@ class UserRepository extends Repository {
 
             // Fail if not all profiles are found
             if (profilesNotFound.length) {
-              return Bluebird.reject(new NotFoundError(`Unable to hydrate the user ${dto._id}. The following profiles don't exist: ${profilesNotFound}`));
+              throw new NotFoundError(`Unable to hydrate the user ${dto._id}. The following profiles don't exist: ${profilesNotFound}`);
             }
 
             return user;

--- a/lib/services/internalEngine/index.js
+++ b/lib/services/internalEngine/index.js
@@ -82,13 +82,27 @@ class InternalEngine {
     if (!this.client) {
       let options;
 
+      // Passed to Elasticsearch's client to make it use
+      // Bluebird instead of ES6 promises
+      const defer = function defer () {
+        let resolve, reject;
+        const
+          promise = new Bluebird((res, rej) => {
+            resolve = res;
+            reject = rej;
+          });
+
+        return {resolve, reject, promise};
+      };
+
       if (this.config.client) {
-        options = Object.assign({}, this.config.client);
+        options = Object.assign({defer}, this.config.client);
       }
       else {
         // keep compatibility layer for the time being
         // @todo: once the install base is clean, remove this
         options = {
+          defer,
           hosts: this.config.hosts || `${this.config.host}:${this.config.port}`,
           apiVersion: this.config.apiVersion
         };


### PR DESCRIPTION
# Description

As stated in #1079 , profiles weren't cached anymore due to the wrong id field being used for storage. This made the cache useless and forced Kuzzle to constantly ask Elasticsearch for profiles data.

This PR also removes a lot of unnecessary promises creation.

# Boyscout

* Use `Bluebird.map` to simplify a few uses of `Bluebird.all`
* the `InternalEngine` service now always returns Bluebird promises instead of ES6 ones
