### PR TITLE
Fix swagger invalid output format

### DIFF
--- a/lib/api/core/swagger.js
+++ b/lib/api/core/swagger.js
@@ -47,7 +47,6 @@ module.exports = function generateSwagger (kuzzle) {
     consumes: [
       'application/json'
     ],
-    host: 'sandbox.kuzzle.io:7512',
     info: {
       contact: {
         email: 'hello@kuzzle.io',
@@ -59,13 +58,11 @@ module.exports = function generateSwagger (kuzzle) {
         name: 'Apache 2',
         url: 'http://opensource.org/licenses/apache2.0'
       },
-      title: 'Kuzzle API'
+      title: 'Kuzzle API',
+      version: require('../../../package').version
     },
     produces: [
       'application/json'
-    ],
-    schemes: [
-      'http'
     ],
     swagger: '2.0',
     paths: {}


### PR DESCRIPTION
## :warning: __Needs some updates on documentation and sdks__

## What does this PR do ?

This PR fixes Kuzzle's swagger routes to make them compatible with the [version 2.0 of the specification](https://swagger.io/docs/specification/2-0/basic-structure/).

1. add required attribute `info.version`
2. remove unneeded hard-coded `host` entry
3. remove unneeded hard-coded `schemes` entry

### How should this be manually tested?

- http://localhost:7512/swagger.json
- http://localhost:7512/swagger.yaml
