### PR TITLE
Add cache expiration for document change subscription

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -50,10 +50,16 @@
     //      transformed in their Canonical Disjunctive Normal Form (CDNF).
     //      Set to 0 for no limit.
     // * subscriptionRooms
-    //      Maximum number of different subscription rooms 
+    //      Maximum number of different subscription rooms
     //      (i.e. different index+collection+filters subscription configurations)
     //      Depends primarily on available memory.
     //      If set to 0, an unlimited number of rooms can be created
+    // * subscriptionDocumentTTL
+    //      Maximum time (in seconds) a document will be kept in cache for real-time subscriptions.
+    //      This cache is used to notify subscriber when a document enter or leave a scope after modifications.
+    //      By default, subscription will be kept 72 hour.
+    //      /!\ Remember that keeping subscription over a long period of time can lead to memory leak. /!\
+    //      Set to 0 to keep subscriptions forever.
     "concurrentRequests": 50,
     "documentsFetchCount": 10000,
     "documentsWriteCount": 200,
@@ -61,7 +67,8 @@
     "requestsBufferWarningThreshold": 5000,
     "subscriptionConditionsCount": 16,
     "subscriptionMinterms": 0,
-    "subscriptionRooms": 1000000
+    "subscriptionRooms": 1000000,
+    "subscriptionDocumentTTL": 259200 // 72 * 60 * 60
   },
 
   // The plugins section lets you define plugins behaviors
@@ -89,7 +96,7 @@
 
     // Custom plugin configurations must be described here.
     // Example:
-    // 
+    //
     // "plugin-name": {
     //   "<configuration property name>": "<value>"
     // }
@@ -463,7 +470,7 @@
     // currently the only database layer we support.
     //   * client:
     //       Elasticsearch constructor options. Use this field to specify your Elasticsearch config options, this object
