### PR TITLE
Fix #1174: granting rights to the "ms" controller should also work with its "memoryStorage" alias

### DIFF
--- a/lib/api/core/models/security/profile.js
+++ b/lib/api/core/models/security/profile.js
@@ -69,11 +69,8 @@ class Profile {
     }
 
     return this.getPolicies()
-      .then(policies => new Bluebird((resolve, reject) => {
-        Bluebird.map(policies, policy => policy.role.isActionAllowed(request, policy.restrictedTo))
-          .then(results => resolve(results.some(r => r)))
-          .catch(reject);
-      }));
+      .then(policies => Bluebird.map(policies, policy => policy.role.isActionAllowed(request, policy.restrictedTo)))
+      .then(results => results.includes(true));
   }
 
   /**

--- a/lib/api/core/models/security/role.js
+++ b/lib/api/core/models/security/role.js
@@ -69,7 +69,13 @@ class Role {
       return Bluebird.resolve(false);
     }
 
-    if (this.controllers[request.input.controller] !== undefined) {
+    // @deprecated - the "memoryStorage" alias should be removed in the next major version
+    // Handles the memory storage controller aliases: ms, memoryStorage
+    if ((request.input.controller === 'ms' || request.input.controller === 'memoryStorage') && (this.controllers.ms || this.controllers.memoryStorage)) {
+      controllerRights = this.controllers.ms || this.controllers.memoryStorage;
+      path.push('ms');
+    }
+    else if (this.controllers[request.input.controller] !== undefined) {
       controllerRights = this.controllers[request.input.controller];
       path.push(request.input.controller);
     }


### PR DESCRIPTION
## What does this PR do?

The memory storage controller has two aliases: `ms` and `memoryStorage`.
As the linked issue states, if a role grants right to only one of these aliases, then requesting access to the other one leads to a `ForbiddenError` error.

Fix #1174 

### How should this be manually tested?

1. Create a role granting access to the `ms` controller, then use it to access to the `memoryStorage` one
2. Vice versa

In these both cases, the current Kuzzle version returns a `ForbiddenError` error. With this PR, rights are properly granted.

### Boyscout

* Simplify promises management in the `profile.isActionAllowed` method