### PR TITLE
add missing protocols directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,4 @@ plugins/enabled/*
 !plugins/enabled/kuzzle-plugin-auth-passport-local
 !plugins/enabled/kuzzle-plugin-logger
 
-#protocols
-/protocols
+

--- a/protocols/.gitignore
+++ b/protocols/.gitignore
@@ -1,0 +1,2 @@
+!.gitignore
+

--- a/protocols/available/.gitignore
+++ b/protocols/available/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/protocols/enabled/.gitignore
+++ b/protocols/enabled/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## What does this PR do ?

Adds missing `protocols/` directory, making Kuzzle protocols documentation easier

