### PR TITLE
Fix performances issue when retrieving/searching numerous users at once

### DIFF
--- a/lib/api/core/entrypoints/embedded/protocols/http.js
+++ b/lib/api/core/entrypoints/embedded/protocols/http.js
@@ -185,7 +185,6 @@ class HttpProtocol extends Protocol {
     }
 
     this.entryPoint.kuzzle.router.http.route(payload, result => {
-
       result.context.protocol = 'http';
       result.context.connectionId = connectionId;
 
@@ -200,7 +199,7 @@ class HttpProtocol extends Protocol {
         }
       }
 
-      debug('sending HTTP request response to proxy: %a', resp);
+      debug('sending HTTP request response to client: %a', resp);
       this.entryPoint.removeConnection(connectionId);
 
       if (resp.headers) {

--- a/lib/api/core/models/repositories/profileRepository.js
+++ b/lib/api/core/models/repositories/profileRepository.js
@@ -215,7 +215,7 @@ class ProfileRepository extends Repository {
    */
   serializeToDatabase (profile) {
     // avoid the profile var mutation
-    return  _.omit(profile, ['_id']);
+    return _.omit(profile, ['_id']);
   }
 
   /**

--- a/lib/api/core/models/repositories/profileRepository.js
+++ b/lib/api/core/models/repositories/profileRepository.js
@@ -85,6 +85,11 @@ class ProfileRepository extends Repository {
 
   /**
    * Loads a Profile object given its id.
+   * Stores the promise of the profile being loaded in the memcache
+   * and then replaces it by the profile itself once it has been loaded
+   *
+   * This is to allow parallelisation while preventing sending requests
+   * to ES, which is slow
    *
    * @param {Array} profileIds - Array of profiles ids
    * @returns {Promise} Resolves to the matching Profile object if found, null if not.
@@ -94,40 +99,25 @@ class ProfileRepository extends Repository {
       return Bluebird.reject(new BadRequestError('Missing profileIds'));
     }
 
-    if (!Array.isArray(profileIds) || profileIds.reduce((prev, profile) => (prev || typeof profile !== 'string'), false)) {
+    if (!Array.isArray(profileIds) || profileIds.some(p => typeof p !== 'string')) {
       return Bluebird.reject(new BadRequestError('An array of strings must be provided as profileIds'));
     }
 
-    if (profileIds.length === 0) {
-      return Bluebird.resolve([]);
-    }
-
-    const 
-      missing = [],
-      profiles = [];
+    const profiles = [];
 
     for (const id of profileIds) {
-      if (this.profiles[id]) {
-        profiles.push(this.profiles[id]);
+      if (!this.profiles[id]) {
+        this.profiles[id] = this.loadOneFromDatabase(id)
+          .then(profile => {
+            this.profiles[id] = profile;
+            return profile;
+          });
       }
-      else {
-        missing.push(id);
-      }
+
+      profiles.push(this.profiles[id]);
     }
 
-    if (missing.length > 0) {
-      return this.loadMultiFromDatabase(missing)
-        .then(loaded => {
-          for (const profile of loaded) {
-            this.profiles[profile._id] = profile;
-            profiles.push(profile);
-          }
-
-          return profiles;
-        });
-    }
-
-    return Bluebird.resolve(profiles);
+    return Bluebird.all(profiles);
   }
 
   /**
@@ -225,11 +215,7 @@ class ProfileRepository extends Repository {
    */
   serializeToDatabase (profile) {
     // avoid the profile var mutation
-    const result = _.merge({}, profile);
-
-    delete result._id;
-
-    return result;
+    return  _.omit(profile, ['_id']);
   }
 
   /**
@@ -277,14 +263,13 @@ class ProfileRepository extends Repository {
           profile.constructor._hash = this.kuzzle.constructor.hash;
         }
 
-        const policiesRoles = extractRoleIds(profile.policies);
+        const policiesRoles = profile.policies.map(p => p.roleId);
+
         return this.kuzzle.repositories.role.loadRoles(policiesRoles)
           .then(roles => {
-            const rolesNotFound = _.difference(policiesRoles, extractRoleIds(roles));
-
             // Fail if not all roles are found
-            if (rolesNotFound.length) {
-              throw new NotFoundError(`Unable to hydrate the profile ${profile._id}. The following role(s) don't exist: ${rolesNotFound}`);
+            if (roles.some(r => r === null)) {
+              throw new NotFoundError(`Unable to hydrate the profile ${profile._id}: missing role(s) in the database`);
             }
 
             return profile;
@@ -295,15 +280,3 @@ class ProfileRepository extends Repository {
 
 
 module.exports = ProfileRepository;
-
-/**
- * @param {object[]} policiesOrRoles
- */
-function extractRoleIds(policiesOrRoles) {
-  return policiesOrRoles.map(element => {
-    if (element.roleId) {
-      return element.roleId;
-    }
-    return element._id;
-  });
-}

--- a/lib/api/core/models/repositories/repository.js
+++ b/lib/api/core/models/repositories/repository.js
@@ -122,9 +122,9 @@ class Repository {
           return [];
         }
 
-        return Bluebird.all(response.hits
-          .filter(doc => doc.found)
-          .map(doc => this.fromDTO(Object.assign({}, doc._source, {_id: doc._id})))
+        return Bluebird.map(
+          response.hits.filter(doc => doc.found),
+          doc => this.fromDTO(Object.assign({}, doc._source, {_id: doc._id}))
         );
       });
   }
@@ -396,7 +396,7 @@ class Repository {
 
     if (raw.hits && raw.hits.length > 0) {
       result.total = raw.total;
-      return Bluebird.all(raw.hits.map(doc => this.fromDTO(Object.assign({}, doc._source, {_id: doc._id}))))
+      return Bluebird.map(raw.hits, doc => this.fromDTO(Object.assign({}, doc._source, {_id: doc._id})))
         .then(hits => {
           result.hits = hits;
           return result;

--- a/lib/api/core/models/repositories/roleRepository.js
+++ b/lib/api/core/models/repositories/roleRepository.js
@@ -59,31 +59,21 @@ class RoleRepository extends Repository {
    * @returns {Promise} Resolves to an array containing the matching found Role objects.
    */
   loadRoles (ids) {
-    const missingIds = [];
-    const promises = [];
+    const roles = [];
 
     for (const id of ids) {
-      if (this.roles[id]) {
-        promises.push(Bluebird.resolve(this.roles[id]));
+      if (!this.roles[id]) {
+        this.roles[id] = this.loadOneFromDatabase(id)
+          .then(role => {
+            this.roles[id] = role;
+            return role;
+          });
       }
-      else {
-        missingIds.push(id);
-      }
+
+      roles.push(this.roles[id]);
     }
 
-    if (missingIds.length > 0) {
-      promises.push(this.loadMultiFromDatabase(missingIds)
-        .then(roles => {
-          for (const role of roles) {
-            this.roles[role._id] = role;
-          }
-          return roles;
-        })
-      );
-    }
-
-    // flatten [r1, r2, [r3, r4]] to [r1, r2, r3, r4]
-    return Bluebird.reduce(promises, (acc, result) => acc.concat(result), []);
+    return Bluebird.all(roles);
   }
 
   /**

--- a/lib/api/core/models/repositories/userRepository.js
+++ b/lib/api/core/models/repositories/userRepository.js
@@ -22,7 +22,6 @@
 'use strict';
 
 const
-  _ = require('lodash'),
   Bluebird = require('bluebird'),
   uuid = require('uuid/v4'),
   User = require('../security/user'),
@@ -119,13 +118,9 @@ class UserRepository extends Repository {
 
         return this.kuzzle.repositories.profile.loadProfiles(user.profileIds)
           .then(profiles => {
-            const
-              profileIds = profiles.map(profile => profile._id),
-              profilesNotFound = _.difference(user.profileIds, profileIds);
-
             // Fail if not all profiles are found
-            if (profilesNotFound.length) {
-              throw new NotFoundError(`Unable to hydrate the user ${dto._id}. The following profiles don't exist: ${profilesNotFound}`);
+            if (profiles.some(p => p === null)) {
+              throw new NotFoundError(`Unable to hydrate the user ${dto._id}: missing profile(s) in the database`);
             }
 
             return user;

--- a/lib/api/core/models/security/profile.js
+++ b/lib/api/core/models/security/profile.js
@@ -73,15 +73,9 @@ class Profile {
 
     return this.getRoles()
       .then(roles => new Bluebird((resolve, reject) => {
-        Bluebird.all(roles.map(role => role.isActionAllowed(request)
-          .then(isAllowed => {
-            if (isAllowed) {
-              resolve(true);
-            }
-          })
-          .catch(reject)
-        ))
-          .then(results => resolve(results.some(r => r)));
+        Bluebird.map(roles, role => role.isActionAllowed(request))
+          .then(results => resolve(results.some(r => r)))
+          .catch(reject);
       }));
   }
 

--- a/lib/api/core/models/security/role.js
+++ b/lib/api/core/models/security/role.js
@@ -100,7 +100,7 @@ class Role {
     }
 
     if (typeof actionRights === 'boolean') {
-      promises.push(Bluebird.resolve(actionRights));
+      promises.push(actionRights);
     }
     else if (typeof actionRights === 'object' && actionRights !== null) {
       promises.push(executeClosure(this, this[_kuzzle], path, actionRights, request));
@@ -286,22 +286,20 @@ function checkIndexRestriction(request, restriction) {
 /**
  * @param {Role} role
  * @param {Request} request
- * @returns {Promise<Boolean>} resolves to a Boolean value
+ * @returns {Boolean} resolves to a Boolean value
  */
 function checkRestrictions(role, request) {
   // If no restrictions, we allow the action:
   if (role.restrictedTo.length === 0) {
-    return Bluebird.resolve(true);
+    return true;
   }
 
   // If the request's action does not refer to an index, restrictions are useless for this action (=> ignore them):
   if (!request.input.resource.index) {
-    return Bluebird.resolve(true);
+    return true;
   }
 
-  return Bluebird.resolve(
-    role.restrictedTo.some(restriction => checkIndexRestriction(request, restriction))
-  );
+  return role.restrictedTo.some(restriction => checkIndexRestriction(request, restriction));
 }
 
 /**

--- a/lib/api/core/models/security/user.js
+++ b/lib/api/core/models/security/user.js
@@ -82,15 +82,9 @@ class User {
 
     return this.getProfiles()
       .then(profiles => new Bluebird((resolve, reject) => {
-        Bluebird.all(profiles.map(profile => profile.isActionAllowed(request)
-          .then(isAllowed => {
-            if (isAllowed) {
-              resolve(true);
-            }
-          })
-          .catch(reject)
-        ))
-          .then(results => resolve(results.some(r => r)));
+        Bluebird.map(profiles, profile => profile.isActionAllowed(request))
+          .then(results => resolve(results.some(r => r)))
+          .catch(reject);
       }));
   }
 }

--- a/lib/services/internalEngine/index.js
+++ b/lib/services/internalEngine/index.js
@@ -44,6 +44,7 @@
 'use strict';
 
 const
+  debug = require('../../kuzzleDebug')('kuzzle:services:internalEngine'),
   ESWrapper = require('../../util/esWrapper'),
   _ = require('lodash'),
   Bluebird = require('bluebird'),
@@ -134,20 +135,21 @@ class InternalEngine {
   search (type, query, options = {}) {
     const
       request = {
+        type,
         index: this.index,
-        type
+        from: options.from,
+        size: options.size,
+        scroll: options.scroll
       };
-
-    _.intersection(Object.keys(options), ['from', 'size', 'scroll']).forEach(opt => {
-      request[opt] = options[opt];
-    });
 
     if (query) {
       request.body = query.query ? {query: query.query} : {query};
     }
 
+    debug('Searching: %a', request);
     return this.client.search(request)
       .then(raw => {
+        debug('> %a results fetched', raw.hits.hits.length);
         const result = raw.hits || {hits: [], total: 0};
 
         // register the scroll id (if any)

--- a/test/api/core/models/repositories/roleRepository.test.js
+++ b/test/api/core/models/repositories/roleRepository.test.js
@@ -57,20 +57,21 @@ describe('Test: repositories/roleRepository', () => {
 
       roleRepository.roles.role3 = role3;
 
-      roleRepository.loadMultiFromDatabase = sinon.stub().returns(Bluebird.resolve([role1, role2, role4]));
+      roleRepository.loadOneFromDatabase = sinon.stub();
+      roleRepository.loadOneFromDatabase.withArgs('role1').resolves(role1);
+      roleRepository.loadOneFromDatabase.withArgs('role2').resolves(role2);
+      roleRepository.loadOneFromDatabase.withArgs('role4').resolves(role4);
 
       return roleRepository.loadRoles(['role1', 'role2', 'role3', 'role4'])
         .then(result => {
-          // in memory roles are first in the result array
           should(result)
             .be.an.Array()
-            .match([
-              role3,
-              role1,
-              role2,
-              role4
-            ])
+            .match([role1, role2, role3, role4])
             .have.length(4);
+          should(roleRepository.loadOneFromDatabase).calledWith('role1');
+          should(roleRepository.loadOneFromDatabase).calledWith('role2');
+          should(roleRepository.loadOneFromDatabase).neverCalledWith('role3');
+          should(roleRepository.loadOneFromDatabase).calledWith('role4');
         });
     });
 

--- a/test/api/core/models/repositories/userRepository.test.js
+++ b/test/api/core/models/repositories/userRepository.test.js
@@ -83,17 +83,12 @@ describe('Test: repositories/userRepository', () => {
 
   describe('#fromDTO', () => {
     it('should return the anonymous user if no _id is set', () => {
-      return userRepository.fromDTO({
-        profileIds: 'a profile'
-      })
+      return userRepository.fromDTO({profileIds: 'a profile'})
         .then(user => assertIsAnonymous(user));
     });
 
     it('should convert a profileIds string into array', () => {
-      return userRepository.fromDTO({
-        _id: 'admin',
-        profileIds: 'admin'
-      })
+      return userRepository.fromDTO({_id: 'admin', profileIds: 'admin'})
         .then(result => {
           should(result.profileIds).be.an.instanceOf(Array);
           should(result.profileIds[0]).be.exactly('admin');
@@ -101,18 +96,15 @@ describe('Test: repositories/userRepository', () => {
     });
 
     it('should reject the promise if the profile cannot be found', () => {
-      kuzzle.repositories.profile.loadProfiles.resolves([]);
+      kuzzle.repositories.profile.loadProfiles.resolves([null]);
 
       return should(userRepository.fromDTO(userInvalidProfile))
         .be.rejectedWith(NotFoundError);
     });
 
     it('should add the default profile if none is set', () => {
-      return userRepository.fromDTO({
-        _id: 'foo'
-      })
+      return userRepository.fromDTO({_id: 'foo'})
         .then(user => should(user.profileIds).match(kuzzle.config.security.restrictedProfileIds));
-
     });
   });
 


### PR DESCRIPTION
# Description

The issue comes from parallelisation: 
1. when instanciating a user object, its associated profiles (and roles) are also loaded using, respectively, the profile and role repositories
2. if the profile/role repository do not have the asked object in memory, it loads it from the database
3. when multiple users are loaded, each user instance tries to load its associated profiles/roles at almost the same time => this triggers duplicate requests to the database to fetch the corresponding objects

This PR fixes the issue by caching the loading task promise in lieu of the actual object, making other calls return the same promise instead of creating new requests. Once the promise gets resolved, the cached promise is replaced by the loaded object.

# Other changes

* the missing profiles/roles detection algorithm has been fixed: the previous code assumed that missing values weren't returned by loadXXX methods, but `null` values are actually returned 
* `user.isActionAllowed` and `profile.isActionAllowed` resolved their returned promises multiple times instead of just once

# Boyscout

* Simplified a few `Bluebird.all` calls using `Bluebird.map` (cosmetic)
* Added a few debug messages to make debugging easier
