### PR TITLE
Add metadata to documents inserted/updated via bulk import

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://travis-ci.org/kuzzleio/kuzzle.svg?branch=master)](https://travis-ci.org/kuzzleio/kuzzle) 
-[![codecov.io](http://codecov.io/github/kuzzleio/kuzzle/coverage.svg?branch=master)](http://codecov.io/github/kuzzleio/kuzzle?branch=master) 
+[![Build Status](https://travis-ci.org/kuzzleio/kuzzle.svg?branch=master)](https://travis-ci.org/kuzzleio/kuzzle)
+[![codecov.io](http://codecov.io/github/kuzzleio/kuzzle/coverage.svg?branch=master)](http://codecov.io/github/kuzzleio/kuzzle?branch=master)
 [![Join the chat at https://gitter.im/kuzzleio/kuzzle](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/kuzzleio/kuzzle?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ![logo](https://kuzzle.io/static/public/images/logo_black.png)
@@ -26,19 +26,19 @@ The easyest way to setup a kuzzle server for Linux-like systems without prerequi
 $ sudo bash -c "$(curl http://get.kuzzle.io/)"
 ```
 
-You can get detailed information about how to [start kuzzle with docker on docs.kuzzle.io](http://docs.kuzzle.io/guide/essentials/installing-kuzzle/#docker)
+You can get detailed information about how to [start kuzzle with docker on docs.kuzzle.io](https://docs.kuzzle.io/guide/essentials/installing-kuzzle/#docker)
 
 ### Manual install
 
-Check our [complete installation guide on docs.kuzzle.io](http://docs.kuzzle.io/guide/essentials/installing-kuzzle/#manually)
+Check our [complete installation guide on docs.kuzzle.io](https://docs.kuzzle.io/guide/essentials/installing-kuzzle/#manually)
 
 ## Quick start with Kuzzle
 
-* [Install and start Kuzzle server](http://docs.kuzzle.io/guide/essentials/installing-kuzzle/)
-* [Choose a SDK](http://docs.kuzzle.io/sdk-reference/)
+* [Install and start Kuzzle server](https://docs.kuzzle.io/guide/essentials/installing-kuzzle/)
+* [Choose a SDK](https://docs.kuzzle.io/sdk-reference/essentials/)
 * Build your application without caring about your backend !
 
-Check the [**Getting started page on docs.kuzzle.io**](http://docs.kuzzle.io/guide/getting-started/)
+Check the [**Getting started page on docs.kuzzle.io**](https://docs.kuzzle.io/guide/getting-started/)
 
 ### NodeJS Sample
 
@@ -47,7 +47,7 @@ npm install kuzzle-sdk
 ```
 
 ```javascript
-const 
+const
     Kuzzle = require('kuzzle-sdk'),
     kuzzle = new Kuzzle('http://localhost:7512')
 
@@ -64,7 +64,7 @@ kuzzle
         // triggered each time a document is updated !
         console.log('message received from kuzzle:', result)
     })
-    
+
 // Creating a document from another app will notify all subscribers
 kuzzle
     .collection('mycollection', 'myindex')
@@ -73,16 +73,16 @@ kuzzle
 
 ### Usefull links
 
-* [Full documentation](http://docs.kuzzle.io/)
-* [SDK Reference](http://docs.kuzzle.io/sdk-reference/)
-* [API Documentation](http://docs.kuzzle.io/api-documentation/)  
-* [Data Validation Documentation](http://docs.kuzzle.io/validation-reference/) 
+* [Full documentation](https://docs.kuzzle.io/)
+* [SDK Reference](https://docs.kuzzle.io/sdk-reference/essentials/)
+* [API Documentation](https://docs.kuzzle.io/api-documentation/connecting-to-kuzzle/)  
+* [Data Validation Documentation](https://docs.kuzzle.io/validation-reference/schema/)
 * [View release notes](https://github.com/kuzzleio/kuzzle/releases)
 
 ## Contributing to Kuzzle
 
 You're welcome to contribute to Kuzzle!
-Feel free to report issues, ask for features or even make pull requests ! 
+Feel free to report issues, ask for features or even make pull requests!
 
 Check our [contributing documentation](./CONTRIBUTING.md) to know about our coding and pull requests rules
 
@@ -90,7 +90,7 @@ Check our [contributing documentation](./CONTRIBUTING.md) to know about our codi
 
 * Follow us on [twitter](https://twitter.com/kuzzleio) to get latest news
 * Register to our monthly [newsletter](http://eepurl.com/bxRxpr) to get highlighed news
-* Visit our [blog](http://kuzzle.io/blog) to be informed about what we are doing
+* Visit our [blog](https://blog.kuzzle.io/) to be informed about what we are doing
 * Come chat with us on [gitter](https://gitter.im/kuzzleio/kuzzle)
 * Ask technical questions on [stack overflow](https://stackoverflow.com/search?q=kuzzle)
 
@@ -99,7 +99,7 @@ Check our [contributing documentation](./CONTRIBUTING.md) to know about our codi
 Kuzzle Enterprise is production-proof, and provides all the business-critical features your need for your business, as
 the scalability, the high-availability (multi-nodes), probes for BI, diagnostic tools & professional services,
 
-[Compare editions to learn more](http://kuzzle.io/kuzzle-enterprise)
+[Compare editions to learn more](https://kuzzle.io/pricing/)
 
 ## License
 

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -624,7 +624,6 @@ class ElasticSearch extends Service {
       esRequest = initESRequest(request, ['consistency', 'refresh', 'timeout', 'fields']),
       userId = request.context.user._id ? String(request.context.user._id) : null,
       dateNow = Date.now();
-    let error = null;
 
     assertWellFormedRefresh(esRequest);
 
@@ -648,7 +647,9 @@ class ElasticSearch extends Service {
 
     // set missing index & type if possible and add metadata
     let lastAction;
-    esRequest.body.forEach(item => {
+    let i; // NOSONAR
+    for(i = 0; i < esRequest.body.length; i++) {
+      const item = esRequest.body[i];
       const action = Object.keys(item)[0];
 
       if (actionNames.indexOf(action) !== -1) {
@@ -659,7 +660,7 @@ class ElasticSearch extends Service {
         }
 
         if (!item[action]._type) {
-          error = new BadRequestError('Missing data collection argument');
+          return Bluebird.reject(new BadRequestError('Missing data collection argument'));
         }
 
         if (!item[action]._index && esRequest.index) {
@@ -667,28 +668,21 @@ class ElasticSearch extends Service {
         }
 
         if (!item[action]._index) {
-          error = new BadRequestError('Missing data index argument');
-          return false;
+          return Bluebird.reject(new BadRequestError('Missing data index argument'));
         }
 
         if (!this.kuzzle.indexCache.exists(item[action]._index, item[action]._type)) {
-          error = new PreconditionError(`Index '${esRequest.index}' and/or collection ${esRequest.type} don't exist`);
-          return false;
+          return Bluebird.reject(new PreconditionError(`Index '${esRequest.index}' and/or collection ${esRequest.type} don't exist`));
         }
 
         if (item[action]._index === this.kuzzle.internalEngine.index) {
-          error = new BadRequestError(`Index "${this.kuzzle.internalEngine.index}" is protected, please use appropriated routes instead`);
-          return false;
+          return Bluebird.reject(new BadRequestError(`Index "${this.kuzzle.internalEngine.index}" is protected, please use appropriated routes instead`));
         }
       } else if (lastAction === 'index' || lastAction === 'create') {
         item._kuzzle_info = kuzzleMetaCreated;
       } else if (lastAction === 'update') {
         item.doc._kuzzle_info = kuzzleMetaUpdated;
       }
-    });
-
-    if (error) {
-      return Bluebird.reject(error);
     }
 
     return this.client.bulk(esRequest)

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -647,6 +647,9 @@ class ElasticSearch extends Service {
 
     // set missing index & type if possible and add metadata
     let lastAction; // NOSONAR
+    // Declaring "i" inside "for" statements downgrades
+    // performances by a factor of 3 to 4
+    // Fixed in Node.js v8.x and up
     let i; // NOSONAR
     for(i = 0; i < esRequest.body.length; i++) {
       const item = esRequest.body[i];

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -621,7 +621,9 @@ class ElasticSearch extends Service {
   import(request) {
     const
       actionNames = ['index', 'create', 'update', 'delete'],
-      esRequest = initESRequest(request, ['consistency', 'refresh', 'timeout', 'fields']);
+      esRequest = initESRequest(request, ['consistency', 'refresh', 'timeout', 'fields']),
+      userId = request.context.user._id ? String(request.context.user._id) : null,
+      dateNow = Date.now();
     let error = null;
 
     assertWellFormedRefresh(esRequest);
@@ -631,12 +633,27 @@ class ElasticSearch extends Service {
     }
 
     esRequest.body = request.input.body.bulkData;
+    const kuzzleMetaCreated = {
+      author: userId,
+      createdAt: dateNow,
+      updatedAt: null,
+      updater: null,
+      active: true,
+      deletedAt: null
+    };
+    const kuzzleMetaUpdated = {
+      updater: userId,
+      updatedAt: dateNow
+    };
 
-    // set missing index & type if possible
+    // set missing index & type if possible and add metadata
+    let lastAction;
     esRequest.body.forEach(item => {
       const action = Object.keys(item)[0];
 
       if (actionNames.indexOf(action) !== -1) {
+        lastAction = action;
+
         if (!item[action]._type && esRequest.type) {
           item[action]._type = esRequest.type;
         }
@@ -663,6 +680,10 @@ class ElasticSearch extends Service {
           error = new BadRequestError(`Index "${this.kuzzle.internalEngine.index}" is protected, please use appropriated routes instead`);
           return false;
         }
+      } else if (lastAction === 'index' || lastAction === 'create') {
+        item._kuzzle_info = kuzzleMetaCreated;
+      } else if (lastAction === 'update') {
+        item.doc._kuzzle_info = kuzzleMetaUpdated;
       }
     });
 
@@ -911,24 +932,24 @@ class ElasticSearch extends Service {
   }
 
   /**
-   * Create multiple documents at once. 
+   * Create multiple documents at once.
    * If a content has no id, one is automatically generated and assigned to it.
    * If a content has a specified identifier, it is rejected if it already exists, unless
    * it's inactive, in which case it is revived
-   * 
+   *
    * @param  {Request} request - Kuzzle API request
-   * @return {Promise} 
+   * @return {Promise}
    */
   mcreate(request) {
-    const 
+    const
       index = request.input.resource.index,
       type = request.input.resource.collection,
       extracted = extractMDocuments(request, {
         _kuzzle_info: {
-          active: true, 
+          active: true,
           author: request.context.user._id ? String(request.context.user._id) : null,
-          updater: null, 
-          updatedAt: null, 
+          updater: null,
+          updatedAt: null,
           deletedAt: null,
           createdAt: Date.now()
         }
@@ -936,7 +957,7 @@ class ElasticSearch extends Service {
 
     // prepare the mget request, but only for document having a specified id
     let mgetRequest;
-    
+
     if (extracted.mgetRequest.body.docs.length > 0) {
       mgetRequest = this.client.mget(extracted.mgetRequest);
     } else {
@@ -945,7 +966,7 @@ class ElasticSearch extends Service {
 
     return mgetRequest
       .then(mgetResult => {
-        const 
+        const
           esRequest = initESRequest(request, ['consistency', 'refresh', 'timeout', 'fields']),
           toImport = [];
 
@@ -982,20 +1003,20 @@ class ElasticSearch extends Service {
   }
 
   /**
-   * Create or replace multiple documents at once. 
-   * 
+   * Create or replace multiple documents at once.
+   *
    * @param  {Request} request - Kuzzle API request
-   * @return {Promise} 
+   * @return {Promise}
    */
   mcreateOrReplace(request) {
-    const 
+    const
       esRequest = initESRequest(request, ['consistency', 'refresh', 'timeout', 'fields']),
       extracted = extractMDocuments(request, {
         _kuzzle_info: {
-          active: true, 
+          active: true,
           author: request.context.user._id ? String(request.context.user._id) : null,
-          updater: null, 
-          updatedAt: null, 
+          updater: null,
+          updatedAt: null,
           deletedAt: null,
           createdAt: Date.now()
         }
@@ -1007,8 +1028,8 @@ class ElasticSearch extends Service {
     for(i = 0; i < extracted.documents.length; i++) {
       esRequest.body.push({
         index: {
-          _index: request.input.resource.index, 
-          _type: request.input.resource.collection, 
+          _index: request.input.resource.index,
+          _type: request.input.resource.collection,
           _id: extracted.documents[i]._id
         }
       });
@@ -1023,18 +1044,18 @@ class ElasticSearch extends Service {
    * Replacements are rejected if targeted documents do not exist,
    * but documents in the trashcan are silently revived
    * (like with the normal "update" method)
-   * 
+   *
    * @param  {Request} request - Kuzzle API request
    * @return {Promise}
    */
   mupdate(request) {
-    const 
+    const
       esRequest = initESRequest(request, ['consistency', 'refresh', 'timeout', 'fields']),
       toImport = [],
       extracted = extractMDocuments(request, {
         _kuzzle_info: {
-          active: true, 
-          updatedAt: Date.now(), 
+          active: true,
+          updatedAt: Date.now(),
           updater: request.context.user._id ? String(request.context.user._id) : null,
           deletedAt: null
         }
@@ -1047,8 +1068,8 @@ class ElasticSearch extends Service {
       if (typeof extracted.documents[i]._id === 'string') {
         esRequest.body.push({
           update: {
-            _index: request.input.resource.index, 
-            _type: request.input.resource.collection, 
+            _index: request.input.resource.index,
+            _type: request.input.resource.collection,
             _id: extracted.documents[i]._id
           }
         });
@@ -1060,31 +1081,31 @@ class ElasticSearch extends Service {
       } else {
         extracted.rejected.push({document: extracted.documents[i], reason: 'a document ID is required'});
       }
-    } 
+    }
 
     return this._mexecute(esRequest, toImport, extracted.rejected);
   }
 
   /**
-   * Replace multiple documents at once. 
+   * Replace multiple documents at once.
    * Replacements are rejected if targeted documents do not exist,
    * but documents in the trashcan are silently revived
    * (like with the normal "replace" method)
-   * 
+   *
    * @param  {Request} request - Kuzzle API request
-   * @return {Promise} 
+   * @return {Promise}
    */
   mreplace(request) {
-    const 
+    const
       index = request.input.resource.index,
       type = request.input.resource.collection,
       toImport = [],
       extracted = extractMDocuments(request, {
         _kuzzle_info: {
-          active: true, 
+          active: true,
           author: request.context.user._id ? String(request.context.user._id) : null,
-          updater: null, 
-          updatedAt: null, 
+          updater: null,
+          updatedAt: null,
           deletedAt: null,
           createdAt: Date.now()
         }
@@ -1124,12 +1145,12 @@ class ElasticSearch extends Service {
 
   /**
    * Delete multiple documents with one request
-   * 
+   *
    * @param  {Request} request - Kuzzle API request
    * @return {Promise}
    */
   mdelete(request) {
-    const 
+    const
       esRequest = initESRequest(request, ['consistency', 'refresh', 'timeout', 'fields']),
       {
         index,
@@ -1139,8 +1160,8 @@ class ElasticSearch extends Service {
       partialErrors = [],
       metadata = {
         _kuzzle_info: {
-          active: false, 
-          deletedAt: Date.now(), 
+          active: false,
+          deletedAt: Date.now(),
           updater: request.context.user._id ? String(request.context.user._id) : null
         }
       };
@@ -1171,7 +1192,7 @@ class ElasticSearch extends Service {
    * Execute an ES request prepared by mcreate, mupdate, mreplace or mdelete
    * Returns a standardized ES response object, containing the list of
    * successfully performed operations, and the rejected ones
-   * 
+   *
    * @param  {Object} esRequest    - Elasticsearch request
    * @param  {Array} documents       - Document sources (format: {_id, _source})
    * @param  {Array} partialErrors - pre-rejected documents
@@ -1191,7 +1212,7 @@ class ElasticSearch extends Service {
     return (documents.length > 0 ? this.client.bulk(esRequest) : Bluebird.resolve({items: []}))
       .then(result => {
         const successes = [];
-        
+
         let i; // NOSONAR
         for (i = 0; i < result.items.length; i++) {
           const item = result.items[i][Object.keys(result.items[i])[0]];
@@ -1407,11 +1428,11 @@ function assertWellFormedRefresh(esRequest) {
 }
 
 /**
- * Extract, inject metadata and validate documents contained 
+ * Extract, inject metadata and validate documents contained
  * in a Request
- * 
+ *
  * Used by mcreate, mupdate, mreplace and mcreateOrReplace
- * 
+ *
  * @param  {Request} request - Kuzzle API request
  * @param  {Object} metadata
  * @return {Object}
@@ -1421,7 +1442,7 @@ function extractMDocuments(request, metadata) {
     rejected: [],
     documents: [],
     mgetRequest: {
-      index: request.input.resource.index, 
+      index: request.input.resource.index,
       type: request.input.resource.collection,
       body: {
         docs: []

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -646,7 +646,7 @@ class ElasticSearch extends Service {
     };
 
     // set missing index & type if possible and add metadata
-    let lastAction;
+    let lastAction; // NOSONAR
     let i; // NOSONAR
     for(i = 0; i < esRequest.body.length; i++) {
       const item = esRequest.body[i];


### PR DESCRIPTION
## What does this PR do ?
<!-- Please fulfill this section -->

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

Documents created or updated using the bulk import route doesn't have their [Document Metadata](https://docs.kuzzle.io/guide/essentials/document-metadata/) created or updated. #1104 
This PR add the metadata to documents created with bulk import.  

The cost of this addition is very small because `import()` already iterate over the request content to add default index and collection.  

### How should this be manually tested?

  - Step 1: Get the branch `git fetch origin 1104-fix-bulk-import-meta && git checkout 1104-fix-bulk-import-meta`
  - Step 2: Run `docker-compose docker-compose -f docker-compose/dev.yml up`
  - Step 3: Create index and collection `node -e "$(wget -O - https://gist.github.com/Aschen/bfda6552932d55b2d9fac8f5edb3a88e/raw/b657e3aafcfe4124ddc5c711217ae0e096558922/indexInit.js)"`
  - Step 4: Download sample data: `wget https://gist.github.com/Aschen/bfda6552932d55b2d9fac8f5edb3a88e/raw/4d04ba9bfdf435ff9e7567cbd2a5d3948eba3007/yellow_cab_10.csv`
  - Step 5: Insert data with bulk API `node -e "$(wget -O - https://gist.github.com/Aschen/bfda6552932d55b2d9fac8f5edb3a88e/raw/a2dba22b19e47ce9c94971cc60252f0855b39cf1/loadBulk.js)"`
  - Step 6: Go to [admin console](http://kuzzle-backoffice.netlify.com/) and check metadata presence on created documents


### Other changes

<!--
  Please describe here all changes not directly linked to the main issue, but made because of it.
  For instance: issues spotted during this PR and fixed on-the-fly, dependencies update, and so on
-->

### Boyscout

  -Use `for(;;)` loop to iterate over bulk documents
