### PR TITLE
allow to search document with empty query through a HTTP GET request

### DIFF
--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -46,6 +46,7 @@ module.exports = [
   /* DEPRECATED - will be removed in v2 */
   {verb: 'get', url: '/:index/_list/:type', controller: 'collection', action: 'list'},
 
+  {verb: 'get', url: '/:index/:collection', controller: 'document', action: 'search'},
   {verb: 'get', url: '/:index/:collection/:_id', controller: 'document', action: 'get'},
   {verb: 'get', url: '/:index/:collection/:_id/_exists', controller: 'document', action: 'exists'},
   {verb: 'get', url: '/_scroll/:scrollId', controller: 'document', action: 'scroll'},

--- a/test/api/controllers/routerController/httpRequest.test.js
+++ b/test/api/controllers/routerController/httpRequest.test.js
@@ -234,7 +234,7 @@ describe('Test: routerController.httpRequest', () => {
   });
 
   it('should return a 404 if the requested route does not exist', (done) => {
-    httpRequest.url = '/foo/bar';
+    httpRequest.url = '/a/b/c/d';
     httpRequest.method = 'GET';
 
     routeController.http.route(httpRequest, result => {
@@ -242,7 +242,7 @@ describe('Test: routerController.httpRequest', () => {
         should(result.response.requestId).be.eql(httpRequest.requestId);
         should(result.response.headers['content-type']).be.eql('application/json');
         should(result.response.status).be.eql(404);
-        should(result.response.error.message).be.eql('API URL not found: /foo/bar');
+        should(result.response.error.message).be.eql('API URL not found: /a/b/c/d');
         done();
       }
       catch (e) {


### PR DESCRIPTION
## What does this PR do ?

fix #447

### How should this be manually tested?

* Create some documents into index `foo` and collection `bar`
* `curl http://kuzzle:7512/foo/bar`
* `curl http://kuzzle:7512/foo/bar?from=10&size=2`
* etc.
