### PR TITLE
Keep Kuzzle metadata in document body

### DIFF
--- a/lib/api/core/auth/formatProcessing.js
+++ b/lib/api/core/auth/formatProcessing.js
@@ -19,6 +19,8 @@
  * limitations under the License.
  */
 
+const _ = require('lodash');
+
 module.exports = {
   /**
    * Serializes role and transforms it into a POJO
@@ -29,7 +31,7 @@ module.exports = {
   formatRoleForSerialization: role => {
     const response = {_id: role._id};
 
-    response._source = role;
+    response._source = _.omit(role, []);
 
     delete response._source._id;
     delete response._source.closures;
@@ -49,7 +51,7 @@ module.exports = {
   formatProfileForSerialization: profile => {
     const response = {_id: profile._id};
 
-    response._source = profile;
+    response._source = _.omit(profile, []);
     delete response._source._id;
 
     response._meta = profile._kuzzle_info || {};
@@ -71,7 +73,7 @@ module.exports = {
     return kuzzle.pluginsManager.trigger('security:formatUserForSerialization', user)
       .then(triggeredUser => ({
         _id: triggeredUser._id,
-        _source: triggeredUser,
+        _source: _.omit(triggeredUser, ['_id']),
         _meta: triggeredUser._kuzzle_info || {}
       }));
   }

--- a/lib/api/core/auth/formatProcessing.js
+++ b/lib/api/core/auth/formatProcessing.js
@@ -31,11 +31,7 @@ module.exports = {
   formatRoleForSerialization: role => {
     const response = {_id: role._id};
 
-    response._source = _.omit(role, []);
-
-    delete response._source._id;
-    delete response._source.closures;
-    delete response._source.restrictedTo;
+    response._source = _.omit(role, ['_id', 'closures', 'restrictedTo']);
 
     response._meta = role._kuzzle_info || {};
 
@@ -51,8 +47,7 @@ module.exports = {
   formatProfileForSerialization: profile => {
     const response = {_id: profile._id};
 
-    response._source = _.omit(profile, []);
-    delete response._source._id;
+    response._source = _.omit(profile, ['_id']);
 
     response._meta = profile._kuzzle_info || {};
 

--- a/lib/api/core/auth/formatProcessing.js
+++ b/lib/api/core/auth/formatProcessing.js
@@ -31,7 +31,7 @@ module.exports = {
   formatRoleForSerialization: role => {
     const response = {_id: role._id};
 
-    response._source = _.omit(role, ['_kuzzle_info']);
+    response._source = role;
 
     delete response._source._id;
     delete response._source.closures;
@@ -51,7 +51,7 @@ module.exports = {
   formatProfileForSerialization: profile => {
     const response = {_id: profile._id};
 
-    response._source = _.omit(profile, ['_kuzzle_info']);
+    response._source = profile;
     delete response._source._id;
 
     response._meta = profile._kuzzle_info || {};
@@ -72,8 +72,8 @@ module.exports = {
      */
     return kuzzle.pluginsManager.trigger('security:formatUserForSerialization', user)
       .then(triggeredUser => ({
-        _id: triggeredUser._id, 
-        _source: _.omit(triggeredUser, ['_kuzzle_info', '_id']), 
+        _id: triggeredUser._id,
+        _source: triggeredUser,
         _meta: triggeredUser._kuzzle_info || {}
       }));
   }

--- a/lib/api/core/auth/formatProcessing.js
+++ b/lib/api/core/auth/formatProcessing.js
@@ -19,8 +19,6 @@
  * limitations under the License.
  */
 
