### PR TITLE
fixes #1124 - kuzzle info mapping mixed versions

### DIFF
--- a/lib/api/core/indexCache.js
+++ b/lib/api/core/indexCache.js
@@ -20,7 +20,9 @@
  */
 'use strict';
 
-const Bluebird = require('bluebird');
+const
+  _ = require('lodash'),
+  Bluebird = require('bluebird');
 
 /**
  * Index/collection cache management
@@ -29,6 +31,8 @@ class IndexCache {
 
   constructor (kuzzle) {
     this.indexes = {};
+    this.defaultMappings = {};
+
     this.kuzzle = kuzzle;
     this.commonMapping = this.kuzzle.config.services.db.commonMapping;
   }
@@ -36,29 +40,58 @@ class IndexCache {
   initInternal (internalEngine) {
     return internalEngine.getMapping()
       .then(mapping => {
-        Object.keys(mapping).forEach(index => {
+        for (const index of Object.keys(mapping)) {
           this.indexes[index] = Object.keys(mapping[index].mappings);
-        });
+        }
       });
   }
 
   init () {
-    return this.kuzzle.internalEngine.listIndexes()
+    const engine = this.kuzzle.internalEngine;
+    const kuzzleInfoFieldsRegex = new RegExp(`^_kuzzle_info\\.(${Object.keys(this.commonMapping._kuzzle_info.properties).join('|')})$`);
+
+    return engine.listIndexes()
       .then(indexes => {
         const promises = [];
 
         for (const index of indexes) {
-          this.indexes[index] = [];
+          if (index === this.kuzzle.internalEngine.index) {
+            continue;
+          }
 
-          promises.push(this.kuzzle.internalEngine.listCollections(index)
+          this.indexes[index] = [];
+          this.defaultMappings[index] = _.cloneDeep(this.commonMapping);
+
+          promises.push(engine.getFieldMapping({
+            index,
+            fields: '_kuzzle_info.*'
+          })
+            .then(kuzInfoMappings => {
+              if (kuzInfoMappings[index] && kuzInfoMappings[index].mappings) {
+                for (const collection of Object.keys(kuzInfoMappings[index].mappings)) {
+                  const collectionInfo = kuzInfoMappings[index].mappings[collection];
+
+                  for (const dotField of Object.keys(collectionInfo).filter(f => kuzzleInfoFieldsRegex.test(f))) {
+                    Object.assign(this.defaultMappings[index]._kuzzle_info.properties, collectionInfo[dotField].mapping);
+                  }
+                  // do not break to catch cases where not all fields are defined
+                }
+              }
+
+              return engine.listCollections(index);
+            })
             .then(collections => {
+              const updateMappingPromises = [];
+
               this.indexes[index] = collections;
 
-              const mapping = {
-                properties: this.commonMapping
-              };
+              for (const collection of collections) {
+                updateMappingPromises.push(engine.updateMapping(collection, {
+                  properties: this.defaultMappings[index]
+                }, index));
+              }
 
-              return Bluebird.map(collections, collection => this.kuzzle.internalEngine.updateMapping(collection, mapping, index));
+              return Bluebird.all(updateMappingPromises);
             })
           );
         }

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -574,10 +574,11 @@ class ElasticSearch extends Service {
 
     const requestBody = request.input.body || {};
     const collectionMapping = requestBody.properties || {};
+    const defaultMapping = this.kuzzle.indexCache.defaultMappings[esRequest.index] || this.config.commonMapping;
 
     esRequest.body = {
       [esRequest.type]: {
-        properties: Object.assign({}, collectionMapping, this.config.commonMapping)
+        properties: Object.assign({}, collectionMapping, defaultMapping)
       }
     };
 
@@ -730,14 +731,28 @@ class ElasticSearch extends Service {
    */
   updateMapping(request) {
     const esRequest = initESRequest(request);
+    const defaultMapping = this.kuzzle.indexCache.defaultMappings[esRequest.index] || this.config.commonMapping;
 
     esRequest.body = request.input.body;
     if (!esRequest.body.properties) {
       esRequest.body.properties = {};
     }
-    esRequest.body.properties = Object.assign({}, this.config.commonMapping, esRequest.body.properties);
+    esRequest.body.properties = Object.assign({}, defaultMapping, esRequest.body.properties);
 
     return this.client.indices.putMapping(esRequest)
+      .catch(error => Bluebird.reject(this.esWrapper.formatESError(error)));
+  }
+
+  /**
+   * Retrieve a mapping for a given field or collection of fields
+   *
+   * @param {Request} request
+   * @returns {Promise}
+   */
+  getFieldMapping(request) {
+    const esRequest = initESRequest(request, ['fields']);
+
+    return this.client.indices.getFieldMapping(esRequest)
       .catch(error => Bluebird.reject(this.esWrapper.formatESError(error)));
   }
 

