### PR TITLE
Test Kuzzle against different node LTS versions

### DIFF
--- a/docker-compose/dev.yml
+++ b/docker-compose/dev.yml
@@ -7,7 +7,7 @@ services:
       - "7513:7512"
 
   kuzzle:
-    image: kuzzleio/dev
+    image: kuzzleio/core-dev
     command: sh -c 'chmod 755 /run.sh && /run.sh'
     volumes:
       - "..:/var/app"

--- a/docker-compose/scripts/run-test.sh
+++ b/docker-compose/scripts/run-test.sh
@@ -4,6 +4,19 @@ set -e
 
 elastic_host=${kuzzle_services__db__client__host:-http://elasticsearch:9200}
 
+if [ "$NODE_LTS" = "6" ]; then
+  NODE_VERSION=$NODE_6_VERSION
+elif [ "$NODE_LTS" = "8" ]; then
+  NODE_VERSION=$NODE_8_VERSION
+else
+  echo "Unsupported Node LTS: $NODE_LTS"
+  exit 1
+fi
+
+echo "Testing Kuzzle against node v$NODE_VERSION"
+n $NODE_VERSION
+
+rm -rf node_modules
 npm install --unsafe-perm
 npm install --unsafe-perm --only=dev
 find -L node_modules/.bin -type f -exec chmod 776 {} \;

--- a/docker-compose/test.yml
+++ b/docker-compose/test.yml
@@ -7,7 +7,7 @@ services:
       - proxy_port=7513
 
   kuzzle:
-    image: kuzzleio/dev
+    image: kuzzleio/core-dev
     command: sh -c 'chmod 755 /run.sh && /run.sh'
     volumes:
       - "..:/var/app"
@@ -29,6 +29,7 @@ services:
       - DEBUG=
       - CUCUMBER_EMBEDDED_HOST=localhost
       - CUCUMBER_PROXY_HOST=proxy
+      - NODE_LTS
       # Travis env var must be propagated into the container
       - TRAVIS
       - TRAVIS_COMMIT

--- a/test/travis-bin/run-tests.sh
+++ b/test/travis-bin/run-tests.sh
@@ -8,5 +8,6 @@ if [ "${TRAVIS_BRANCH}" != "master" ]; then
   export DOCKER_PROXY_TAG=":develop"
 fi
 
-docker-compose -f docker-compose/test.yml run kuzzle
+NODE_LTS=6 docker-compose -f docker-compose/test.yml run kuzzle
 
+NODE_LTS=8 docker-compose -f docker-compose/test.yml run kuzzle


### PR DESCRIPTION
## What does this PR do ?

This PR use the `kuzzleio/core-dev` image to run Kuzzle tests against different node versions (6 and 8 LTS for now)

### How should this be manually tested?

  - Step 1 : Run the tests : `sh test/travis-bin/run-tests.sh`

### Other changes

 - Use `kuzzleio/core-dev` image for development in `docker-compose/dev.yml`
