### PR TITLE
Add script to build and push docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,16 @@ group: edge
 
 jdk: oraclejdk8
 
+env:
+  global:
+    - secure: U0+F9Dk03aCycppFX83SZnSvo7syf9NJ2Hns/87wpafjKRXlyUKt3XEsqVUKW+hpI3Me0Av8bjJEBGxchv9xEk+8HcNfzIV8qdfOClym2GF/fY2M2Jjdy4XW7eNsZIYXKo4GHw/+flVRSVR+IG0XP74CuVcAUR/bjMiZomRPJJmfeZ8vaUXbM5P2rTKj4pvtxhR9dFDIzz4XgMBaGvuOVQmmYcms6zlanYkuk2ZDRgZRrnL7BGPkxYjhYvcNLjG4EA9VLqMs/CSdUQMI4BcW3+mI0bGmB25FhjUnMFHLuZctyw4zc42Lzi+Mjept9ynUnKZeTa2W3p5qEYsCr1grT2kScr3NpzacRkRtwEa943zrLFThMkXITVIFACAfelDcDxzAO16Gmqr1Khai6pSAyiQFDJsap/WlZ9JK+mFjsW1hI+jO3HZ30F+TVeaiLp9UFZEg8+DpHueHlwEz3NhPzdg1tWdH8e+itX33Ro0LBjEtX/9MH/ztDycVIs4R+ouSRvrSWH3/vj/653b3xHpJ7/n9OtM8OIpq1xDMpZxBLBtleCD3dUkbDxy8G5qSxPAOk7GZ1GDmiufCYTQXu1rgY7dXj+vCaXyH9f7zwu8WielEoU/0GPUb36usnUGyJkXXgdgGpVdSe73NmGyZgUwp7IQEkOb5507KVy6nEPpIWLI=
+
 services:
-- docker
+ - docker
 
 script:
-- bash test/travis-bin/run-tests.sh
-- bash test/travis-bin/sonar.sh
+ - bash test/travis-bin/run-tests.sh
+ - bash test/travis-bin/sonar.sh
 
 cache:
   directories:
@@ -19,7 +23,7 @@ cache:
 notifications:
   webhooks:
     urls:
-    - https://webhooks.gitter.im/e/8e145155fbaaf37cffea
+     - https://webhooks.gitter.im/e/8e145155fbaaf37cffea
     on_success: change
     on_failure: always
     on_start: never
@@ -41,3 +45,7 @@ deploy:
 
 addons:
   sonarqube: true
+
+after_success:
+  - docker login -u aschen -p $DOCKER_PASSWORD
+  - bash build-docker-images.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ jdk: oraclejdk8
 
 env:
   global:
+    # DockerHub password for aschen (amaret@kuzzle.io) account
     - secure: U0+F9Dk03aCycppFX83SZnSvo7syf9NJ2Hns/87wpafjKRXlyUKt3XEsqVUKW+hpI3Me0Av8bjJEBGxchv9xEk+8HcNfzIV8qdfOClym2GF/fY2M2Jjdy4XW7eNsZIYXKo4GHw/+flVRSVR+IG0XP74CuVcAUR/bjMiZomRPJJmfeZ8vaUXbM5P2rTKj4pvtxhR9dFDIzz4XgMBaGvuOVQmmYcms6zlanYkuk2ZDRgZRrnL7BGPkxYjhYvcNLjG4EA9VLqMs/CSdUQMI4BcW3+mI0bGmB25FhjUnMFHLuZctyw4zc42Lzi+Mjept9ynUnKZeTa2W3p5qEYsCr1grT2kScr3NpzacRkRtwEa943zrLFThMkXITVIFACAfelDcDxzAO16Gmqr1Khai6pSAyiQFDJsap/WlZ9JK+mFjsW1hI+jO3HZ30F+TVeaiLp9UFZEg8+DpHueHlwEz3NhPzdg1tWdH8e+itX33Ro0LBjEtX/9MH/ztDycVIs4R+ouSRvrSWH3/vj/653b3xHpJ7/n9OtM8OIpq1xDMpZxBLBtleCD3dUkbDxy8G5qSxPAOk7GZ1GDmiufCYTQXu1rgY7dXj+vCaXyH9f7zwu8WielEoU/0GPUb36usnUGyJkXXgdgGpVdSe73NmGyZgUwp7IQEkOb5507KVy6nEPpIWLI=
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ jdk: oraclejdk8
 
 env:
   global:
