### PR TITLE
Fix #1115: Standardize the scrollId return value

### DIFF
--- a/features/step_definitions/readDocument.js
+++ b/features/step_definitions/readDocument.js
@@ -123,8 +123,8 @@ Then(/^I ?(don't)* find a document with "([^"]*)"(?: in field "([^"]*)")?(?: in 
         return Bluebird.reject(body.error);
       }
 
-      if (body.result && body.result._scroll_id) {
-        this.scrollId = body.result._scroll_id;
+      if (body.result && body.result.scrollId) {
+        this.scrollId = body.result.scrollId;
       }
 
       if (body.result && body.result.hits && body.result.total !== 0) {

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -1408,7 +1408,7 @@ function formatSearchResults(result) {
 
   if (_result._scroll_id) {
     // @deprecated - _result._scroll_id is kept for backward compatibility
-    // only. It should be removed by the next major versio
+    // only. It should be removed by the next major version
     _result.scrollId = _result._scroll_id;
   }
 

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -147,7 +147,7 @@ class ElasticSearch extends Service {
         return this.kuzzle.services.list.internalCache.pexpire(cacheKey, ttl);
       })
       .then(() => this.client.scroll(esRequest))
-      .then(result => flattenSearchResults(result))
+      .then(result => formatSearchResults(result))
       .catch(error => Bluebird.reject(this.esWrapper.formatESError(error)));
   }
 
@@ -167,19 +167,19 @@ class ElasticSearch extends Service {
 
     return this.client.search(esRequest)
       .then(result => {
-        const flattened = flattenSearchResults(result);
+        const formatted = formatSearchResults(result);
 
-        if (flattened._scroll_id !== undefined) {
+        if (formatted.scrollId !== undefined) {
           const
             // ms(scroll) may return undefined if in microseconds or in nanoseconds
             ttl = ms(esRequest.scroll) || ms(this.config.defaults.scrollTTL),
-            key = scrollCachePrefix + this.kuzzle.constructor.hash(flattened._scroll_id);
+            key = scrollCachePrefix + this.kuzzle.constructor.hash(formatted.scrollId);
 
           return this.kuzzle.services.list.internalCache.psetex(key, ttl, 0)
-            .then(() => flattened);
+            .then(() => formatted);
         }
 
-        return flattened;
+        return formatted;
       })
       .catch(error => Bluebird.reject(this.esWrapper.formatESError(error)));
   }
@@ -1401,10 +1401,16 @@ function addActiveFilter(esRequest) {
  * @param result
  * @returns {object}
  */
-function flattenSearchResults(result) {
+function formatSearchResults(result) {
   const _result = result.hits ? _.extend(result, result.hits) : result;
 
   _result.hits = _result.hits.map(obj => prepareMetadata(obj));
+
+  if (_result._scroll_id) {
+    // @deprecated - _result._scroll_id is kept for backward compatibility
+    // only. It should be removed by the next major versio
+    _result.scrollId = _result._scroll_id;
+  }
 
   return _result;
 }

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -202,6 +202,7 @@ describe('Test: ElasticSearch service', () => {
           should(result.total).be.exactly(0);
           should(result.hits).be.an.Array();
           should(result._scroll_id).be.an.exactly('banana42');
+          should(result.scrollId).be.an.exactly('banana42');
         });
     });
 

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -201,8 +201,8 @@ describe('Test: ElasticSearch service', () => {
           should(result).be.an.Object();
           should(result.total).be.exactly(0);
           should(result.hits).be.an.Array();
-          should(result._scroll_id).be.an.exactly('banana42');
-          should(result.scrollId).be.an.exactly('banana42');
+          should(result._scroll_id).be.exactly('banana42');
+          should(result.scrollId).be.exactly('banana42');
         });
     });
 


### PR DESCRIPTION
## What does this PR do?

While `security:searchRoles`, `security:searchProfiles` and `security:searchUsers` return a `scrollId` value in their response when a scroll is required, the API route `document:search` returns a `_scroll_id` value, directly from ES.

This is confusing and inconsistent. To prevent breaking changes, this PR duplicates the `_scroll_id` value into a new `scrollId` one. An upcoming PR for our documentation will be created shortly, to deprecate the old `_scroll_id` return value.

Fix #1115

