### PR TITLE
should not generate a dump on SIGTERM

### DIFF
--- a/lib/api/kuzzle.js
+++ b/lib/api/kuzzle.js
@@ -182,7 +182,6 @@ class Kuzzle extends EventEmitter {
  */
 function registerErrorHandlers(kuzzle) {
   const coreDumpSignals = {
-    SIGHUP: 1,
     // SIGINT: 2, force a graceful shutdown
     SIGQUIT: 3,
     // SIGILL: 4, can not be handled
@@ -192,7 +191,7 @@ function registerErrorHandlers(kuzzle) {
     // SIGSEGV: 11, can not be handled
     SIGPIPE: 13,
     // SIGBUS: 10, can not be handled
-    SIGTERM: 15
+    // SIGTERM: 15, normal termination
   };
   const request = new Request({
     controller: 'actions',
@@ -224,6 +223,7 @@ function registerErrorHandlers(kuzzle) {
       .finally(() => process.exit(1));
   });
 
+  // abnormal termination signals => generate a core dump
   Object.keys(coreDumpSignals).forEach(signal => {
     process.removeAllListeners(signal);
     process.on(signal, () => {
@@ -237,16 +237,16 @@ function registerErrorHandlers(kuzzle) {
   // signal SIGTRAP is used to generate a kuzzle dump without stopping it
   process.removeAllListeners('SIGTRAP');
   process.on('SIGTRAP', () => {
-    console.error('ERROR: Caught signal: SIGTRAP'); // eslint-disable-line no-console
+    console.error('Caught signal SIGTRAP => generating a core dump'); // eslint-disable-line no-console
     request.input.args.suffix = 'signal-sigtrap';
     kuzzle.cliController.actions.dump(request);
   });
 
-  // gracefully exits on a SIGINT signal
-  process.removeAllListeners('SIGINT');
-  process.on('SIGINT', () => {
-    kuzzle.cliController.actions.shutdown();
-  });
+  // gracefully exits on normal termination
+  for (const signal of ['SIGINT', 'SIGTERM']) {
+    process.removeAllListeners(signal);
+    process.on(signal, () => kuzzle.cliController.actions.shutdown());
+  }
 }
 
 module.exports = Kuzzle;

--- a/lib/api/kuzzle.js
+++ b/lib/api/kuzzle.js
@@ -182,16 +182,14 @@ class Kuzzle extends EventEmitter {
  */
 function registerErrorHandlers(kuzzle) {
   const coreDumpSignals = {
-    // SIGINT: 2, force a graceful shutdown
     SIGQUIT: 3,
     // SIGILL: 4, can not be handled
     SIGABRT: 6,
     // SIGFPE: 8, can not be handled
     // SIGKILL: 9, can not be handled
     // SIGSEGV: 11, can not be handled
-    SIGPIPE: 13,
+    SIGPIPE: 13
     // SIGBUS: 10, can not be handled
-    // SIGTERM: 15, normal termination
   };
   const request = new Request({
     controller: 'actions',

--- a/test/api/kuzzle.test.js
+++ b/test/api/kuzzle.test.js
@@ -9,7 +9,7 @@ describe('/lib/api/kuzzle.js', () => {
   let kuzzle;
 
   beforeEach(() => {
-    let mock = new KuzzleMock();
+    const mock = new KuzzleMock();
     kuzzle = new Kuzzle();
 
     [
@@ -108,32 +108,47 @@ describe('/lib/api/kuzzle.js', () => {
         should(processRemoveAllListenersSpy.getCall(1).args[0]).be.exactly('uncaughtException');
         should(processOnSpy.getCall(1).args[0]).be.exactly('uncaughtException');
 
-        should(processRemoveAllListenersSpy.getCall(2).args[0]).be.exactly('SIGHUP');
-        should(processOnSpy.getCall(2).args[0]).be.exactly('SIGHUP');
+        should(processRemoveAllListenersSpy.getCall(2).args[0]).be.exactly('SIGQUIT');
+        should(processOnSpy.getCall(2).args[0]).be.exactly('SIGQUIT');
 
-        should(processRemoveAllListenersSpy.getCall(3).args[0]).be.exactly('SIGQUIT');
-        should(processOnSpy.getCall(3).args[0]).be.exactly('SIGQUIT');
+        should(processRemoveAllListenersSpy.getCall(3).args[0]).be.exactly('SIGABRT');
+        should(processOnSpy.getCall(3).args[0]).be.exactly('SIGABRT');
 
-        should(processRemoveAllListenersSpy.getCall(4).args[0]).be.exactly('SIGABRT');
-        should(processOnSpy.getCall(4).args[0]).be.exactly('SIGABRT');
+        should(processRemoveAllListenersSpy.getCall(4).args[0]).be.exactly('SIGPIPE');
+        should(processOnSpy.getCall(4).args[0]).be.exactly('SIGPIPE');
 
-        should(processRemoveAllListenersSpy.getCall(5).args[0]).be.exactly('SIGPIPE');
-        should(processOnSpy.getCall(5).args[0]).be.exactly('SIGPIPE');
+        should(processRemoveAllListenersSpy.getCall(5).args[0]).be.exactly('SIGTRAP');
+        should(processOnSpy.getCall(5).args[0]).be.exactly('SIGTRAP');
 
-        should(processRemoveAllListenersSpy.getCall(6).args[0]).be.exactly('SIGTERM');
-        should(processOnSpy.getCall(6).args[0]).be.exactly('SIGTERM');
+        should(processRemoveAllListenersSpy.getCall(6).args[0]).be.exactly('SIGINT');
+        should(processOnSpy.getCall(6).args[0]).be.exactly('SIGINT');
 
-        should(processRemoveAllListenersSpy.getCall(7).args[0]).be.exactly('SIGTRAP');
-        should(processOnSpy.getCall(7).args[0]).be.exactly('SIGTRAP');
+        should(processRemoveAllListenersSpy.getCall(7).args[0]).be.exactly('SIGTERM');
+        should(processOnSpy.getCall(7).args[0]).be.exactly('SIGTERM');
       });
     });
 
-    it('does not really test anything but increases coverage', () => {
+    it('should not start if it fails initializing its internal storage', () => {
       const error = new Error('error');
 
       kuzzle.internalEngine.init.rejects(error);
 
-      return should(kuzzle.start()).be.rejectedWith(error);
+      return should(kuzzle.start()).be.rejectedWith(error)
+        .then(() => {
+          should(kuzzle.internalEngine.bootstrap.all).not.be.called();
+          should(kuzzle.validation.init).not.be.called();
+          should(kuzzle.pluginsManager.init).not.be.called();
+          should(kuzzle.pluginsManager.run).not.be.called();
+          should(kuzzle.services.init).not.be.called();
+          should(kuzzle.indexCache.init).not.be.called();
+          should(kuzzle.pluginsManager.trigger).be.called();
+          should(kuzzle.funnel.init).not.be.called();
+          should(kuzzle.router.init).not.be.called();
+          should(kuzzle.statistics.init).not.be.called();
+          should(kuzzle.entryPoints.init).not.be.called();
+          should(kuzzle.repositories.init).not.be.called();
+          should(kuzzle.cliController.init).not.be.called();
+        });
     });
   });
 });


### PR DESCRIPTION
# Description

Upon catching the SIGTERM signal, Kuzzle should not generate a dump report and should instead perform a graceful shutdown

# Other changes

Upgraded a not-so-useless test :open_mouth: 