### PR TITLE
Fix document:mGet "includeTrash" option

### DIFF
--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -222,6 +222,7 @@ class ElasticSearch extends Service {
     const esRequest = initESRequest(request);
 
     esRequest.body = request.input.body;
+    delete esRequest.body.includeTrash;
 
     return this.client.mget(esRequest)
       .then(result => {


### PR DESCRIPTION
## What does this PR do ?

Fix a bug in mGet where we give the raw request to the elasticSearch client without removing the attribute includeTrash.
