### PR TITLE
set ulimits for elasticsearch

### DIFF
--- a/docker-compose/dev.yml
+++ b/docker-compose/dev.yml
@@ -43,6 +43,8 @@ services:
 
   elasticsearch:
     image: kuzzleio/elasticsearch:5.4.1
+    ulimits:
+      nofile: 65536
     environment:
       - cluster.name=kuzzle
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"

--- a/docker-compose/test.yml
+++ b/docker-compose/test.yml
@@ -43,6 +43,8 @@ services:
 
   elasticsearch:
     image: kuzzleio/elasticsearch:5.4.1
+    ulimits:
+      nofile: 65536
     environment:
       - cluster.name=kuzzle
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"


### PR DESCRIPTION
## What does this PR do ?

Sets the maximum number of open files to 65k+ as required by ES (see https://www.elastic.co/guide/en/elasticsearch/reference/current/setting-system-settings.html#limits.conf)

