### PR TITLE
Fix #1015: Add token expiration information to login response

### DIFF
--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -127,12 +127,12 @@ class AuthController {
         }
 
         return this.kuzzle.repositories.token.generateToken(response.content, request, options)
-          .then(token => {
-            return {
-              _id: token.userId,
-              jwt: token.jwt
-            };
-          });
+          .then(token => ({
+            _id: token.userId,
+            jwt: token.jwt,
+            expiresAt: token.expiresAt,
+            ttl: token.ttl
+          }));
       });
   }
 

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -48,7 +48,9 @@ describe('Test the auth controller', () => {
       const token = new Token({
         _id: 'foobar#bar',
         jwt: 'bar',
-        userId: 'foobar'
+        userId: 'foobar',
+        expiresAt: 4567,
+        ttl: 1234
       });
 
       kuzzle.repositories.token.generateToken.resolves(token);
@@ -56,7 +58,12 @@ describe('Test the auth controller', () => {
       return authController.login(request)
         .then(response => {
           should(kuzzle.pluginsManager.trigger).calledWith('auth:strategyAuthenticated', {strategy: 'mockup', content: user});
-          should(response).match({_id: 'foobar', jwt: 'bar'});
+          should(response).match({
+            _id: 'foobar',
+            jwt: 'bar',
+            expiresAt: 4567,
+            ttl: 1234
+          });
           should(kuzzle.repositories.token.generateToken).calledWith(user, request, {});
         });
     });
@@ -105,7 +112,9 @@ describe('Test the auth controller', () => {
       const token = new Token({
         _id: 'foobar#bar',
         jwt: 'bar',
-        userId: 'foobar'
+        userId: 'foobar',
+        expiresAt: 4567,
+        ttl: 1234
       });
 
       kuzzle.repositories.token.generateToken.resolves(token);
@@ -114,7 +123,12 @@ describe('Test the auth controller', () => {
 
       return authController.login(request)
         .then(response => {
-          should(response).match({_id: 'foobar', jwt: 'bar'});
+          should(response).match({
+            _id: 'foobar',
+            jwt: 'bar',
+            expiresAt: 4567,
+            ttl: 1234
+          });
           should(kuzzle.repositories.token.generateToken).calledWith(user, request, {expiresIn: '1s'});
         });
     });


### PR DESCRIPTION
## What does this PR do?

Add expiration informations to login responses (expiration datetime in epoch-millis + ttl in milliseconds)

Fix #1015

### How should this be manually tested?

- Login
- Check Kuzzle's response
- ????
- Profit!
