### PR TITLE
Initialize repositories before plugins

### DIFF
--- a/docker-compose/test.yml
+++ b/docker-compose/test.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 services:
   proxy:
@@ -29,7 +29,7 @@ services:
       - DEBUG=
       - CUCUMBER_EMBEDDED_HOST=localhost
       - CUCUMBER_PROXY_HOST=proxy
-      - NODE_LTS
+      - NODE_LTS=${NODE_LTS:-8}
       # Travis env var must be propagated into the container
       - TRAVIS
       - TRAVIS_COMMIT

--- a/lib/api/kuzzle.js
+++ b/lib/api/kuzzle.js
@@ -129,6 +129,7 @@ class Kuzzle extends EventEmitter {
       .then(() => this.validation.init())
       .then(() => this.indexCache.init())
       .then(() => this.funnel.init())
+      .then(() => this.repositories.init())
       .then(() => this.pluginsManager.init())
       .then(() => this.pluginsManager.run())
       .then(() => this.pluginsManager.trigger('log:info', 'Services initiated'))
@@ -143,7 +144,7 @@ class Kuzzle extends EventEmitter {
           maxMinTerms: this.config.limits.subscriptionMinterms
         });
 
-        return this.repositories.init();
+        return true;
       })
       .then(() => this.validation.curateSpecification())
       .then(() => this.entryPoints.init())

--- a/lib/api/kuzzle.js
+++ b/lib/api/kuzzle.js
@@ -144,9 +144,8 @@ class Kuzzle extends EventEmitter {
           maxMinTerms: this.config.limits.subscriptionMinterms
         });
 
-        return true;
+        return this.validation.curateSpecification();
       })
-      .then(() => this.validation.curateSpecification())
       .then(() => this.entryPoints.init())
       .then(() => {
         this.pluginsManager.trigger('core:kuzzleStart', 'Kuzzle is started');


### PR DESCRIPTION
## What does this PR do ?

This PR change the initialization sequence of Kuzzle.  
Now the repositories are initialized before the plugin so the plugin can use the repositories at initialization.  

Fix: https://github.com/kuzzleio/kuzzle/issues/1165

### How should this be manually tested?

  - Step 1 : Execute this request in a plugin `init()` function
```
    return this.context.accessors.execute(new this.context.constructors.Request({
        controller: 'security',
        action: 'createOrReplaceRole',
        refresh: 'wait_for',
        _id: 'admin',
        body: {
          "controllers": {
            "*": {
              "actions": {
                "*": true
              }
            }
          }
        }
    }))
    .catch(err => console.warn('ERROR ', err))
```
 
### Other changes

 - Propagate `NODE_LTS` env variable to the proxy