-    # DockerHub password for aschen (amaret@kuzzle.io) account
-    - secure: U0+F9Dk03aCycppFX83SZnSvo7syf9NJ2Hns/87wpafjKRXlyUKt3XEsqVUKW+hpI3Me0Av8bjJEBGxchv9xEk+8HcNfzIV8qdfOClym2GF/fY2M2Jjdy4XW7eNsZIYXKo4GHw/+flVRSVR+IG0XP74CuVcAUR/bjMiZomRPJJmfeZ8vaUXbM5P2rTKj4pvtxhR9dFDIzz4XgMBaGvuOVQmmYcms6zlanYkuk2ZDRgZRrnL7BGPkxYjhYvcNLjG4EA9VLqMs/CSdUQMI4BcW3+mI0bGmB25FhjUnMFHLuZctyw4zc42Lzi+Mjept9ynUnKZeTa2W3p5qEYsCr1grT2kScr3NpzacRkRtwEa943zrLFThMkXITVIFACAfelDcDxzAO16Gmqr1Khai6pSAyiQFDJsap/WlZ9JK+mFjsW1hI+jO3HZ30F+TVeaiLp9UFZEg8+DpHueHlwEz3NhPzdg1tWdH8e+itX33Ro0LBjEtX/9MH/ztDycVIs4R+ouSRvrSWH3/vj/653b3xHpJ7/n9OtM8OIpq1xDMpZxBLBtleCD3dUkbDxy8G5qSxPAOk7GZ1GDmiufCYTQXu1rgY7dXj+vCaXyH9f7zwu8WielEoU/0GPUb36usnUGyJkXXgdgGpVdSe73NmGyZgUwp7IQEkOb5507KVy6nEPpIWLI=
+    # DockerHub password for kuzzleteam account
+    secure: "VlK2mDM3pIR1XPK+PVTfaGZzyp2auK4HFvwl4k9Jz9AohVCxzIcvFpq7lFMiwy/Mk/2pk/QaK3d3ZbEW7LxDwDt2lhKUWIX7w4p0pfRx7SbSdOpN1ZpZ2v3tNbbgmpyLfxIwu9FW9/9klmnpaC/ai5vllJ1tJesYMBxJZ20Qx36qv9A42Ia35z/kJwqBJNkl2H7KCcpjc+ORGEySN0tHqmrlR3qMH/XGjYBR5KrrF617R+Ja1I2f6PXu/dWfUlWi7BogB9qSNmVq2Xq2ZN2x8DBQWrLav9xeONHNJW48SfCYvOnsi/vpmQr/61zvCtkMNLN7FOg7SHdkpFwvlHN4Fe1aR0keDqb86kr5xCAkciXsT8cWau1YIoz7XqesmGfSQVeC9PTsO7ku/sYao/2gB4eOw7Eq5imrHVHFbVEj78SEA8u5OLT96jzflLeBqb4U3M3sEQXwUPkQDjdkD0WnTHzhHY2J/1tRBsKKhiyIdFryIqzmJPB6z8THVQp7F+RHXCWn7iVobmh8BjuONiK4XOfj4tAzJHmNdIi53wvHmcKgjHUl8oq705BESmmpYUlT6fTIBeBsLRpy9qjZweMzgU/dOlZXrDZcPgRJKrYrJiNmmTo96mbWOV8jBmTv/Pp/Noi4OOGpAC6KMKp67uox9hcjvemX0HP4hsCsbc3CBss="
 
 services:
  - docker
@@ -48,5 +48,5 @@ addons:
   sonarqube: true
 
 after_success:
-  - docker login -u aschen -p $DOCKER_PASSWORD
+  - docker login -u kuzzleteam -p $DOCKER_PASSWORD
   - bash build-docker-images.sh

--- a/build-docker-images.sh
+++ b/build-docker-images.sh
@@ -50,9 +50,6 @@ if [ -z "$TRAVIS_BRANCH" ]; then
   exit 1
 fi
 
-if [ ! "$TRAVIS_BRANCH" == "1.x" ]
-
-
 if [ "$TRAVIS_BRANCH" == "1.x" ]; then
   git_clone
 

