### PR TITLE
KZL-174 Expose to plugins a SDK instance directly mapped to the funnel

### DIFF
--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -366,7 +366,7 @@ class FunnelController {
       .then(newRequest => {
         modifiedRequest = newRequest;
 
-        return this.callController(controllers, newRequest);
+        return callController(controllers, newRequest);
       })
       .then(responseData => {
         modifiedRequest.setResult(responseData, {status: request.status === 102 ? 200 : request.status});
@@ -399,7 +399,7 @@ class FunnelController {
     return Bluebird.resolve()
       .then(() => {
         const controllers = this.getControllers(request);
-        return this.callController(controllers, request);
+        return callController(controllers, request);
       })
       .catch(e => {
         this.handleErrorDump(e);
@@ -502,27 +502,6 @@ class FunnelController {
   }
 
   /**
-   * Invoke a controller function, checking that its return
-   * value is a Promise. If not, wraps the returned value
-   * in a rejected Promise and returns it.
-   *
-   * Used to make Kuzzle safe from badly implemented plugins
-   *
-   * @param  {Object} controllers
-   * @param  {Request} request
-   * @return {Promise}
-   */
-  callController(controllers, request) {
-    const ret = controllers[request.input.controller][request.input.action](request);
-
-    if (!ret || typeof ret.then !== 'function') {
-      return Bluebird.reject(new PluginImplementationError(`Unexpected return value from action ${request.input.controller}/${request.input.action}: expected a Promise`));
-    }
-
-    return ret;
-  }
-
-  /**
    * Populates the given request with the error and calls the callback
    *
    * @param {Error} error
@@ -592,6 +571,27 @@ class FunnelController {
  */
 function capitalizeFirstLetter(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+/**
+ * Invoke a controller function, checking that its return
+ * value is a Promise. If not, wraps the returned value
+ * in a rejected Promise and returns it.
+ *
+ * Used to make Kuzzle safe from badly implemented plugins
+ *
+ * @param  {Object} controllers
+ * @param  {Request} request
+ * @return {Promise}
+ */
+function callController(controllers, request) {
+  const ret = controllers[request.input.controller][request.input.action](request);
+
+  if (!ret || typeof ret.then !== 'function') {
+    return Bluebird.reject(new PluginImplementationError(`Unexpected return value from action ${request.input.controller}/${request.input.action}: expected a Promise`));
+  }
+
+  return ret;
 }
 
 module.exports = FunnelController;

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -366,7 +366,7 @@ class FunnelController {
       .then(newRequest => {
         modifiedRequest = newRequest;
 
-        return callController(controllers, newRequest);
+        return this.callController(controllers, newRequest);
       })
       .then(responseData => {
         modifiedRequest.setResult(responseData, {status: request.status === 102 ? 200 : request.status});
@@ -412,7 +412,7 @@ class FunnelController {
     }
 
     Bluebird.resolve()
-      .then(() => callController(controllers, request))
+      .then(() => this.callController(controllers, request))
       .then(response => {
         request.setResult(response, {status: request.status === 102 ? 200 : request.status});
         callback(null, request);
@@ -523,6 +523,27 @@ class FunnelController {
   }
 
   /**
+   * Invoke a controller function, checking that its return
+   * value is a Promise. If not, wraps the returned value
+   * in a rejected Promise and returns it.
+   *
+   * Used to make Kuzzle safe from badly implemented plugins
+   *
+   * @param  {Object} controllers
+   * @param  {Request} request
+   * @return {Promise}
+   */
+  callController(controllers, request) {
+    const ret = controllers[request.input.controller][request.input.action](request);
+
+    if (!ret || typeof ret.then !== 'function') {
+      return Bluebird.reject(new PluginImplementationError(`Unexpected return value from action ${request.input.controller}/${request.input.action}: expected a Promise`));
+    }
+
+    return ret;
+  }
+
+  /**
    * Populates the given request with the error and calls the callback
    *
    * @param {Error} error
@@ -592,27 +613,6 @@ class FunnelController {
  */
 function capitalizeFirstLetter(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
-}
-
-/**
- * Invoke a controller function, checking that its return
- * value is a Promise. If not, wraps the returned value
- * in a rejected Promise and returns it.
- *
- * Used to make Kuzzle safe from badly implemented plugins
- *
- * @param  {Object} controllers
- * @param  {Request} request
- * @return {Promise}
- */
-function callController(controllers, request) {
-  const ret = controllers[request.input.controller][request.input.action](request);
-
-  if (!ret || typeof ret.then !== 'function') {
-    return Bluebird.reject(new PluginImplementationError(`Unexpected return value from action ${request.input.controller}/${request.input.action}: expected a Promise`));
-  }
-
-  return ret;
 }
 
 module.exports = FunnelController;

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -390,42 +390,21 @@ class FunnelController {
    * Similar to execute, except that:
    *   - plugin requests do not trigger API events
    *   - plugin requests are not counted towards requests statistics
-   *   - plugins can choose to disable the overload protection mechanism
+   *   - plugins the overload protection mechanism is disabled
    *
    * @param {Request} request
-   * @param {boolean} overloadProtect
-   * @param {Function} callback
-   * @returns {Number} -1: delayed, 0: processing, 1: error
+   * @returns {Promise}
    */
-  executePluginRequest(request, callback) {
-    request.clearError();
-    request.status = 102;
-
-    let controllers;
-
-    try {
-      controllers = this.getControllers(request);
-    }
-    catch(e) {
-      callback(e);
-      return 1;
-    }
-
-    Bluebird.resolve()
-      .then(() => this.callController(controllers, request))
-      .then(response => {
-        request.setResult(response, {status: request.status === 102 ? 200 : request.status});
-        callback(null, request);
-        return null;
+  executePluginRequest(request) {
+    return Bluebird.resolve()
+      .then(() => {
+        const controllers = this.getControllers(request);
+        return this.callController(controllers, request);
       })
       .catch(e => {
-        request.setError(e);
         this.handleErrorDump(e);
-        callback(e);
-        return null;
+        return Bluebird.reject(e);
       });
-
-    return 0;
   }
 
   handleProcessRequestError(modifiedRequest, request, controllers, error) {

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -24,6 +24,8 @@
 const
   Bluebird = require('bluebird'),
   _ = require('lodash'),
+  KuzzleSDK = require('kuzzle-sdk').Kuzzle,
+  FunnelProtocol = require('../sdk/funnelProtocol'),
   PluginImplementationError = require('kuzzle-common-objects').errors.PluginImplementationError,
   Request = require('kuzzle-common-objects').Request,
   PluginRepository = require('../models/repositories/pluginRepository'),
@@ -65,7 +67,8 @@ class PluginContext {
         // Lowercasing the plugin name is needed because Elasticsearch
         // forbids uppercased characters in index names.
         internalEngineIndex = `%plugin:${pluginName}`.toLowerCase(),
-        pluginInternalEngine = new InternalEngine(kuzzle, internalEngineIndex);
+        pluginInternalEngine = new InternalEngine(kuzzle, internalEngineIndex),
+        sdk = new KuzzleSDK(new FunnelProtocol(kuzzle.funnel));
 
       pluginInternalEngine.init(new PluginInternalEngineBootstrap(pluginName, kuzzle, pluginInternalEngine));
 
@@ -121,6 +124,22 @@ class PluginContext {
       Object.defineProperty(this.accessors, 'trigger', {
         enumerable: true,
         get: () => curryTrigger(kuzzle, pluginName)
+      });
+
+      Object.defineProperty(this.accessors, 'sdk', {
+        enumerable: true,
+        get: () => ({
+          query: sdk.query.bind(sdk),
+          auth: sdk.auth,
+          bulk: sdk.bulk,
+          collection: sdk.collection,
+          document: sdk.document,
+          index: sdk.index,
+          ms: sdk.ms,
+          realtime: sdk.realtime,
+          security: sdk.security,
+          server: sdk.server
+        })
       });
 
       /**

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -174,7 +174,6 @@ class PluginContext {
 /**
  * @param {Kuzzle} kuzzle
  * @param {Request} request
- * @param {boolean} [overloadProtect]
  * @param {Function} [callback]
  */
 function execute (kuzzle, request, callback) {
@@ -207,27 +206,29 @@ function execute (kuzzle, request, callback) {
     return deferred;
   }
 
-  kuzzle.funnel.executePluginRequest(request, (err, response) => {
-    if (callback) {
-      try {
-        callback(err, response);
-      }
-      catch (e) {
-        kuzzle.pluginsManager.trigger('log:error', new PluginImplementationError(e));
+  request.clearError();
+  request.status = 102;
 
-        if (err) {
-          kuzzle.pluginsManager.trigger('log:error', `Previous error: ${err}`);
+  kuzzle.funnel.executePluginRequest(request)
+    .then(response => {
+      request.setResult(response, {status: request.status === 102 ? 200 : request.status});
+      if (callback) {
+        try {
+          return callback(null, request);
+        }
+        catch (err) {
+          kuzzle.pluginsManager.trigger('log:error', new PluginImplementationError(err));
+          return callback(err);
         }
       }
-    }
-    else {
-      if (err) {
-        return reject(err);
+      resolve(request);
+    })
+    .catch(err => {
+      if (callback) {
+        return callback(err);
       }
-
-      resolve(response);
-    }
-  });
+      reject(err);
+    });
 
   if (!callback) {
     return deferred;

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -210,8 +210,8 @@ function execute (kuzzle, request, callback) {
   request.status = 102;
 
   kuzzle.funnel.executePluginRequest(request)
-    .then(response => {
-      request.setResult(response, {status: request.status === 102 ? 200 : request.status});
+    .then(result => {
+      request.setResult(result, {status: request.status === 102 ? 200 : request.status});
       if (callback) {
         try {
           return callback(null, request);

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -86,6 +86,9 @@ class PluginContext {
         }
       });
 
+      /**
+        * @deprecated will be removed in v2, replaced by "sdk" accessor
+        */
       Object.defineProperty(this.accessors, 'execute', {
         enumerable: true,
         get: () => (...args) => execute(kuzzle, ...args)
@@ -172,6 +175,7 @@ class PluginContext {
 }
 
 /**
+ * @deprecated will be removed in v2, replaced by "sdk" accessor
  * @param {Kuzzle} kuzzle
  * @param {Request} request
  * @param {Function} [callback]

--- a/lib/api/core/sdk/funnelProtocol.js
+++ b/lib/api/core/sdk/funnelProtocol.js
@@ -1,0 +1,42 @@
+/*
+ * Kuzzle, a backend software, self-hostable and ready to use
+ * to power modern apps
+ *
+ * Copyright 2015-2017 Kuzzle
+ * mailto: support AT kuzzle.io
+ * website: http://kuzzle.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const KuzzleEventEmitter = require('kuzzle-sdk').KuzzleEventEmitter;
+
+class FunnelProtocol extends KuzzleEventEmitter {
+  constructor(kuzzle) {
+    super();
+    this.kuzzle = kuzzle;
+  }
+
+  isReady() {
+    return true;
+  }
+
+  query (request) {
+    return this.funnel.callController(request)
+      .then(result => result.response);
+  }
+}
+
+module.exports = FunnelProtocol;

--- a/lib/api/core/sdk/funnelProtocol.js
+++ b/lib/api/core/sdk/funnelProtocol.js
@@ -37,11 +37,7 @@ class FunnelProtocol extends KuzzleEventEmitter {
   }
 
   query (request) {
-    const
-      kuzRequest = new Request(request),
-      controllers = this.funnel.getControllers(kuzRequest);
-
-    return this.funnel.callController(controllers, kuzRequest)
+    return this.funnel.executePluginRequest(new Request(request))
       .then(result => ({result}));
   }
 }

--- a/lib/api/core/sdk/funnelProtocol.js
+++ b/lib/api/core/sdk/funnelProtocol.js
@@ -2,7 +2,7 @@
  * Kuzzle, a backend software, self-hostable and ready to use
  * to power modern apps
  *
- * Copyright 2015-2017 Kuzzle
+ * Copyright 2015-2018 Kuzzle
  * mailto: support AT kuzzle.io
  * website: http://kuzzle.io
  *
@@ -21,12 +21,15 @@
 
 'use strict';
 
-const KuzzleEventEmitter = require('kuzzle-sdk').KuzzleEventEmitter;
+const
+  KuzzleEventEmitter = require('kuzzle-sdk').KuzzleEventEmitter,
+  Request = require('kuzzle-common-objects').Request;
 
 class FunnelProtocol extends KuzzleEventEmitter {
-  constructor(kuzzle) {
+  constructor(funnel) {
     super();
-    this.kuzzle = kuzzle;
+    this.funnel = funnel;
+    this.id = 'funnel';
   }
 
   isReady() {
@@ -34,8 +37,12 @@ class FunnelProtocol extends KuzzleEventEmitter {
   }
 
   query (request) {
-    return this.funnel.callController(request)
-      .then(result => result.response);
+    const
+      kuzRequest = new Request(request),
+      controllers = this.funnel.getControllers(kuzRequest);
+
+    return this.funnel.callController(controllers, kuzRequest)
+      .then(result => ({result}));
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3123,14 +3123,11 @@
       }
     },
     "kuzzle-sdk": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/kuzzle-sdk/-/kuzzle-sdk-5.0.12.tgz",
-      "integrity": "sha1-yqlVnR2louM02gJw6B9vbYXtUTg=",
+      "version": "git://github.com/kuzzleio/sdk-javascript.git#b56ed5effafa7bd8e332f5819ecdcfed49b5713b",
+      "from": "git://github.com/kuzzleio/sdk-javascript.git#6.x",
       "requires": {
-        "bluebird": "3.5.1",
-        "nyc": "12.0.2",
-        "uuid": "3.3.2",
-        "ws": "6.0.0"
+        "min-req-promise": "^1.0.1",
+        "uws": "10.148.0"
       }
     },
     "lazy": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "jsonwebtoken": "^8.3.0",
     "koncorde": "^1.1.7",
     "kuzzle-common-objects": "^3.0.13",
-    "kuzzle-sdk": "^5.0.12",
+    "kuzzle-sdk": "git://github.com/kuzzleio/sdk-javascript.git#6.x",
     "lodash": "4.17.10",
     "moment": "^2.22.2",
     "ms": "^2.1.1",

--- a/test/api/core/pluginContext/pluginContext.test.js
+++ b/test/api/core/pluginContext/pluginContext.test.js
@@ -197,7 +197,7 @@ describe('Plugin Context', () => {
       });
 
       should(context.accessors).be.an.Object().and.not.be.empty();
-      should(context.accessors).have.properties(['execute', 'validation', 'storage', 'trigger', 'strategies']);
+      should(context.accessors).have.properties(['execute', 'validation', 'storage', 'trigger', 'strategies', 'sdk']);
     });
 
     it('should expose a data validation accessor', () => {
@@ -231,6 +231,21 @@ describe('Plugin Context', () => {
 
       should(strategies.add).be.a.Function();
       should(strategies.remove).be.a.Function();
+    });
+
+    it('should expose an SDK client accessor', () => {
+      const sdk = context.accessors.sdk;
+
+      should(sdk.query).be.a.Function();
+      should(sdk.auth).be.an.Object();
+      should(sdk.bulk).be.an.Object();
+      should(sdk.collection).be.an.Object();
+      should(sdk.document).be.an.Object();
+      should(sdk.index).be.an.Object();
+      should(sdk.ms).be.an.Object();
+      should(sdk.realtime).be.an.Object();
+      should(sdk.security).be.an.Object();
+      should(sdk.server).be.an.Object();
     });
   });
 

--- a/test/api/core/sdk/funnelProtocol.test.js
+++ b/test/api/core/sdk/funnelProtocol.test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const
+  should = require('should'),
+  sinon = require('sinon'),
+  Request = require('kuzzle-common-objects').Request,
+  FunnelProtocol = require('../../../../lib/api/core/sdk/funnelProtocol');
+
+describe('Test: sdk/funnelProtocol', () => {
+  let funnelProtocol;
+
+  const funnel = {};
+
+  beforeEach(() => {
+    funnel.getControllers = sinon.stub().returns({
+      foo: 'bar',
+      bar: 'baz'
+    });
+
+    funnel.callController = sinon.stub().resolves('sdk result');
+
+    funnelProtocol = new FunnelProtocol(funnel);
+  });
+
+  describe('#isReady', () => {
+    it('should return true', () => {
+      should(funnelProtocol.isReady()).be.true();
+    });
+  });
+
+  describe('#query', () => {
+    it('should call getControllers with the constructed request', () => {
+      return funnelProtocol.query({controller: 'foo', action: 'bar'})
+        .then(() => {
+          should(funnel.getControllers).be.calledOnce();
+
+          const req = funnel.getControllers.firstCall.args[0];
+          should(req).be.an.instanceOf(Request);
+          should(req.input.controller).be.equal('foo');
+          should(req.input.action).be.equal('bar');
+        });
+    });
+
+    it('should call callController with the constructed request', () => {
+      return funnelProtocol.query({controller: 'foo', action: 'bar'})
+        .then(() => {
+          should(funnel.callController).be.calledOnce();
+
+          const
+            controllers = funnel.callController.firstCall.args[0],
+            req = funnel.callController.firstCall.args[1];
+
+          should(controllers).match({foo: 'bar', bar: 'baz'});
+
+          should(req).be.an.instanceOf(Request);
+          should(req.input.controller).be.equal('foo');
+          should(req.input.action).be.equal('bar');
+        });
+    });
+
+    it('should return the result in the good format', () => {
+      return funnelProtocol.query({controller: 'foo', action: 'bar'})
+        .then(res => {
+          should(res.result).be.exactly('sdk result');
+        });
+    });
+  });
+});

--- a/test/api/core/sdk/funnelProtocol.test.js
+++ b/test/api/core/sdk/funnelProtocol.test.js
@@ -12,12 +12,7 @@ describe('Test: sdk/funnelProtocol', () => {
   const funnel = {};
 
   beforeEach(() => {
-    funnel.getControllers = sinon.stub().returns({
-      foo: 'bar',
-      bar: 'baz'
-    });
-
-    funnel.callController = sinon.stub().resolves('sdk result');
+    funnel.executePluginRequest = sinon.stub().resolves('sdk result');
 
     funnelProtocol = new FunnelProtocol(funnel);
   });
@@ -29,29 +24,12 @@ describe('Test: sdk/funnelProtocol', () => {
   });
 
   describe('#query', () => {
-    it('should call getControllers with the constructed request', () => {
+    it('should call executePluginRequest with the constructed request', () => {
       return funnelProtocol.query({controller: 'foo', action: 'bar'})
         .then(() => {
-          should(funnel.getControllers).be.calledOnce();
+          should(funnel.executePluginRequest).be.calledOnce();
 
-          const req = funnel.getControllers.firstCall.args[0];
-          should(req).be.an.instanceOf(Request);
-          should(req.input.controller).be.equal('foo');
-          should(req.input.action).be.equal('bar');
-        });
-    });
-
-    it('should call callController with the constructed request', () => {
-      return funnelProtocol.query({controller: 'foo', action: 'bar'})
-        .then(() => {
-          should(funnel.callController).be.calledOnce();
-
-          const
-            controllers = funnel.callController.firstCall.args[0],
-            req = funnel.callController.firstCall.args[1];
-
-          should(controllers).match({foo: 'bar', bar: 'baz'});
-
+          const req = funnel.executePluginRequest.firstCall.args[0];
           should(req).be.an.instanceOf(Request);
           should(req.input.controller).be.equal('foo');
           should(req.input.action).be.equal('bar');

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -73,7 +73,7 @@ class KuzzleMock extends Kuzzle {
       processRequest: this.sandbox.stub().resolves(),
       checkRights: this.sandbox.stub(),
       getEventName: this.sandbox.spy(),
-      executePluginRequest: this.sandbox.stub()
+      executePluginRequest: this.sandbox.stub().resolves()
     };
 
     this.gc = {


### PR DESCRIPTION
## What does this PR do ?

Apply https://jira.kaliop.net/browse/KZL-176 and https://jira.kaliop.net/browse/KZL-177

This creates a custom light network wrapper for SDK that is directly mapped to the funnel.
And exposes a SDK instance with this wrapper to the plugins.


### How should this be manually tested?

Create a plugin and add hooks or custom routes which calls `context.accessors.sdk.<somectrl>.<someaction>`

### Other changes

* `funnel.executePluginRequest` now returns a promise (no need to use callbacks anymore since we disabled the overload protection for this method)
* deprecate `context.accessors.execute` method (will be removed in V2)

### Boyscout

fix some jsdocs