### PR TITLE
fixes #1125 - aggs & sort on user search

### DIFF
--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -554,7 +554,7 @@ class SecurityController {
     checkSearchPageLimit(request, this.kuzzle.config.limits.documentsFetchCount);
 
     return this.kuzzle.repositories.user.search(
-      request.input.body && request.input.body.query ? request.input.body.query : {},
+      request.input.body ? request.input.body : {},
       request.input.args
     ).then(response => formatUserSearchResult(this.kuzzle, formatProcessing.formatUserForSerialization, response));
   }

--- a/lib/api/core/models/repositories/repository.js
+++ b/lib/api/core/models/repositories/repository.js
@@ -400,8 +400,10 @@ class Repository {
       hits: []
     };
 
-    if (raw.scrollId) {
-      result.scrollId = raw.scrollId;
+    for (const arg of ['aggregations', 'scrollId']) {
+      if (raw[arg]) {
+        result[arg] = raw[arg];
+      }
     }
 
     if (raw.hits && raw.hits.length > 0) {

--- a/lib/services/internalEngine/index.js
+++ b/lib/services/internalEngine/index.js
@@ -128,11 +128,11 @@ class InternalEngine {
   /**
    * Search documents from elasticsearch with a query
    * @param {string} type - data collection
-   * @param {object} [query] - optional query
+   * @param {object} [body] - optional query body
    * @param {object} [options] - optional search arguments (from, size, scroll)
    * @returns {Promise} resolve documents matching the query
    */
-  search (type, query, options = {}) {
+  search (type, body, options = {}) {
     const
       request = {
         type,
@@ -142,15 +142,38 @@ class InternalEngine {
         scroll: options.scroll
       };
 
-    if (query) {
-      request.body = query.query ? {query: query.query} : {query};
+    if (body) {
+      for (const arg of [
+        'aggs',
+        'highlight',
+        'query',
+        'sort'
+      ]) {
+        if (body[arg]) {
+          if (!request.body) {
+            request.body = {};
+          }
+          request.body[arg] = body[arg];
+        }
+      }
+
+      if (!request.body) {
+        request.body = {
+          query: body
+        };
+      }
     }
 
     debug('Searching: %a', request);
     return this.client.search(request)
       .then(raw => {
         debug('> %a results fetched', raw.hits.hits.length);
+
         const result = raw.hits || {hits: [], total: 0};
+
+        if (raw.aggregations) {
+          result.aggregations = raw.aggregations;
+        }
 
         // register the scroll id (if any)
         if (raw._scroll_id) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2805,7 +2805,7 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc="
     },
     "inquirer": {
       "version": "3.3.0",
@@ -6499,7 +6499,7 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk=",
       "dev": true
     },
     "regex-not": {
@@ -6927,7 +6927,7 @@
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
       "requires": {
         "base": "0.11.2",
         "debug": "2.6.9",
@@ -6942,7 +6942,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
           }
@@ -7748,7 +7748,7 @@
     "use": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
-      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+      "integrity": "sha1-FHFr8D/f79AwQK71jYtLhfOnxUQ=",
       "requires": {
         "kind-of": "6.0.2"
       }


### PR DESCRIPTION
## What does this PR do ?

This PR adds the ability to include some aggregations and sort options to a user search query.

In addition, the `highlight` argument is now allowed too.

Fixes: #1125 

### How should this be manually tested?

Send a user search query containing a `sort`, `aggs` and/or `highlight` to Kuzzle.

You should get the matching response from the given arguments.
