### PR TITLE
Hotfix: JWTs TTL reset to default cache TTL (24min)

### DIFF
--- a/lib/api/core/models/repositories/repository.js
+++ b/lib/api/core/models/repositories/repository.js
@@ -197,6 +197,7 @@ class Repository {
     if (!this.cacheEngine) {
       return this.loadOneFromDatabase(id);
     }
+
     return this.loadFromCache(id, options)
       .then(object => {
         if (object === null) {
@@ -308,9 +309,18 @@ class Repository {
    * @returns {*}
    */
   refreshCacheTTL (object, options = {}) {
-    const 
-      ttl = options.ttl !== undefined ? options.ttl : this.ttl,
-      key = options.key || this.getCacheKey(object._id);
+    const key = options.key || this.getCacheKey(object._id);
+    let ttl;
+
+    if (options.ttl !== undefined) {
+      ttl = options.ttl;
+    } else if (object.ttl !== undefined) { 
+      // if a TTL has been defined at the entry creation, we should
+      // use it 
+      ttl = object.ttl;
+    } else {
+      ttl = this.ttl;
+    }
 
     if (ttl === false) {
       return this.cacheEngine.persist(key);

--- a/lib/api/core/models/repositories/tokenRepository.js
+++ b/lib/api/core/models/repositories/tokenRepository.js
@@ -248,6 +248,18 @@ class TokenRepository extends Repository {
         }));
       });
   }
+
+  /**
+   * The repository main class refreshes automatically the TTL
+   * of accessed entries, letting only unaccessed entries expire
+   *
+   * But tokens' TTL must remain the same than their expiration time,
+   * refreshing a token entry has no meaning.
+   *
+   * So we need to override the TTL auto-refresh function to disable it
+   */
+  refreshCacheTTL() {
+  }
 }
 
 module.exports = TokenRepository;


### PR DESCRIPTION
# Description

The global repository system has an auto-refresh feature. The idea behind that feature is that, if a cache item is frequently accessed, then it should be kept in the cache indefinitely, while entries that are accessed only once expire after some time (default: 1440 seconds), freeing up cache space.

That feature had 2 issues that this PR fixes: 

* it ignored the configured entry TTL and always used the configure default TTL. If entries are created with a different TTL to reflect different needs, the auto-refresh will override that value whenever the entry is accessed
* JWTs are handled by a specialized repository (the `tokenRepository` module), which creates cache entries with the same TTL than the token's one. Unfortunately, the auto-refresh feature was not disabled for this repository, leading to entries TTL being reset to the default 1440s each time a token was being accessed

Stricter unit tests have been added to make sure that this problem never arises again

# Boyscout 

The `repository` unit tests now use the mocked Kuzzle stubs instead of creating new ones.
