### PR TITLE
Prevent a crash when using pre-1.4.0 configuration files

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -103,11 +103,6 @@
     // }
   },
 
-  // Queue names used by Kuzzle internal communications
-  "queues": {
-    "remoteActionQueue": "remote-action-queue"
-  },
-
   // The repositories are used internally by Kuzzle to store its data (users,
   // permissions, configuration etc.)
   "repositories": {

--- a/default.config.js
+++ b/default.config.js
@@ -199,7 +199,6 @@ module.exports = {
       defaultInitTimeout: 10000,
       retryInterval: 1000
     },
-
     internalCache: {
       backend: 'redis',
       node: {

--- a/lib/services/index.js
+++ b/lib/services/index.js
@@ -70,7 +70,19 @@ class Services {
     debug('initializing internal services:\nwhitelist: %O\nblacklist: %O', whitelist, blacklist);
 
     const promises = Object.keys(this.kuzzle.config.services)
-      .filter(key => key !== 'common')
+      .filter(key => {
+        // @deprecated - "internalBroker" was an internal service until Kuzzle 1.4.0
+        // Filtering this configuration allows users to upgrade their Kuzzle from pre-1.4.0
+        // without generating a breaking change because of an old configuration file
+        // This filter can be removed as soon as Kuzzle v1.x support ends
+        if (key === 'internalBroker') {
+          // eslint-disable-next-line no-console
+          console.warn('[WARN] Ignoring the "internalBroker" service entry found in the kuzzlerc file. This service is deprecated and its corresponding entry in custom configuration files should be removed.');
+          return false;
+        }
+
+        return key !== 'common';
+      })
       .map(service => {
         // We need to use a deferred promise here as the internalEngine (es) promises do not implement `finally`.
         let opt = {service};


### PR DESCRIPTION
## What does this PR do ?

Prevent a crash occuring at startup after having upgraded Kuzzle while keeping old config files, making the dynamic service loader trying to require the now absent `internalBroker` service.
The crash has been replaced with a lengthy warning message explaining to Kuzzle users that `internalBroker` entries should now be removed from their configuration files.

Note: the warning only occurs if an `internalBroker` entry is found in the configuration files. Kuzzle still crashes if a non-existent service is configured, as intended.

### How should this be manually tested?

Add a `internalBroker` entry in the services configuration (as it was defined in pre-1.4.0 for instance): Kuzzle crashes in 1.4.0, and prints a simple warning with this PR.
