### PR TITLE
remove SIGPIPE from the list of abnormal termination signals

### DIFF
--- a/lib/api/kuzzle.js
+++ b/lib/api/kuzzle.js
@@ -181,16 +181,6 @@ class Kuzzle extends EventEmitter {
  * @param {Kuzzle} kuzzle
  */
 function registerErrorHandlers(kuzzle) {
-  const coreDumpSignals = {
-    SIGQUIT: 3,
-    // SIGILL: 4, can not be handled
-    SIGABRT: 6,
-    // SIGFPE: 8, can not be handled
-    // SIGKILL: 9, can not be handled
-    // SIGSEGV: 11, can not be handled
-    SIGPIPE: 13
-    // SIGBUS: 10, can not be handled
-  };
   const request = new Request({
     controller: 'actions',
     action: 'dump',
@@ -226,15 +216,15 @@ function registerErrorHandlers(kuzzle) {
   });
 
   // abnormal termination signals => generate a core dump
-  Object.keys(coreDumpSignals).forEach(signal => {
+  for (const signal of ['SIGQUIT', 'SIGABRT']) {
     process.removeAllListeners(signal);
     process.on(signal, () => {
       console.error(`ERROR: Caught signal: ${signal}`); // eslint-disable-line no-console
       request.input.args.suffix = 'signal-'.concat(signal.toLowerCase());
       kuzzle.cliController.actions.dump(request)
-        .finally(() => process.exit(coreDumpSignals[signal] + 128));
+        .finally(() => process.exit(1));
     });
-  });
+  }
 
   // signal SIGTRAP is used to generate a kuzzle dump without stopping it
   process.removeAllListeners('SIGTRAP');

--- a/test/api/kuzzle.test.js
+++ b/test/api/kuzzle.test.js
@@ -114,17 +114,14 @@ describe('/lib/api/kuzzle.js', () => {
         should(processRemoveAllListenersSpy.getCall(3).args[0]).be.exactly('SIGABRT');
         should(processOnSpy.getCall(3).args[0]).be.exactly('SIGABRT');
 
-        should(processRemoveAllListenersSpy.getCall(4).args[0]).be.exactly('SIGPIPE');
-        should(processOnSpy.getCall(4).args[0]).be.exactly('SIGPIPE');
+        should(processRemoveAllListenersSpy.getCall(4).args[0]).be.exactly('SIGTRAP');
+        should(processOnSpy.getCall(4).args[0]).be.exactly('SIGTRAP');
 
-        should(processRemoveAllListenersSpy.getCall(5).args[0]).be.exactly('SIGTRAP');
-        should(processOnSpy.getCall(5).args[0]).be.exactly('SIGTRAP');
+        should(processRemoveAllListenersSpy.getCall(5).args[0]).be.exactly('SIGINT');
+        should(processOnSpy.getCall(5).args[0]).be.exactly('SIGINT');
 
-        should(processRemoveAllListenersSpy.getCall(6).args[0]).be.exactly('SIGINT');
-        should(processOnSpy.getCall(6).args[0]).be.exactly('SIGINT');
-
-        should(processRemoveAllListenersSpy.getCall(7).args[0]).be.exactly('SIGTERM');
-        should(processOnSpy.getCall(7).args[0]).be.exactly('SIGTERM');
+        should(processRemoveAllListenersSpy.getCall(6).args[0]).be.exactly('SIGTERM');
+        should(processOnSpy.getCall(6).args[0]).be.exactly('SIGTERM');
       });
     });
 


### PR DESCRIPTION
## What does this PR do?

Upon receiving a SIGPIPE signal, Kuzzle creates a coredump and shuts itself down. Simply put: SIGPIPE is currently considered by Kuzzle as an abnormal termination signal.

This should not be the case, as a SIGPIPE signal may be emitted for various reasons, for instance when a network socket we're currently reading is abruptly closed.

This means that there is a way to force-close Kuzzle from its API: simply bombard it with requests, and then close the connection while doing it. Repeating the process enough time (or doing it in parallel by opening multiple sockets) will sooner or later trigger a SIGPIPE.

This PR removes SIGPIPE from the list of abnormal termination signals. I simplified the signal registering code a bit in the process.

### How should this be manually tested?

Start a [Kuzzle Benchmark](https://github.com/kuzzleio/kuzzle-benchmark) with at least 1000 clients, and then interrupt the benchmark in the middle of it.
