### PR TITLE
[Hotfix] load roles and profiles fromDTO after reset

### DIFF
--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -27,8 +27,6 @@ const
   Bluebird = require('bluebird'),
   formatProcessing = require('../core/auth/formatProcessing'),
   Request = require('kuzzle-common-objects').Request,
-  Role = require('../core/models/security/role'),
-  Profile = require('../core/models/security/profile'),
   {
     NotFoundError,
     BadRequestError,

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -1033,8 +1033,8 @@ function createOrReplaceProfile (profileRepository, request, opts) {
  */
 function resetRoles (defaults, roleRepository) {
   const promises = ['admin', 'default', 'anonymous'].map(id => {
-    const role = Object.assign(new Role(), {_id: id}, defaults[id]);
-    return roleRepository.validateAndSaveRole(role);
+    return roleRepository.fromDTO(Object.assign(new Role(), {_id: id}, defaults[id]))
+      .then(role => roleRepository.validateAndSaveRole(role));
   });
 
   return Bluebird.all(promises);
@@ -1046,8 +1046,8 @@ function resetRoles (defaults, roleRepository) {
  */
 function resetProfiles (profileRepository) {
   const promises = ['admin', 'default', 'anonymous'].map(id => {
-    const profile = Object.assign(new Profile(), {_id: id, policies: [{roleId: id}]});
-    return profileRepository.validateAndSaveProfile(profile);
+    return profileRepository.fromDTO(Object.assign(new Profile(), {_id: id, policies: [{roleId: id}]}))
+      .then(profile => profileRepository.validateAndSaveProfile(profile));
   });
 
   return Bluebird.all(promises);

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -1033,7 +1033,7 @@ function createOrReplaceProfile (profileRepository, request, opts) {
  */
 function resetRoles (defaults, roleRepository) {
   const promises = ['admin', 'default', 'anonymous'].map(id => {
-    return roleRepository.fromDTO(Object.assign(new Role(), {_id: id}, defaults[id]))
+    return roleRepository.fromDTO(Object.assign({_id: id}, defaults[id]))
       .then(role => roleRepository.validateAndSaveRole(role));
   });
 
@@ -1046,7 +1046,7 @@ function resetRoles (defaults, roleRepository) {
  */
 function resetProfiles (profileRepository) {
   const promises = ['admin', 'default', 'anonymous'].map(id => {
-    return profileRepository.fromDTO(Object.assign(new Profile(), {_id: id, policies: [{roleId: id}]}))
+    return profileRepository.fromDTO({_id: id, policies: [{roleId: id}]})
       .then(profile => profileRepository.validateAndSaveProfile(profile));
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {

--- a/test/api/controllers/securityController/createFirstAdmin.test.js
+++ b/test/api/controllers/securityController/createFirstAdmin.test.js
@@ -101,9 +101,13 @@ describe('Test: security controller - createFirstAdmin', () => {
   });
 
   describe('#resetRoles', () => {
-    it('should call validateAndSaveRole with all default roles', () => {
+    it('should call fromDTO and validateAndSaveRole with all default roles', () => {
       const
-        validateAndSaveRole = sandbox.stub().returns(Promise.resolve()),
+        roleRepository = {
+          fromDTO: role => Promise.resolve(role),
+          validateAndSaveRole: sandbox.stub().returns(Promise.resolve())
+        },
+        fromDTOSpy = sinon.spy(roleRepository, 'fromDTO'),
         mock = {
           admin: {
             controllers: {
@@ -134,49 +138,63 @@ describe('Test: security controller - createFirstAdmin', () => {
           }
         };
 
-      return SecurityController.__get__('resetRoles')(mock, {validateAndSaveRole})
+      return SecurityController.__get__('resetRoles')(mock, roleRepository)
         .then(() => {
-          try {
-            should(validateAndSaveRole).have.callCount(3);
-            should(validateAndSaveRole.firstCall).be.calledWithMatch({_id: 'admin', controllers: {foo: {actions: {bar: true}}}});
-            should(validateAndSaveRole.secondCall).be.calledWithMatch({_id: 'default', controllers: {baz: {actions: {yolo: true}}}});
-            should(validateAndSaveRole.thirdCall).be.calledWithMatch({_id: 'anonymous', controllers: {anon: {actions: {ymous: true}}}});
-            return Promise.resolve();
-          }
-          catch (error) {
-            return Promise.reject(error);
-          }
+          should(fromDTOSpy).have.callCount(3);
+          should(roleRepository.validateAndSaveRole).have.callCount(3);
+
+          should(fromDTOSpy.firstCall).be.calledWithMatch({_id: 'admin', controllers: {foo: {actions: {bar: true}}}});
+          should(roleRepository.validateAndSaveRole.firstCall).be.calledWithMatch({_id: 'admin', controllers: {foo: {actions: {bar: true}}}});
+
+          should(fromDTOSpy.secondCall).be.calledWithMatch({_id: 'default', controllers: {baz: {actions: {yolo: true}}}});
+          should(roleRepository.validateAndSaveRole.secondCall).be.calledWithMatch({_id: 'default', controllers: {baz: {actions: {yolo: true}}}});
+
+          should(fromDTOSpy.thirdCall).be.calledWithMatch({_id: 'anonymous', controllers: {anon: {actions: {ymous: true}}}});
+          should(roleRepository.validateAndSaveRole.thirdCall).be.calledWithMatch({_id: 'anonymous', controllers: {anon: {actions: {ymous: true}}}});
         });
     });
   });
 
   describe('#resetProfiles', () => {
-    it('should call validateAndSaveProfile with all default profiles and rights policies', () => {
+    it('should call fromDTO and validateAndSaveProfile with all default profiles and rights policies', () => {
       const
-        validateAndSaveProfile = sandbox.stub().returns(Promise.resolve());
+        profileRepository = {
+          fromDTO: profile => Promise.resolve(profile),
+          validateAndSaveProfile: sandbox.stub().returns(Promise.resolve())
+        },
+        fromDTOSpy = sinon.spy(profileRepository, 'fromDTO');
 
-      return SecurityController.__get__('resetProfiles')({validateAndSaveProfile})
+      return SecurityController.__get__('resetProfiles')(profileRepository)
         .then(() => {
+          should(fromDTOSpy).have.callCount(3);
+          should(profileRepository.validateAndSaveProfile).have.callCount(3);
 
-          try {
-            should(validateAndSaveProfile).have.callCount(3);
-            should(validateAndSaveProfile.firstCall).be.calledWithMatch({
-              _id: 'admin',
-              policies: [{roleId: 'admin'}]
-            });
-            should(validateAndSaveProfile.secondCall).be.calledWithMatch({
-              _id: 'default',
-              policies: [{roleId: 'default'}]
-            });
-            should(validateAndSaveProfile.thirdCall).be.calledWithMatch({
-              _id: 'anonymous',
-              policies: [{roleId: 'anonymous'}]
-            });
-            return Promise.resolve();
-          }
-          catch (error) {
-            return Promise.reject(error);
-          }
+          should(fromDTOSpy.firstCall).be.calledWithMatch({
+            _id: 'admin',
+            policies: [{roleId: 'admin'}]
+          });
+          should(profileRepository.validateAndSaveProfile.firstCall).be.calledWithMatch({
+            _id: 'admin',
+            policies: [{roleId: 'admin'}]
+          });
+
+          should(fromDTOSpy.secondCall).be.calledWithMatch({
+            _id: 'default',
+            policies: [{roleId: 'default'}]
+          });
+          should(profileRepository.validateAndSaveProfile.secondCall).be.calledWithMatch({
+            _id: 'default',
+            policies: [{roleId: 'default'}]
+          });
+
+          should(fromDTOSpy.thirdCall).be.calledWithMatch({
+            _id: 'anonymous',
+            policies: [{roleId: 'anonymous'}]
+          });
+          should(profileRepository.validateAndSaveProfile.thirdCall).be.calledWithMatch({
+            _id: 'anonymous',
+            policies: [{roleId: 'anonymous'}]
+          });
         });
     });
   });


### PR DESCRIPTION
### Changes types

- [X] Bugfix:  #1091 

### Description

While resetting roles and profiles after `createFirstAdmin`, the in-memory profiles and roles where not correctly re-initialized as `Profile`/`Role` objects able to call methods from repositories.

As a consequence, we were not able to log-in anymore after this action.

To fix that issue, we call now `Repository.fromDTO` instead of creating the objects from scratch.


### How should this be manually tested?

  - Start an empty kuzzle instance
  - Call the `createFirstAdmin` action (either [with the API](https://docs.kuzzle.io/api-documentation/controller-security/create-first-admin/), or with a Console admin), with the "reset" option enabled
  - Try to login with the new admin user created

Before the fix: you cannot login, and get a "412 Precondition Failed" error (thrown here: https://github.com/kuzzleio/kuzzle/blob/1.2.12/lib/api/core/models/security/profile.js#L50 )

After the fix: you can login again ;)