-const _ = require('lodash');
-
 module.exports = {
   /**
    * Serializes role and transforms it into a POJO

--- a/lib/api/core/notifier.js
+++ b/lib/api/core/notifier.js
@@ -146,7 +146,7 @@ class NotifierController {
       }
 
       this.notifyDocument(rooms, request, scope, state, request.input.action, {
-        _source: _.omit(request.input.body, ['_kuzzle_info']),
+        _source: request.input.body,
         _id: request.input.resource._id
       });
     }
@@ -198,13 +198,10 @@ class NotifierController {
     return this.kuzzle.services.list.internalCache.get(cachePrefix + request.id)
       .then(rooms => {
         if (rooms !== null) {
-          const _meta = request.input.body._kuzzle_info;
-          delete request.input.body._kuzzle_info;
-
           rawMatchedRooms = rooms;
           matchedRooms = JSON.parse(rooms);
           this.notifyDocument(matchedRooms, request, 'in', 'done', 'replace', {
-            _meta,
+            _meta: request.input.body._kuzzle_info,
             _source: request.input.body,
             _id: request.input.resource._id
           });

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -1364,19 +1364,18 @@ function flattenSearchResults(result) {
 }
 
 /**
- * Move _kuzzle_info to root attribute _meta
+ * Copy _kuzzle_info to root attribute _meta
+ * This behavior will be deprecated
  *
  * @param response
  * @return {object}
  */
 function prepareMetadata(response) {
-  const prepared = _.omit(response, '_source._kuzzle_info');
-
   if (response._source && response._source._kuzzle_info) {
-    prepared._meta = response._source._kuzzle_info;
+    response._meta = response._source._kuzzle_info;
   }
 
-  return prepared;
+  return response;
 }
 
 /**

--- a/test/api/core/notifier/notifyDocumentReplace.test.js
+++ b/test/api/core/notifier/notifyDocumentReplace.test.js
@@ -46,7 +46,7 @@ describe('Test: notifier.notifyDocumentReplace', () => {
           .calledWith(['foo'], request, 'in', 'done', 'replace', {
             _meta: {'can I has': 'cheezburgers?'},
             _id: request.input.resource._id,
-            _source: {foo: 'bar'}
+            _source: {foo: 'bar', _kuzzle_info: {'can I has': 'cheezburgers?'}}
           });
 
         should(notifier.notifyDocument.getCall(1))

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -516,7 +516,7 @@ describe('Test: ElasticSearch service', () => {
       return should(elasticsearch.get(request)).be.rejectedWith(BadRequestError);
     });
 
-    it('should allow expose kuzzle metadata in _kuzzle_info and _meta properties', () => {
+    it('should allow expose kuzzle metadata in _source._kuzzle_info and _meta properties', () => {
       elasticsearch.client.get.returns(Bluebird.resolve({_source: {_kuzzle_info: {active: true}}}));
 
       request.input.body = null;

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -515,6 +515,18 @@ describe('Test: ElasticSearch service', () => {
 
       return should(elasticsearch.get(request)).be.rejectedWith(BadRequestError);
     });
+
+    it('should allow expose kuzzle metadata in _kuzzle_info and _meta properties', () => {
+      elasticsearch.client.get.returns(Bluebird.resolve({_source: {_kuzzle_info: {active: true}}}));
+
+      request.input.body = null;
+      request.input.resource._id = createdDocumentId;
+
+      return elasticsearch.get(request)
+        .then(response => {
+          should(response._source._kuzzle_info).be.eql(response._meta);
+        });
+    });
   });
 
   describe('#mget', () => {
@@ -1964,12 +1976,14 @@ describe('Test: ElasticSearch service', () => {
           });
           should(result.error).be.an.Array().and.be.empty();
           should(result.result).match([
-            {_id: 'foo', _source: {foo: 'bar'}, _meta: metadata, status: 201},
-            {_id: 'bar', _source: {bar: 'foo'}, _meta: metadata, status: 201}
+            {_id: 'foo', _source: {foo: 'bar', _kuzzle_info: metadata}, _meta: metadata, status: 201},
+            {_id: 'bar', _source: {bar: 'foo', _kuzzle_info: metadata}, _meta: metadata, status: 201}
           ]);
 
           should(result.result[0]._meta.createdAt).be.approximately(now, 100);
           should(result.result[1]._meta.createdAt).be.approximately(now, 100);
+          should(result.result[0]._source._kuzzle_info.createdAt).be.approximately(now, 100);
+          should(result.result[1]._source._kuzzle_info.createdAt).be.approximately(now, 100);
         });
     });
 
@@ -2038,13 +2052,14 @@ describe('Test: ElasticSearch service', () => {
             {document: {_id: 'foo4', body: {foo: 'bar4'}}, reason: 'document already exists'}
           ]);
           should(result.result).match([
-            {_id: 'foo?', _source: {foo: 'bar_'}, _meta: metadata, status: 201},
-            {_id: 'foo2', _source: {foo: 'bar2'}, _meta: metadata, status: 201},
-            {_id: 'foo3', _source: {foo: 'bar3'}, _meta: metadata, status: 201}
+            {_id: 'foo?', _source: {foo: 'bar_', _kuzzle_info: metadata}, _meta: metadata, status: 201},
+            {_id: 'foo2', _source: {foo: 'bar2', _kuzzle_info: metadata}, _meta: metadata, status: 201},
+            {_id: 'foo3', _source: {foo: 'bar3', _kuzzle_info: metadata}, _meta: metadata, status: 201}
           ]);
 
           for(let i = 0; i < 3; i++) {
             should(result.result[i]._meta.createdAt).be.approximately(now, 100);
+            should(result.result[i]._source._kuzzle_info.createdAt).be.approximately(now, 100);
           }
         });
     });
@@ -2076,13 +2091,14 @@ describe('Test: ElasticSearch service', () => {
             ]
           });
           should(result.error).match([
-            {_id: 'bar', _source: {bar: 'foo'}, _meta: metadata, status: 400}
+            {_id: 'bar', _source: {bar: 'foo', _kuzzle_info: metadata}, _meta: metadata, status: 400}
           ]);
           should(result.result).match([
-            {_id: 'foo', _source: {foo: 'bar'}, _meta: metadata, status: 201}
+            {_id: 'foo', _source: {foo: 'bar', _kuzzle_info: metadata}, _meta: metadata, status: 201}
           ]);
 
           should(result.result[0]._meta.createdAt).be.approximately(now, 100);
+          should(result.result[0]._source._kuzzle_info.createdAt).be.approximately(now, 100);
         });
     });
   });
@@ -2138,12 +2154,14 @@ describe('Test: ElasticSearch service', () => {
           });
           should(result.error).be.an.Array().and.be.empty();
           should(result.result).match([
-            {_id: 'foo', _source: {foo: 'bar'}, _meta: metadata, status: 201},
-            {_id: 'bar', _source: {bar: 'foo'}, _meta: metadata, status: 201}
+            {_id: 'foo', _source: {foo: 'bar', _kuzzle_info: metadata}, _meta: metadata, status: 201},
+            {_id: 'bar', _source: {bar: 'foo', _kuzzle_info: metadata}, _meta: metadata, status: 201}
           ]);
 
           should(result.result[0]._meta.createdAt).be.approximately(now, 100);
           should(result.result[1]._meta.createdAt).be.approximately(now, 100);
+          should(result.result[0]._source._kuzzle_info.createdAt).be.approximately(now, 100);
+          should(result.result[1]._source._kuzzle_info.createdAt).be.approximately(now, 100);
         });
     });
 
@@ -2173,13 +2191,14 @@ describe('Test: ElasticSearch service', () => {
             ]
           });
           should(result.error).match([
-            {_id: 'bar', _source: {bar: 'foo'}, _meta: metadata, status: 400}
+            {_id: 'bar', _source: {bar: 'foo', _kuzzle_info: metadata}, _meta: metadata, status: 400}
           ]);
           should(result.result).match([
-            {_id: 'foo', _source: {foo: 'bar'}, _meta: metadata, status: 201}
+            {_id: 'foo', _source: {foo: 'bar', _kuzzle_info: metadata}, _meta: metadata, status: 201}
           ]);
 
           should(result.result[0]._meta.createdAt).be.approximately(now, 100);
+          should(result.result[0]._source._kuzzle_info.createdAt).be.approximately(now, 100);
         });
     });
   });
@@ -2233,12 +2252,14 @@ describe('Test: ElasticSearch service', () => {
           });
           should(result.error).be.an.Array().and.be.empty();
           should(result.result).match([
-            {_id: 'foo', _source: {foo: 'bar'}, _meta: metadata, status: 201},
-            {_id: 'bar', _source: {bar: 'foo'}, _meta: metadata, status: 201}
+            {_id: 'foo', _source: {foo: 'bar', _kuzzle_info: metadata}, _meta: metadata, status: 201},
+            {_id: 'bar', _source: {bar: 'foo', _kuzzle_info: metadata}, _meta: metadata, status: 201}
           ]);
 
           should(result.result[0]._meta.updatedAt).be.approximately(now, 100);
           should(result.result[1]._meta.updatedAt).be.approximately(now, 100);
+          should(result.result[0]._source._kuzzle_info.updatedAt).be.approximately(now, 100);
+          should(result.result[1]._source._kuzzle_info.updatedAt).be.approximately(now, 100);
         });
     });
 
@@ -2268,13 +2289,13 @@ describe('Test: ElasticSearch service', () => {
             ]
           });
           should(result.error).match([
-            {_id: 'bar', _source: {bar: 'foo'}, _meta: metadata, status: 400}
+            {_id: 'bar', _source: {bar: 'foo', _kuzzle_info: metadata}, _meta: metadata, status: 400}
           ]);
           should(result.result).match([
-            {_id: 'foo', _source: {foo: 'bar'}, _meta: metadata, status: 201}
+            {_id: 'foo', _source: {foo: 'bar', _kuzzle_info: metadata}, _meta: metadata, status: 201}
           ]);
 
-          should(result.result[0]._meta.updatedAt).be.approximately(now, 100);
+          should(result.result[0]._source._kuzzle_info.updatedAt).be.approximately(now, 100);
         });
     });
 
@@ -2367,10 +2388,11 @@ describe('Test: ElasticSearch service', () => {
             {document: {_id: 'foo1', _source: {foo: 'bar1'}}, reason: 'cannot replace a non-existing document (use mCreateOrReplace if you need to create non-existing documents)'},
           ]);
           should(result.result).match([
-            {_id: 'foo2', _source: {foo: 'bar2'}, _meta: metadata, status: 201},
+            {_id: 'foo2', _source: {foo: 'bar2', _kuzzle_info: metadata}, _meta: metadata, status: 201},
           ]);
 
           should(result.result[0]._meta.createdAt).be.approximately(now, 100);
+          should(result.result[0]._source._kuzzle_info.createdAt).be.approximately(now, 100);
         });
     });
 
@@ -2406,13 +2428,14 @@ describe('Test: ElasticSearch service', () => {
             ]
           });
           should(result.error).match([
-            {_id: 'bar', _source: {bar: 'foo'}, _meta: metadata, status: 400}
+            {_id: 'bar', _source: {bar: 'foo', _kuzzle_info: metadata}, _meta: metadata, status: 400}
           ]);
           should(result.result).match([
-            {_id: 'foo', _source: {foo: 'bar'}, _meta: metadata, status: 201}
+            {_id: 'foo', _source: {foo: 'bar', _kuzzle_info: metadata}, _meta: metadata, status: 201}
           ]);
 
           should(result.result[0]._meta.createdAt).be.approximately(now, 100);
+          should(result.result[0]._source._kuzzle_info.createdAt).be.approximately(now, 100);
         });
     });
 


### PR DESCRIPTION
## What does this PR do ?

Kuzzle add metadata to documents. These metadata are stored in the `_kuzzle_info` property of each documents.  
When we retrieve documents, we move these metadata outside the document body in the `_meta` property : 

_Document stored in ES_
```
{
  age: 42,
  name: "Gordon Freeman",
  _kuzzle_info: {
      active: true,
      author: 'test',
      updater: null,
      updatedAt: null,
      deletedAt: null
  }
}
```

_Response from Kuzzle_
```
{
  _source: {
    age: 42,
    name: "Gordon Freeman"
  },
  _meta: {
    active: true,
    author: 'test',
    updater: null,
    updatedAt: null,
    deletedAt: null
  }
}
```

This can lead to confusion if users want to search documents by `author` because they have to search for the field `_kuzzle_info.author` despite the response expose the author outside document body in the `_meta` property.   
We will deprecate this behavior pending the next major release.   
More context here : https://jira.kaliop.net/browse/KZL-37

This PR also expose the Kuzzle metadata inside the document body.  

_New response from Kuzzle_
```
{
  _source: {
    age: 42,
    name: "Gordon Freeman",
    _kuzzle_info: {
      active: true,
      author: 'test',
      updater: null,
      updatedAt: null,
      deletedAt: null
    }
  },
  _meta: {
    active: true,
    author: 'test',
    updater: null,
    updatedAt: null,
    deletedAt: null
  }
}

```

Doc https://github.com/kuzzleio/documentation/pull/486

### How should this be manually tested?

  - Step 1 : Download PR scripts : `wget -O pr_files.zip https://gist.github.com/Aschen/732e466b40d618109a33cdff5c894c49/archive/76667f7dca61ba35089871a4e4f7f7feb20f48ad.zip && unzip pr_files.zip && mv 732e466b*/* . && rm pr_files.zip`
  - Step 2 : Create a document : `node create-document.js`, you should see the _kuzzle_info field in the document body
