### PR TITLE
disable dump by default

### DIFF
--- a/default.config.js
+++ b/default.config.js
@@ -10,7 +10,7 @@
  */
 module.exports = {
   dump: {
-    enabled: true,
+    enabled: false,
     history: {
       coredump: 3,
       reports: 5

--- a/test/api/controllers/funnelController/executePluginRequest.test.js
+++ b/test/api/controllers/funnelController/executePluginRequest.test.js
@@ -95,6 +95,7 @@ describe('funnelController.executePluginRequest', () => {
   it('should dump on errors in whitelist', done => {
     funnel.handleErrorDump = originalHandleErrorDump;
     kuzzle.adminController.dump = sinon.stub();
+    kuzzle.config.dump.enabled = true;
 
     const
       rq = new Request({controller: 'testme', action: 'action'}),
@@ -106,6 +107,32 @@ describe('funnelController.executePluginRequest', () => {
       setTimeout(() => {
         should(kuzzle.pluginsManager.trigger).be.called();
         should(kuzzle.adminController.dump).be.called();
+        done();
+      }, 50);
+    };
+
+    try {
+      funnel.executePluginRequest(rq, callback);
+    }
+    catch (e) {
+      done(e);
+    }
+  });
+
+  it('should not dump on errors if dump is disabled', done => {
+    funnel.handleErrorDump = originalHandleErrorDump;
+    kuzzle.adminController.dump = sinon.stub();
+    kuzzle.config.dump.enabled = false;
+
+    const
+      rq = new Request({controller: 'testme', action: 'action'}),
+      error = new KuzzleInternalError('foo\nbar');
+
+    funnel.controllers.testme.action.rejects(error);
+
+    const callback = () => {
+      setTimeout(() => {
+        should(kuzzle.adminController.dump).not.be.called();
         done();
       }, 50);
     };


### PR DESCRIPTION
## What does this PR do ?

This PR updates Kuzzle's default configuration by disabling dumps in case of crash.

The reasons are : 

- don't fill users' disk space without their consent
- dumps can take a LONG time to process, which leads to even more unavailability of Kuzzle
- we never encountered in any situation where digging into the dump helped
- most if not all dumps cannot be debugged anyway