### PR TITLE
deprecate "constructor" auth option and replace it with "authenticator"

### DIFF
--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -23,6 +23,7 @@
 
 const
   Bluebird = require('bluebird'),
+  _ = require('lodash'),
   PluginImplementationError = require('kuzzle-common-objects').errors.PluginImplementationError,
   Request = require('kuzzle-common-objects').Request,
   PluginRepository = require('../models/repositories/pluginRepository'),
@@ -318,6 +319,15 @@ function instantiateRequest(request, data, options = {}) {
 function curryAddStrategy(kuzzle, pluginName) {
   return function addStrategy(name, strategy) {
     return new Bluebird((resolve, reject) => {
+      // strategy constructors cannot be used directly to dynamically
+      // add new strategies, because they cannot
+      // be serialized and propagated to other cluster nodes
+      // so if a strategy is not defined using an authenticator, we have
+      // to reject the call
+      if (!_.isPlainObject(strategy) || !_.isPlainObject(strategy.config) || !_.isString(strategy.config.authenticator)) {
+        return reject(new PluginImplementationError(`[${pluginName}] Strategy ${name}: dynamic strategy registration can only be done using an "authenticator" option (see https://tinyurl.com/y7boozbk).`));
+      }
+
       try {
         kuzzle.pluginsManager.registerStrategy(pluginName, name, strategy);
       }

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -2,7 +2,7 @@
  * Kuzzle, a backend software, self-hostable and ready to use
  * to power modern apps
  *
- * Copyright 2015-2017 Kuzzle
+ * Copyright 2015-2018 Kuzzle
  * mailto: support AT kuzzle.io
  * website: http://kuzzle.io
  *

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -61,6 +61,22 @@ class PluginsManager {
     this.strategies = {};
     this.routes = [];
 
+    // Structure:
+    // {
+    //   pluginName: {
+    //     authName: <constructor>,
+    //     authname2: <constructor>,
+    //     ...
+    //   },
+    //   pluginName2: {
+    //     ...
+    //   }
+    // }
+    //
+    // This structure prevents authenticator names collisions between
+    // multiple auth. plugins
+    this.authenticators = {};
+
     this.config = kuzzle.config.plugins;
   }
 
@@ -219,7 +235,7 @@ class PluginsManager {
    * @returns {string[]}
    */
   getStrategyFields (strategyName) {
-    return this.strategies[strategyName].strategy.config.fields;
+    return this.strategies[strategyName].strategy.config.fields || [];
   }
 
   /**
@@ -254,63 +270,83 @@ class PluginsManager {
    * @param {string} pluginName
    * @param {string} strategyName
    * @param {object} strategy
-   * @throws {PluginsImplementationError} If the strategy is invalid
+   * @throws {PluginImplementationError} If the strategy is invalid
    */
   validateStrategy (pluginName, strategyName, strategy) {
-    if (!isObject(strategy)) {
-      throw new PluginImplementationError(`Invalid properties for strategy "${strategyName}": must be an object.`);
+    const errorPrefix = `[${pluginName}] Strategy ${strategyName}:`;
+
+    if (!_.isPlainObject(strategy)) {
+      throw new PluginImplementationError(`${errorPrefix} expected the strategy description to be an object, got: ${strategy}`);
     }
 
-    if (this.strategies[strategyName]) {
-      throw new PluginImplementationError(`An authentication strategy "${strategyName}" has already been registered.`);
+    if (!_.isPlainObject(strategy.methods)) {
+      throw new PluginImplementationError(`${errorPrefix} expected a "methods" property of type "object", got: ${strategy.methods}`);
     }
 
-    if (!isObject(strategy.methods)) {
-      throw new PluginImplementationError(`"methods" object missing from the strategy '${strategyName}' properties.`);
-    }
-    else {
-      const pluginObject = this.plugins[pluginName].object;
+    const pluginObject = this.plugins[pluginName].object;
 
-      // required methods check
-      ['exists', 'create', 'update', 'delete', 'validate', 'verify'].forEach(methodName => {
-        if (!isString(strategy.methods[methodName])) {
-          throw new PluginImplementationError(`Missing method "${methodName}" in the strategy '${strategyName}' properties.`);
+    // required methods check
+    ['exists', 'create', 'update', 'delete', 'validate', 'verify'].forEach(methodName => {
+      if (!_.isString(strategy.methods[methodName])) {
+        throw new PluginImplementationError(`${errorPrefix} expected a "${methodName}" property of type "string", got: ${strategy.methods[methodName]}`);
+      }
+
+      if (!_.isFunction(pluginObject[strategy.methods[methodName]])) {
+        throw new PluginImplementationError(`${errorPrefix} the strategy method "${strategy.methods[methodName]}" must point to an exposed function`);
+      }
+    });
+
+    // optional methods check
+    ['getInfo', 'getById', 'afterRegister' ].forEach(name => {
+      const optionalMethodName = strategy.methods[name];
+
+      if (!_.isNil(optionalMethodName)) {
+        if (!_.isString(optionalMethodName)) {
+          throw new PluginImplementationError(`${errorPrefix} expected the "${name}" property to be of type "string", got: ${optionalMethodName}`);
         }
 
-        if (!isFunction(pluginObject[strategy.methods[methodName]])) {
-          throw new PluginImplementationError(`The strategy method "${strategy.methods[methodName]}" must point to a plugin function.`);
+        if (!_.isFunction(pluginObject[optionalMethodName])) {
+          throw new PluginImplementationError(`${errorPrefix} the strategy method "${optionalMethodName}" must point to an exposed function`);
         }
-      });
+      }
+    });
 
-      // optional methods check
-      ['getInfo', 'getById', 'afterRegister' ].forEach(name => {
-        const optionalMethodName = strategy.methods[name];
-
-        if (optionalMethodName && (!isString(optionalMethodName) || !isFunction(pluginObject[optionalMethodName]))) {
-          throw new PluginImplementationError(`The strategy method "${optionalMethodName}" must be a function.`);
-        }
-      });
+    if (!_.isPlainObject(strategy.config)) {
+      throw new PluginImplementationError(`${errorPrefix} expected a "config" property of type "object", got: ${strategy.config}`);
     }
 
-    if (!isObject(strategy.config)) {
-      throw new PluginImplementationError(`"config" object missing from the strategy '${strategyName}' properties.`);
+    // @deprecated since version 1.4.0
+    // Note: since "constructor" is a reserved keyword, and since
+    // any object, even POJOs, have a default constructor, we need
+    // to consider a native function to be an unspecified "constructor"
+    // property
+    if (!_.isNil(strategy.config.constructor) && !_.isNative(strategy.config.constructor)) {
+      if (!_.isNil(strategy.config.authenticator)) {
+        throw new PluginImplementationError(`${errorPrefix} the "authenticator" and "constructor" parameters cannot both be set`);
+      }
+
+      if (isConstructor(strategy.config.constructor)) {
+        // eslint-disable-next-line no-console
+        console.warn(`${errorPrefix} the strategy "constructor" property is deprecated, please use "authenticator" instead (see https://tinyurl.com/y7boozbk)`);
+      } else {
+        throw new PluginImplementationError(`${errorPrefix} invalid "constructor" property value: constructor expected`);
+      }
+    } else if (!_.isString(strategy.config.authenticator)) {
+      throw new PluginImplementationError(`${errorPrefix} expected an "authenticator" property of type "string", got: ${strategy.config.authenticator}`);
+    } else if (!this.authenticators[pluginName][strategy.config.authenticator]) {
+      throw new PluginImplementationError(`${errorPrefix} unknown authenticator value: ${strategy.config.authenticator}`);
     }
-    else {
-      if (!isFunction(strategy.config.constructor)) {
-        throw new PluginImplementationError(`The constructor of the strategy "${strategyName}" must be a function.`);
-      }
 
-      if (!isObject(strategy.config.strategyOptions)) {
-        throw new PluginImplementationError(`The "strategyOptions" object of the strategy "${strategyName}" must be an object.`);
-      }
+    for (const opt of ['strategyOptions', 'authenticateOptions']) {
+      const obj = strategy.config[opt];
 
-      if (!isObject(strategy.config.authenticateOptions)) {
-        throw new PluginImplementationError(`The "authenticateOptions" object of the strategy "${strategyName}" must be an object.`);
+      if (!_.isNil(obj) && !_.isPlainObject(obj)) {
+        throw new PluginImplementationError(`${errorPrefix} expected the "${opt}" property to be of type "object", got: ${obj}`);
       }
+    }
 
-      if (!strategy.config.fields || !Array.isArray(strategy.config.fields)) {
-        throw new PluginImplementationError(`The "fields" property of the strategy "${strategyName}" must be an array.`);
-      }
+    if (!_.isNil(strategy.config.fields) && !Array.isArray(strategy.config.fields)) {
+      throw new PluginImplementationError(`${errorPrefix} expected the "fields" property to be of type "array", got: ${strategy.config.fields}`);
     }
   }
 
@@ -393,7 +429,7 @@ class PluginsManager {
   }
 
   /**
-   * Registers an authentication strategy.
+   * Register an authentication strategy.
    *
    * @param {string} pluginName - plugin name
    * @param {string} strategyName - strategy name
@@ -401,15 +437,21 @@ class PluginsManager {
    * @throws {PluginImplementationError} If the strategy is invalid or if registration fails
    */
   registerStrategy(pluginName, strategyName, strategy) {
+    const errorPrefix = `[${pluginName}] Strategy ${strategyName}:`;
     this.validateStrategy(pluginName, strategyName, strategy);
+
+    if (this.strategies[strategyName]) {
+      this.unregisterStrategy(pluginName, strategyName);
+    }
 
     const
       plugin = this.plugins[pluginName],
       methods = {};
 
-    // wrapping plugin methods to force their context and to
-    // cast uncaught errors into PluginImplementationError errors
-    Object.keys(strategy.methods).filter(name => name !== 'verify').forEach(methodName => {
+    // wrap plugin methods to force their context and to
+    // convert uncaught exception into PluginImplementationError
+    // promise rejections
+    for (const methodName of Object.keys(strategy.methods).filter(name => name !== 'verify')) {
       methods[methodName] = (...args) => {
         return new Bluebird((resolve, reject) => {
           try {
@@ -420,68 +462,69 @@ class PluginsManager {
           }
         });
       };
-    });
+    }
 
     const
-      opts = Object.assign(strategy.config.strategyOptions || {}, {passReqToCallback: true}),
+      opts = Object.assign({}, strategy.config.strategyOptions, {passReqToCallback: true}),
       verifyAdapter = (...args) => {
-        const callback = args[args.length - 1];
-
-        const ret = plugin.object[strategy.methods.verify](...args.slice(0, -1));
+        const
+          callback = args[args.length - 1],
+          ret = plugin.object[strategy.methods.verify](...args.slice(0, -1));
 
         // catching plugins returning non-thenable content
-        if (!ret || typeof ret.then !== 'function') {
-          return callback(new PluginImplementationError(`Unexpected response from strategy "${strategyName}": expected a Promise`));
+        if (!ret || !_.isFunction(ret.then)) {
+          return callback(new PluginImplementationError(`${errorPrefix} expected the "verify" to return a Promise, got: `));
         }
 
-        return ret
+        let message = null;
+
+        ret
           .then(result => {
-            if (result && typeof result === 'object') {
-              if (result.kuid && typeof result.kuid === 'string') {
-                this.kuzzle.repositories.user.load(result.kuid)
-                  .then(user => {
-                    if (user === null) {
-                      callback(new PluginImplementationError(`The strategy "${strategyName}" returned an unknown Kuzzle user identifier.`));
-                    }
-                    else {
-                      callback(null, user);
-                    }
-
-                    return null;
-                  })
-                  .catch(error => callback(error));
-              }
-              else if (result.message && typeof result.message === 'string') {
-                callback(null, false, result);
-              }
-              else {
-                callback(null, false, `Was not able to log in using the strategy "${strategyName}"`);
-              }
-            }
-            else if (result === false) {
-              callback(null, false);
-            }
-            else {
-              callback(new PluginImplementationError('Unexpected authentification strategy result'));
+            if (result === false) {
+              return false;
             }
 
+            if (!_.isPlainObject(result)) {
+              throw new PluginImplementationError(`${errorPrefix} invalid authentication strategy result`);
+            }
+
+            if (result.kuid && typeof result.kuid === 'string') {
+              return this.kuzzle.repositories.user.load(result.kuid);
+            }
+
+            if (result.message && typeof result.message === 'string') {
+              message = result.message;
+            } else {
+              message = `Unable to log in using the strategy "${strategyName}"`;
+            }
+
+            return false;
+          })
+          .then(result => {
+            if (result === null) {
+              throw new PluginImplementationError(`${errorPrefix} returned an unknown Kuzzle user identifier`);
+            }
+
+            callback(null, result, message);
             return null;
           })
           .catch(error => callback(error));
       };
 
     try {
-      const constructedStrategy = new strategy.config.constructor(opts, verifyAdapter);
+      const
+        Ctor = _.get(this.authenticators, [pluginName, strategy.config.authenticator], strategy.config.constructor),
+        instance = new Ctor(opts, verifyAdapter);
 
       this.strategies[strategyName] = {strategy, methods, owner: pluginName};
-      this.kuzzle.passport.use(strategyName, constructedStrategy, strategy.config.authenticateOptions);
+      this.kuzzle.passport.use(strategyName, instance, strategy.config.authenticateOptions);
 
       if (methods.afterRegister) {
-        methods.afterRegister(constructedStrategy);
+        methods.afterRegister(instance);
       }
     }
     catch (e) {
-      throw new PluginImplementationError(`Unable to register "${strategyName}" authentication strategy: ${e.message}.`);
+      throw new PluginImplementationError(`${errorPrefix}: ${e.message}.`);
     }
   }
 
@@ -529,7 +572,7 @@ class PluginsManager {
       const list = Array.isArray(fn) ? fn : [fn];
 
       for (const target of list) {
-        if (!isFunction(plugin.object[target])) {
+        if (!_.isFunction(plugin.object[target])) {
           throw new PluginImplementationError(`Unable to configure pipe with method ${plugin.name}.${target}: function not found`);
         }
 
@@ -546,7 +589,7 @@ class PluginsManager {
       const list = Array.isArray(fn) ? fn : [fn];
 
       for (const target of list) {
-        if (!isFunction(plugin.object[target])) {
+        if (!_.isFunction(plugin.object[target])) {
           throw new PluginImplementationError(`Unable to configure hook with method ${plugin.name}.${target}: function not found`);
         }
 
@@ -569,7 +612,7 @@ class PluginsManager {
         description = plugin.object.controllers[controller],
         errorControllerPrefix = `Unable to inject controller "${controller}" from plugin "${plugin.name}":`;
 
-      if (!isObject(description)) {
+      if (!_.isPlainObject(description)) {
         throw new PluginImplementationError(`${errorControllerPrefix} Incorrect controller description type (expected object, got: "${typeof description}")`);
       }
 
@@ -580,7 +623,7 @@ class PluginsManager {
           throw new PluginImplementationError(`${errorControllerPrefix} Invalid action description (expected non-empty string, got: "${typeof action}")`);
         }
 
-        if (!isFunction(plugin.object[description[action]])) {
+        if (!_.isFunction(plugin.object[description[action]])) {
           throw new PluginImplementationError(`${errorControllerPrefix} Action "${plugin.name + '.' + description[action]}" is not a function`);
         }
 
@@ -634,24 +677,31 @@ class PluginsManager {
    * @throws {PluginImplementationError} If strategies registration fails
    */
   _initAuthentication (plugin) {
-    const errorPrefix = `Unable to inject authentication strategies from plugin "${plugin.name}": `;
+    const errorPrefix = `[${plugin.name}]:`;
 
-    if (!isObject(plugin.object.strategies) || Object.keys(plugin.object.strategies).length === 0) {
-      throw new PluginImplementationError(`${errorPrefix}The exposed "strategies" plugin property must be a non-empty object`);
+    if (!_.isPlainObject(plugin.object.strategies) || _.isEmpty(plugin.object.strategies)) {
+      throw new PluginImplementationError(`${errorPrefix} the exposed "strategies" plugin property must be a non-empty object`);
     }
 
-    Object.keys(plugin.object.strategies).forEach(strategyName => {
-      const strategy = plugin.object.strategies[strategyName];
+    // @todo the _.isNil test need to be removed as soon as the
+    // "strategy.config.constructor" property is no longer supported
+    if (!_.isNil(plugin.object.authenticators)) {
+      if (!_.isPlainObject(plugin.object.authenticators)) {
+        throw new PluginImplementationError(`${errorPrefix} the exposed "authenticators" plugin property must be of type "object"`);
+      }
 
-      try {
-        this.registerStrategy(plugin.name, strategyName, strategy);
+      for (const authenticator of Object.keys(plugin.object.authenticators)) {
+        if (!isConstructor(plugin.object.authenticators[authenticator])) {
+          throw new PluginImplementationError(`${errorPrefix} invalid authenticator ${authenticator}: expected a constructor`);
+        }
       }
-      catch (err) {
-        // registerStrategy can only throw PluginImplementationError exceptions
-        err.message = errorPrefix + err.message;
-        throw err;
-      }
-    });
+
+      this.authenticators[plugin.name] = Object.assign({}, plugin.object.authenticators);
+    }
+
+    for (const name of Object.keys(plugin.object.strategies)) {
+      this.registerStrategy(plugin.name, name, plugin.object.strategies[name]);
+    }
   }
 }
 
@@ -842,28 +892,19 @@ function getWildcardEvent (event) {
 }
 
 /**
- * @param {object|*} object
- * @returns {boolean}
- */
-function isObject(object) {
-  return object && typeof object === 'object' && !Array.isArray(object);
-}
-
-/**
+ * Test if the provided argument is a constructor or not
  *
- * @param {function|*} func
- * @returns {boolean}
+ * @param  {*} arg
+ * @return {Boolean}
  */
-function isFunction(func) {
-  return func && typeof func === 'function';
-}
+function isConstructor (arg) {
+  try {
+    Reflect.construct(Object, [], arg);
+  } catch (e) {
+    return false;
+  }
 
-/**
- * @param {string|*} string
- * @returns {boolean}
- */
-function isString(string) {
-  return string && typeof string === 'string';
+  return true;
 }
 
 module.exports = PluginsManager;

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -2,7 +2,7 @@
  * Kuzzle, a backend software, self-hostable and ready to use
  * to power modern apps
  *
- * Copyright 2015-2017 Kuzzle
+ * Copyright 2015-2018 Kuzzle
  * mailto: support AT kuzzle.io
  * website: http://kuzzle.io
  *
@@ -61,20 +61,22 @@ class PluginsManager {
     this.strategies = {};
     this.routes = [];
 
-    // Structure:
-    // {
-    //   pluginName: {
-    //     authName: <constructor>,
-    //     authname2: <constructor>,
-    //     ...
-    //   },
-    //   pluginName2: {
-    //     ...
-    //   }
-    // }
-    //
-    // This structure prevents authenticator names collisions between
-    // multiple auth. plugins
+    /**
+     * @example
+     * {
+     *   pluginName: {
+     *     authName: <constructor>,
+     *     authname2: <constructor>,
+     *     ...
+     *   },
+     *   pluginName2: {
+     *     ...
+     *   }
+     * }
+     *
+     * This structure prevents authenticator names collisions between
+     * multiple auth. plugins
+     */
     this.authenticators = {};
 
     this.config = kuzzle.config.plugins;

--- a/test/api/core/pluginContext/pluginContext.test.js
+++ b/test/api/core/pluginContext/pluginContext.test.js
@@ -369,7 +369,11 @@ describe('Plugin Context', () => {
   describe('#strategies', () => {
     it('should allow to add a strategy and link it to its owner plugin', () => {
       const
-        mockedStrategy = {},
+        mockedStrategy = {
+          config: {
+            authenticator: 'foo'
+          }
+        },
         result = context.accessors.strategies.add('foo', mockedStrategy);
 
       should(result).be.a.Promise();
@@ -389,11 +393,21 @@ describe('Plugin Context', () => {
       const error = new Error('foobar');
       kuzzle.pluginsManager.registerStrategy.throws(error);
 
-      const result = context.accessors.strategies.add('foo', {});
+      const result = context.accessors.strategies.add('foo', {
+        config: {
+          authenticator: 'foobar'
+        }
+      });
 
       should(result).be.a.Promise();
 
       return should(result).be.rejectedWith(error);
+    });
+
+    it('should throw if no authenticator is provided', () => {
+
+      return should(context.accessors.strategies.add('foo', null))
+        .rejectedWith(PluginImplementationError, {message: '[pluginName] Strategy foo: dynamic strategy registration can only be done using an "authenticator" option (see https://tinyurl.com/y7boozbk).\nThis is probably not a Kuzzle error, but a problem with a plugin implementation.'});
     });
 
     it('should allow to remove a strategy', () => {


### PR DESCRIPTION
# Description

* The `strategy.config.constructor` property, taking an object constructor is now deprecated, in favor of `strategy.config.authenticator`. That new property only accepts a string value
* Authentication plugins using the new `strategy.config.authenticator` property (and they must if they need to run on a cluster env.) now need to expose a new `authenticators` object, containing the list of available Passport constructors
* Registering an already existing strategy will no longer throw an error. Instead, the old strategy is properly removed before the new one is added. This change was made to make plugin development experience smoothier on a cluster environment
* The `fields`, `strategyOptions` and `authenticateOptions` parameters for the `strategy.config` object are now optional
* The function `pluginContext.strategies.add` now throws a `PluginImplementationError` error if the provided strategy contains a `constructor` property instead of an `authenticator` one

Fix https://github.com/kuzzleio/kuzzle/pull/1145

# Boyscout

* Simplify the pluginsManager.registerStrategy method by lowering the overall complexity and flattening the promise chain
* Replace type detection functions with Lodash ones: there was no added value to have our own functions
* Fix typos in error messages
* Add missing unit tests on the plugins "verify" method wrapper
