### PR TITLE
Fix: authentication rejection not forwarded

### DIFF
--- a/lib/api/core/auth/passportWrapper.js
+++ b/lib/api/core/auth/passportWrapper.js
@@ -58,26 +58,34 @@ class PassportWrapper {
       // (Proof: HTTP redirection unit test)
       response.addEndListener(() => resolve(response));
 
-      passport.authenticate(strategyName, this.options[strategyName] || {}, (err, user, info) => {
-        if (err !== null) {
-          if (err instanceof KuzzleError) {
-            reject(err);
+      try {
+        passport.authenticate(strategyName, this.options[strategyName] || {}, (err, user, info) => {
+          if (err !== null) {
+            if (err instanceof KuzzleError) {
+              reject(err);
+            }
+            else {
+              reject(new PluginImplementationError(err));
+            }
+          }
+          else if (!user) {
+            const error = new UnauthorizedError(info);
+            error.details = {
+              subCode: error.subCodes.AuthenticationError
+            };
+            reject(error);
           }
           else {
-            reject(new PluginImplementationError(err));
+            resolve(user);
           }
+        })(request, response);
+      } catch (e) {
+        if (!(e instanceof KuzzleError)) {
+          reject(new PluginImplementationError(e));
+        } else {
+          reject(e);
         }
-        else if (!user) {
-          const error = new UnauthorizedError(info.message);
-          error.details = {
-            subCode: error.subCodes.AuthenticationError
-          };
-          reject(error);
-        }
-        else {
-          resolve(user);
-        }
-      })(request, response);
+      }
     });
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {


### PR DESCRIPTION
## What does this PR do?

When an authentication plugin rejects a login attempt while providing a reason, that reason is not forwarded by Kuzzle in the resulting error response.

This prevents plugin developers to forward the rejection reason, and can lead to confusion on the user side.

### How should this be manually tested?

Attempt to log in using our default `local` strategy plugin, with an invalid login name or password. The result is a generic `UnauthorizedError` error without a message, while a `wrong login name or password` message (provided by the auth. plugin) is expected.

### Other changes

If a plugin's `verify` function throws a non-KuzzleError error, that error is forwarded as is, instead of being cast as a `PluginImplementationError` error.
