### PR TITLE
Add strict format checking to profile definitions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 <!--
-  This template is not optional.
+  This template is optional.
   It simply serves to provide a guide to allow a better review of pull requests.
 -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 <!--
-  This template is not mandatory.
+  This template is not optional.
   It simply serves to provide a guide to allow a better review of pull requests.
 -->
 
@@ -11,7 +11,7 @@
 
 
 ## What does this PR do ?
-<!-- Please fulfill this section -->
+<!-- Please fill this section -->
 
 <!--
   Please include a summary of the change and which issue is fixed.

--- a/lib/api/core/models/security/profile.js
+++ b/lib/api/core/models/security/profile.js
@@ -112,11 +112,26 @@ class Profile {
 
         let j = 0;
         for (const restriction of policy.restrictedTo) {
-          if (typeof restriction !== 'object') {
+          if (restriction === null || typeof restriction !== 'object' || Array.isArray(restriction)) {
             return Bluebird.reject(new BadRequestError(`policies[${i}].restrictedTo[${j}] should be an object`));
           }
-          if (!restriction.index) {
+
+          if (restriction.index === null || restriction.index === undefined) {
             return Bluebird.reject(new BadRequestError(`policies[${i}].restrictedTo[${j}] Missing mandatory attribute "index"`));
+          }
+
+          if (typeof restriction.index !== 'string' || restriction.index.length === 0) {
+            return Bluebird.reject(new BadRequestError(`policies[${i}].restrictedTo[${j}] Attribute "index" must be a non-empty string value`));
+          }
+
+          if (restriction.collections !== undefined && restriction.collections !== null) {
+            if (!Array.isArray(restriction.collections)) {
+              return Bluebird.reject(new BadRequestError(`policies[${i}].restrictedTo[${j}] Attribute "collections" must be of type "array"`));
+            }
+
+            if (restriction.collections.some(c => typeof c !== 'string' || c.length === 0)) {
+              return Bluebird.reject(new BadRequestError(`policies[${i}].restrictedTo[${j}] Attribute "collections" can only contain non-empty string values`));
+            }
           }
 
           for (const member of Object.keys(restriction)) {

--- a/lib/api/core/models/security/user.js
+++ b/lib/api/core/models/security/user.js
@@ -57,17 +57,13 @@ class User {
    */
   getRights() {
     return this.getProfiles()
-      .then(profiles => {
-        const promises = profiles.map(profile => profile.getRights());
+      .then(profiles => Bluebird.map(profiles, profile => profile.getRights()))
+      .then(results => {
+        const rights = {};
 
-        return Bluebird.all(promises)
-          .then(results => {
-            const rights = {};
+        results.forEach(right => _.assignWith(rights, right, Policies.merge));
 
-            results.forEach(right => _.assignWith(rights, right, Policies.merge));
-
-            return Bluebird.resolve(rights);
-          });
+        return rights;
       });
   }
 

--- a/test/api/core/models/repositories/profileRepository.test.js
+++ b/test/api/core/models/repositories/profileRepository.test.js
@@ -407,7 +407,7 @@ describe('Test: repositories/profileRepository', () => {
           done(new Error('The promise is not rejected'));
         })
         .catch(e => {
-          should(e).be.an.instanceOf(BadRequestError);
+          should(e).be.an.instanceOf(BadRequestError).and.match({message: 'Missing profile id'});
           should(kuzzle.pluginsManager.trigger).not.be.called();
           done();
         })

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -193,7 +193,8 @@ class KuzzleMock extends Kuzzle {
         load: sinon.stub().resolves(),
         loadMultiFromDatabase: sinon.stub().resolves(),
         loadProfiles: sinon.stub().resolves(),
-        searchProfiles: sinon.stub().resolves()
+        searchProfiles: sinon.stub().resolves(),
+        validateAndSaveProfile: sinon.stub()
       },
       role: {
         deleteRole: sinon.stub().resolves(),


### PR DESCRIPTION
## Description

(Fix #1095 and more)

Kuzzle was way too lax when validating profile definitions submitted through the API. This had the unfortunate following effects:

* users were able to set the `restrictedTo.collections` as a non-array value, leading to inconsistent results when accessing that profile once stored in Kuzzle (#1095)
* users were able to add a `null` value as a policy, leading to a kuzzle crash

Unit tests have been added to enforce a very strict Profile format, and the code has then been updated to match the added tests.

### How can this be tested?

**Case 1:**

Using the following `PUT` HTTP request sent to this URL: `http://<server>:7512/profiles/foo`

```
{
  "policies": [
    {
      "roleId": "foo-role", 
      "restrictedTo": [null,
        {"index": "foo", "collections": ["foo", "bar"]}
      ]
    }
  ]
}
```
```
curl -H "Content-Type: application/json" -X PUT -d '{"policies": [{"roleId": "foo-role", "restrictedTo": [null,{"index": "foo", "collections": ["foo", "bar"]}]}]}' http://localhost:7512/profiles/foo
```
Before: Kuzzle crashes.
After: Kuzzle answers with a `BadRequestError`

**Case 2:**

Using the following `PUT` HTTP request sent to this URL: `http://<server>:7512/profiles/foo`

```
{
  "policies": [
    {
      "roleId": "foo-role", 
      "restrictedTo": [
        {"index": "foo", "collections": "bar"}
      ]
    }
  ]
}
```
```
curl -H "Content-Type: application/json" -X PUT -d '{"policies": [{"roleId": "foo-role", "restrictedTo": [{"index": "foo", "collections": "bar"}]}]}' http://localhost:7512/profiles/foo
```
Before: Kuzzle accepts the profile. When using `getUserRights` on a user using that profile afterwards, the returned response is messy.
After: Kuzzle answers with a `BadRequestError`


### Boyscout

* typo fixes in the issues/PRs templates
* (cosmetic) the `models/security/users:getRights` function has been simplified by using `Bluebird.map`
* added unit tests checking profile formats in `security:createOrReplaceProfile` and `security:createProfile` API route (complements the main part of that PR's changes)
* `kuzzle.repositories.profile.validateAndSaveProfile` has been added to the `KuzzleMock` class

