### PR TITLE
Fix documentation URL in the startup message

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -14,15 +14,15 @@ Starts a Kuzzle instance in the foreground.
 
 # Create the first administrative user account
 
-You will need it to connect to the admin console
+This is a recommended first step to secure your Kuzzle Backend
 
 ```
 $ kuzzle createFirstAdmin
 ```
 
-will guide you through the creation process of the first admin user and fix the rights to other user types if needed.
+This command will guide you through the creation process of the first admin user and fix the rights to other user types if needed.
 
-**Note:** This command is interactive and let you choose to reset the roles rights or not.
+**Note:** This command is interactive and let you choose whether you want to apply the default secured roles and profiles or not
 
 # Reset Kuzzle
 

--- a/bin/commands/start.js
+++ b/bin/commands/start.js
@@ -145,7 +145,7 @@ function commandStart (options) {
           if (!res) {
             console.log(cout.warn('[!] [WARNING] There is no administrator user yet: everyone has administrator rights.'));
             console.log(cout.notice('[ℹ] You can use the CLI or the admin console to create the first administrator user.'));
-            console.log(cout.notice('    For more information: http://docs.kuzzle.io/guide/essentials/security'));
+            console.log(cout.notice('    For more information: https://docs.kuzzle.io/guide/essentials/security'));
           }
         });
     })


### PR DESCRIPTION
## What does this PR do ?

Documentation URLs should be HTTPS, not HTTP, like it is in our startup message.


### Boyscout

Better `createFirstAdmin` documentation in the CLI README file.