-    //       is passed through to the Elasticsearch constructor and can contain all options/keys outlined here: 
+    //       is passed through to the Elasticsearch constructor and can contain all options/keys outlined here:
     //       https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/configuration.html
     "db": {
       "backend": "elasticsearch",

--- a/lib/api/core/notifier.js
+++ b/lib/api/core/notifier.js
@@ -39,9 +39,9 @@ class NotifierController {
   }
 
   /**
-   * Broadcasts a notification about a document change or a 
+   * Broadcasts a notification about a document change or a
    * real-time message
-   * 
+   *
    * @param  {Array} rooms - Subscribed rooms to notify
    * @param  {Request} request - Request at the origin of the notification
    * @param  {string} scope - 'in' or 'out'
@@ -69,7 +69,7 @@ class NotifierController {
   /**
    * Broadcast a notification about a user entering or leaving
    * the provided room
-   * 
+   *
    * @param  {string} room - Room entered or left
    * @param  {Request} request - User (un)subscription request
    * @param  {string} scope - 'in' or 'out'
@@ -88,7 +88,7 @@ class NotifierController {
 
   /**
    * Send a server notification to a provided connection identifier
-   * 
+   *
    * @param  {Array} rooms - User's rooms to notify
    * @param  {string} connectionId - User's connection identifier
    * @param  {string} type - Server notification type
@@ -126,13 +126,13 @@ class NotifierController {
    * @param {Request} request
    * @param {string} scope - Scope of the notification
    * @param {string} state - State of the notification
-   * @returns {Object} 
+   * @returns {Object}
    */
   publish (request, scope, state) {
     const rooms = this.kuzzle.realtime.test(
-      request.input.resource.index, 
-      request.input.resource.collection, 
-      request.input.body || {}, 
+      request.input.resource.index,
+      request.input.resource.collection,
+      request.input.body || {},
       request.input.resource._id
     );
 
@@ -142,7 +142,7 @@ class NotifierController {
          since we have the complete document, we use the cache to avoid performing another test when
          notifying about document creations
          */
-        this.kuzzle.services.list.internalCache.setex(getCachePrefix(request) + request.id, 10, JSON.stringify(rooms));
+        this._setCacheWithTTL(getCachePrefix(request) + request.id, JSON.stringify(rooms), 10);
       }
 
       this.notifyDocument(rooms, request, scope, state, request.input.action, {
@@ -159,7 +159,7 @@ class NotifierController {
    *
    * @param {Request} request
    * @param {object} newDocument - the newly created document
-   * @returns {Promise} 
+   * @returns {Promise}
    */
   notifyDocumentCreate (request, newDocument) {
     const cachePrefix = getCachePrefix(request);
@@ -172,7 +172,7 @@ class NotifierController {
             _id: newDocument._id
           });
 
-          return this.kuzzle.services.list.internalCache.set(cachePrefix + newDocument._id, rooms);
+          return this._setCacheWithTTL(cachePrefix + newDocument._id, rooms);
         }
 
         return null;
@@ -191,7 +191,7 @@ class NotifierController {
    */
   notifyDocumentReplace (request) {
     const cachePrefix = getCachePrefix(request);
-    let 
+    let
       matchedRooms = [],
       rawMatchedRooms = null;
 
@@ -225,14 +225,14 @@ class NotifierController {
           return this.kuzzle.services.list.internalCache.del(cachePrefix + request.input.resource._id);
         }
 
-        return this.kuzzle.services.list.internalCache.set(cachePrefix + request.input.resource._id, rawMatchedRooms);
+        return this._setCacheWithTTL(cachePrefix + request.input.resource._id, rawMatchedRooms);
       })
       .catch(error => this.kuzzle.pluginsManager.trigger('log:error', error));
   }
 
   /**
    * Notify rooms matching multiple documents changes: creations, replacements,
-   * or updates 
+   * or updates
    *
    * @param {Request} request - object describing the original user request
    * @param {Array} documents - new documents
@@ -240,7 +240,7 @@ class NotifierController {
    * @returns {Promise}
    */
   notifyDocumentMChanges (request, documents, cached) {
-    const 
+    const
       prefix = getCachePrefix(request),
       controllerAction = request.input.action,
       cacheIds = [];
@@ -259,7 +259,7 @@ class NotifierController {
         const idsToDelete = [];
 
         for (i = 0; i < documents.length; i++) {
-          const 
+          const
             documentAction = documents[i].created ? 'create' : controllerAction,
             rooms = this.kuzzle.realtime.test(
               request.input.resource.index,
@@ -283,7 +283,7 @@ class NotifierController {
               _id: documents[i]._id
             });
 
-            this.kuzzle.services.list.internalCache.set(cacheIds[i], JSON.stringify(rooms));
+            this._setCacheWithTTL(cacheIds[i], JSON.stringify(rooms));
           } else if (hits[i] !== null && hits[i] !== undefined) {
             idsToDelete.push(cacheIds[i]);
           }
@@ -346,7 +346,7 @@ class NotifierController {
         }
 
         if (matchedRooms.length > 0) {
-          return this.kuzzle.services.list.internalCache.set(cachePrefix + updatedDocument._id, JSON.stringify(matchedRooms));
+          return this._setCacheWithTTL(cachePrefix + updatedDocument._id, JSON.stringify(matchedRooms));
         }
 
         return this.kuzzle.services.list.internalCache.del(cachePrefix + updatedDocument._id);
@@ -375,7 +375,7 @@ class NotifierController {
 
     return this.kuzzle.services.list.storageEngine.mget(getRequest)
       .then(deleted => {
-        const 
+        const
           cachePrefix = getCachePrefix(request),
           cacheKeys = [];
 
@@ -407,7 +407,7 @@ class NotifierController {
   /**
    * Trigger a notify global event and, if accepted by plugins,
    * dispatch the payload to subscribers
-   * 
+   *
    * @param  {Array} channels - Subscribers channels to notify
    * @param  {Notification.User|Notification.Document|Notification.Server} notification
    * @param  {string} [connectionId] - Notify this connection, or broadcast if not provided
@@ -417,8 +417,8 @@ class NotifierController {
     this.kuzzle.pluginsManager.trigger('notify:dispatch', notification)
       .then(updatedNotification => {
         this.kuzzle.entryPoints.dispatch(connectionId ? 'notify' : 'broadcast', {
-          channels, 
-          connectionId, 
+          channels,
+          connectionId,
           payload: updatedNotification
         });
       });
@@ -494,17 +494,33 @@ class NotifierController {
         .then(updatedNotification => this._dispatch(channels, updatedNotification));
     }
   }
+
+  /**
+   * Set something in Redis cache with a TTL if it's provided.
+   * Use the ttl passed in parameter or the default value set in limits.subscriptionDocumentTTL.
+   *
+   * @param {string} key - Redis key to use
+   * @param {string} value - Value to store
+   * @param {integer} ttl - TTL value for the key, use limits.subscriptionDocumentTTL by default.
+   */
+  _setCacheWithTTL (key, value, ttl = this.kuzzle.config.limits.subscriptionDocumentTTL) {
+    if (ttl === 0) {
+      return this.kuzzle.services.list.internalCache.set(key, value);
+    }
+
+    return this.kuzzle.services.list.internalCache.setex(key, ttl, value);
+  }
 }
 
 function getCachePrefix(request) {
-  return '{'  
-    // start of redis key hash tag 
+  return '{'
+    // start of redis key hash tag
     // (see https://redis.io/topics/cluster-spec#keys-distribution-model)
     + 'notif/'
-    + request.input.resource.index 
-    + '/' 
-    + request.input.resource.collection 
-    + '}'     
+    + request.input.resource.index
+    + '/'
+    + request.input.resource.collection
+    + '}'
     // end of redis key hash tag
     + '/';
 }

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -55,10 +55,10 @@ function loadConfig () {
 /**
  * RC params can be overriden using environment variables,
  * in which case all values are passed as strings.
- * 
- * When dealing with configuration, we can safely assume the expected 
+ *
+ * When dealing with configuration, we can safely assume the expected
  * correct type
- * 
+ *
  * @param {object} cfg - configuration loaded using RC
  * @return {object} correctly typed configuration
  */
@@ -84,7 +84,7 @@ function unstringify (cfg) {
         cfg[k] = unstringify(cfg[k]);
       }
     });
-  
+
   return cfg;
 }
 
@@ -104,11 +104,13 @@ function checkLimitsConfig (cfg) {
     'requestsBufferWarningThreshold',
     'subscriptionConditionsCount',
     'subscriptionMinterms',
-    'subscriptionRooms'
+    'subscriptionRooms',
+    'subscriptionDocumentTTL'
   ];
   const canBeZero = [
     'subscriptionMinterms',
-    'subscriptionRooms'
+    'subscriptionRooms',
+    'subscriptionDocumentTTL'
   ];
 
   if (cfg.limits && (typeof cfg.limits !== 'object' || Array.isArray(cfg.limits))) {

--- a/test/api/core/notifier/notifyDocumentReplace.test.js
+++ b/test/api/core/notifier/notifyDocumentReplace.test.js
@@ -41,7 +41,7 @@ describe('Test: notifier.notifyDocumentReplace', () => {
     return notifier.notifyDocumentReplace(request)
       .then(() => {
         should(notifier.notifyDocument.callCount).be.eql(2);
-        
+
         should(notifier.notifyDocument.getCall(0))
           .calledWith(['foo'], request, 'in', 'done', 'replace', {
             _meta: {'can I has': 'cheezburgers?'},
@@ -65,11 +65,12 @@ describe('Test: notifier.notifyDocumentReplace', () => {
 
         should(internalCache.del).not.be.called();
 
-        should(internalCache.set).calledOnce();
-        should(internalCache.set).calledWith(
-          `{notif/${request.input.resource.index}/${request.input.resource.collection}}/${request.input.resource._id}`, 
-          JSON.stringify(['foo'])
-        );
+        should(internalCache.setex)
+          .calledOnce()
+          .calledWith(
+            `{notif/${request.input.resource.index}/${request.input.resource.collection}}/${request.input.resource._id}`,
+            kuzzle.config.limits.subscriptionDocumentTTL,
+            JSON.stringify(['foo']));
       });
   });
 });

--- a/test/config/index.test.js
+++ b/test/config/index.test.js
@@ -68,7 +68,7 @@ describe('lib/config/index.js', () => {
   });
 
   describe('#checkLimits', () => {
-    const 
+    const
       checkLimits = Config.__get__('checkLimitsConfig'),
       // checkLimits normally receives a defaulted version of Kuzzle configuration
       getcfg = config => {
@@ -99,7 +99,8 @@ describe('lib/config/index.js', () => {
     it('should throw on 0-valued limits except for special cases', () => {
       const canBeZero = [
         'subscriptionMinterms',
-        'subscriptionRooms'
+        'subscriptionRooms',
+        'subscriptionDocumentTTL'
       ];
 
       for (const limit of Object.keys(defaultConfig.limits)) {
@@ -128,7 +129,7 @@ describe('lib/config/index.js', () => {
       });
 
       should(() => checkLimits(config)).throw(KuzzleInternalError, {message: 'Invalid configuration: the concurrentRequests limit configuration must be strictly inferior to requestsBufferSize'});
-      
+
       config.limits.concurrentRequests = config.limits.requestsBufferSize;
       should(() => checkLimits(config)).throw(KuzzleInternalError, {message: 'Invalid configuration: the concurrentRequests limit configuration must be strictly inferior to requestsBufferSize'});
     });


### PR DESCRIPTION

## What does this PR do ?
<!-- Please fulfill this section -->

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
Redis is used by Kuzzle to cache documents that enter or left a scope.  
Whenever a document is updated, replaced or deleted, these cached item are used to tell if the document enter or left scopes.   
When a document is created, catched by a real-time filter and never updated again, it will stay cached in Redis forever.  

This PR add a TTL to this cache. By default the TTL is set to 72 hours.  
It can be configured in the `.kuzzlerc` under the value `limits.subscriptionDocumentTTL`.  
If a value of 0 is provided, cache will live in Redis forever.  

User should set this value with cautious because it can lead to memory leaks.  

See [backlog#245](https://github.com/kuzzleio/kuzzle-backlog/issues/245)

### How should this be manually tested?

  - Step 1 : Add this line to the `docker-compose/dev.yml` file before launching the Kuzzle stack `      - kuzzle_limits__subscriptionDocumentTTL=20`
  - Step 2 : Run `docker-compose -f docker-compose/dev.yml up`
  - Step 3 : Start a subscription with no filter with the admin console
  - Step 4 : Create a document with the admin console
  - Step 5 : List all keys in Redis : `docker-compose -f docker-compose/dev.yml exec redis redis-cli KEYS \*`. You should see a key starting with `{notif/<index name>/<collection name>/<document id>`
  - Step 6 : Wait 20sec and run the same command again. The key should have disappear.

### Other changes

### Boyscout

<!--
  Describe here minor improvements in the code base and not directly linked to the main changes:
  typos fixes, better/new comments, small code simplification, new debug messages, and so on.
-->
