### PR TITLE
Add support for compressed HTTP requests (gzip, deflate)

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -320,7 +320,7 @@
         //    Set to "false" to disable HTTP support
         // * maxFormFileSize:
         //    Maximum size of requests sent via http forms
-        // * maxEncodingsCount:
+        // * maxEncodingLayers:
         //    Maximum number of encoding layers that can be applied
         //    to an http message, using the Content-Encoding header.
         //    This parameter is meant to prevent abuses by setting an
@@ -334,7 +334,7 @@
         //    compression support is disabled
         "enabled": true,
         "maxFormFileSize": "1mb",
-        "maxEncodingsCount": 3,
+        "maxEncodingLayers": 3,
         "allowCompression": true
       },
       "socketio": {

--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -316,9 +316,26 @@
     // protocols can be extended using plugins and configured in this section.
     "protocols": {
       "http": {
+        // * enabled:
+        //    Set to "false" to disable HTTP support
+        // * maxFormFileSize:
+        //    Maximum size of requests sent via http forms
+        // * maxEncodingsCount:
+        //    Maximum number of encoding layers that can be applied
+        //    to an http message, using the Content-Encoding header.
+        //    This parameter is meant to prevent abuses by setting an
+        //    abnormally large number of encodings, forcing Kuzzle to
+        //    allocate as many decoders to handle the incoming request.
+        // * allowCompression:
+        //    Enable support for compressed requests, using the
+        //    Content-Encoding header
+        //    Currently supported compression algorithms: gzip, deflate, identity
+        //    Note: "identity" is always an accepted value, even if
+        //    compression support is disabled
         "enabled": true,
-        // maximum size of documents sent via http forms
-        "maxFormFileSize": "1mb"
+        "maxFormFileSize": "1mb",
+        "maxEncodingsCount": 3,
+        "allowCompression": true
       },
       "socketio": {
         "enabled": true,

--- a/cucumber.js
+++ b/cucumber.js
@@ -26,9 +26,9 @@
  */
 module.exports = {
   httpEmbedded: '--fail-fast --tags "not @realtime" --world-parameters \'{"protocol": "http", "port": 7512}\'',
-  socketioEmbedded: '--fail-fast --world-parameters \'{"protocol": "socketio", "port": 7512}\'',
-  websocketEmbedded: '--fail-fast --world-parameters \'{"protocol": "websocket", "port": 7512}\'',
+  socketioEmbedded: '--fail-fast --tags "not @http" --world-parameters \'{"protocol": "socketio", "port": 7512}\'',
+  websocketEmbedded: '--fail-fast --tags "not @http" --world-parameters \'{"protocol": "websocket", "port": 7512}\'',
   httpProxy: '--fail-fast --tags "not @realtime" --world-parameters \'{"protocol": "http", "port": 7513}\'',
-  socketioProxy: '--fail-fast --world-parameters \'{"protocol": "socketio", "port": 7513}\'',
-  websocketProxy: '--fail-fast --world-parameters \'{"protocol": "websocket", "port": 7513}\''
+  socketioProxy: '--fail-fast --tags "not @http" --world-parameters \'{"protocol": "socketio", "port": 7513}\'',
+  websocketProxy: '--fail-fast --tags "not @http" --world-parameters \'{"protocol": "websocket", "port": 7513}\''
 };

--- a/default.config.js
+++ b/default.config.js
@@ -178,7 +178,9 @@ module.exports = {
     protocols: {
       http: {
         enabled: true,
-        maxFormFileSize: '1MB'
+        maxFormFileSize: '1MB',
+        maxEncodingsCount: 3,
+        allowCompression: true
       },
       socketio: {
         enabled: true,

--- a/default.config.js
+++ b/default.config.js
@@ -179,7 +179,7 @@ module.exports = {
       http: {
         enabled: true,
         maxFormFileSize: '1MB',
-        maxEncodingsCount: 3,
+        maxEncodingLayers: 3,
         allowCompression: true
       },
       socketio: {

--- a/features/kuzzle.feature
+++ b/features/kuzzle.feature
@@ -15,7 +15,7 @@ Feature: Kuzzle functional tests
 
   @http
   Scenario: Send a request compressed with multiple algorithms
-    Given a request compressed with "deflate, gzip, deflate, identity"
+    Given a request compressed with "deflate, gzip, identity"
     When I write the document
     Then I should receive a document id
     Then I'm able to get the document

--- a/features/kuzzle.feature
+++ b/features/kuzzle.feature
@@ -1,4 +1,38 @@
 Feature: Kuzzle functional tests
+  @http
+  Scenario: Send a request compressed with gzip
+    Given a request compressed with "gzip"
+    When I write the document
+    Then I should receive a document id
+    Then I'm able to get the document
+
+  @http
+  Scenario: Send a request compressed with deflate
+    Given a request compressed with "deflate"
+    When I write the document
+    Then I should receive a document id
+    Then I'm able to get the document
+
+  @http
+  Scenario: Send a request compressed with multiple algorithms
+    Given a request compressed with "deflate, gzip, deflate, identity"
+    When I write the document
+    Then I should receive a document id
+    Then I'm able to get the document
+
+  @http
+  Scenario: Receive a request compressed with gzip
+    Given an expected response compressed with "gzip"
+    When I write the document
+    Then I should receive a document id
+    Then I'm able to get the document
+
+  @http
+  Scenario: Receive a request compressed with deflate
+    Given an expected response compressed with "deflate"
+    When I write the document
+    Then I should receive a document id
+    Then I'm able to get the document
 
   Scenario: Check server Health
     When I check server health

--- a/features/step_definitions/httpCompression.js
+++ b/features/step_definitions/httpCompression.js
@@ -1,0 +1,12 @@
+const
+  {
+    Given
+  } = require('cucumber');
+
+Given(/^a request compressed with "([^"]*)"$/, function(algorithm) {
+  this.api.encode(algorithm);
+});
+
+Given(/^an expected response compressed with "([^"]*)"$/, function(algorithm) {
+  this.api.decode(algorithm);
+});

--- a/features/support/api/http.js
+++ b/features/support/api/http.js
@@ -1,7 +1,20 @@
 const
   _ = require('lodash'),
   rp = require('request-promise'),
-  routes = require('../../../lib/config/httpRoutes');
+  routes = require('../../../lib/config/httpRoutes'),
+  zlib = require('zlib');
+
+function checkAlgorithm(algorithm) {
+  const
+    supported = ['identity', 'gzip', 'deflate'],
+    list = algorithm.split(',').map(a => a.trim().toLowerCase());
+
+  for(const l of list) {
+    if (!supported.some(a => a === l)) {
+      throw new Error(`Unsupported compression algorithm: ${l}`);
+    }
+  }
+}
 
 class HttpApi {
   constructor (world) {
@@ -15,6 +28,9 @@ class HttpApi {
     };
 
     this.isRealtimeCapable = false;
+
+    this.encoding = 'identity';
+    this.expectedEncoding = 'identity';
   }
 
   _getRequest (index, collection, controller, action, args) {
@@ -147,17 +163,50 @@ class HttpApi {
    * @return {Promise.<IncomingMessage>}
    */
   callApi (options) {
+    if (!options.headers) {
+      options.headers = {};
+    }
+
     if (this.world.currentUser && this.world.currentUser.token) {
-      if (!options.headers) {
-        options.headers = {};
-      }
       options.headers = _.extend(options.headers, {authorization: 'Bearer ' + this.world.currentUser.token});
     }
 
-    options.json = true;
+    if (this.body && this.encoding !== 'identity') {
+      options.headers['content-encoding'] = this.encoding;
+
+      const algorithms = this.encoding.split(',').map(a => a.trim().toLowerCase());
+
+      for(const algorithm of algorithms) {
+        if (algorithm === 'gzip') {
+          options.body = zlib.gzipSync(JSON.stringify(options.body));
+        } else if (algorithm === 'deflate') {
+          options.body = zlib.deflateSync(JSON.stringify(options.body));
+        }
+      }
+    } else {
+      options.json = true;
+    }
+
+    if (this.expectedEncoding !== 'identity') {
+      options.headers['accept-encoding'] = this.expectedEncoding;
+
+      // despite the name, that options asks "request" to handle
+      // both gzip or deflate compressed responses
+      options.gzip = true;
+    }
+
     options.forever = true;
 
-    return rp(options);
+    return rp(options)
+      .then(response => {
+        // we need to manually parse the stringified json if
+        // we sent a compressed buffer through the request module
+        if (this.body && this.encoding !== 'identity') {
+          return JSON.parse(response);
+        }
+
+        return response;
+      });
   }
 
   callMemoryStorage (command, args) {
@@ -1180,6 +1229,15 @@ class HttpApi {
     return this.callApi(options);
   }
 
+  encode(algorithm) {
+    checkAlgorithm(algorithm);
+    this.encoding = algorithm;
+  }
+
+  decode(algorithm) {
+    checkAlgorithm(algorithm);
+    this.expectedEncoding = algorithm;
+  }
 }
 
 module.exports = HttpApi;

--- a/features/support/api/http.js
+++ b/features/support/api/http.js
@@ -171,16 +171,17 @@ class HttpApi {
       options.headers = _.extend(options.headers, {authorization: 'Bearer ' + this.world.currentUser.token});
     }
 
-    if (this.body && this.encoding !== 'identity') {
+    if (options.body && this.encoding !== 'identity') {
+      options.body = JSON.stringify(options.body);
       options.headers['content-encoding'] = this.encoding;
 
       const algorithms = this.encoding.split(',').map(a => a.trim().toLowerCase());
 
       for(const algorithm of algorithms) {
         if (algorithm === 'gzip') {
-          options.body = zlib.gzipSync(JSON.stringify(options.body));
+          options.body = zlib.gzipSync(options.body);
         } else if (algorithm === 'deflate') {
-          options.body = zlib.deflateSync(JSON.stringify(options.body));
+          options.body = zlib.deflateSync(options.body);
         }
       }
     } else {
@@ -201,7 +202,7 @@ class HttpApi {
       .then(response => {
         // we need to manually parse the stringified json if
         // we sent a compressed buffer through the request module
-        if (this.body && this.encoding !== 'identity') {
+        if (options.body && this.encoding !== 'identity') {
           return JSON.parse(response);
         }
 

--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -100,6 +100,10 @@ After({tags: '@validation'}, function () {
   return cleanValidations.call(this);
 });
 
+After({tags: '@http'}, function () {
+  this.api.encode('identity');
+  this.api.decode('identity');
+});
 
 function cleanSecurity () {
   if (this.currentUser) {

--- a/lib/api/core/entrypoints/embedded/protocols/http.js
+++ b/lib/api/core/entrypoints/embedded/protocols/http.js
@@ -308,7 +308,7 @@ class HttpProtocol extends Protocol {
       }
 
       for (const encoding of encodings) {
-        let pipe = null;
+        let pipe;
 
         if (this.decoders[encoding]) {
           pipe = this.decoders[encoding]();

--- a/lib/api/core/entrypoints/embedded/protocols/http.js
+++ b/lib/api/core/entrypoints/embedded/protocols/http.js
@@ -31,10 +31,12 @@ const
   Writable = require('stream').Writable,
   HttpFormDataStream = require('../service/httpFormDataStream'),
   {
+    KuzzleError,
     BadRequestError,
     SizeLimitError
   } = require('kuzzle-common-objects').errors,
-  Request = require('kuzzle-common-objects').Request;
+  Request = require('kuzzle-common-objects').Request,
+  zlib = require('zlib');
 
 /**
  * @class HttpProtocol
@@ -100,71 +102,69 @@ class HttpProtocol extends Protocol {
       if (!request.headers['content-type'] || request.headers['content-type'].startsWith('application/json')) {
         stream = new Writable({
           write(chunk, encoding, callback) {
-            debug('[%s] writing chunk: %a', connection.id, chunk.toString());
-            payload.content += chunk.toString();
+            /*
+             * The content-length header can be bypassed and
+             * is not reliable enough. We have to enforce the HTTP
+             * max size limit while reading the stream too
+             */
+            streamLength += chunk.length;
+            if (streamLength > this.maxRequestSize) {
+              return request.emit('error', new SizeLimitError('Error: maximum HTTP request size exceeded'));
+            }
+
+            const str = chunk.toString();
+
+            debug('[%s] writing chunk: %a', connection.id, str);
+            payload.content += str;
             callback();
           }
-        });
-
-        stream.on('error', err => {
-          debug('[%s] stream error: %a', connection.id, err);
-          stream.end();
-          request
-            .removeAllListeners('data')
-            .removeAllListeners('end')
-            .resume();
-          return this._replyWithError(connection.id, payload, response, err);
         });
       } else {
         try {
           stream = new HttpFormDataStream({
             headers: request.headers,
             limits: {fileSize: this.maxFormFileSize}
-          }, payload);
+          }, payload, request);
         } catch (error) {
           request.resume();
-          return this._replyWithError(connection.id, payload, response, new BadRequestError(error.message));
+          return this._replyWithError(connection.id, payload, response, new BadRequestError(error));
         }
-
-        stream.on('error', err => {
-          debug('[%s] stream error:\n%O', connection.id, err);
-          /*
-           * Force Dicer parser to finish prematurely
-           * without throwing an 'Unexpected end of multipart data' error :
-           */
-          stream._parser.parser._finished = true;
-          stream.end();
-
-          request
-            .removeAllListeners('data')
-            .removeAllListeners('end')
-            .resume();
-          return this._replyWithError(connection.id, payload, response, err);
-        });
       }
 
-      request.on('data', chunk => {
-        debug('[%s] receiving chunk data: %a', connection.id, chunk.toString());
+      let pipes;
 
-        streamLength += chunk.length;
+      try {
+        pipes = this._uncompress(request);
+      } catch(err) {
+        return this._replyWithError(connection.id, payload, response, err);
+      }
 
-        /*
-         * The content-length header can be bypassed and
-         * is not reliable enough. We have to enforce the HTTP
-         * max size limit while reading the stream too
-         */
-        if (streamLength > this.maxRequestSize) {
-          return stream.emit('error', new SizeLimitError('Error: maximum HTTP request size exceeded'));
-        }
-        stream.write(chunk);
+      // We plug our writable stream to the last pipe of the chain
+      if (pipes.length > 0) {
+        pipes[pipes.length-1].pipe(stream);
+      } else {
+        request.pipe(stream);
+      }
+
+      // We forward all pipe errors to the request's event handler
+      request.on('error', err => {
+        const kerr = err instanceof KuzzleError ? err : new BadRequestError(err);
+        // remove all pipes before flushing the stream
+        request.unpipe();
+        request.removeAllListeners().resume();
+        stream.removeAllListeners().end();
+
+        // When an error occurs on a Readable Stream, the
+        // registered pipes are NOT freed automatically
+        pipes.forEach(pipe => pipe.close());
+
+        return this._replyWithError(connection.id, payload, response, kerr);
       });
 
-      request.on('end', () => {
+      stream.on('finish', () => {
         debug('[%s] End Request', connection.id);
-        stream.end(() => {
-          payload.headers['content-type'] = 'application/json';
-          this._sendRequest(connection.id, response, payload);
-        });
+        payload.headers['content-type'] = 'application/json';
+        this._sendRequest(connection.id, response, payload);
       });
     });
   }
@@ -290,6 +290,44 @@ class HttpProtocol extends Protocol {
     return data;
   }
 
+  /**
+   * Returns a new Readable Stream configured with
+   * uncompression algorithms if needed
+   *
+   * @param  {http.IncomingMessage} request
+   * @return {Array.<stream.Readable>}
+   * @throws {BadRequestError} If invalid compression algorithm is set
+   */
+  _uncompress(request) {
+    const pipes = [];
+
+    if (request.headers['content-encoding']) {
+      for (const encoding of request.headers['content-encoding'].split(',')) {
+        const trimmed = encoding.trim();
+        let pipe = null;
+
+        if (trimmed === 'gzip') {
+          pipe = zlib.createGunzip();
+        } else if (trimmed === 'deflate') {
+          pipe = zlib.createInflate();
+        } else if (trimmed !== 'identity') {
+          request.removeAllListeners().resume();
+          throw new BadRequestError(`Error: Unsupported compression algorithm "${encoding}"`);
+        }
+
+        if (pipe) {
+          const lastPipe = pipes.length > 0 ? pipes[pipes.length-1] : request;
+          lastPipe.pipe(pipe);
+          pipes.push(pipe);
+
+          // forward zlib errors to the request global error handler
+          pipe.on('error', error => request.emit('error', error));
+        }
+      }
+    }
+
+    return pipes;
+  }
 }
 
 module.exports = HttpProtocol;

--- a/lib/api/core/entrypoints/embedded/protocols/http.js
+++ b/lib/api/core/entrypoints/embedded/protocols/http.js
@@ -56,12 +56,10 @@ class HttpProtocol extends Protocol {
    */
   init(entryPoint) {
     super.init(entryPoint);
-    this.entryPoint = entryPoint;
 
     debug('initializing http Server with config: %a', entryPoint.config);
 
     this.maxFormFileSize = bytes.parse(entryPoint.config.protocols.http.maxFormFileSize);
-
     this.server = entryPoint.httpServer;
 
     if (this.maxFormFileSize === null || isNaN(this.maxFormFileSize)) {
@@ -69,56 +67,32 @@ class HttpProtocol extends Protocol {
     }
 
     this.server.on('request', (request, response) => {
-      const payload = {
-        requestId: uuid.v4(),
-        url: request.url,
-        method: request.method,
-        headers: request.headers,
-        content: ''
-      };
-      let
-        stream,
-        streamLength = 0,
+      const
+        payload = {
+          requestId: uuid.v4(),
+          url: request.url,
+          method: request.method,
+          headers: request.headers,
+          content: ''
+        },
         ips = [request.socket.remoteAddress];
+      let stream;
 
       if (request.headers['x-forwarded-for']) {
-        ips = request.headers['x-forwarded-for']
-          .split(',')
-          .map(s => s.trim())
-          .concat(ips);
+        request.headers['x-forwarded-for'].split(',').forEach(s => ips.push(s.trim()));
+      }
+
+      if (request.headers['content-length'] > this.maxRequestSize) {
+        request.resume();
+        return this._replyWithError(connection.id, payload, response, new SizeLimitError('Error: maximum HTTP request size exceeded'));
       }
 
       const connection = new ClientConnection('HTTP/' + request.httpVersion, ips, request.headers);
       debug('[%s] receiving HTTP request: %a', connection.id, payload);
       this.entryPoint.newConnection(connection);
 
-      if (request.headers['content-length'] > this.maxRequestSize) {
-        request
-          .removeAllListeners()
-          .resume();
-        return this._replyWithError(connection.id, payload, response, new SizeLimitError('Error: maximum HTTP request size exceeded'));
-      }
-
       if (!request.headers['content-type'] || request.headers['content-type'].startsWith('application/json')) {
-        stream = new Writable({
-          write(chunk, encoding, callback) {
-            /*
-             * The content-length header can be bypassed and
-             * is not reliable enough. We have to enforce the HTTP
-             * max size limit while reading the stream too
-             */
-            streamLength += chunk.length;
-            if (streamLength > this.maxRequestSize) {
-              return request.emit('error', new SizeLimitError('Error: maximum HTTP request size exceeded'));
-            }
-
-            const str = chunk.toString();
-
-            debug('[%s] writing chunk: %a', connection.id, str);
-            payload.content += str;
-            callback();
-          }
-        });
+        stream = this._createWriteStream(connection.id, payload);
       } else {
         try {
           stream = new HttpFormDataStream({
@@ -139,14 +113,14 @@ class HttpProtocol extends Protocol {
         return this._replyWithError(connection.id, payload, response, err);
       }
 
-      // We plug our writable stream to the last pipe of the chain
+      // We attach our writable stream to the last pipe of the chain
       if (pipes.length > 0) {
         pipes[pipes.length-1].pipe(stream);
       } else {
         request.pipe(stream);
       }
 
-      // We forward all pipe errors to the request's event handler
+      // We forwarded all pipe errors to the request's event handler
       request.on('error', err => {
         const kerr = err instanceof KuzzleError ? err : new BadRequestError(err);
         // remove all pipes before flushing the stream
@@ -327,6 +301,38 @@ class HttpProtocol extends Protocol {
     }
 
     return pipes;
+  }
+
+  /**
+   * Create a new Writable stream configured to receive a HTTP request
+   * @param  {string} connectionId
+   * @param  {Object} payload
+   * @return {stream.Writable}
+   */
+  _createWriteStream(connectionId, payload) {
+    const maxRequestSize = this.maxRequestSize; // prevent context mismatch
+    let streamLength = 0;
+
+    return new Writable({
+      write(chunk, encoding, callback) {
+        /*
+         * The content-length header can be bypassed and
+         * is not reliable enough. We have to enforce the HTTP
+         * max size limit while reading the stream too
+         */
+        streamLength += chunk.length;
+
+        if (streamLength > maxRequestSize) {
+          return callback(new SizeLimitError('Error: maximum HTTP request size exceeded'));
+        }
+
+        const str = chunk.toString();
+
+        debug('[%s] writing chunk: %a', connection.id, str);
+        payload.content += str;
+        callback();
+      }
+    });
   }
 }
 

--- a/lib/api/core/entrypoints/embedded/protocols/http.js
+++ b/lib/api/core/entrypoints/embedded/protocols/http.js
@@ -95,7 +95,7 @@ class HttpProtocol extends Protocol {
 
       if (request.headers['content-length'] > this.maxRequestSize) {
         request.resume();
-        return this._replyWithError(connection.id, payload, response, new SizeLimitError('Error: maximum HTTP request size exceeded'));
+        return this._replyWithError(connection.id, payload, response, new SizeLimitError('Maximum HTTP request size exceeded'));
       }
 
 
@@ -345,7 +345,7 @@ class HttpProtocol extends Protocol {
         streamLength += chunk.length;
 
         if (streamLength > maxRequestSize) {
-          return callback(new SizeLimitError('Error: maximum HTTP request size exceeded'));
+          return callback(new SizeLimitError('Maximum HTTP request size exceeded'));
         }
 
         const str = chunk.toString();
@@ -375,6 +375,7 @@ class HttpProtocol extends Protocol {
 
     // for now, we accept gzip, deflate and identity
     const decoders = {};
+
     decoders.gzip = allowCompression ? zlib.createGunzip : disabledfn;
     decoders.deflate = allowCompression ? zlib.createInflate : disabledfn;
     decoders.identity = () => null;

--- a/lib/api/core/entrypoints/embedded/protocols/http.js
+++ b/lib/api/core/entrypoints/embedded/protocols/http.js
@@ -166,7 +166,6 @@ class HttpProtocol extends Protocol {
 
     if (payload.json) {
       payload.content = JSON.stringify(payload.json);
-      delete payload.json;
     }
 
     this.entryPoint.kuzzle.router.http.route(payload, result => {
@@ -192,9 +191,18 @@ class HttpProtocol extends Protocol {
           response.setHeader(header, resp.headers[header]);
         }
       }
-      response.writeHead(resp.status);
-      response.end(this._contentToPayload(resp, payload.url));
 
+      const data = this._contentToPayload(resp, payload.url);
+
+      this._compress(data, response, payload.headers, (err, buf) => {
+        if (err) {
+          const kuzerr = err instanceof KuzzleError ? err : new BadRequestError(err);
+          return this._replyWithError(connectionId, payload, response, kuzerr);
+        }
+
+        response.writeHead(resp.status);
+        response.end(buf);
+      });
     });
   }
 
@@ -236,7 +244,7 @@ class HttpProtocol extends Protocol {
    * @param {String} invokedUrl - invoked URL. Used to check if the ?pretty
    *                              argument was passed by the client, changing
    *                              the payload format
-   * @return {String|Buffer}
+   * @return {Buffer}
    */
   _contentToPayload(result, invokedUrl) {
     let data;
@@ -250,7 +258,7 @@ class HttpProtocol extends Protocol {
          we stringify the content.
          */
         if (result.content instanceof Buffer || (result.content.type === 'Buffer' && Array.isArray(result.content.data))) {
-          data = Buffer.from(result.content);
+          data = result.content;
         }
         else {
           data = JSON.stringify(result.content);
@@ -272,7 +280,7 @@ class HttpProtocol extends Protocol {
       data = JSON.stringify(result.content, undefined, indent);
     }
 
-    return data;
+    return Buffer.from(data);
   }
 
   /**
@@ -288,18 +296,19 @@ class HttpProtocol extends Protocol {
   _uncompress(request) {
     const pipes = [];
     if (request.headers['content-encoding']) {
-      const encodings = request.headers['content-encoding'].split(',');
+      const encodings = request.headers['content-encoding']
+        .split(',')
+        .map(e => e.trim().toLowerCase());
 
       if (encodings.length > this.maxEncodingsCount) {
         throw new BadRequestError('Too many encodings');
       }
 
       for (const encoding of encodings) {
-        const trimmed = encoding.trim();
         let pipe = null;
 
-        if (this.decoders[trimmed]) {
-          pipe = this.decoders[trimmed]();
+        if (this.decoders[encoding]) {
+          pipe = this.decoders[encoding]();
         } else {
           request.removeAllListeners().resume();
           throw new BadRequestError(`Unsupported compression algorithm "${encoding}"`);
@@ -370,8 +379,36 @@ class HttpProtocol extends Protocol {
     // for now, we accept gzip, deflate and identity
     const decoders = {};
     decoders.gzip = allowCompression ? zlib.createGunzip : disabledfn;
-    decoders.inflate = allowCompression ? zlib.createInflate : disabledfn;
-    decoders.identity = () => new PassThrough();
+    decoders.deflate = allowCompression ? zlib.createInflate : disabledfn;
+    decoders.identity = () => null;
+
+    return decoders;
+  }
+
+  /**
+   * [_compress description]
+   * @param  {Buffer} data     - data to compress
+   * @param  {ServerResponse} response
+   * @param  {Object} headers
+   * @param  {Function} callback
+   */
+  _compress(data, response, headers, callback) {
+    if (headers['accept-encoding']) {
+      const allowedEncodings = new Set(headers['accept-encoding']
+        .split(',')
+        .map(e => e.trim().toLowerCase()));
+
+      // gzip should be preferred over deflate
+      if (allowedEncodings.has('gzip')) {
+        response.setHeader('Content-Encoding', 'gzip');
+        return zlib.gzip(data, callback);
+      } else if (allowedEncodings.has('deflate')) {
+        response.setHeader('Content-Encoding', 'deflate');
+        return zlib.deflate(data, callback);
+      }
+    }
+
+    callback(null, data);
   }
 }
 

--- a/lib/api/core/entrypoints/embedded/protocols/http.js
+++ b/lib/api/core/entrypoints/embedded/protocols/http.js
@@ -28,7 +28,10 @@ const
   url = require('url'),
   ClientConnection = require('../clientConnection'),
   Protocol = require('./protocol'),
-  Writable = require('stream').Writable,
+  {
+    Writable,
+    PassThrough
+  } = require('stream'),
   HttpFormDataStream = require('../service/httpFormDataStream'),
   {
     KuzzleError,
@@ -45,8 +48,11 @@ class HttpProtocol extends Protocol {
   constructor() {
     super();
 
-    this.maxFormFileSize = null;
+    this.maxFormFileSize = 0;
     this.server = null;
+    this.maxEncodings = 0;
+    this.allowCompression = false;
+    this.decoders = {};
   }
 
   /**
@@ -60,11 +66,16 @@ class HttpProtocol extends Protocol {
     debug('initializing http Server with config: %a', entryPoint.config);
 
     this.maxFormFileSize = bytes.parse(entryPoint.config.protocols.http.maxFormFileSize);
+    this.maxEncodings = entryPoint.config.protocols.http.maxEncodingsCount;
     this.server = entryPoint.httpServer;
 
-    if (this.maxFormFileSize === null || isNaN(this.maxFormFileSize)) {
-      throw new Error('Invalid HTTP "maxFormFileSize" parameter');
+    for (const numericParameter of ['maxFormFileSize', 'maxEncodings']) {
+      if (this[numericParameter] === null || isNaN(this[numericParameter])) {
+        throw new Error(`Invalid HTTP "${numericParameter}" parameter value: expected a numeric value`);
+      }
     }
+
+    this.decoders = this._setDecoders();
 
     this.server.on('request', (request, response) => {
       const
@@ -271,22 +282,27 @@ class HttpProtocol extends Protocol {
    * @param  {http.IncomingMessage} request
    * @return {Array.<stream.Readable>}
    * @throws {BadRequestError} If invalid compression algorithm is set
+   *                           or if the value does not comply to the
+   *                           way the Kuzzle server is configured
    */
   _uncompress(request) {
     const pipes = [];
-
     if (request.headers['content-encoding']) {
-      for (const encoding of request.headers['content-encoding'].split(',')) {
+      const encodings = request.headers['content-encoding'].split(',');
+
+      if (encodings.length > this.maxEncodingsCount) {
+        throw new BadRequestError('Too many encodings');
+      }
+
+      for (const encoding of encodings) {
         const trimmed = encoding.trim();
         let pipe = null;
 
-        if (trimmed === 'gzip') {
-          pipe = zlib.createGunzip();
-        } else if (trimmed === 'deflate') {
-          pipe = zlib.createInflate();
-        } else if (trimmed !== 'identity') {
+        if (this.decoders[trimmed]) {
+          pipe = this.decoders[trimmed]();
+        } else {
           request.removeAllListeners().resume();
-          throw new BadRequestError(`Error: Unsupported compression algorithm "${encoding}"`);
+          throw new BadRequestError(`Unsupported compression algorithm "${encoding}"`);
         }
 
         if (pipe) {
@@ -328,11 +344,34 @@ class HttpProtocol extends Protocol {
 
         const str = chunk.toString();
 
-        debug('[%s] writing chunk: %a', connection.id, str);
+        debug('[%s] writing chunk: %a', connectionId, str);
         payload.content += str;
         callback();
       }
     });
+  }
+
+  /**
+   * Initialize the decoders property according to the current
+   * server configuration
+   * @return {Objet} A set of all supported decoders
+   */
+  _setDecoders() {
+    const
+      allowCompression = this.entryPoint.config.protocols.http.allowCompression,
+      disabledfn = () => {
+        throw new BadRequestError('Compression support is disabled');
+      };
+
+    if (typeof this.allowCompression !== 'boolean') {
+      throw new Error('Invalid HTTP "allowCompression" parameter value: expected a boolean');
+    }
+
+    // for now, we accept gzip, deflate and identity
+    const decoders = {};
+    decoders.gzip = allowCompression ? zlib.createGunzip : disabledfn;
+    decoders.inflate = allowCompression ? zlib.createInflate : disabledfn;
+    decoders.identity = () => new PassThrough();
   }
 }
 

--- a/lib/api/core/entrypoints/embedded/protocols/http.js
+++ b/lib/api/core/entrypoints/embedded/protocols/http.js
@@ -225,7 +225,7 @@ class HttpProtocol extends Protocol {
       'Content-Type': 'application/json',
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods' : 'GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
+      'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Length, Content-Encoding, X-Kuzzle-Volatile'
     });
 
     response.end(result.content);

--- a/lib/api/core/entrypoints/embedded/protocols/http.js
+++ b/lib/api/core/entrypoints/embedded/protocols/http.js
@@ -28,10 +28,7 @@ const
   url = require('url'),
   ClientConnection = require('../clientConnection'),
   Protocol = require('./protocol'),
-  {
-    Writable,
-    PassThrough
-  } = require('stream'),
+  Writable = require('stream').Writable,
   HttpFormDataStream = require('../service/httpFormDataStream'),
   {
     KuzzleError,
@@ -50,8 +47,7 @@ class HttpProtocol extends Protocol {
 
     this.maxFormFileSize = 0;
     this.server = null;
-    this.maxEncodings = 0;
-    this.allowCompression = false;
+    this.maxEncodingLayers = 0;
     this.decoders = {};
   }
 
@@ -66,10 +62,10 @@ class HttpProtocol extends Protocol {
     debug('initializing http Server with config: %a', entryPoint.config);
 
     this.maxFormFileSize = bytes.parse(entryPoint.config.protocols.http.maxFormFileSize);
-    this.maxEncodings = entryPoint.config.protocols.http.maxEncodingsCount;
+    this.maxEncodingLayers = entryPoint.config.protocols.http.maxEncodingLayers;
     this.server = entryPoint.httpServer;
 
-    for (const numericParameter of ['maxFormFileSize', 'maxEncodings']) {
+    for (const numericParameter of ['maxFormFileSize', 'maxEncodingLayers']) {
       if (this[numericParameter] === null || isNaN(this[numericParameter])) {
         throw new Error(`Invalid HTTP "${numericParameter}" parameter value: expected a numeric value`);
       }
@@ -93,14 +89,15 @@ class HttpProtocol extends Protocol {
         request.headers['x-forwarded-for'].split(',').forEach(s => ips.push(s.trim()));
       }
 
+      const connection = new ClientConnection('HTTP/' + request.httpVersion, ips, request.headers);
+      this.entryPoint.newConnection(connection);
+      debug('[%s] receiving HTTP request: %a', connection.id, payload);
+
       if (request.headers['content-length'] > this.maxRequestSize) {
         request.resume();
         return this._replyWithError(connection.id, payload, response, new SizeLimitError('Error: maximum HTTP request size exceeded'));
       }
 
-      const connection = new ClientConnection('HTTP/' + request.httpVersion, ips, request.headers);
-      debug('[%s] receiving HTTP request: %a', connection.id, payload);
-      this.entryPoint.newConnection(connection);
 
       if (!request.headers['content-type'] || request.headers['content-type'].startsWith('application/json')) {
         stream = this._createWriteStream(connection.id, payload);
@@ -184,7 +181,6 @@ class HttpProtocol extends Protocol {
       }
 
       debug('sending HTTP request response to client: %a', resp);
-      this.entryPoint.removeConnection(connectionId);
 
       if (resp.headers) {
         for (const header of Object.keys(resp.headers)) {
@@ -202,6 +198,7 @@ class HttpProtocol extends Protocol {
 
         response.writeHead(resp.status);
         response.end(buf);
+        this.entryPoint.removeConnection(connectionId);
       });
     });
   }
@@ -233,7 +230,7 @@ class HttpProtocol extends Protocol {
 
     response.end(result.content);
 
-    delete this.entryPoint.clients[connectionId];
+    this.entryPoint.removeConnection(connectionId);
   }
 
   /**
@@ -300,7 +297,7 @@ class HttpProtocol extends Protocol {
         .split(',')
         .map(e => e.trim().toLowerCase());
 
-      if (encodings.length > this.maxEncodingsCount) {
+      if (encodings.length > this.maxEncodingLayers) {
         throw new BadRequestError('Too many encodings');
       }
 
@@ -372,8 +369,8 @@ class HttpProtocol extends Protocol {
         throw new BadRequestError('Compression support is disabled');
       };
 
-    if (typeof this.allowCompression !== 'boolean') {
-      throw new Error('Invalid HTTP "allowCompression" parameter value: expected a boolean');
+    if (typeof allowCompression !== 'boolean') {
+      throw new Error('Invalid HTTP "allowCompression" parameter value: expected a boolean value');
     }
 
     // for now, we accept gzip, deflate and identity
@@ -393,7 +390,7 @@ class HttpProtocol extends Protocol {
    * @param  {Function} callback
    */
   _compress(data, response, headers, callback) {
-    if (headers['accept-encoding']) {
+    if (headers && headers['accept-encoding']) {
       const allowedEncodings = new Set(headers['accept-encoding']
         .split(',')
         .map(e => e.trim().toLowerCase()));

--- a/lib/api/core/entrypoints/embedded/protocols/http.js
+++ b/lib/api/core/entrypoints/embedded/protocols/http.js
@@ -292,10 +292,16 @@ class HttpProtocol extends Protocol {
    */
   _uncompress(request) {
     const pipes = [];
+
     if (request.headers['content-encoding']) {
       const encodings = request.headers['content-encoding']
         .split(',')
         .map(e => e.trim().toLowerCase());
+
+      // encodings are listed in the same order they have been applied
+      // this means that we need to invert the list to correctly
+      // decode the message
+      encodings.reverse();
 
       if (encodings.length > this.maxEncodingLayers) {
         throw new BadRequestError('Too many encodings');

--- a/lib/api/core/entrypoints/embedded/protocols/http.js
+++ b/lib/api/core/entrypoints/embedded/protocols/http.js
@@ -52,7 +52,7 @@ class HttpProtocol extends Protocol {
   }
 
   /**
-   * Initializes the HTTP server
+   * Initialize the HTTP server
    *
    * @param {EmbeddedEntryPoint} entryPoint
    */
@@ -152,7 +152,7 @@ class HttpProtocol extends Protocol {
   }
 
   /**
-   * Sends a request to Kuzzle and forwards the response back to the client
+   * Send a request to Kuzzle and forwards the response back to the client
    *
    * @param {string} connectionId - connection Id
    * @param {ServerResponse} response
@@ -234,7 +234,7 @@ class HttpProtocol extends Protocol {
   }
 
   /**
-   * Converts a Kuzzle query result into an appropriate payload format
+   * Convert a Kuzzle query result into an appropriate payload format
    * to send back to the client
    *
    * @param {Object} result
@@ -281,7 +281,7 @@ class HttpProtocol extends Protocol {
   }
 
   /**
-   * Returns a new Readable Stream configured with
+   * Return a new Readable Stream configured with
    * uncompression algorithms if needed
    *
    * @param  {http.IncomingMessage} request
@@ -390,7 +390,9 @@ class HttpProtocol extends Protocol {
   }
 
   /**
-   * [_compress description]
+   * Compress an outgoing message according to the
+   * specified accept-encoding HTTP header
+   *
    * @param  {Buffer} data     - data to compress
    * @param  {ServerResponse} response
    * @param  {Object} headers

--- a/lib/api/core/entrypoints/embedded/protocols/protocol.js
+++ b/lib/api/core/entrypoints/embedded/protocols/protocol.js
@@ -31,7 +31,7 @@ class Protocol {
     this.maxRequestSize = bytes.parse(entryPoint.config.maxRequestSize);
 
     if (this.maxRequestSize === null || isNaN(this.maxRequestSize)) {
-      throw new Error('Invalid "maxRequestSize" parameter');
+      throw new Error('Invalid "maxRequestSize" parameter value: expected a numeric value');
     }
   }
 

--- a/lib/api/core/entrypoints/embedded/protocols/protocol.js
+++ b/lib/api/core/entrypoints/embedded/protocols/protocol.js
@@ -23,9 +23,11 @@ const bytes = require('bytes');
 class Protocol {
   constructor() {
     this.maxRequestSize = null;
+    this.entryPoint = null;
   }
 
   init(entryPoint) {
+    this.entryPoint = entryPoint;
     this.maxRequestSize = bytes.parse(entryPoint.config.maxRequestSize);
 
     if (this.maxRequestSize === null || isNaN(this.maxRequestSize)) {

--- a/lib/api/core/entrypoints/embedded/protocols/socketio.js
+++ b/lib/api/core/entrypoints/embedded/protocols/socketio.js
@@ -41,8 +41,7 @@ class SocketIoProtocol extends Protocol {
 
     this.sockets = {};
     this.io = null;
-
-    this.entryPoint = null;
+    this.kuzzle = null;
   }
 
   init(entryPoint) {
@@ -53,7 +52,6 @@ class SocketIoProtocol extends Protocol {
       return;
     }
 
-    this.entryPoint = entryPoint;
     this.kuzzle = this.entryPoint.kuzzle;
 
     // SocketIo server listens by default to "/socket.io" path

--- a/lib/api/core/entrypoints/embedded/protocols/websocket.js
+++ b/lib/api/core/entrypoints/embedded/protocols/websocket.js
@@ -43,6 +43,7 @@ class WebsocketProtocol extends Protocol {
     this.connectionPool = {};
     this.server = null;
     this.protocol = 'websocket';
+    this.kuzzle = null;
   }
 
   /**
@@ -57,7 +58,6 @@ class WebsocketProtocol extends Protocol {
       return;
     }
 
-    this.entryPoint = entryPoint;
     this.kuzzle = this.entryPoint.kuzzle;
 
     this.server = new WebSocketServer({

--- a/lib/api/core/entrypoints/embedded/service/httpFormDataStream.js
+++ b/lib/api/core/entrypoints/embedded/service/httpFormDataStream.js
@@ -29,9 +29,10 @@ const
  * @class HttpFormDataStream
  * @param {Object} opts
  * @param {Object} payload
+ * @param {http.IncomingMessage} request
  */
 class HttpFormDataStream extends Busboy {
-  constructor(opts, payload) {
+  constructor(opts, payload, request) {
     super(opts);
     payload.json = {};
 
@@ -46,7 +47,15 @@ class HttpFormDataStream extends Busboy {
         file
           .removeAllListeners()
           .resume();
-        this.emit('error', new SizeLimitError('Error: maximum HTTP file size exceeded'));
+
+        /*
+         * Force Dicer parser to finish prematurely
+         * without throwing an 'Unexpected end of multipart data' error :
+         */
+        this._parser.parser._finished = true;
+
+        // Forward the error to the request stream
+        request.emit('error', new SizeLimitError('Error: maximum HTTP file size exceeded'));
       });
 
       file.on('end', () => {

--- a/lib/api/core/entrypoints/embedded/service/httpFormDataStream.js
+++ b/lib/api/core/entrypoints/embedded/service/httpFormDataStream.js
@@ -55,7 +55,7 @@ class HttpFormDataStream extends Busboy {
         this._parser.parser._finished = true;
 
         // Forward the error to the request stream
-        request.emit('error', new SizeLimitError('Error: maximum HTTP file size exceeded'));
+        request.emit('error', new SizeLimitError('Maximum HTTP file size exceeded'));
       });
 
       file.on('end', () => {

--- a/lib/api/core/httpRouter/index.js
+++ b/lib/api/core/httpRouter/index.js
@@ -55,7 +55,7 @@ class Router {
       'Accept-Encoding': 'identity',
       'Access-Control-Allow-Origin': kuzzle.config.http.accessControlAllowOrigin || '*',
       'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS,HEAD',
-      'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding'
+      'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding, Content-Length, X-Kuzzle-Volatile'
     };
 
     if (this.kuzzle.config.server.protocols.http.allowCompression === true) {

--- a/lib/api/core/httpRouter/index.js
+++ b/lib/api/core/httpRouter/index.js
@@ -58,7 +58,7 @@ class Router {
       'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding'
     };
 
-    if (this.kuzzle.config.protocols.http.allowCompression === true) {
+    if (this.kuzzle.config.server.protocols.http.allowCompression === true) {
       this.defaultHeaders['Accept-Encoding'] = 'gzip,deflate,identity';
     }
 

--- a/lib/api/core/httpRouter/index.js
+++ b/lib/api/core/httpRouter/index.js
@@ -52,11 +52,15 @@ class Router {
 
     this.defaultHeaders = {
       'content-type': 'application/json',
-      'Accept-Encoding': 'identity, gzip, deflate',
+      'Accept-Encoding': 'identity',
       'Access-Control-Allow-Origin': kuzzle.config.http.accessControlAllowOrigin || '*',
       'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS,HEAD',
       'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding'
     };
+
+    if (this.kuzzle.config.protocols.http.allowCompression === true) {
+      this.defaultHeaders['Accept-Encoding'] = 'gzip,deflate,identity';
+    }
 
     this.routes = {
       GET: new RoutePart(),

--- a/lib/api/core/httpRouter/index.js
+++ b/lib/api/core/httpRouter/index.js
@@ -52,9 +52,10 @@ class Router {
 
     this.defaultHeaders = {
       'content-type': 'application/json',
+      'Accept-Encoding': 'identity, gzip, deflate',
       'Access-Control-Allow-Origin': kuzzle.config.http.accessControlAllowOrigin || '*',
       'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS,HEAD',
-      'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
+      'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding'
     };
 
     this.routes = {

--- a/test/api/controllers/routerController/httpRequest.test.js
+++ b/test/api/controllers/routerController/httpRequest.test.js
@@ -18,6 +18,13 @@ describe('Test: routerController.httpRequest', () => {
         http: {
           routes: require('../../../../lib/config/httpRoutes'),
           accessControlAllowOrigin: 'foobar'
+        },
+        server: {
+          protocols: {
+            http: {
+
+            }
+          }
         }
       },
       pluginsManager: {

--- a/test/api/core/entrypoints/embedded/protocols/http.test.js
+++ b/test/api/core/entrypoints/embedded/protocols/http.test.js
@@ -668,7 +668,7 @@ describe('/lib/api/core/entrypoints/embedded/protocols/http', () => {
           'Content-Type': 'application/json',
           'Access-Control-Allow-Origin': '*',
           'Access-Control-Allow-Methods' : 'GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS',
-          'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
+          'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Length, Content-Encoding, X-Kuzzle-Volatile'
         });
     });
 

--- a/test/api/core/entrypoints/embedded/protocols/socketio.test.js
+++ b/test/api/core/entrypoints/embedded/protocols/socketio.test.js
@@ -35,9 +35,7 @@ describe('/lib/api/core/entrypoints/embedded/protocols/socketio', () => {
     it ('should do nothing if the protocol is disabled', () => {
       entrypoint.config.protocols.socketio.enabled = false;
       protocol.init(entrypoint);
-
-      should(protocol.entryPoint)
-        .be.null();
+      should(protocol.io).be.null();
     });
 
     it('should create the socket and attach events', () => {
@@ -46,11 +44,8 @@ describe('/lib/api/core/entrypoints/embedded/protocols/socketio', () => {
 
       protocol.init(entrypoint);
 
-      should(protocol.io.set)
-        .be.calledOnce();
-
-      should(protocol.io.on)
-        .be.calledTwice();
+      should(protocol.io.set).be.calledOnce();
+      should(protocol.io.on).be.calledTwice();
 
       {
         const onConnectionH = protocol.io.on.firstCall.args[1];

--- a/test/api/core/entrypoints/embedded/protocols/websocket.test.js
+++ b/test/api/core/entrypoints/embedded/protocols/websocket.test.js
@@ -32,10 +32,9 @@ describe('/lib/api/core/entrypoints/embedded/protocols/websocket', () => {
   describe('#init', () => {
     it('should do nothing if the protocol is not enabled', () => {
       entrypoint.config.protocols.websocket.enabled = false;
-      
+
       protocol.init(entrypoint);
-      should(protocol.entryPoint)
-        .be.undefined();
+      should(protocol.server).be.null();
     });
 
     it('should launch a websocket server and bind events to it', () => {

--- a/test/api/core/httpRouter/httpRouter.test.js
+++ b/test/api/core/httpRouter/httpRouter.test.js
@@ -70,6 +70,57 @@ describe('core/httpRouter', () => {
     });
   });
 
+  describe('#default headers', () => {
+    it('should define appropriate default HTTP headers', () => {
+      should(router.defaultHeaders).eql({
+        'content-type': 'application/json',
+        'Accept-Encoding': 'gzip,deflate,identity',
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS,HEAD',
+        'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding'
+      });
+    });
+
+    it('should update the list of accepted compression algorithms if compression is disabled', () => {
+      kuzzleMock.config.server.protocols.http.allowCompression = false;
+      router = new Router(kuzzleMock);
+
+      should(router.defaultHeaders).eql({
+        'content-type': 'application/json',
+        'Accept-Encoding': 'identity',
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS,HEAD',
+        'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding'
+      });
+    });
+
+    it('should set the default allow-origin header to "*" if undefined in the config', () => {
+      delete kuzzleMock.config.http.accessControlAllowOrigin;
+      router = new Router(kuzzleMock);
+
+      should(router.defaultHeaders).eql({
+        'content-type': 'application/json',
+        'Accept-Encoding': 'gzip,deflate,identity',
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS,HEAD',
+        'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding'
+      });
+    });
+
+    it('should take the value of the allow-origin header from the config file, if set', () => {
+      kuzzleMock.config.http.accessControlAllowOrigin = 'foobar';
+      router = new Router(kuzzleMock);
+
+      should(router.defaultHeaders).eql({
+        'content-type': 'application/json',
+        'Accept-Encoding': 'gzip,deflate,identity',
+        'Access-Control-Allow-Origin': 'foobar',
+        'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS,HEAD',
+        'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding'
+      });
+    });
+  });
+
   describe('#routing requests', () => {
     it('should invoke the registered handler on a known route', () => {
       router.post('/foo/bar', handler);

--- a/test/api/core/httpRouter/httpRouter.test.js
+++ b/test/api/core/httpRouter/httpRouter.test.js
@@ -77,7 +77,7 @@ describe('core/httpRouter', () => {
         'Accept-Encoding': 'gzip,deflate,identity',
         'Access-Control-Allow-Origin': '*',
         'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS,HEAD',
-        'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding'
+        'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding, Content-Length, X-Kuzzle-Volatile'
       });
     });
 
@@ -90,7 +90,7 @@ describe('core/httpRouter', () => {
         'Accept-Encoding': 'identity',
         'Access-Control-Allow-Origin': '*',
         'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS,HEAD',
-        'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding'
+        'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding, Content-Length, X-Kuzzle-Volatile'
       });
     });
 
@@ -103,7 +103,7 @@ describe('core/httpRouter', () => {
         'Accept-Encoding': 'gzip,deflate,identity',
         'Access-Control-Allow-Origin': '*',
         'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS,HEAD',
-        'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding'
+        'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding, Content-Length, X-Kuzzle-Volatile'
       });
     });
 
@@ -116,7 +116,7 @@ describe('core/httpRouter', () => {
         'Accept-Encoding': 'gzip,deflate,identity',
         'Access-Control-Allow-Origin': 'foobar',
         'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS,HEAD',
-        'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding'
+        'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding, Content-Length, X-Kuzzle-Volatile'
       });
     });
   });


### PR DESCRIPTION
:warning: HTTP Proxy functional tests will fail until https://github.com/kuzzleio/kuzzle-proxy/pull/100 is merged (and docker images are updated)

## What does this PR do?

* Add support for incoming compressed HTTP requests (accepted algorithms: gzip, deflate). As per the RFC, the `content-encoding` headers contains the *list* of compression algorithms used, in the order used to compress the data (a request may be compressed with multiple layers of gzip and/or deflate)
* Add support for outgoing compressed HTTP requests. This is controlled by the requesting client, using the `accept-encoding` header. Accepted algorithms: gzip, deflate. Because deflate is often badly implemented by clients, gzip is preferred when given a choice 
* The HTTP headers sent by default by Kuzzle now contain an `accept-encoding` headers
* Two new configuration parameters have been added allowing administrators to control this feature:
  * `server.protocols.http.allowCompression` (boolean, default: `true`): used to enable/disable the feature for *incoming* requests
  * `server.protocols.http.maxEncodingLayers` (integer, default: `3`): limits the number of compression layers, to prevent cpu/memory bombs

### How should this be manually tested?

New HTTP-only functional tests have been added, automatically testing the feature.
If you want to check manually, use your favorite HTTP client and play with the `content-encoding` and `accept-encoding` headers

### Other changes

* Reading HTTP incoming messages is now properly done, using stream pipes, instead of emulating that feature with events
* Promoted the `entryPoint` property in the protocol implementations in the abstract Protocol class, DRYifying it

### Boyscout

* Add more extensive HTTP options documentation in the `.kuzzlerc.sample` file
* Add missing headers in the `Access-Control-Allow-Headers` list (fix #1135)