--- a/build-docker-images.sh
+++ b/build-docker-images.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+print_something() {
+  something=$1
+
+  echo "##############################################################"
+  echo ""
+  echo $something
+  echo ""
+  echo "##############################################################"
+}
+
+docker_build() {
+  image=$1
+  tag=$2
+  build_arg=$3
+
+  print_something "Build image kuzzleio/$image:$tag from kuzzle-containers/$image/Dockerfile"
+
+  docker build -t kuzzleio/$image:$tag -f kuzzle-containers/$image/Dockerfile --build-arg $build_arg kuzzle-containers/$image
+}
+
+docker_tag() {
+  image=$1
+  tag=$2
+
+  print_something "Tag image kuzzleio/$image with $tag"
+
+  docker tag kuzzleio/$image kuzzleio/$image:$tag
+}
+
+docker_push() {
+  image=$1
+  tag=$2
+
+  print_something "Push image kuzzleio/$image:$tag to Dockerhub"
+
+  docker push kuzzleio/$image:$tag
+}
+
+git_clone() {
+  git clone --depth 1 https://github.com/kuzzleio/kuzzle-containers
+  # cp ../kuzzle-containers .
+  # use a test docker repository for now
+  mv kuzzle-containers/kuzzle kuzzle-containers/kuzzle-test
+}
+
+if [ -z "$TRAVIS_BRANCH" ]; then
+  echo "TRAVIS_BRANCH not found"
+  exit 1
+fi
+
+if [ ! "$TRAVIS_BRANCH" == "1.x" ]
+
+
+if [ "$TRAVIS_BRANCH" == "1.x" ]; then
+  git_clone
+
+  tag="develop"
+
+  docker_build 'plugin-dev' $tag kuzzle_branch=$TRAVIS_BRANCH
+  docker_build 'kuzzle-test' $tag current_tag=$tag
+
+  docker_push 'plugin-dev' $tag
+  docker_push 'kuzzle-test' $tag
+
+  rm -rf kuzzle-containers
+elif [ "$TRAVIS_BRANCH" == "master" ]; then
+  git_clone
+
+  tag=$TRAVIS_TAG
+
+  docker_build 'plugin-dev' $tag kuzzle_branch=$TRAVIS_BRANCH
+  docker_build 'kuzzle-test' $tag current_tag=$tag
+
+  docker_tag "plugin-dev:$tag" latest
+  docker_tag "kuzzle-test:$tag" latest
+
+  docker_push 'plugin-dev' $tag
+  docker_push 'kuzzle-test' $tag
+
+  docker_push 'plugin-dev' 'latest'
+  docker_push 'kuzzle-test' 'latest'
+
+  rm -rf kuzzle-containers
+fi

--- a/build-docker-images.sh
+++ b/build-docker-images.sh
@@ -53,6 +53,7 @@ fi
 
 if [ "$TRAVIS_BRANCH" == "1.x" ]; then
   git_clone
+
   tag="develop"
 
   docker_build 'plugin-dev' $tag kuzzle_branch=$TRAVIS_BRANCH
@@ -67,17 +68,20 @@ elif [ "$TRAVIS_BRANCH" == "master" ]; then
 
   tag=$TRAVIS_TAG
 
-  docker_build 'plugin-dev' $tag kuzzle_branch=$TRAVIS_BRANCH
-  docker_build 'kuzzle-test' $tag current_tag=$tag
+  # Build and push only if we had a tag (it may be a hotfix merge).
+  if [ ! -z "$tag" ]; then
+    docker_build 'plugin-dev' $tag kuzzle_branch=$TRAVIS_BRANCH
+    docker_build 'kuzzle-test' $tag current_tag=$tag
 
-  docker_tag "plugin-dev:$tag" latest
-  docker_tag "kuzzle-test:$tag" latest
+    docker_tag "plugin-dev:$tag" latest
+    docker_tag "kuzzle-test:$tag" latest
 
-  docker_push 'plugin-dev' $tag
-  docker_push 'kuzzle-test' $tag
+    docker_push 'plugin-dev' $tag
+    docker_push 'kuzzle-test' $tag
 
-  docker_push 'plugin-dev' 'latest'
-  docker_push 'kuzzle-test' 'latest'
+    docker_push 'plugin-dev' 'latest'
+    docker_push 'kuzzle-test' 'latest'
+  fi
 
   rm -rf kuzzle-containers
 fi


### PR DESCRIPTION
## What does this PR do ?

:warning: This won't work until https://github.com/kuzzleio/kuzzle-containers/pull/39 is merged :warning: 

This PR add a script to build the docker images `plugin-dev` and `kuzzle`.  
Actually `kuzzle` is named `kuzzle-test` to ensure everything is ok before replacing the old `kuzzle` image hosted on Dockerhub by the new one.

The script will be triggered in 2 cases:
 - When a PR is merged on `1.x` : the script will build the images using the `1.x` branch of Kuzzle, then tag them with `develop` and push them to Dockerhub
 - When a release is merged on `master` : the script will build the images using the `master` branch, then tag them with the release tag (inside `TRAVIS_TAG` env variable) and the `latest` tag and push everything to Dockerhub

### How should this be manually tested?

  - Step 1 : Merge of release on `master` simulation: `TRAVIS_BRANCH=master TRAVIS_TAG=1.4.0 bash deploy.sh`
  - Step 2 : Merge of development branch on `1.x`: `TRAVIS_BRANCH=1.x bash deploy.sh`