### PR TITLE
remove promise warnings from the internal engine's bootstrap

### DIFF
--- a/lib/services/internalEngine/bootstrap.js
+++ b/lib/services/internalEngine/bootstrap.js
@@ -156,9 +156,7 @@ class InternalEngineBootstrap {
     };
 
     return this.db.updateMapping('users', mapping)
-      .then(() => {
-        this.kuzzle.indexCache.add(this.db.index, 'users');
-      });
+      .then(() => this.kuzzle.indexCache.add(this.db.index, 'users'));
   }
 
   createValidationCollection (validationConfiguration) {
@@ -199,11 +197,9 @@ class InternalEngineBootstrap {
         return Bluebird.all(promises);
       }
 
-      return Bluebird.resolve();
+      return null;
     })
-      .then(() => {
-        this.kuzzle.indexCache.add(this.db.index, 'validations');
-      });
+      .then(() => this.kuzzle.indexCache.add(this.db.index, 'validations'));
   }
 
   * _getJWTSecretGen () {


### PR DESCRIPTION
Remove Bluebird warnings generated because of inconsistent returned values by the internal engine's bootstrap

This is just a cosmetic change, cleaning up logs from useless warnings when starting Kuzzle from scratch