### PR TITLE
Hotfix: auth. rejection reason not forwarded to users

### DIFF
--- a/lib/api/core/auth/passportWrapper.js
+++ b/lib/api/core/auth/passportWrapper.js
@@ -58,7 +58,7 @@ class PassportWrapper {
       // (Proof: HTTP redirection unit test)
       response.addEndListener(() => resolve(response));
 
-      passport.authenticate(strategyName, this.options[strategyName] || {}, (err, user, info) => {
+      const authCB = (err, user, info) => {
         if (err !== null) {
           if (err instanceof KuzzleError) {
             reject(err);
@@ -77,7 +77,17 @@ class PassportWrapper {
         else {
           resolve(user);
         }
-      })(request, response);
+      };
+
+      try {
+        passport.authenticate(strategyName, this.options[strategyName] || {}, authCB)(request, response);
+      } catch (e) {
+        if (e instanceof KuzzleError) {
+          reject(e);
+        } else {
+          reject(new PluginImplementationError(e));
+        }
+      }
     });
   }
 

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -511,7 +511,7 @@ class PluginsManager {
               throw new PluginImplementationError(`${errorPrefix} returned an unknown Kuzzle user identifier`);
             }
 
-            callback(null, result, message);
+            callback(null, result, {message});
             return null;
           })
           .catch(error => callback(error));
@@ -768,6 +768,10 @@ function loadPlugins(config, kuzzleVersion, rootPath) {
     // We need to ignore the case of plugin names while checking for name conflicts,
     // because we have to lowercase the name of the plugin to create a dedicated
     // Elasticsearch index.
+    if (!packageJson.name || packageJson.name.length === 0) {
+      throw new PluginImplementationError(`Unable to load plugin from path "${pluginDirName}"; No "name" property provided in package.json`);
+    }
+
     const lowercased = packageJson.name.toLowerCase();
 
     for (const name of Object.keys(loadedPlugins)) {

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -765,13 +765,13 @@ function loadPlugins(config, kuzzleVersion, rootPath) {
       throw new PluginImplementationError(`Unable to load plugin from path "${pluginDirName}"; No package.json found.`);
     }
 
-    // We need to ignore the case of plugin names while checking for name conflicts,
-    // because we have to lowercase the name of the plugin to create a dedicated
-    // Elasticsearch index.
     if (!packageJson.name || packageJson.name.length === 0) {
       throw new PluginImplementationError(`Unable to load plugin from path "${pluginDirName}"; No "name" property provided in package.json`);
     }
 
+    // We need to ignore the case of plugin names while checking for name conflicts,
+    // because we have to lowercase the name of the plugin to create a dedicated
+    // Elasticsearch index.
     const lowercased = packageJson.name.toLowerCase();
 
     for (const name of Object.keys(loadedPlugins)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "1.4.4",
+  "version": "1.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.4.4",
+  "version": "1.4.3",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {

--- a/test/api/core/pluginsManager/strategy.test.js
+++ b/test/api/core/pluginsManager/strategy.test.js
@@ -397,7 +397,7 @@ describe('PluginsManager: strategy management', () => {
       verifyAdapter((err, res, msg) => {
         try {
           should(res).be.false();
-          should(msg).be.null();
+          should(msg).be.eql({message: null});
           should(err).be.null();
           done();
         }
@@ -412,7 +412,7 @@ describe('PluginsManager: strategy management', () => {
       verifyAdapter((err, res, msg) => {
         try {
           should(res).be.false();
-          should(msg).be.eql('Unable to log in using the strategy "someStrategy"');
+          should(msg).be.eql({message: 'Unable to log in using the strategy "someStrategy"'});
           should(err).be.null();
           done();
         }
@@ -427,7 +427,7 @@ describe('PluginsManager: strategy management', () => {
       verifyAdapter((err, res, msg) => {
         try {
           should(res).be.false();
-          should(msg).be.eql('"NONE SHALL PASS!" -The Black Knight');
+          should(msg).be.eql({message: '"NONE SHALL PASS!" -The Black Knight'});
           should(err).be.null();
           done();
         }


### PR DESCRIPTION
## What does this PR do?

When an authentication plugin rejects a login attempt while providing a reason, that reason is not forwarded by Kuzzle in the resulting error response.

This prevents plugin developers to forward the rejection reason, and can lead to confusion on the user side.

This bug has been introduced in Kuzzle 1.4.0

### How should this be manually tested?

Attempt to log in using our default `local` strategy plugin, with an invalid login name or password. The result is a generic `UnauthorizedError` error without a message, while a `wrong login name or password` message (provided by the auth. plugin) is expected.

### Other changes

* If a plugin's `verify` function throws a non-KuzzleError error, that error is forwarded as is, instead of being cast as a `PluginImplementationError` error.
* If a plugin's `package.json` file has no `name` defined, Kuzzle crashes instead of not starting with an appropriate error message