--- a/lib/services/internalEngine/index.js
+++ b/lib/services/internalEngine/index.js
@@ -446,6 +446,17 @@ class InternalEngine {
   }
 
   /**
+   * Retrieves the mapping of one or several given fields
+   *
+   * @param data
+   * @returns {Promise}
+   */
+  getFieldMapping (data) {
+    return this.client.indices.getFieldMapping(data)
+      .catch(error => this.esWrapper.formatESError(error));
+  }
+
+  /**
    * Retrieve mapping definiton of index or index/collection
    *
    * @returns {Promise}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "@sinonjs/formatio": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-      "integrity": "sha1-hNt+nrVTHfGKjF4L+25EnlXmVLI=",
+      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
         "samsam": "1.3.0"
@@ -101,7 +101,7 @@
     "anymatch": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-      "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
+      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "requires": {
         "micromatch": "3.1.10",
         "normalize-path": "2.1.1"
@@ -150,7 +150,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
     },
     "arr-union": {
       "version": "3.1.0",
@@ -180,7 +180,7 @@
     "arraybuffer.slice": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
-      "integrity": "sha1-O7xCdd1YTMGxCAm4nU6LY6aednU="
+      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
     },
     "arrify": {
       "version": "1.0.1",
@@ -231,12 +231,12 @@
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha1-ePrtjD0HSrgfIrTphdeehzj3IPg="
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
     "async-listener": {
       "version": "0.6.9",
       "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.9.tgz",
-      "integrity": "sha1-UbyV5BCVQX8zki+03uTyMrMiZIg=",
+      "integrity": "sha512-E7Z2/QMs0EPt/o9wpYO/J3hmMCDdr1aVDS3ttlur5D5JlZtxhfuOwi4e7S8zbYIxA5qOOYdxfqGj97XAfdNvkQ==",
       "requires": {
         "semver": "5.5.0",
         "shimmer": "1.2.0"
@@ -293,7 +293,7 @@
     "base": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-      "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "requires": {
         "cache-base": "1.0.1",
         "class-utils": "0.3.6",
@@ -530,7 +530,7 @@
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-      "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "requires": {
         "collection-visit": "1.0.0",
         "component-emitter": "1.2.1",
@@ -625,7 +625,7 @@
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-      "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "requires": {
         "arr-union": "3.1.0",
         "define-property": "0.2.5",
@@ -677,7 +677,7 @@
     "cli-table-redemption": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cli-table-redemption/-/cli-table-redemption-1.0.1.tgz",
-      "integrity": "sha1-A1nYw033SYACnXbf8HGgWhJ8T90=",
+      "integrity": "sha512-SjVCciRyx01I4azo2K2rcc0NP/wOceXGzG1ZpYkEulbbIxDA/5YWv0oxG2HtQ4v8zPC6bgbRI7SbNaTZCxMNkg==",
       "requires": {
         "chalk": "1.1.3"
       }
@@ -797,7 +797,7 @@
     "continuation-local-storage": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
-      "integrity": "sha1-EfYT906RT+mzTJKtLSj+auHbf/s=",
+      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
       "requires": {
         "async-listener": "0.6.9",
         "emitter-listener": "1.1.1"
@@ -827,7 +827,7 @@
     "cron": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/cron/-/cron-1.3.0.tgz",
-      "integrity": "sha1-fkWZaOr5ThpEW+eWzkAhZsI0ZZ0=",
+      "integrity": "sha512-K/SF7JlgMmNjcThWxkKvsHhey2EDB4CeOEWJ9aXWj3fbQJppsvTPIeyLdHfNq5IbbsMUUjRW1nr5dSO95f2E4w==",
       "requires": {
         "moment-timezone": "0.5.16"
       }
@@ -974,7 +974,7 @@
     "deep-metrics": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/deep-metrics/-/deep-metrics-0.0.1.tgz",
-      "integrity": "sha1-isMzMZXMXsoFmyJOscph/EzaUP0=",
+      "integrity": "sha512-732WmZgCWxOkf4QBvrCjPPuT6wTEzaGye/4JqYsU/sO0J53UNX4PBwK0JV262BZ5cxgLmKhU+NlrtKdPDgybkg==",
       "requires": {
         "semver": "5.5.0"
       }
@@ -982,7 +982,7 @@
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-      "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "requires": {
         "is-descriptor": "1.0.2",
         "isobject": "3.0.1"
@@ -1189,7 +1189,7 @@
     "engine.io-parser": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
-      "integrity": "sha1-TA9M/3mq7su9z96maoI8YIVAkZY=",
+      "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
       "requires": {
         "after": "0.8.2",
         "arraybuffer.slice": "0.0.7",
@@ -1479,7 +1479,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
           }
@@ -1529,7 +1529,7 @@
         "is-extendable": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
             "is-plain-object": "2.0.4"
           }
@@ -1561,7 +1561,7 @@
     "extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-      "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "requires": {
         "array-unique": "0.3.2",
         "define-property": "1.0.0",
@@ -2697,7 +2697,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-data-descriptor": {
       "version": "0.1.4",
@@ -2787,7 +2787,7 @@
     "is-odd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-      "integrity": "sha1-dkZiRnH9fqVYzNmieVGC8pWPGyQ=",
+      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
       "requires": {
         "is-number": "4.0.0"
       },
@@ -2795,7 +2795,7 @@
         "is-number": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha1-ACbjf1RU1z41bf5lZGmYZ8an8P8="
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
         }
       }
     },
@@ -2826,7 +2826,7 @@
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
         "isobject": "3.0.1"
       }
@@ -2857,7 +2857,7 @@
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0="
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
     },
     "isarray": {
       "version": "1.0.0",
@@ -3000,7 +3000,7 @@
     "just-extend": {
       "version": "1.1.27",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-      "integrity": "sha1-7G55QQ/5FORyZSq/oOYDwD1g6QU=",
+      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
       "dev": true
     },
     "jwa": {
@@ -3027,7 +3027,7 @@
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE="
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
     },
     "knuth-shuffle-seeded": {
       "version": "1.0.6",
@@ -3183,7 +3183,7 @@
     "lodash.merge": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha1-rcJdnLmbk5HFliTzefu6YNcRHVQ="
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
     },
     "lodash.noop": {
       "version": "3.0.1",
@@ -3228,7 +3228,7 @@
     "lolex": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
-      "integrity": "sha1-hflFBCUQO/nnpgZo6iXcQydMqAc=",
+      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
       "dev": true
     },
     "lower-case": {
@@ -3372,7 +3372,7 @@
     "mixin-deep": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "requires": {
         "for-in": "1.0.2",
         "is-extendable": "1.0.1"
@@ -3381,7 +3381,7 @@
         "is-extendable": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
             "is-plain-object": "2.0.4"
           }
@@ -3497,7 +3497,7 @@
     "nanomatch": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-      "integrity": "sha1-h59xUMstq3pHElkGbBBO7m4Pp8I=",
+      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
       "requires": {
         "arr-diff": "4.0.0",
         "array-unique": "0.3.2",
@@ -3522,7 +3522,7 @@
     "needle": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
-      "integrity": "sha1-8U78ac7hAktyyLIce9+UpzHcEvo=",
+      "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
       "requires": {
         "debug": "2.6.9",
         "iconv-lite": "0.4.19",
@@ -3532,7 +3532,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
           }
@@ -6862,7 +6862,7 @@
     "pidusage": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pidusage/-/pidusage-1.2.0.tgz",
-      "integrity": "sha1-Ze6WrOTgikzT+SQJlshbNnFx7pI="
+      "integrity": "sha512-OGo+iSOk44HRJ8q15AyG570UYxcm5u+R99DI8Khu8P3tKGkVu5EZX4ywHglWSTMNNXQ274oeGpYrvFEhDIFGPg=="
     },
     "pify": {
       "version": "2.3.0",
@@ -6951,7 +6951,7 @@
     "pm2-axon": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pm2-axon/-/pm2-axon-3.1.0.tgz",
-      "integrity": "sha1-G0Un8zheIDrcGlsEiLtS8DInMdo=",
+      "integrity": "sha512-5sBM+vHw0Cp2K9CJ9ZOYhKtNCCcgQ0eKOyFrSo5Jusbq9FfvuelsMG4WDaxkqosaQbf8N5YfyHhD7eOUcnm5rQ==",
       "requires": {
         "amp": "0.3.1",
         "amp-message": "0.1.2",
@@ -6970,7 +6970,7 @@
     "pm2-deploy": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/pm2-deploy/-/pm2-deploy-0.3.9.tgz",
-      "integrity": "sha1-re7ndcVtUrjyUbqbCr4NtQoB38c=",
+      "integrity": "sha512-IYF45fPwfLE27BivrtodK7zzN56BNDErK7brcldIHjVIHLlk+cdhijq3kwTkPPP3Tpc3H2C942QGRgjg0hHajA==",
       "requires": {
         "async": "1.5.2",
         "tv4": "1.3.0"
@@ -6994,7 +6994,7 @@
     "pmx": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/pmx/-/pmx-1.6.4.tgz",
-      "integrity": "sha1-RaDrvzwwLlG3UUgV8JgX23mv1ZM=",
+      "integrity": "sha512-uk6REZHe8j3RhGlFUfyVwFrE6JFhZigTpMFs/4iYO4MzCqVTpNp1cED032oCc4R+m32wUITV/2RDmPX21T1LLg==",
       "requires": {
         "debug": "3.1.0",
         "deep-metrics": "0.0.1",
@@ -7165,13 +7165,13 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk=",
       "dev": true
     },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-      "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "requires": {
         "extend-shallow": "3.0.2",
         "safe-regex": "1.1.0"
@@ -7438,7 +7438,7 @@
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w="
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
     "retry": {
       "version": "0.12.0",
@@ -7503,13 +7503,13 @@
     "samsam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha1-jR2TUOJWItow3j5EumkrUiGrfFA=",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
       "dev": true
     },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "seed-random": {
       "version": "2.2.0",
@@ -7541,7 +7541,7 @@
     "set-value": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "requires": {
         "extend-shallow": "2.0.1",
         "is-extendable": "0.1.1",
@@ -7592,7 +7592,7 @@
     "shimmer": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.0.tgz",
-      "integrity": "sha1-+Wb3VVeJdj502IQRk2haXnhzZmU="
+      "integrity": "sha512-xTCx2vohXC2EWWDqY/zb4+5Mu28D+HYNSOuFzsyRDRvI/e1ICb69afwaUwfjr+25ZXldbOLyp+iDUZHq8UnTag=="
     },
     "should": {
       "version": "13.2.1",
@@ -7768,7 +7768,7 @@
     "snapdragon-node": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-      "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "requires": {
         "define-property": "1.0.0",
         "isobject": "3.0.1",
@@ -7814,7 +7814,7 @@
     "snapdragon-util": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-      "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "requires": {
         "kind-of": "3.2.2"
       },
@@ -8026,7 +8026,7 @@
     "source-map-resolve": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
-      "integrity": "sha1-etD1k/IoFZjoVN+A8ZquS5LXoRo=",
+      "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "requires": {
         "atob": "2.1.0",
         "decode-uri-component": "0.2.0",
@@ -8059,7 +8059,7 @@
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "requires": {
         "extend-shallow": "3.0.2"
       }
@@ -8425,7 +8425,7 @@
     "to-regex": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-      "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "requires": {
         "define-property": "2.0.2",
         "extend-shallow": "3.0.2",
@@ -8488,7 +8488,7 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "typedarray": {
@@ -8500,7 +8500,7 @@
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha1-n+FTahCmZKZSZqHjzPhf02MCvJw="
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
     "union-value": {
       "version": "1.0.0",
@@ -8602,7 +8602,7 @@
     "upath": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.4.tgz",
-      "integrity": "sha1-7iMhugp4bFCXPbBDpQt7y6giNh0="
+      "integrity": "sha512-d4SJySNBXDaQp+DPrziv3xGS6w3d2Xt69FijJr86zMPBy23JEloMCEOUBBzuN7xCtjLCnmB9tI/z7SBCahHBOw=="
     },
     "upper-case": {
       "version": "1.1.3",
@@ -8665,7 +8665,7 @@
     "v8-compile-cache": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-1.1.2.tgz",
-      "integrity": "sha1-jTLk8Wl0ZUZX5nbg5GejSOibDcQ="
+      "integrity": "sha512-ejdrifsIydN1XDH7EuR2hn8ZrkRKUYF7tUcBjBy/lhrCvs2K+zRlbW9UHc0IQ9RsYFZJFqJrieoIHfkCa0DBRA=="
     },
     "validator": {
       "version": "9.4.1",
@@ -8727,7 +8727,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
           }

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -107,6 +107,7 @@ class KuzzleMock extends Kuzzle {
 
     this.indexCache = {
       indexes: {},
+      defaultMappings: {},
       add: sinon.stub(),
       exists: sinon.stub(),
       init: sinon.stub().resolves(),
@@ -134,6 +135,8 @@ class KuzzleMock extends Kuzzle {
       exists: sinon.stub().resolves(),
       expire: sinon.stub().resolves(),
       get: sinon.stub().resolves(foo),
+      getFieldMapping: sinon.stub().resolves(),
+      getMapping: sinon.stub().resolves(),
       mget: sinon.stub().resolves({hits: [foo]}),
       index: 'internalIndex',
       init: sinon.stub().resolves(),
@@ -145,8 +148,7 @@ class KuzzleMock extends Kuzzle {
       scroll: sinon.stub().resolves(),
       search: sinon.stub().resolves(),
       update: sinon.stub().resolves(),
-      updateMapping: sinon.stub().resolves(foo),
-      getMapping: sinon.stub()
+      updateMapping: sinon.stub().resolves(foo)
     };
 
     this.once = sinon.stub();

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -1360,6 +1360,37 @@ describe('Test: ElasticSearch service', () => {
           should(elasticsearch.config.commonMapping).eql(mapping);
         });
     });
+
+    it('should reuse a previously defined common mapping', () => {
+      kuzzle.indexCache.defaultMappings[index] = {
+        gordon: { type: 'text' }
+      };
+
+      return elasticsearch.updateMapping(new Request({
+        index,
+        collection,
+        body: {
+          properties: {
+            freeman: { type: 'boolean' }
+          }
+        }
+      }))
+        .then(() => {
+          const esReq = elasticsearch.client.indices.putMapping.firstCall.args[0];
+
+          should(esReq).eql({
+            index,
+            type: collection,
+            body: {
+              properties: {
+                gordon: { type: 'text' },
+                freeman: { type: 'boolean' }
+              }
+            }
+          });
+        });
+
+    });
   });
 
   describe('#getMapping', () => {
@@ -1599,6 +1630,44 @@ describe('Test: ElasticSearch service', () => {
         });
     });
 
+    it('should reuse a previously created common mapping', () => {
+      elasticsearch.client.indices.putMapping.resolves({});
+      elasticsearch.kuzzle.indexCache.exists.returns(true);
+
+      request.input.resource.collection = '%foobar';
+
+      kuzzle.indexCache.defaultMappings[index] = {
+        gordon: { type: 'text' }
+      };
+
+      const collectionMapping = {
+        properties: {
+          freeman:  { type: 'keyword' },
+          _kuzzle_info: {
+            properties: {
+              author: { type: 'keyword' }
+            }
+          }
+        }
+      };
+      request.input.body = collectionMapping;
+
+      return elasticsearch.createCollection(request)
+        .then(() => {
+          const esReq = elasticsearch.client.indices.putMapping.firstCall.args[0];
+
+          should(esReq.body['%foobar'].properties).eql({
+            gordon:   { type: 'text' },
+            freeman:  { type: 'keyword' },
+            _kuzzle_info: {
+              properties: {
+                author: { type: 'keyword' }
+              }
+            }
+          });
+        });
+
+    });
   });
 
   describe('#truncateCollection', () => {


### PR DESCRIPTION
## What does this PR do ?

This PR fixes #1124 by allowing to use different historical versions of Kuzzle internal metadata mappings.

### How should this be manually tested?

```bash
export es=http://localhost:9200

curl -XPUT $es/index
curl -XPUT -d '{
  "properties": {
    "_kuzzle_info": {
      "properties": {
        "author": { "type": "text" }
      }
    }
  }
}' $es/index/_mapping/col1
curl -XPUT -d '{"properties": {}}' $es/index/_mapping/col2

curl -XPUT $es/index2
curl -XPUT -d '{"properties": {}}' $es/index2/_mapping/col1

// restart kuzzle
curl $es/index*/_mapping/?pretty

// index collections should have _kuzzle_info.author set as "text"
// index2 collections should have _kuzzle_info.author set as "keyword"
```
