### PR TITLE
Kuzzle CLI was unable to connect to Kuzzle Server

### DIFF
--- a/features/support/api/websocket.js
+++ b/features/support/api/websocket.js
@@ -1,7 +1,7 @@
 const
   Bluebird = require('bluebird'),
   WsApiBase = require('./websocketBase'),
-  Ws = require('uws');
+  Ws = require('ws');
 
 class WebSocketApi extends WsApiBase {
 

--- a/lib/api/core/entrypoints/embedded/protocols/websocket.js
+++ b/lib/api/core/entrypoints/embedded/protocols/websocket.js
@@ -80,7 +80,7 @@ class WebsocketProtocol extends Protocol {
       return false;
     }
 
-    let ips = [request.connection && request.connection.remoteAddress];
+    let ips = request.connection ? [request.connection.remoteAddress] : [];
     if (request.headers && request.headers['x-forwarded-for']) {
       ips = request.headers['x-forwarded-for']
         .split(',')

--- a/lib/api/core/entrypoints/embedded/protocols/websocket.js
+++ b/lib/api/core/entrypoints/embedded/protocols/websocket.js
@@ -25,7 +25,7 @@ const
   debug = require('../../../../../kuzzleDebug')('kuzzle:entry-point:protocols:websocket'),
   Protocol = require('./protocol'),
   Request = require('kuzzle-common-objects').Request,
-  WebSocketServer = require('uws').Server,
+  WebSocketServer = require('ws').Server,
   ClientConnection = require('../clientConnection'),
   {
     BadRequestError,

--- a/lib/api/core/entrypoints/embedded/protocols/websocket.js
+++ b/lib/api/core/entrypoints/embedded/protocols/websocket.js
@@ -66,7 +66,7 @@ class WebsocketProtocol extends Protocol {
       perMessageDeflate: false
     });
 
-    this.server.on('connection', socket => this.onConnection(socket));
+    this.server.on('connection', (socket, request) => this.onConnection(socket, request));
     this.server.on('error', error => this.onServerError(error));
   }
 
@@ -74,23 +74,21 @@ class WebsocketProtocol extends Protocol {
     this.kuzzle.pluginsManager.trigger('log:error', `[websocket] An error has occured "${error.message}":\n${error.stack}`);
   }
 
-  onConnection(clientSocket) {
-    const req = clientSocket.upgradeReq;
-
-    if (req && req.url && req.url.startsWith('/socket.io/')) {
+  onConnection(clientSocket, request) {
+    if (request.url && request.url.startsWith('/socket.io/')) {
       // Discarding request management here: let socket.io protocol manage this connection
       return false;
     }
 
-    let ips = [req && req.connection && req.connection.remoteAddress || clientSocket._socket.remoteAddress];
-    if (req.headers['x-forwarded-for']) {
-      ips = req.headers['x-forwarded-for']
+    let ips = [request.connection && request.connection.remoteAddress];
+    if (request.headers && request.headers['x-forwarded-for']) {
+      ips = request.headers['x-forwarded-for']
         .split(',')
         .map(s => s.trim())
         .concat(ips);
     }
 
-    const connection = new ClientConnection(this.protocol, ips, req.headers);
+    const connection = new ClientConnection(this.protocol, ips, request.headers);
     debug('[%s] creating Websocket connection', connection.id);
 
     try {

--- a/lib/services/broker/wsBrokerClient.js
+++ b/lib/services/broker/wsBrokerClient.js
@@ -26,7 +26,7 @@ const
   path = require('path'),
   Bluebird = require('bluebird'),
   KuzzleInternalError = require('kuzzle-common-objects').errors.InternalError,
-  WS = require('uws');
+  WS = require('ws');
 
 /**
  * Websocket client implementation for Kuzzle internal broker

--- a/lib/services/broker/wsBrokerServer.js
+++ b/lib/services/broker/wsBrokerServer.js
@@ -30,7 +30,7 @@ const
   fs = require('fs'),
   http = require('http'),
   net = require('net'),
-  WS = require('uws').Server;
+  WS = require('ws').Server;
 
 /**
  * Web Socket server implementation of Kuzzle's internal broker.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8453,6 +8453,18 @@
             "debug": "3.1.0",
             "engine.io-parser": "2.1.2",
             "ws": "3.3.3"
+          },
+          "dependencies": {
+            "ws": {
+              "version": "3.3.3",
+              "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+              "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+              "requires": {
+                "async-limiter": "1.0.0",
+                "safe-buffer": "5.1.1",
+                "ultron": "1.1.1"
+              }
+            }
           }
         },
         "engine.io-client": {
@@ -8471,6 +8483,18 @@
             "ws": "3.3.3",
             "xmlhttprequest-ssl": "1.5.5",
             "yeast": "0.1.2"
+          },
+          "dependencies": {
+            "ws": {
+              "version": "3.3.3",
+              "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+              "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+              "requires": {
+                "async-limiter": "1.0.0",
+                "safe-buffer": "5.1.1",
+                "ultron": "1.1.1"
+              }
+            }
           }
         },
         "isarray": {
@@ -8555,6 +8579,19 @@
             "ws": "3.3.3",
             "xmlhttprequest-ssl": "1.5.5",
             "yeast": "0.1.2"
+          },
+          "dependencies": {
+            "ws": {
+              "version": "3.3.3",
+              "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+              "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+              "dev": true,
+              "requires": {
+                "async-limiter": "1.0.0",
+                "safe-buffer": "5.1.1",
+                "ultron": "1.1.1"
+              }
+            }
           }
         },
         "isarray": {
@@ -9241,6 +9278,23 @@
         "kind-of": "6.0.2"
       }
     },
+    "utf-8-validate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-4.0.0.tgz",
+      "integrity": "sha512-JS/c6nR/qauqSdvTksgDO1142kYddTXz42y5X/he188B/kgcFLLB4l9CfZd+hGic/ORgsL+pPfwr9lYsL/80Fw==",
+      "requires": {
+        "bindings": "1.3.0",
+        "nan": "2.8.0",
+        "prebuild-install": "2.3.0"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+          "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
+        }
+      }
+    },
     "util-arity": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/util-arity/-/util-arity-1.1.0.tgz",
@@ -9256,11 +9310,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
-    },
-    "uws": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/uws/-/uws-9.14.0.tgz",
-      "integrity": "sha512-HNMztPP5A1sKuVFmdZ6BPVpBQd5bUjNC8EFMFiICK+oho/OQsAJy5hnIx4btMHiOk8j04f/DbIlqnEZ9d72dqg=="
     },
     "v8-compile-cache": {
       "version": "1.1.2",
@@ -9431,13 +9480,11 @@
       }
     },
     "ws": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-      "integrity": "sha1-8c+E/i1ekB686U767OeF8YeiKPI=",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.1.1.tgz",
+      "integrity": "sha512-bOusvpCb09TOBLbpMKszd45WKC2KPtxiyiHanv+H2DE3Az+1db5a/L7sVJZVDPUC1Br8f0SKRr1KjLpD1U/IAw==",
       "requires": {
-        "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "ultron": "1.1.1"
+        "async-limiter": "1.0.0"
       }
     },
     "xmlhttprequest-ssl": {

--- a/package.json
+++ b/package.json
@@ -52,13 +52,14 @@
     "socket.io": "^2.1.0",
     "sorted-array": "^2.0.2",
     "triple-beam": "^1.1.0",
+    "utf-8-validate": "^4.0.0",
     "uuid": "^3.2.1",
-    "uws": "^9.14.0",
     "validator": "^9.4.1",
     "winston": "^2.4.1",
     "winston-elasticsearch": "^0.5.8",
     "winston-syslog": "^2.0.0",
-    "winston-transport": "^3.0.1"
+    "winston-transport": "^3.0.1",
+    "ws": "^5.1.1"
   },
   "repository": {
     "type": "git",

--- a/test/api/core/entrypoints/embedded/protocols/websocket.test.js
+++ b/test/api/core/entrypoints/embedded/protocols/websocket.test.js
@@ -20,7 +20,7 @@ describe('/lib/api/core/entrypoints/embedded/protocols/websocket', () => {
     WebSocketServer = sinon.spy(function () {
       this.on = sinon.spy();
     });
-    mockrequire('uws', {
+    mockrequire('ws', {
       Server: WebSocketServer
     });
 

--- a/test/services/implementations/broker.test.js
+++ b/test/services/implementations/broker.test.js
@@ -8,7 +8,7 @@ const
   sinon = require('sinon'),
   sandbox = sinon.sandbox.create(),
   should = require('should'),
-  WS = require('uws'),
+  WS = require('ws'),
   CircularList = require('easy-circular-list'),
   KuzzleMock = require('../../mocks/kuzzle.mock'),
   WSClientMock = require('../../mocks/services/ws.mock'),
@@ -137,7 +137,7 @@ describe('Test: Internal broker', () => {
       it('should construct a WS client', () => {
         const WSStub = sandbox.stub();
 
-        mockrequire('uws', WSStub);
+        mockrequire('ws', WSStub);
         mockrequire.reRequire('../../../lib/services/broker/wsBrokerClient');
 
         const WSClient = rewire('../../../lib/services/broker/wsBrokerClient');
@@ -735,7 +735,7 @@ describe('Test: Internal broker', () => {
           })
         });
 
-        mockrequire('uws', {
+        mockrequire('ws', {
           Server: sinon.spy(WSServerMock)
         });
 


### PR DESCRIPTION
Kuzzle CLI has a special access to Kuzzle Server: it doesn't need authentification, and there is no rights check on commands it can pass to the server.
To make this unrestricted access secure, the CLI can only connect to Kuzzle through a local Unix Domain socket created specially by the Kuzzle Server. No network port is open for the CLI, and we do not attend to ever open one, as we want Kuzzle to be as secure as possible.

Recently, #1064 replaced [ws](https://www.npmjs.com/package/ws) with [uWebSockets](https://www.npmjs.com/package/uws), as the latter is much more performant than the former. Problem is: uws doesn't support Unix Domain sockets, so since Kuzzle 1.2.10, the CLI doesn't work anymore.

This PR fixes that problem by rolling back our dependencies to ws.

Changes are also made to upgrade ws from v3 to v5