### PR TITLE
Add test running with node V8

### DIFF
--- a/docker-compose/scripts/run-test.sh
+++ b/docker-compose/scripts/run-test.sh
@@ -4,8 +4,12 @@ set -e
 
 elastic_host=${kuzzle_services__db__client__host:-http://elasticsearch:9200}
 
+# Remove node_modules installed with a different version of node
+rm -rf node_modules/
+
 npm install --unsafe
 npm install --unsafe --only=dev
+
 docker-compose/scripts/install-plugins.sh
 
 echo "[$(date --rfc-3339 seconds)] - Waiting for elasticsearch to be available"

--- a/docker-compose/test.yml
+++ b/docker-compose/test.yml
@@ -7,7 +7,7 @@ services:
       - proxy_port=7513
 
   kuzzle:
-    image: kuzzleio/dev
+    image: kuzzleio/dev${NODE_MAJOR}
     command: sh -c 'chmod 755 /run.sh && /run.sh'
     volumes:
       - "..:/var/app"
@@ -46,4 +46,3 @@ services:
     environment:
       - cluster.name=kuzzle
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
     "acorn": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
+      "integrity": "sha1-9HPdR+AnegjijpvsWu6wR1HwuMk="
     },
     "acorn-jsx": {
       "version": "3.0.1",
@@ -210,7 +210,7 @@
     "assertion-error-formatter": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error-formatter/-/assertion-error-formatter-2.0.1.tgz",
-      "integrity": "sha512-cjC3jUCh9spkroKue5PDSKH5RFQ/KNuZJhk3GwHYmB/8qqETxLOmMdLH+ohi/VukNzxDlMvIe7zScvLoOdhb6Q==",
+      "integrity": "sha1-a73/rsji+p4rDrFYv+NTEy18Cps=",
       "dev": true,
       "requires": {
         "diff": "3.5.0",
@@ -608,7 +608,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
     },
     "class-utils": {
@@ -799,7 +799,7 @@
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -828,7 +828,7 @@
     "commander": {
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+      "integrity": "sha1-30boZ9D8Kuxmo0ZitAapzK//Ww8="
     },
     "component-bind": {
       "version": "1.0.0",
@@ -927,7 +927,7 @@
     "cucumber": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cucumber/-/cucumber-4.1.0.tgz",
-      "integrity": "sha512-XF1BrEaIXnwo40Txi1DWnyQk7qbFatdSWg/nQGS6PHXDqWbkSeO67Fyn8PUhTIn5AmGVNjvEsoWUs5QFrvrGmg==",
+      "integrity": "sha1-2Trx3ooFv2Qorp1AIeCw1AZoNRg=",
       "dev": true,
       "requires": {
         "assertion-error-formatter": "2.0.1",
@@ -1151,13 +1151,13 @@
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
       "dev": true
     },
     "doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
       "dev": true,
       "requires": {
         "esutils": "2.0.2"
@@ -1334,7 +1334,7 @@
     "eslint": {
       "version": "4.19.1",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
-      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+      "integrity": "sha1-MtHWU+HZBAiFS/spbwdux+GGowA=",
       "dev": true,
       "requires": {
         "ajv": "5.5.2",
@@ -1398,7 +1398,7 @@
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
@@ -1407,7 +1407,7 @@
         "chalk": {
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "integrity": "sha1-JQ3JawdJG/1gHmSNZt319gx6XGU=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.1",
@@ -1427,7 +1427,7 @@
         "supports-color": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "integrity": "sha1-WySsFduA+pJ89SJ6SjP9PEx2dsA=",
           "dev": true,
           "requires": {
             "has-flag": "3.0.0"
@@ -1448,13 +1448,13 @@
     "eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "integrity": "sha1-PzGA+y4pEBdxastMnW1bXDSmqB0=",
       "dev": true
     },
     "espree": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "integrity": "sha1-sPRHGHyKi+2US4FaZgvd9d610ac=",
       "dev": true,
       "requires": {
         "acorn": "5.5.3",
@@ -1475,7 +1475,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
           }
@@ -1490,7 +1490,7 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
       "dev": true
     },
     "esquery": {
@@ -1505,7 +1505,7 @@
     "esrecurse": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
       "dev": true,
       "requires": {
         "estraverse": "4.2.0"
@@ -1665,7 +1665,7 @@
     "external-editor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+      "integrity": "sha1-PQJqIbf5W1cmOH1CAKwWDTcsO0g=",
       "dev": true,
       "requires": {
         "chardet": "0.4.2",
@@ -1676,7 +1676,7 @@
         "tmp": {
           "version": "0.0.33",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
           "dev": true,
           "requires": {
             "os-tmpdir": "1.0.2"
@@ -1841,7 +1841,7 @@
     "fs-extra": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+      "integrity": "sha1-QU0BEM3QZwVzTQVWUsVBEmDDGr0=",
       "requires": {
         "graceful-fs": "4.1.11",
         "jsonfile": "4.0.0",
@@ -2955,7 +2955,7 @@
     "ignore": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+      "integrity": "sha1-YSKJv7PCIOGGpYEYYY1b6MG6sCE=",
       "dev": true
     },
     "imurmurhash": {
@@ -2997,7 +2997,7 @@
     "inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
       "dev": true,
       "requires": {
         "ansi-escapes": "3.0.0",
@@ -3025,7 +3025,7 @@
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
@@ -3034,7 +3034,7 @@
         "chalk": {
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "integrity": "sha1-JQ3JawdJG/1gHmSNZt319gx6XGU=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.1",
@@ -3051,7 +3051,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -3070,7 +3070,7 @@
         "supports-color": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "integrity": "sha1-WySsFduA+pJ89SJ6SjP9PEx2dsA=",
           "dev": true,
           "requires": {
             "has-flag": "3.0.0"
@@ -3277,7 +3277,7 @@
     "is-resolvable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
       "dev": true
     },
     "is-stream": {
@@ -3321,7 +3321,7 @@
     "js-combinatorics": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/js-combinatorics/-/js-combinatorics-0.5.3.tgz",
-      "integrity": "sha512-egCSKDP7vcTlwSyIVuipmGc4Btxpb8ftQ+dhRMgQHJ9JwifXS/yBeTokLADjoJmip4T20yEMJK4YT/DNkOTUtQ=="
+      "integrity": "sha1-XaWhxGMuxZ/fjUncz+We8IgSKxU="
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -3332,7 +3332,7 @@
     "js-yaml": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+      "integrity": "sha1-WXwai9VxUvJtYizkEXhRpR9euu8=",
       "dev": true,
       "requires": {
         "argparse": "1.0.10",
@@ -3401,7 +3401,7 @@
     "jsonwebtoken": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.0.tgz",
-      "integrity": "sha512-1Wxh8ADP3cNyPl8tZ95WtraHXCAyXupgc0AhMHjU9er98BV+UcKsO7OJUjfhIu0Uba9A40n1oSx8dbJYrm+EoQ==",
+      "integrity": "sha1-aQ7DqefpXiiENHzj6eudOJqlmLM=",
       "requires": {
         "jws": "3.1.4",
         "lodash.includes": "4.3.0",
@@ -3470,7 +3470,7 @@
     "koncorde": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/koncorde/-/koncorde-1.1.5.tgz",
-      "integrity": "sha512-iMTxWh755OFOvae6xKEBe9cFVkGEQhvHgX4EvmEBbZ1lW4P2Vg0kExjmxC0FiiobelX6KjwOwFJ18ICc8EKoIQ==",
+      "integrity": "sha1-vR/Vl8diDoQUaoPX/qV7YpIGr4k=",
       "requires": {
         "bluebird": "3.5.1",
         "boost-geospatial-index": "1.0.3",
@@ -3512,7 +3512,7 @@
     "lodash": {
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+      "integrity": "sha1-maktZcAnLevoyWtgV7yPv6O+1RE="
     },
     "lodash.assign": {
       "version": "4.2.0",
@@ -3669,7 +3669,7 @@
     "lru-cache": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-      "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+      "integrity": "sha1-RSNLLm4vKzPaElYkxGZJKaAiTD8=",
       "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
@@ -3761,7 +3761,7 @@
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
       "dev": true
     },
     "mimic-response": {
@@ -3793,7 +3793,7 @@
     "minizlib": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
-      "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+      "integrity": "sha1-EeE2WM5GvDpwomeqxYNZ0eDCnOs=",
       "requires": {
         "minipass": "2.2.1"
       }
@@ -3921,7 +3921,7 @@
     "mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "integrity": "sha1-lQCAV6Vsr63CvGPd5/n/aVWUjjI=",
       "dev": true,
       "requires": {
         "any-promise": "1.3.0",
@@ -4015,7 +4015,7 @@
     "no-case": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
       "dev": true,
       "requires": {
         "lower-case": "1.1.4"
@@ -4032,7 +4032,7 @@
     "node-interval-tree": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/node-interval-tree/-/node-interval-tree-1.3.3.tgz",
-      "integrity": "sha512-K9vk96HdTK5fEipJwxSvIIqwTqr4e3HRJeJrNxBSeVMNSC/JWARRaX7etOLOuTmrRMeOI/K5TCJu3aWIwZiNTw==",
+      "integrity": "sha1-Ff+5BM3ggnAhSsrOjcdlPomuMrc=",
       "requires": {
         "shallowequal": "1.0.2"
       }
@@ -4098,7 +4098,7 @@
     "nyc": {
       "version": "11.6.0",
       "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.6.0.tgz",
-      "integrity": "sha512-ZaXCh0wmbk2aSBH2B5hZGGvK2s9aM8DIm2rVY+BG3Fx8tUS+bpJSswUVZqOD1YfCmnYRFSqgYJSr7UeeUcW0jg==",
+      "integrity": "sha1-2ce1H/zra7oJmkaDpq3BszG5iFM=",
       "dev": true,
       "requires": {
         "archy": "1.0.0",
@@ -7468,7 +7468,7 @@
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "integrity": "sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=",
       "dev": true
     },
     "pm2": {
@@ -7761,7 +7761,7 @@
     "reify": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/reify/-/reify-0.14.2.tgz",
-      "integrity": "sha512-gJA67pCidAROSmr4/8SQuMQXtZwtSvoVIDR6KjoWxnO4LSD8iYNjMcRrHuQQ/c8cXYaoCpEQh0rO9CNNu1z5lA==",
+      "integrity": "sha1-dQlHBtBhWeC0diBz191ZCqQ84+o=",
       "requires": {
         "acorn": "5.5.3",
         "minizlib": "1.1.0",
@@ -7791,7 +7791,7 @@
     "request": {
       "version": "2.85.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
-      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "integrity": "sha1-WgNhWkfGFCCz65m326IE+DYD4fo=",
       "dev": true,
       "requires": {
         "aws-sign2": "0.7.0",
@@ -7863,7 +7863,7 @@
             "boom": {
               "version": "5.2.0",
               "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+              "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
               "dev": true,
               "requires": {
                 "hoek": "4.2.1"
@@ -7901,7 +7901,7 @@
         "hawk": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+          "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
           "dev": true,
           "requires": {
             "boom": "4.3.1",
@@ -7913,7 +7913,7 @@
         "hoek": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+          "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs=",
           "dev": true
         },
         "http-signature": {
@@ -7936,13 +7936,13 @@
         "qs": {
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+          "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg=",
           "dev": true
         },
         "sntp": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-          "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+          "integrity": "sha1-LGzsFP7cIiJznK+bXD2F0cxaLMg=",
           "dev": true,
           "requires": {
             "hoek": "4.2.1"
@@ -8029,7 +8029,7 @@
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
       "dev": true,
       "requires": {
         "glob": "7.1.2"
@@ -8128,7 +8128,7 @@
     "shallowequal": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.0.2.tgz",
-      "integrity": "sha512-zlVXeVUKvo+HEv1e2KQF/csyeMKx2oHvatQ9l6XjCUj3agvC8XGf6R9HvIPDSmp8FNPvx7b5kaEJTRi7CqxtEw=="
+      "integrity": "sha1-FWHb3vuMAUCBADGQhXZNo/z4P48="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -8163,7 +8163,7 @@
     "should": {
       "version": "13.2.1",
       "resolved": "https://registry.npmjs.org/should/-/should-13.2.1.tgz",
-      "integrity": "sha512-l+/NwEMO+DcstsHEwPHRHzC9j4UOE3VQwJGcMWSsD/vqpqHbnQ+1iSHy64Ihmmjx1uiRPD9pFadTSc3MJtXAgw==",
+      "integrity": "sha1-hObr+7FFx54K5CMHsls/YtyvV04=",
       "dev": true,
       "requires": {
         "should-equal": "2.0.0",
@@ -8197,7 +8197,7 @@
     "should-sinon": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/should-sinon/-/should-sinon-0.0.6.tgz",
-      "integrity": "sha512-ScBOH5uW5QVFaONmUnIXANSR6z5B8IKzEmBP3HE5sPOCDuZ88oTMdUdnKoCVQdLcCIrRrhRLPS5YT+7H40a04g==",
+      "integrity": "sha1-vgQafJKPRKycz13AQtAyYYzin4Q=",
       "dev": true
     },
     "should-type": {
@@ -8209,7 +8209,7 @@
     "should-type-adaptors": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
-      "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+      "integrity": "sha1-QB5/M7VTMDOUTVzYvytlAneS4no=",
       "dev": true,
       "requires": {
         "should-type": "1.4.0",
@@ -8271,7 +8271,7 @@
     "slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "integrity": "sha1-BE8aSdiEL/MHqta1Be0Xi9lQE00=",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0"
@@ -8695,7 +8695,7 @@
     "stack-generator": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.2.tgz",
-      "integrity": "sha512-Qj3X+vY7qQ0OOLQomEihHk5SSnSPCI3z4RfB8kDk9lnzwznBODlkWODitEo8sHpp0a2VdSy3yuJkabNsQN5RGA==",
+      "integrity": "sha1-PBPZUqWWq5MY/sBmnQod+Lhxdsc=",
       "dev": true,
       "requires": {
         "stackframe": "1.0.4"
@@ -8709,13 +8709,13 @@
     "stackframe": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
-      "integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw==",
+      "integrity": "sha1-NXskqZL5Qny6a1RdlqFO0svKGHs=",
       "dev": true
     },
     "stacktrace-gps": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.0.2.tgz",
-      "integrity": "sha512-9o+nWhiz5wFnrB3hBHs2PTyYrS60M1vvpSzHxwxnIbtY2q9Nt51hZvhrG1+2AxD374ecwyS+IUwfkHRE/2zuGg==",
+      "integrity": "sha1-M/i6pEZzI6sr0YFu+ieZQrpDHMw=",
       "dev": true,
       "requires": {
         "source-map": "0.5.6",
@@ -8873,7 +8873,7 @@
     "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "integrity": "sha1-ozRHN1OR52atNNNIbm4q7chNLjY=",
       "dev": true,
       "requires": {
         "ajv": "5.5.2",
@@ -8905,7 +8905,7 @@
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
@@ -8914,7 +8914,7 @@
         "chalk": {
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "integrity": "sha1-JQ3JawdJG/1gHmSNZt319gx6XGU=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.1",
@@ -8931,7 +8931,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -8950,7 +8950,7 @@
         "supports-color": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "integrity": "sha1-WySsFduA+pJ89SJ6SjP9PEx2dsA=",
           "dev": true,
           "requires": {
             "has-flag": "3.0.0"
@@ -9319,7 +9319,7 @@
     "validator": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
-      "integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA=="
+      "integrity": "sha1-q/Rm05i1Yc0kMFARLG/x3mzBJmM="
     },
     "verror": {
       "version": "1.10.0",
@@ -9391,7 +9391,7 @@
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"
@@ -9413,7 +9413,7 @@
     "winston": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.1.tgz",
-      "integrity": "sha512-k/+Dkzd39ZdyJHYkuaYmf4ff+7j+sCIy73UCOWHYA67/WXU+FF/Y6PF28j+Vy7qNRPHWO+dR+/+zkoQWPimPqg==",
+      "integrity": "sha1-o6kmUQVWQmPGeFtFg7jIrKJv3tY=",
       "requires": {
         "async": "1.0.0",
         "colors": "1.0.3",
@@ -9433,7 +9433,7 @@
     "winston-elasticsearch": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/winston-elasticsearch/-/winston-elasticsearch-0.5.8.tgz",
-      "integrity": "sha512-3ttL/aBymTHv8uhHWAG6AHAluIHrBLHsu1ukvhYcAxaHkD2T6wCRAFhjWysfWPqLUhv7z6+R1y/WMq6eM/28Ig==",
+      "integrity": "sha1-wMXNUwgBfAVcLKNahQuT7CAh+IM=",
       "requires": {
         "debug": "3.1.0",
         "elasticsearch": "14.2.2",
@@ -9447,7 +9447,7 @@
     "winston-syslog": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/winston-syslog/-/winston-syslog-2.0.0.tgz",
-      "integrity": "sha512-20915SaP9DzXoY9gcb9Efyj+mKz4marNKadryDfgF3BwV2eqloN9drFa71P/+28hW61foUiLfRPeeVauwuimzQ==",
+      "integrity": "sha1-5BMw7P/jfBlx5dEUTv+azjLVuiw=",
       "requires": {
         "cycle": "1.0.3",
         "glossy": "0.1.7",

--- a/test/travis-bin/run-tests.sh
+++ b/test/travis-bin/run-tests.sh
@@ -10,3 +10,4 @@ fi
 
 docker-compose -f docker-compose/test.yml run kuzzle
 
+NODE_MAJOR=8 docker-compose -f docker-compose/test.yml run kuzzle


### PR DESCRIPTION
## What does this PR do ?

:warning: Depends on https://github.com/kuzzleio/kuzzle-containers/pull/35 (Now merged)

This PR add the testing of Kuzzle against NodeJS 8.11.1.  
The tests uses the new `kuzzleio/dev8` container. (See this [PR](https://github.com/kuzzleio/kuzzle-containers/pull/35))  

I added an environment variable `NODE_MAJOR` which can be set to `8` to use  the new images in the `docker-compose/test.yml` file.

Fix https://github.com/kuzzleio/kuzzle/issues/995

### How should this be manually tested?

  - Step 1 : Run the tests with both NodeJS version : `bash test/travis-bin/run-tests.sh`
Or
  - Step 1 : Run only the test with NodeJS 8 : `NODE_MAJOR=8 docker-compose -f docker-compose/test.yml run kuzzle`
