### PR TITLE
Rename Kuzzle server to Kuzzle Backend

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -14,15 +14,15 @@ Starts a Kuzzle instance in the foreground.
 
 # Create the first administrative user account
 
-You will need it to connect to the admin console
+This is a recommended first step to secure your Kuzzle Backend
 
 ```
 $ kuzzle createFirstAdmin
 ```
 
-will guide you through the creation process of the first admin user and fix the rights to other user types if needed.
+This command will guide you through the creation process of the first admin user and fix the rights to other user types if needed.
 
-**Note:** This command is interactive and let you choose to reset the roles rights or not.
+**Note:** This command is interactive and let you choose whether you want to apply the default secured roles and profiles or not
 
 # Reset Kuzzle
 

--- a/bin/README.md
+++ b/bin/README.md
@@ -41,7 +41,7 @@ You can perform a reset followed by a fixtures and/or mappings import by doing:
 $ kuzzle reset --fixtures /path/to/the/fixtures/file.json --mappings /path/to/the/mappings/file.json
 ```
 
-## Reset the Kuzzle server from a script or cron
+## Reset the Kuzzle Backend from a script or cron
 
 ```
 $ kuzzle reset --noint

--- a/bin/commands/start.js
+++ b/bin/commands/start.js
@@ -145,7 +145,7 @@ function commandStart (options) {
           if (!res) {
             console.log(cout.warn('[!] [WARNING] There is no administrator user yet: everyone has administrator rights.'));
             console.log(cout.notice('[ℹ] You can use the CLI or the admin console to create the first administrator user.'));
-            console.log(cout.notice('    For more information: http://docs.kuzzle.io/guide/essentials/security'));
+            console.log(cout.notice('    For more information: https://docs.kuzzle.io/guide/essentials/security'));
           }
         });
     })

--- a/bin/commands/start.js
+++ b/bin/commands/start.js
@@ -36,7 +36,7 @@ function commandStart (options) {
     kuzzle = new (require('../../lib/api/kuzzle'))(),
     cout = new ColorOutput(options);
 
-  console.log(cout.kuz('[ℹ] Starting Kuzzle server'));
+  console.log(cout.kuz('[ℹ] Starting Kuzzle Backend'));
 
   kuzzle.start(params)
     // fixtures && mapping
@@ -139,7 +139,7 @@ function commandStart (options) {
         });
     })
     .then(() => {
-      console.log(cout.kuz('[✔] Kuzzle server ready'));
+      console.log(cout.kuz('[✔] Kuzzle Backend ready'));
       return kuzzle.internalEngine.bootstrap.adminExists()
         .then(res => {
           if (!res) {

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -154,7 +154,7 @@ class FunnelController {
      The request is then discarded and an error is returned to the sender
      */
     if (this.requestsCacheQueue.length >= this.kuzzle.config.limits.requestsBufferSize) {
-      const error = new ServiceUnavailableError('Request discarded: Kuzzle Server is temporarily overloaded');
+      const error = new ServiceUnavailableError('Request discarded: Kuzzle Backend is temporarily overloaded');
 
       this.kuzzle.pluginsManager.trigger('log:error', error);
       request.setError(error);

--- a/lib/api/core/entrypoints/embedded/protocols/http.js
+++ b/lib/api/core/entrypoints/embedded/protocols/http.js
@@ -286,7 +286,7 @@ class HttpProtocol extends Protocol {
    * @return {Array.<stream.Readable>}
    * @throws {BadRequestError} If invalid compression algorithm is set
    *                           or if the value does not comply to the
-   *                           way the Kuzzle server is configured
+   *                           way the Kuzzle Backend is configured
    */
   _uncompress(request) {
     const pipes = [];

--- a/lib/api/kuzzle.js
+++ b/lib/api/kuzzle.js
@@ -108,9 +108,9 @@ class Kuzzle extends EventEmitter {
   }
 
   /**
-   * Initializes all the needed components of a Kuzzle Server instance.
+   * Initializes all the needed components of a Kuzzle Backend instance.
    *
-   * By default, this script runs a standalone Kuzzle Server instance:
+   * By default, this script runs a standalone Kuzzle Backend instance:
    *   - Internal services
    *   - Controllers
    *

--- a/test/api/kuzzle.test.js
+++ b/test/api/kuzzle.test.js
@@ -31,7 +31,7 @@ describe('/lib/api/kuzzle.js', () => {
     });
   });
 
-  it('should construct a kuzzle server object with emit and listen event', (done) => {
+  it('should build a kuzzle backend object with emit and listen event', (done) => {
     kuzzle.on('event', () => {
       done();
     });


### PR DESCRIPTION
## What does this PR do ?

Fix https://github.com/kuzzleio/documentation/issues/428: rename "Kuzzle server" to "Kuzzle Backend"


### Boyscout

* the link to our documentation website in the console message was using HTTP instead of HTTPS
* update the `createFirstAdmin` CLI documentation
