### PR TITLE
KZL 290 - Add fixtures for securities

### DIFF
--- a/bin/commands/start.js
+++ b/bin/commands/start.js
@@ -43,102 +43,20 @@ function commandStart (options) {
   kuzzle.start(params)
     // fixtures && mapping
     .then(() => {
-      const requests = [];
-
-      if (params.mappings) {
-        let mappings;
-
-        try {
-          mappings = JSON.parse(fs.readFileSync(params.mappings, 'utf8'));
-        }
-        catch (e) {
-          console.log(cout.error(`[✖] The file ${params.mappings} cannot be parsed. Abort.`));
-          process.exit(1);
-        }
-
-        console.log(cout.notice(`[ℹ] Loading mappings from ${params.mappings} into storage layer`));
-
-        for (const index of Object.keys(mappings)) {
-          for (const collection of Object.keys(mappings[index])) {
-            requests.push(new Request({
-              index,
-              collection,
-              body: mappings[index][collection]
-            }));
-          }
-        }
+      if (! params.mappings) {
+        return null;
       }
 
-      return requests;
-    })
-    .each(rq => {
-      const
-        index = rq.input.resource.index,
-        indexRequest = new Request({index});
-
-      return kuzzle.services.list.storageEngine.indexExists(indexRequest)
-        .then(exist => {
-          if (!exist) {
-            console.log(cout.notice(`[ℹ] Creating index: ${index}`));
-            return kuzzle.services.list.storageEngine.createIndex(indexRequest);
-          }
-        })
-        .then(() => kuzzle.services.list.storageEngine.updateMapping(rq))
-        .then(() => kuzzle.services.list.storageEngine.refreshIndex(indexRequest))
-        .then(() => {
-          const collection = rq.input.resource.collection;
-
-          kuzzle.indexCache.add(index, collection);
-          console.log(cout.ok(`[✔] Mappings for ${index}/${collection} successfully applied`));
-
-          return null;
-        });
+      return kuzzle.janitor.loadMappings(params.mappings)
+        .then(() => console.log(cout.ok(`[✔] Mappings successfully applied`)));
     })
     .then(() => {
-      const requests = [];
-
-      if (params.fixtures) {
-        let fixtures;
-
-        try {
-          fixtures = JSON.parse(fs.readFileSync(params.fixtures, 'utf8'));
-        }
-        catch (e) {
-          console.log(cout.error(`[✖] The file ${params.fixtures} cannot be parsed. Abort.`));
-          process.exit(1);
-        }
-
-        console.log(cout.notice(`[ℹ] Loading fixtures from ${params.fixtures} into storage layer`));
-
-        for (const index of Object.keys(fixtures)) {
-          for (const collection of Object.keys(fixtures[index])) {
-            requests.push(new Request({
-              index,
-              collection,
-              body: {
-                bulkData: fixtures[index][collection]
-              }
-            }));
-          }
-        }
+      if (! params.fixtures) {
+        return null;
       }
 
-      return requests;
-    })
-    .each(rq => {
-      return kuzzle.services.list.storageEngine.import(rq)
-        .then(res => {
-          if (res.partialErrors && res.partialErrors.length > 0) {
-            // use native console to allow default output trimming in case of big fixtures
-            console.error(res.partialErrors);
-            throw new PartialError(`Some data was not imported for ${rq.input.resource.index}/${rq.input.resource.collection} (${res.partialErrors.length}/${res.items.length + res.partialErrors.length}).`, res.partialErrors);
-          }
-          return res;
-        })
-        .then(res => {
-          return kuzzle.services.list.storageEngine.refreshIndex(new Request({index: rq.input.resource.index}))
-            .then(() => console.log(cout.ok(`[✔] Fixtures for ${rq.input.resource.index}/${rq.input.resource.collection} successfully loaded: ${res.items.length} documents created`)));
-        });
+      return kuzzle.janitor.loadFixtures(params.fixtures)
+        .then(() => console.log(cout.ok(`[✔] Fixtures successfully loaded`)));
     })
     .then(() => {
       console.log(cout.kuz('[✔] Kuzzle server ready'));

--- a/bin/commands/start.js
+++ b/bin/commands/start.js
@@ -59,6 +59,14 @@ function commandStart (options) {
         .then(() => console.log(cout.ok(`[✔] Fixtures successfully loaded`)));
     })
     .then(() => {
+      if (! params.securities) {
+        return null;
+      }
+
+      return kuzzle.janitor.loadSecurities(params.securities)
+        .then(() => console.log(cout.ok(`[✔] Roles, profiles and users successfully loaded`)));
+    })
+    .then(() => {
       console.log(cout.kuz('[✔] Kuzzle server ready'));
       return kuzzle.internalEngine.bootstrap.adminExists()
         .then(res => {

--- a/bin/commands/start.js
+++ b/bin/commands/start.js
@@ -22,12 +22,7 @@
 /* eslint-disable no-console */
 
 const
-  fs = require('fs'),
   rc = require('rc'),
-  {
-    Request,
-    errors: { PartialError }
-  } = require('kuzzle-common-objects'),
   ColorOutput = require('./colorOutput');
 
 const
@@ -48,7 +43,7 @@ function commandStart (options) {
       }
 
       return kuzzle.janitor.loadMappings(params.mappings)
-        .then(() => console.log(cout.ok(`[✔] Mappings successfully applied`)));
+        .then(() => console.log(cout.ok('[✔] Mappings successfully applied')));
     })
     .then(() => {
       if (! params.fixtures) {
@@ -56,7 +51,7 @@ function commandStart (options) {
       }
 
       return kuzzle.janitor.loadFixtures(params.fixtures)
-        .then(() => console.log(cout.ok(`[✔] Fixtures successfully loaded`)));
+        .then(() => console.log(cout.ok('[✔] Fixtures successfully loaded')));
     })
     .then(() => {
       if (! params.securities) {
@@ -64,7 +59,7 @@ function commandStart (options) {
       }
 
       return kuzzle.janitor.loadSecurities(params.securities)
-        .then(() => console.log(cout.ok(`[✔] Roles, profiles and users successfully loaded`)));
+        .then(() => console.log(cout.ok('[✔] Roles, profiles and users successfully loaded')));
     })
     .then(() => {
       console.log(cout.kuz('[✔] Kuzzle server ready'));

--- a/bin/kuzzle
+++ b/bin/kuzzle
@@ -83,6 +83,7 @@ program
   .description('start a Kuzzle instance')
   .option('    --fixtures <file>', 'import data from file')
   .option('    --mappings <file>', 'apply mappings from file')
+  .option('    --securities <file>', 'create roles, profiles and users from file')
   .action(require('./commands/start'));
 
 // $ kuzzle dump

--- a/bin/kuzzle
+++ b/bin/kuzzle
@@ -83,7 +83,7 @@ program
   .description('start a Kuzzle instance')
   .option('    --fixtures <file>', 'import data from file')
   .option('    --mappings <file>', 'apply mappings from file')
-  .option('    --securities <file>', 'create roles, profiles and users from file')
+  .option('    --securities <file>', 'import roles, profiles and users from file')
   .action(require('./commands/start'));
 
 // $ kuzzle dump

--- a/docker-compose/config/pm2-dev.json
+++ b/docker-compose/config/pm2-dev.json
@@ -4,7 +4,7 @@
     "script"       : "bin/kuzzle",
     "args"         : ["start"],
     "watch"        : ["lib/**/*.js", "default.config.js", "plugins/enabled/**/*.js"],
-    "node_args"    : "--inspect",
+    "node_args"    : "--inspect=0.0.0.0:9229",
     "kill_timeout" : 15000
   }]
 }

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -56,7 +56,7 @@ const
  * @param {object} pojoUser
  */
 const persistUser = Bluebird.coroutine(function* persistUserGenerator (kuzzle, request, pojoUser) {
-  const loadedUser = yield kuzzle.repositories.user.load(pojoUser._id);
+  const loadedUser = yield kuzzle.repositories.user.load(pojoUser._id, { returnNull: true });
 
   if (loadedUser !== null) {
     throw new PreconditionError(`user "${pojoUser._id}" already exist.`);
@@ -334,8 +334,10 @@ class SecurityController {
   deleteRole(request) {
     assertHasId(request);
 
-    return this.kuzzle.repositories.role.getRoleFromRequest(request)
-      .then(role => this.kuzzle.repositories.role.delete(role, {refresh: request.input.args.refresh}));
+    const options = { refresh: request.input.args.refresh };
+
+    return this.kuzzle.repositories.role.load(request.input.resource._id)
+      .then(role => this.kuzzle.repositories.role.delete(role, options));
   }
 
   /**
@@ -418,8 +420,10 @@ class SecurityController {
   deleteProfile(request) {
     assertHasId(request);
 
-    return this.kuzzle.repositories.profile.getProfileFromRequest(request)
-      .then(profile => this.kuzzle.repositories.profile.delete(profile, {refresh: request.input.args.refresh}));
+    const options = { refresh: request.input.args.refresh };
+
+    return this.kuzzle.repositories.profile.load(request.input.resource._id)
+      .then(profile => this.kuzzle.repositories.profile.delete(profile, options));
   }
 
   /**
@@ -530,7 +534,7 @@ class SecurityController {
     assertHasId(request);
 
     const options = { refresh: request.input.args.refresh };
-    
+
     return this.kuzzle.repositories.user.load(request.input.resource._id)
       .then(user => this.kuzzle.repositories.user.delete(user, options));
   }

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -56,7 +56,17 @@ const
  * @param {object} pojoUser
  */
 const persistUser = Bluebird.coroutine(function* persistUserGenerator (kuzzle, request, pojoUser) {
-  const loadedUser = yield kuzzle.repositories.user.load(pojoUser._id, { returnNull: true });
+  let loadedUser;
+
+  try {
+    loadedUser = yield kuzzle.repositories.user.load(pojoUser._id);
+  }
+  catch (error) {
+    if (! (error instanceof NotFoundError)) {
+      throw error;
+    }
+    loadedUser = null;
+  }
 
   if (loadedUser !== null) {
     throw new PreconditionError(`user "${pojoUser._id}" already exist.`);
@@ -79,9 +89,10 @@ const persistUser = Bluebird.coroutine(function* persistUserGenerator (kuzzle, r
       throw new KuzzleInternalError(`Internal database inconsistency detected: existing credentials found on non-existing user ${pojoUser._id}`);
     }
 
-    const validateMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'validate');
 
     try {
+      const validateMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'validate');
+
       yield validateMethod(
         request,
         request.input.body.credentials[strategy],
@@ -91,7 +102,9 @@ const persistUser = Bluebird.coroutine(function* persistUserGenerator (kuzzle, r
       );
     }
     catch (error) {
-      throw new BadRequestError(error);
+      if (! (error instanceof NotFoundError)) {
+        throw new BadRequestError(error);
+      }
     }
   }
 

--- a/lib/api/core/janitor.js
+++ b/lib/api/core/janitor.js
@@ -58,10 +58,10 @@ class Janitor {
   loadSecurities (filePath) {
     return this._loadJson(filePath)
       .then(securities => {
-        return this._createRoles(securities.roles)
-          .then(() => this._createProfiles(securities.profiles))
+        return this._createSecurity('createOrReplaceRole', securities.roles)
+          .then(() => this._createSecurity('createOrReplaceProfile', securities.profiles))
           .then(() => this._deleteUsers(securities.users))
-          .then(() => this._createUsers(securities.users));
+          .then(() => this._createSecurity('createUser', securities.users));
       });
   }
 
@@ -490,54 +490,18 @@ class Janitor {
     });
   }
 
-  _createRoles (roles) {
-    if (! roles) {
+  _createSecurity (action, objects) {
+    if (! objects) {
       return Bluebird.resolve();
     }
 
-    return Bluebird.map(Object.keys(roles), roleId => {
+    return Bluebird.map(Object.keys(objects), id => {
       const request = new Request({
         controller: 'security',
-        action: 'createOrReplaceRole',
+        action,
         refresh: 'wait_for',
-        _id: roleId,
-        body: roles[roleId]
-      });
-
-      return this.kuzzle.funnel.processRequest(request);
-    });
-  }
-
-  _createProfiles (profiles) {
-    if (! profiles) {
-      return Bluebird.resolve();
-    }
-
-    return Bluebird.map(Object.keys(profiles), profileId => {
-      const request = new Request({
-        controller: 'security',
-        action: 'createOrReplaceProfile',
-        refresh: 'wait_for',
-        _id: profileId,
-        body: profiles[profileId]
-      });
-
-      return this.kuzzle.funnel.processRequest(request);
-    });
-  }
-
-  _createUsers (users) {
-    if (! users) {
-      return Bluebird.resolve();
-    }
-
-    return Bluebird.map(Object.keys(users), userId => {
-      const request = new Request({
-        controller: 'security',
-        action: 'createUser',
-        refresh: 'wait_for',
-        _id: userId,
-        body: users[userId]
+        _id: id,
+        body: objects[id]
       });
 
       return this.kuzzle.funnel.processRequest(request);

--- a/lib/api/core/janitor.js
+++ b/lib/api/core/janitor.js
@@ -495,13 +495,13 @@ class Janitor {
       return Bluebird.resolve();
     }
 
-    return Bluebird.map(Object.keys(objects), id => {
+    return Bluebird.map(Object.keys(objects), _id => {
       const request = new Request({
-        controller: 'security',
         action,
+        _id,
+        controller: 'security',
         refresh: 'wait_for',
-        _id: id,
-        body: objects[id]
+        body: objects[_id]
       });
 
       return this.kuzzle.funnel.processRequest(request);

--- a/lib/api/core/janitor.js
+++ b/lib/api/core/janitor.js
@@ -49,6 +49,122 @@ class Janitor {
   }
 
   /**
+   * Load database fixtures into Kuzzle
+   *
+   * @param {String} filePath
+   * @returns {Promise}
+   */
+  loadFixtures (filePath) {
+    return new Bluebird((resolve, reject) => {
+      fs.readFile(filePath, 'utf8', (error, data) => {
+        if (error) {
+          return reject(error);
+        }
+
+        try {
+          const fixtures = JSON.parse(data);
+
+          resolve(fixtures);
+        }
+        catch (e) {
+          reject(e);
+        }
+      });
+    })
+    .then(fixtures => {
+      const requests = [];
+
+      for (const index of Object.keys(fixtures)) {
+        for (const collection of Object.keys(fixtures[index])) {
+          requests.push(new Request({
+            index,
+            collection,
+            body: {
+              bulkData: fixtures[index][collection]
+            }
+          }));
+        }
+      }
+
+      return requests;
+    })
+    .each(request => {
+      return this.kuzzle.services.list.storageEngine.import(request)
+        .then(res => {
+          if (res.partialErrors && res.partialErrors.length > 0) {
+            throw new PartialError(`Some data was not imported for ${request.input.resource.index}/${request.input.resource.collection} (${res.partialErrors.length}/${res.items.length + res.partialErrors.length}).`, res.partialErrors);
+          }
+        })
+        .then(() => {
+          const indexRequest = new Request({ index: request.input.resource.index });
+
+          return this.kuzzle.services.list.storageEngine.refreshIndex(indexRequest);
+        });
+    });
+  }
+
+  /**
+   * Load database mappings into Kuzzle
+   *
+   * @param {String} filePath
+   * @returns {Promise}
+   */
+  loadMappings (filePath) {
+    return new Bluebird((resolve, reject) => {
+      fs.readFile(filePath, 'utf8', (error, data) => {
+        if (error) {
+          return reject(error);
+        }
+
+        try {
+          const mappings = JSON.parse(data);
+
+          resolve(mappings);
+        }
+        catch (e) {
+          reject(e);
+        }
+      });
+    })
+    .then(mappings => {
+      const requests = [];
+
+      for (const index of Object.keys(mappings)) {
+        for (const collection of Object.keys(mappings[index])) {
+          requests.push(new Request({
+            index,
+            collection,
+            body: mappings[index][collection]
+          }));
+        }
+      }
+
+      return requests;
+    })
+    .each(request => {
+      const
+        index = request.input.resource.index,
+        indexRequest = new Request({index});
+
+      return this.kuzzle.services.list.storageEngine.indexExists(indexRequest)
+        .then(exist => {
+          if (! exist) {
+            return this.kuzzle.services.list.storageEngine.createIndex(indexRequest);
+          }
+        })
+        .then(() => this.kuzzle.services.list.storageEngine.updateMapping(request))
+        .then(() => this.kuzzle.services.list.storageEngine.refreshIndex(indexRequest))
+        .then(() => {
+          const collection = request.input.resource.collection;
+
+          this.kuzzle.indexCache.add(index, collection);
+
+          return null;
+        });
+    });
+  }
+
+  /**
    * Gracefully exits after processing remaining requests
    *
    * @param {Kuzzle} kuzzle

--- a/lib/api/core/janitor.js
+++ b/lib/api/core/janitor.js
@@ -29,6 +29,7 @@ const
   {
     BadRequestError,
     InternalError: KuzzleInternalError,
+    PartialError
   } = require('kuzzle-common-objects').errors,
   pm2 = require('pm2'),
   path = require('path'),
@@ -64,73 +65,6 @@ class Janitor {
       });
   }
 
-  _createRoles (roles) {
-    const promises = Object.keys(roles).map(roleId => {
-      const request = new Request({
-        controller: 'security',
-        action: 'createOrReplaceRole',
-        refresh: 'wait_for',
-        _id: roleId,
-        body: roles[roleId]
-      });
-
-      return this.kuzzle.funnel.processRequest(request);
-    });
-
-    return Bluebird.all(promises);
-  }
-
-  _createProfiles (profiles) {
-    const promises = Object.keys(profiles).map(profileId => {
-      const request = new Request({
-        controller: 'security',
-        action: 'createOrReplaceProfile',
-        refresh: 'wait_for',
-        _id: profileId,
-        body: profiles[profileId]
-      });
-
-      return this.kuzzle.funnel.processRequest(request);
-    });
-
-    return Bluebird.all(promises);
-  }
-
-  _createUsers (users) {
-    const promises = Object.keys(users).map(userId => {
-      const request = new Request({
-        controller: 'security',
-        action: 'createUser',
-        refresh: 'wait_for',
-        _id: userId,
-        body: users[userId]
-      });
-
-      return this.kuzzle.funnel.processRequest(request);
-    });
-
-    return Bluebird.all(promises);
-  }
-
-  _deleteUsers (users) {
-    const
-      ids = Object.keys(users).map(userId => userId),
-      request = new Request({
-        controller: 'security',
-        action: 'mDeleteUsers',
-        refresh: 'wait_for',
-        body: { ids }
-      });
-
-    return this.kuzzle.funnel.processRequest(request)
-      .catch(error => {
-        if (error.status === 206) {
-          return Bluebird.resolves();
-        }
-
-        return Bluebird.reject(error);
-      });
-  }
   /**
    * Load database fixtures into Kuzzle
    *
@@ -548,6 +482,90 @@ class Janitor {
         }
       });
     });
+  }
+
+  _createRoles (roles) {
+    if (! roles) {
+      return Bluebird.resolve();
+    }
+
+    const promises = Object.keys(roles).map(roleId => {
+      const request = new Request({
+        controller: 'security',
+        action: 'createOrReplaceRole',
+        refresh: 'wait_for',
+        _id: roleId,
+        body: roles[roleId]
+      });
+
+      return this.kuzzle.funnel.processRequest(request);
+    });
+
+    return Bluebird.all(promises);
+  }
+
+  _createProfiles (profiles) {
+    if (! profiles) {
+      return Bluebird.resolve();
+    }
+
+    const promises = Object.keys(profiles).map(profileId => {
+      const request = new Request({
+        controller: 'security',
+        action: 'createOrReplaceProfile',
+        refresh: 'wait_for',
+        _id: profileId,
+        body: profiles[profileId]
+      });
+
+      return this.kuzzle.funnel.processRequest(request);
+    });
+
+    return Bluebird.all(promises);
+  }
+
+  _createUsers (users) {
+    if (! users) {
+      return Bluebird.resolve();
+    }
+
+    const promises = Object.keys(users).map(userId => {
+      const request = new Request({
+        controller: 'security',
+        action: 'createUser',
+        refresh: 'wait_for',
+        _id: userId,
+        body: users[userId]
+      });
+
+      return this.kuzzle.funnel.processRequest(request);
+    });
+
+    return Bluebird.all(promises);
+  }
+
+  _deleteUsers (users) {
+    if (! users) {
+      return Bluebird.resolve();
+    }
+
+    const
+      ids = Object.keys(users).map(userId => userId),
+      request = new Request({
+        controller: 'security',
+        action: 'mDeleteUsers',
+        refresh: 'wait_for',
+        body: { ids }
+      });
+
+    return this.kuzzle.funnel.processRequest(request)
+      .catch(error => {
+        if (error.status === 206) {
+          return Bluebird.resolves();
+        }
+
+        return Bluebird.reject(error);
+      });
   }
 
 }

--- a/lib/api/core/janitor.js
+++ b/lib/api/core/janitor.js
@@ -49,58 +49,126 @@ class Janitor {
   }
 
   /**
+   * Load roles, profiles and users fixtures into Kuzzle
+   *
+   * @param {String} filePath
+   * @returns {Promise}
+   */
+  loadSecurities (filePath) {
+    return this._loadJson(filePath)
+      .then(securities => {
+        return this._createRoles(securities.roles)
+          .then(() => this._createProfiles(securities.profiles))
+          .then(() => this._deleteUsers(securities.users))
+          .then(() => this._createUsers(securities.users));
+      });
+  }
+
+  _createRoles (roles) {
+    const promises = Object.keys(roles).map(roleId => {
+      const request = new Request({
+        controller: 'security',
+        action: 'createOrReplaceRole',
+        refresh: 'wait_for',
+        _id: roleId,
+        body: roles[roleId]
+      });
+
+      return this.kuzzle.funnel.processRequest(request);
+    });
+
+    return Bluebird.all(promises);
+  }
+
+  _createProfiles (profiles) {
+    const promises = Object.keys(profiles).map(profileId => {
+      const request = new Request({
+        controller: 'security',
+        action: 'createOrReplaceProfile',
+        refresh: 'wait_for',
+        _id: profileId,
+        body: profiles[profileId]
+      });
+
+      return this.kuzzle.funnel.processRequest(request);
+    });
+
+    return Bluebird.all(promises);
+  }
+
+  _createUsers (users) {
+    const promises = Object.keys(users).map(userId => {
+      const request = new Request({
+        controller: 'security',
+        action: 'createUser',
+        refresh: 'wait_for',
+        _id: userId,
+        body: users[userId]
+      });
+
+      return this.kuzzle.funnel.processRequest(request);
+    });
+
+    return Bluebird.all(promises);
+  }
+
+  _deleteUsers (users) {
+    const
+      ids = Object.keys(users).map(userId => userId),
+      request = new Request({
+        controller: 'security',
+        action: 'mDeleteUsers',
+        refresh: 'wait_for',
+        body: { ids }
+      });
+
+    return this.kuzzle.funnel.processRequest(request)
+      .catch(error => {
+        if (error.status === 206) {
+          return Bluebird.resolves();
+        }
+
+        return Bluebird.reject(error);
+      });
+  }
+  /**
    * Load database fixtures into Kuzzle
    *
    * @param {String} filePath
    * @returns {Promise}
    */
   loadFixtures (filePath) {
-    return new Bluebird((resolve, reject) => {
-      fs.readFile(filePath, 'utf8', (error, data) => {
-        if (error) {
-          return reject(error);
-        }
+    return this._loadJson(filePath)
+      .then(fixtures => {
+        const requests = [];
 
-        try {
-          const fixtures = JSON.parse(data);
-
-          resolve(fixtures);
-        }
-        catch (e) {
-          reject(e);
-        }
-      });
-    })
-    .then(fixtures => {
-      const requests = [];
-
-      for (const index of Object.keys(fixtures)) {
-        for (const collection of Object.keys(fixtures[index])) {
-          requests.push(new Request({
-            index,
-            collection,
-            body: {
-              bulkData: fixtures[index][collection]
-            }
-          }));
-        }
-      }
-
-      return requests;
-    })
-    .each(request => {
-      return this.kuzzle.services.list.storageEngine.import(request)
-        .then(res => {
-          if (res.partialErrors && res.partialErrors.length > 0) {
-            throw new PartialError(`Some data was not imported for ${request.input.resource.index}/${request.input.resource.collection} (${res.partialErrors.length}/${res.items.length + res.partialErrors.length}).`, res.partialErrors);
+        for (const index of Object.keys(fixtures)) {
+          for (const collection of Object.keys(fixtures[index])) {
+            requests.push(new Request({
+              index,
+              collection,
+              body: {
+                bulkData: fixtures[index][collection]
+              }
+            }));
           }
-        })
-        .then(() => {
-          const indexRequest = new Request({ index: request.input.resource.index });
+        }
 
-          return this.kuzzle.services.list.storageEngine.refreshIndex(indexRequest);
-        });
-    });
+        return requests;
+      })
+      .each(request => {
+        return this.kuzzle.services.list.storageEngine.import(request)
+          .then(res => {
+            if (res.partialErrors && res.partialErrors.length > 0) {
+              throw new PartialError(`Some data was not imported for ${request.input.resource.index}/${request.input.resource.collection} (${res.partialErrors.length}/${res.items.length + res.partialErrors.length}).`, res.partialErrors);
+            }
+          })
+          .then(() => {
+            const indexRequest = new Request({ index: request.input.resource.index });
+
+            return this.kuzzle.services.list.storageEngine.refreshIndex(indexRequest);
+          });
+      });
   }
 
   /**
@@ -110,58 +178,43 @@ class Janitor {
    * @returns {Promise}
    */
   loadMappings (filePath) {
-    return new Bluebird((resolve, reject) => {
-      fs.readFile(filePath, 'utf8', (error, data) => {
-        if (error) {
-          return reject(error);
-        }
+    return this._loadJson(filePath)
+      .then(mappings => {
+        const requests = [];
 
-        try {
-          const mappings = JSON.parse(data);
-
-          resolve(mappings);
-        }
-        catch (e) {
-          reject(e);
-        }
-      });
-    })
-    .then(mappings => {
-      const requests = [];
-
-      for (const index of Object.keys(mappings)) {
-        for (const collection of Object.keys(mappings[index])) {
-          requests.push(new Request({
-            index,
-            collection,
-            body: mappings[index][collection]
-          }));
-        }
-      }
-
-      return requests;
-    })
-    .each(request => {
-      const
-        index = request.input.resource.index,
-        indexRequest = new Request({index});
-
-      return this.kuzzle.services.list.storageEngine.indexExists(indexRequest)
-        .then(exist => {
-          if (! exist) {
-            return this.kuzzle.services.list.storageEngine.createIndex(indexRequest);
+        for (const index of Object.keys(mappings)) {
+          for (const collection of Object.keys(mappings[index])) {
+            requests.push(new Request({
+              index,
+              collection,
+              body: mappings[index][collection]
+            }));
           }
-        })
-        .then(() => this.kuzzle.services.list.storageEngine.updateMapping(request))
-        .then(() => this.kuzzle.services.list.storageEngine.refreshIndex(indexRequest))
-        .then(() => {
-          const collection = request.input.resource.collection;
+        }
 
-          this.kuzzle.indexCache.add(index, collection);
+        return requests;
+      })
+      .each(request => {
+        const
+          index = request.input.resource.index,
+          indexRequest = new Request({index});
 
-          return null;
-        });
-    });
+        return this.kuzzle.services.list.storageEngine.indexExists(indexRequest)
+          .then(exist => {
+            if (! exist) {
+              return this.kuzzle.services.list.storageEngine.createIndex(indexRequest);
+            }
+          })
+          .then(() => this.kuzzle.services.list.storageEngine.updateMapping(request))
+          .then(() => this.kuzzle.services.list.storageEngine.refreshIndex(indexRequest))
+          .then(() => {
+            const collection = request.input.resource.collection;
+
+            this.kuzzle.indexCache.add(index, collection);
+
+            return null;
+          });
+      });
   }
 
   /**
@@ -476,6 +529,25 @@ class Janitor {
   _halt () {
     console.log('Halted.');
     process.exit(0);
+  }
+
+  _loadJson (filePath) {
+    return new Bluebird((resolve, reject) => {
+      fs.readFile(filePath, 'utf8', (error, rawData) => {
+        if (error) {
+          return reject(error);
+        }
+
+        try {
+          const data = JSON.parse(rawData);
+
+          resolve(data);
+        }
+        catch (e) {
+          reject(e);
+        }
+      });
+    });
   }
 
 }

--- a/lib/api/core/janitor.js
+++ b/lib/api/core/janitor.js
@@ -465,6 +465,12 @@ class Janitor {
     process.exit(0);
   }
 
+  /**
+   * Load a json file into a javascript object.
+   * It's better than a simple require because we asynchronously read the file
+   * and we avoid RCE if a javascript file is provided instead of JSON
+   *
+   */
   _loadJson (filePath) {
     return new Bluebird((resolve, reject) => {
       fs.readFile(filePath, 'utf8', (error, rawData) => {
@@ -489,7 +495,7 @@ class Janitor {
       return Bluebird.resolve();
     }
 
-    const promises = Object.keys(roles).map(roleId => {
+    return Bluebird.map(Object.keys(roles), roleId => {
       const request = new Request({
         controller: 'security',
         action: 'createOrReplaceRole',
@@ -500,8 +506,6 @@ class Janitor {
 
       return this.kuzzle.funnel.processRequest(request);
     });
-
-    return Bluebird.all(promises);
   }
 
   _createProfiles (profiles) {
@@ -509,7 +513,7 @@ class Janitor {
       return Bluebird.resolve();
     }
 
-    const promises = Object.keys(profiles).map(profileId => {
+    return Bluebird.map(Object.keys(profiles), profileId => {
       const request = new Request({
         controller: 'security',
         action: 'createOrReplaceProfile',
@@ -520,8 +524,6 @@ class Janitor {
 
       return this.kuzzle.funnel.processRequest(request);
     });
-
-    return Bluebird.all(promises);
   }
 
   _createUsers (users) {
@@ -529,7 +531,7 @@ class Janitor {
       return Bluebird.resolve();
     }
 
-    const promises = Object.keys(users).map(userId => {
+    return Bluebird.map(Object.keys(users), userId => {
       const request = new Request({
         controller: 'security',
         action: 'createUser',
@@ -540,8 +542,6 @@ class Janitor {
 
       return this.kuzzle.funnel.processRequest(request);
     });
-
-    return Bluebird.all(promises);
   }
 
   _deleteUsers (users) {
@@ -550,7 +550,7 @@ class Janitor {
     }
 
     const
-      ids = Object.keys(users).map(userId => userId),
+      ids = Object.keys(users),
       request = new Request({
         controller: 'security',
         action: 'mDeleteUsers',
@@ -561,10 +561,10 @@ class Janitor {
     return this.kuzzle.funnel.processRequest(request)
       .catch(error => {
         if (error.status === 206) {
-          return Bluebird.resolves();
+          return null;
         }
 
-        return Bluebird.reject(error);
+        throw error;
       });
   }
 

--- a/lib/api/core/models/repositories/pluginRepository.js
+++ b/lib/api/core/models/repositories/pluginRepository.js
@@ -107,7 +107,7 @@ class PluginRepository extends Repository {
    * @returns {Promise}
    */
   load (documentId) {
-    return super.load(documentId);
+    return super.load(documentId, { returnNull: true });
   }
 
   /**

--- a/lib/api/core/models/repositories/pluginRepository.js
+++ b/lib/api/core/models/repositories/pluginRepository.js
@@ -21,6 +21,9 @@
 
 const
   _ = require('lodash'),
+  {
+    NotFoundError
+  } = require('kuzzle-common-objects').errors,
   Repository = require('./repository');
 
 class PluginRepository extends Repository {
@@ -103,11 +106,21 @@ class PluginRepository extends Repository {
   }
 
   /**
+   * If we load a user that does not exists, we have to resolve the promise with null
+   * instead of throwing NotFoundError
+   *
    * @param {string} documentId
    * @returns {Promise}
    */
   load (documentId) {
-    return super.load(documentId, { returnNull: true });
+    return super.load(documentId)
+      .catch(error => {
+        if (this.collection === 'users' && (error instanceof NotFoundError)) {
+          return Promise.resolve(null);
+        }
+
+        throw error;
+      });
   }
 
   /**

--- a/lib/api/core/models/repositories/profileRepository.js
+++ b/lib/api/core/models/repositories/profileRepository.js
@@ -76,9 +76,8 @@ class ProfileRepository extends Repository {
 
     return super.load(id)
       .then(profile => {
-        if (profile) {
-          this.profiles[id] = profile;
-        }
+        this.profiles[id] = profile;
+
         return profile;
       });
   }

--- a/lib/api/core/models/repositories/repository.js
+++ b/lib/api/core/models/repositories/repository.js
@@ -80,10 +80,15 @@ class Repository {
   }
 
   /**
+   * The options object currently accepts one optional parameter:
+   * - returnNull, which allow to return null instead of reject the promise if the object is not found
+   * Actually this behavior is only used by the persistUser generator in the securityController and in the PluginRepository load method
+   *
    * @param {string} id
+   * @param {object} [options]
    * @returns {Promise} resolves on a new ObjectConstructor()
    */
-  loadOneFromDatabase (id) {
+  loadOneFromDatabase (id, options = {}) {
     return this.databaseEngine.get(this.collection, id)
       .then(response => {
         if (response._id) {
@@ -98,15 +103,19 @@ class Repository {
 
           return this.fromDTO(dto);
         }
+
         return null;
       })
       .catch(error => {
-        if (error.status === 404) {
-          // no content found, we return null without failing
-          return Bluebird.resolve(null);
+        if (error.status !== 404) {
+          return Bluebird.reject(error);
         }
 
-        return Bluebird.reject(error);
+        if (! options.returnNull) {
+          return Bluebird.reject(new NotFoundError(`Unable to find ${this._objectName()} with id '${id}'`));
+        }
+
+        return Bluebird.resolve(null);
       });
   }
 
@@ -189,9 +198,11 @@ class Repository {
    * If the object is not found in Cache and found in the Database,
    * it will be written to cache also.
    *
-   * The opts object currently accepts one optional parameter: key, which forces
-   * the cache key to fetch.
+   * The opts object currently accepts two optional parameter:
+   * - key, which forces the cache key to fetch.
    * In case the key is not provided, it defauls to <collection>/id, i.e.: this.kuzzle/users/12
+   * - returnNull, which allow to return null instead of reject the promise if the object is not found
+   * Actually this behavior is only used by the persistUser generator in the securityController and in the PluginRepository load method
    *
    * @param {string} id - The id of the object to get
    * @param {object} [options] - Optional options.
@@ -199,7 +210,7 @@ class Repository {
    */
   load (id, options = {}) {
     if (!this.cacheEngine) {
-      return this.loadOneFromDatabase(id);
+      return this.loadOneFromDatabase(id, options);
     }
 
     return this.loadFromCache(id, options)
@@ -209,11 +220,12 @@ class Repository {
             return null;
           }
 
-          return this.loadOneFromDatabase(id)
+          return this.loadOneFromDatabase(id, options)
             .then(objectFromDatabase => {
               if (objectFromDatabase !== null) {
                 this.persistToCache(objectFromDatabase);
               }
+
               return objectFromDatabase;
             });
         }

--- a/lib/api/core/models/repositories/repository.js
+++ b/lib/api/core/models/repositories/repository.js
@@ -26,6 +26,7 @@ const
   {
     BadRequestError,
     InternalError: KuzzleInternalError,
+    NotFoundError
   } = require('kuzzle-common-objects').errors;
 
 const _kuzzle = Symbol.for('_kuzzle');
@@ -244,6 +245,10 @@ class Repository {
    * @returns {Promise}
    */
   delete (object, options = {}) {
+    if (! object) {
+      return Bluebird.reject(new NotFoundError(`Unable to find ${this._objectName()}`));
+    }
+
     if (! object._id) {
       return Bluebird.reject(new BadRequestError(`Missing ${this._objectName()} id`));
     }

--- a/lib/api/core/models/repositories/repository.js
+++ b/lib/api/core/models/repositories/repository.js
@@ -189,7 +189,7 @@ class Repository {
    * If the object is not found in Cache and found in the Database,
    * it will be written to cache also.
    *
-   * The opts object currently accepts ont optional parameter: key, which forces
+   * The opts object currently accepts one optional parameter: key, which forces
    * the cache key to fetch.
    * In case the key is not provided, it defauls to <collection>/id, i.e.: this.kuzzle/users/12
    *

--- a/lib/api/core/models/repositories/repository.js
+++ b/lib/api/core/models/repositories/repository.js
@@ -80,15 +80,10 @@ class Repository {
   }
 
   /**
-   * The options object currently accepts one optional parameter:
-   * - returnNull, which allow to return null instead of reject the promise if the object is not found
-   * Actually this behavior is only used by the persistUser generator in the securityController and in the PluginRepository load method
-   *
    * @param {string} id
-   * @param {object} [options]
    * @returns {Promise} resolves on a new ObjectConstructor()
    */
-  loadOneFromDatabase (id, options = {}) {
+  loadOneFromDatabase (id) {
     return this.databaseEngine.get(this.collection, id)
       .then(response => {
         if (response._id) {
@@ -107,15 +102,11 @@ class Repository {
         return null;
       })
       .catch(error => {
-        if (error.status !== 404) {
-          return Bluebird.reject(error);
+        if (error.status === 404) {
+          throw new NotFoundError(`Unable to find ${this._objectName()} with id '${id}'`);
         }
 
-        if (! options.returnNull) {
-          return Bluebird.reject(new NotFoundError(`Unable to find ${this._objectName()} with id '${id}'`));
-        }
-
-        return Bluebird.resolve(null);
+        throw error;
       });
   }
 
@@ -198,11 +189,9 @@ class Repository {
    * If the object is not found in Cache and found in the Database,
    * it will be written to cache also.
    *
-   * The opts object currently accepts two optional parameter:
-   * - key, which forces the cache key to fetch.
+   * The opts object currently accepts ont optional parameter: key, which forces
+   * the cache key to fetch.
    * In case the key is not provided, it defauls to <collection>/id, i.e.: this.kuzzle/users/12
-   * - returnNull, which allow to return null instead of reject the promise if the object is not found
-   * Actually this behavior is only used by the persistUser generator in the securityController and in the PluginRepository load method
    *
    * @param {string} id - The id of the object to get
    * @param {object} [options] - Optional options.
@@ -210,7 +199,7 @@ class Repository {
    */
   load (id, options = {}) {
     if (!this.cacheEngine) {
-      return this.loadOneFromDatabase(id, options);
+      return this.loadOneFromDatabase(id);
     }
 
     return this.loadFromCache(id, options)
@@ -220,7 +209,7 @@ class Repository {
             return null;
           }
 
-          return this.loadOneFromDatabase(id, options)
+          return this.loadOneFromDatabase(id)
             .then(objectFromDatabase => {
               if (objectFromDatabase !== null) {
                 this.persistToCache(objectFromDatabase);

--- a/lib/api/core/models/repositories/roleRepository.js
+++ b/lib/api/core/models/repositories/roleRepository.js
@@ -117,7 +117,7 @@ class RoleRepository extends Repository {
     }
 
     if (typeof id !== 'string') {
-      return Bluebird.reject(new BadRequestError('A role ID must be provided'));
+      return Bluebird.reject(new BadRequestError(`Invalid argument: Expected profile id to be a string, received "${typeof id}"`));
     }
 
     if (this.roles[id]) {
@@ -126,9 +126,8 @@ class RoleRepository extends Repository {
 
     return this.loadOneFromDatabase(id)
       .then(role => {
-        if (role) {
-          this.roles[role._id] = role;
-        }
+        this.roles[role._id] = role;
+
         return role;
       });
   }

--- a/lib/api/core/models/repositories/userRepository.js
+++ b/lib/api/core/models/repositories/userRepository.js
@@ -98,12 +98,24 @@ class UserRepository extends Repository {
     super.init({});
   }
 
-  load (id) {
+  /**
+   * Load a user from the repository
+   *
+   * The options object currently accepts one optional parameter:
+   * - returnNull, which allow to return null instead of reject the promise if the object is not found
+   * Actually this behavior is only used by the persistUser generator in the securityController and the load method in PluginRepository
+   *
+   * @param {string} id
+   * @param {object} options
+   * @return {Promise|null}
+   *
+   */
+  load (id, options = {}) {
     if (id === 'anonymous' || id === '-1') {
       return Bluebird.resolve(this.anonymous());
     }
 
-    return super.load(id);
+    return super.load(id, options);
   }
 
   persist (user, options = {}) {

--- a/lib/api/core/models/repositories/userRepository.js
+++ b/lib/api/core/models/repositories/userRepository.js
@@ -101,21 +101,16 @@ class UserRepository extends Repository {
   /**
    * Load a user from the repository
    *
-   * The options object currently accepts one optional parameter:
-   * - returnNull, which allow to return null instead of reject the promise if the object is not found
-   * Actually this behavior is only used by the persistUser generator in the securityController and the load method in PluginRepository
-   *
    * @param {string} id
-   * @param {object} options
    * @return {Promise|null}
    *
    */
-  load (id, options = {}) {
+  load (id) {
     if (id === 'anonymous' || id === '-1') {
       return Bluebird.resolve(this.anonymous());
     }
 
-    return super.load(id, options);
+    return super.load(id);
   }
 
   persist (user, options = {}) {
@@ -130,8 +125,9 @@ class UserRepository extends Repository {
     return this.anonymous()
       .then(anonymous => {
         if (user._id === anonymous._id && user.profileIds.indexOf('anonymous') === -1) {
-          return Bluebird.reject(new BadRequestError('Anonymous user must be assigned the anonymous profile'));
+          throw new BadRequestError('Anonymous user must be assigned the anonymous profile');
         }
+
         return this.persistToDatabase(user, databaseOptions);
       })
       .then(() => this.persistToCache(user, cacheOptions))

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -282,7 +282,7 @@ class ElasticSearch extends Service {
 
         // Add metadata
         esRequest.body._kuzzle_info = {
-          author: getUserId(request),
+          author: this._getUserId(request),
           createdAt: Date.now(),
           updatedAt: null,
           updater: null,
@@ -338,7 +338,7 @@ class ElasticSearch extends Service {
   createOrReplace(request) {
     const
       esRequest = initESRequest(request, ['refresh']),
-      userId = getUserId(request);
+      userId = this._getUserId(request);
 
     esRequest.id = request.input.resource._id;
     esRequest.body = request.input.body;
@@ -399,7 +399,7 @@ class ElasticSearch extends Service {
         esRequest.body._kuzzle_info = {
           active: true,
           updatedAt: Date.now(),
-          updater: getUserId(request)
+          updater: this._getUserId(request)
         };
 
         esRequest.body = {doc: esRequest.body};
@@ -424,7 +424,7 @@ class ElasticSearch extends Service {
         type: esRequest.type,
         id: request.input.resource._id
       },
-      userId = getUserId(request);
+      userId = this._getUserId(request);
 
     esRequest.id = request.input.resource._id;
     esRequest.body = request.input.body;
@@ -490,7 +490,7 @@ class ElasticSearch extends Service {
             _kuzzle_info: {
               active: false,
               deletedAt: Date.now(),
-              updater: getUserId(request)
+              updater: this._getUserId(request)
             }
           }
         };
@@ -528,7 +528,7 @@ class ElasticSearch extends Service {
       .then(ids => {
         ids.forEach(id => {
           esRequestBulk.body.push({update: {_index: esRequestBulk.index, _type: esRequestBulk.type, _id: id}});
-          esRequestBulk.body.push({doc: {_kuzzle_info: { active: false, deletedAt: ts, updater: getUserId(request)}}});
+          esRequestBulk.body.push({doc: {_kuzzle_info: { active: false, deletedAt: ts, updater: this._getUserId(request)}}});
         });
 
         if (esRequestBulk.body.length === 0) {
@@ -642,7 +642,7 @@ class ElasticSearch extends Service {
     const
       actionNames = ['index', 'create', 'update', 'delete'],
       esRequest = initESRequest(request, ['consistency', 'refresh', 'timeout', 'fields']),
-      userId = getUserId(request),
+      userId = this._getUserId(request),
       dateNow = Date.now();
 
     assertWellFormedRefresh(esRequest);
@@ -990,7 +990,7 @@ class ElasticSearch extends Service {
       extracted = extractMDocuments(request, {
         _kuzzle_info: {
           active: true,
-          author: getUserId(request),
+          author: this._getUserId(request),
           updater: null,
           updatedAt: null,
           deletedAt: null,
@@ -1057,7 +1057,7 @@ class ElasticSearch extends Service {
       extracted = extractMDocuments(request, {
         _kuzzle_info: {
           active: true,
-          author: getUserId(request),
+          author: this._getUserId(request),
           updater: null,
           updatedAt: null,
           deletedAt: null,
@@ -1099,7 +1099,7 @@ class ElasticSearch extends Service {
         _kuzzle_info: {
           active: true,
           updatedAt: Date.now(),
-          updater: getUserId(request),
+          updater: this._getUserId(request),
           deletedAt: null
         }
       });
@@ -1146,7 +1146,7 @@ class ElasticSearch extends Service {
       extracted = extractMDocuments(request, {
         _kuzzle_info: {
           active: true,
-          author: getUserId(request),
+          author: this._getUserId(request),
           updater: null,
           updatedAt: null,
           deletedAt: null,
@@ -1205,7 +1205,7 @@ class ElasticSearch extends Service {
         _kuzzle_info: {
           active: false,
           deletedAt: Date.now(),
-          updater: getUserId(request)
+          updater: this._getUserId(request)
         }
       };
 
@@ -1273,6 +1273,14 @@ class ElasticSearch extends Service {
         return {result: successes, error: partialErrors};
       })
       .catch(err => Bluebird.reject(this.esWrapper.formatESError(err)));
+  }
+
+  _getUserId (request) {
+    if (request.context.user && request.context.user._id) {
+      return String(request.context.user._id);
+    }
+
+    return null;
   }
 }
 
@@ -1520,12 +1528,4 @@ function extractMDocuments(request, metadata) {
   }
 
   return result;
-}
-
-function getUserId (request) {
-  if (request.context.user) {
-    return request.context.user._id ? String(request.context.user._id) : null;
-  }
-
-  return null;
 }

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -282,7 +282,7 @@ class ElasticSearch extends Service {
 
         // Add metadata
         esRequest.body._kuzzle_info = {
-          author: request.context.user._id ? String(request.context.user._id) : null,
+          author: getUserId(request),
           createdAt: Date.now(),
           updatedAt: null,
           updater: null,
@@ -338,7 +338,7 @@ class ElasticSearch extends Service {
   createOrReplace(request) {
     const
       esRequest = initESRequest(request, ['refresh']),
-      userId = request.context.user._id ? String(request.context.user._id) : null;
+      userId = getUserId(request);
 
     esRequest.id = request.input.resource._id;
     esRequest.body = request.input.body;
@@ -399,7 +399,7 @@ class ElasticSearch extends Service {
         esRequest.body._kuzzle_info = {
           active: true,
           updatedAt: Date.now(),
-          updater: request.context.user._id ? String(request.context.user._id) : null
+          updater: getUserId(request)
         };
 
         esRequest.body = {doc: esRequest.body};
@@ -424,7 +424,7 @@ class ElasticSearch extends Service {
         type: esRequest.type,
         id: request.input.resource._id
       },
-      userId = request.context.user._id ? String(request.context.user._id) : null;
+      userId = getUserId(request);
 
     esRequest.id = request.input.resource._id;
     esRequest.body = request.input.body;
@@ -490,7 +490,7 @@ class ElasticSearch extends Service {
             _kuzzle_info: {
               active: false,
               deletedAt: Date.now(),
-              updater: request.context.user._id ? String(request.context.user._id) : null
+              updater: getUserId(request)
             }
           }
         };
@@ -528,7 +528,7 @@ class ElasticSearch extends Service {
       .then(ids => {
         ids.forEach(id => {
           esRequestBulk.body.push({update: {_index: esRequestBulk.index, _type: esRequestBulk.type, _id: id}});
-          esRequestBulk.body.push({doc: {_kuzzle_info: { active: false, deletedAt: ts, updater: request.context.user._id ? String(request.context.user._id) : null}}});
+          esRequestBulk.body.push({doc: {_kuzzle_info: { active: false, deletedAt: ts, updater: getUserId(request)}}});
         });
 
         if (esRequestBulk.body.length === 0) {
@@ -642,7 +642,7 @@ class ElasticSearch extends Service {
     const
       actionNames = ['index', 'create', 'update', 'delete'],
       esRequest = initESRequest(request, ['consistency', 'refresh', 'timeout', 'fields']),
-      userId = request.context.user._id ? String(request.context.user._id) : null,
+      userId = getUserId(request),
       dateNow = Date.now();
 
     assertWellFormedRefresh(esRequest);
@@ -990,7 +990,7 @@ class ElasticSearch extends Service {
       extracted = extractMDocuments(request, {
         _kuzzle_info: {
           active: true,
-          author: request.context.user._id ? String(request.context.user._id) : null,
+          author: getUserId(request),
           updater: null,
           updatedAt: null,
           deletedAt: null,
@@ -1057,7 +1057,7 @@ class ElasticSearch extends Service {
       extracted = extractMDocuments(request, {
         _kuzzle_info: {
           active: true,
-          author: request.context.user._id ? String(request.context.user._id) : null,
+          author: getUserId(request),
           updater: null,
           updatedAt: null,
           deletedAt: null,
@@ -1099,7 +1099,7 @@ class ElasticSearch extends Service {
         _kuzzle_info: {
           active: true,
           updatedAt: Date.now(),
-          updater: request.context.user._id ? String(request.context.user._id) : null,
+          updater: getUserId(request),
           deletedAt: null
         }
       });
@@ -1146,7 +1146,7 @@ class ElasticSearch extends Service {
       extracted = extractMDocuments(request, {
         _kuzzle_info: {
           active: true,
-          author: request.context.user._id ? String(request.context.user._id) : null,
+          author: getUserId(request),
           updater: null,
           updatedAt: null,
           deletedAt: null,
@@ -1205,7 +1205,7 @@ class ElasticSearch extends Service {
         _kuzzle_info: {
           active: false,
           deletedAt: Date.now(),
-          updater: request.context.user._id ? String(request.context.user._id) : null
+          updater: getUserId(request)
         }
       };
 
@@ -1520,4 +1520,12 @@ function extractMDocuments(request, metadata) {
   }
 
   return result;
+}
+
+function getUserId (request) {
+  if (request.context.user) {
+    return request.context.user._id ? String(request.context.user._id) : null;
+  }
+
+  return null;
 }

--- a/test/api/controllers/securityController/roles.test.js
+++ b/test/api/controllers/securityController/roles.test.js
@@ -248,7 +248,7 @@ describe('Test: security controller - roles', () => {
     it('should return response with on deleteRole call', done => {
       const role = {my: 'role'};
 
-      kuzzle.repositories.role.getRoleFromRequest.resolves(role);
+      kuzzle.repositories.role.load.resolves(role);
       kuzzle.repositories.role.delete.resolves();
 
       securityController.deleteRole(new Request({_id: 'test',body: {}}))

--- a/test/api/core/janitor.test.js
+++ b/test/api/core/janitor.test.js
@@ -28,7 +28,7 @@ describe('Test: core/janitor', () => {
     janitor = new Janitor(kuzzle);
   });
 
-  describe.only('#loadSecurities', () => {
+  describe('#loadSecurities', () => {
     let
       fsStub;
 

--- a/test/api/core/janitor.test.js
+++ b/test/api/core/janitor.test.js
@@ -28,6 +28,90 @@ describe('Test: core/janitor', () => {
     janitor = new Janitor(kuzzle);
   });
 
+  describe.only('#loadSecurities', () => {
+    let
+      fsStub;
+
+    const
+      securities = require('../../mocks/securities.json');
+
+    afterEach(() => {
+      mockrequire.stopAll();
+    });
+
+    beforeEach(() => {
+      fsStub = {
+        readFile: sinon.stub()
+      };
+
+      mockrequire('fs-extra', fsStub);
+
+      Janitor = mockrequire.reRequire('../../../lib/api/core/janitor');
+      janitor = new Janitor(kuzzle);
+    });
+
+    it('create or replace roles', done => {
+      fsStub.readFile.yields(null, JSON.stringify({ roles: securities.roles }));
+      kuzzle.funnel.processRequest.resolves(true);
+
+      janitor.loadSecurities('path')
+        .then(() => {
+          should(kuzzle.funnel.processRequest.callCount).be.eql(2);
+
+          should(kuzzle.funnel.processRequest.getCall(1).args[0].input.action).be.eql('createOrReplaceRole');
+          should(kuzzle.funnel.processRequest.getCall(0).args[0].input.resource._id).be.eql('driver');
+          should(kuzzle.funnel.processRequest.getCall(0).args[0].input.body.controllers.document.actions['*']).be.eql(true);
+
+          done();
+        })
+        .catch(error => {
+          done(error);
+        });
+    });
+
+    it('create or replace profiles', done => {
+      fsStub.readFile.yields(null, JSON.stringify({ profiles: securities.profiles }));
+      kuzzle.funnel.processRequest.resolves(true);
+
+      janitor.loadSecurities('path')
+        .then(() => {
+          should(kuzzle.funnel.processRequest.callCount).be.eql(2);
+
+          should(kuzzle.funnel.processRequest.getCall(1).args[0].input.action).be.eql('createOrReplaceProfile');
+          should(kuzzle.funnel.processRequest.getCall(1).args[0].input.resource._id).be.eql('customer');
+          should(kuzzle.funnel.processRequest.getCall(1).args[0].input.body.policies[0].roleId).be.eql('customer');
+
+          done();
+        })
+        .catch(error => {
+          done(error);
+        });
+    });
+
+    it('delete then create users', done => {
+      fsStub.readFile.yields(null, JSON.stringify({ users: securities.users }));
+      kuzzle.funnel.processRequest.resolves(true);
+
+      janitor.loadSecurities('path')
+        .then(() => {
+          should(kuzzle.funnel.processRequest.callCount).be.eql(3);
+
+          should(kuzzle.funnel.processRequest.getCall(0).args[0].input.action).be.eql('mDeleteUsers');
+          should(kuzzle.funnel.processRequest.getCall(0).args[0].input.body.ids).be.eql(['gfreeman', 'bcalhoun']);
+
+          should(kuzzle.funnel.processRequest.getCall(1).args[0].input.action).be.eql('createUser');
+          should(kuzzle.funnel.processRequest.getCall(1).args[0].input.resource._id).be.eql('gfreeman');
+          should(kuzzle.funnel.processRequest.getCall(1).args[0].input.body.content.profileIds).be.eql(['driver']);
+
+          done();
+        })
+        .catch(error => {
+          done(error);
+        });
+    });
+
+  });
+
   describe('#loadFixtures', () => {
     let
       fsStub;
@@ -36,7 +120,7 @@ describe('Test: core/janitor', () => {
       fixtures = require('../../mocks/fixtures.json');
 
     afterEach(() => {
-     mockrequire.stopAll();
+      mockrequire.stopAll();
     });
 
     beforeEach(() => {
@@ -53,16 +137,16 @@ describe('Test: core/janitor', () => {
     it('create index and collection that does not exists', done => {
       fsStub.readFile.yields(null, JSON.stringify(fixtures));
       const storageEngine = kuzzle.services.list.storageEngine;
-      storageEngine.import.onCall(0).resolves(false)
-                               .onCall(1).resolves(true)
-                               .onCall(2).resolves(false);
+      storageEngine.import.onCall(0).resolves(false);
+      storageEngine.import.onCall(1).resolves(true);
+      storageEngine.import.onCall(2).resolves(false);
 
       janitor.loadFixtures('path')
         .then(() => {
           should(storageEngine.import.callCount).be.eql(3);
           should(storageEngine.import.getCall(0).args[0].input.resource.index).be.eql('nyc-open-data');
           should(storageEngine.import.getCall(0).args[0].input.resource.collection).be.eql('yellow-taxi');
-          should(storageEngine.import.getCall(0).args[0].input.body.bulkData[1]).be.eql({ "name": "alyx" });
+          should(storageEngine.import.getCall(0).args[0].input.body.bulkData[1]).be.eql({ name: 'alyx' });
 
           should(storageEngine.refreshIndex.callCount).be.eql(3);
 
@@ -82,7 +166,7 @@ describe('Test: core/janitor', () => {
       mappings = require('../../mocks/mappings.json');
 
     afterEach(() => {
-     mockrequire.stopAll();
+      mockrequire.stopAll();
     });
 
     beforeEach(() => {
@@ -99,9 +183,9 @@ describe('Test: core/janitor', () => {
     it('create index and collection that does not exists', done => {
       fsStub.readFile.yields(null, JSON.stringify(mappings));
       const storageEngine = kuzzle.services.list.storageEngine;
-      storageEngine.indexExists.onCall(0).resolves(false)
-                               .onCall(1).resolves(true)
-                               .onCall(2).resolves(false);
+      storageEngine.indexExists.onCall(0).resolves(false);
+      storageEngine.indexExists.onCall(1).resolves(true);
+      storageEngine.indexExists.onCall(2).resolves(false);
 
       janitor.loadMappings('path')
         .then(() => {
@@ -111,7 +195,7 @@ describe('Test: core/janitor', () => {
 
           should(storageEngine.updateMapping.callCount).be.eql(3);
           should(storageEngine.updateMapping.getCall(0).args[0].input.resource.collection).be.eql('yellow-taxi');
-          should(storageEngine.updateMapping.getCall(0).args[0].input.body.properties).be.eql({ "name": { "type": "text" } });
+          should(storageEngine.updateMapping.getCall(0).args[0].input.body.properties).be.eql({ name: { type: 'text' } });
 
           should(storageEngine.refreshIndex.callCount).be.eql(3);
 

--- a/test/api/core/models/repositories/profileRepository.test.js
+++ b/test/api/core/models/repositories/profileRepository.test.js
@@ -60,12 +60,15 @@ describe('Test: repositories/profileRepository', () => {
         });
     });
 
-    it('should return null if the profile does not exist', () => {
+    it('should reject if the profile does not exist', done => {
       kuzzle.internalEngine.get.rejects(new NotFoundError('Not found'));
 
-      return profileRepository.load('idontexist')
-        .then(result => {
-          should(result).be.null();
+      profileRepository.load('idontexist')
+        .then(() => done(new Error('Should reject with NotFoundError')))
+        .catch(error => {
+          should(error).be.instanceOf(NotFoundError);
+          should(error.message).eql('Unable to find profile with id \'idontexist\'');
+          done();
         });
     });
 

--- a/test/api/core/models/repositories/repository.test.js
+++ b/test/api/core/models/repositories/repository.test.js
@@ -262,6 +262,15 @@ describe('Test: repositories/repository', () => {
         });
     });
 
+    it('should return a 404 if the given object is not present', done => {
+      repository.delete(null)
+        .then(() => done(new Error('should throw error')))
+        .catch(error => {
+          should(error).be.instanceOf(NotFoundError);
+          done();
+        });
+    });
+
     it('should delete an object from both cache and database when pertinent', () => {
       const someObject = { _id: 'someId' };
 

--- a/test/api/core/models/repositories/repository.test.js
+++ b/test/api/core/models/repositories/repository.test.js
@@ -49,13 +49,6 @@ describe('Test: repositories/repository', () => {
         });
     });
 
-    it('should return null for an non existing id with returnNull to true', () => {
-      kuzzle.internalEngine.get.rejects(new NotFoundError('Not found'));
-
-      return repository.loadOneFromDatabase(-9999, { returnNull: true })
-        .then(result => should(result).be.null());
-    });
-
     it('should reject the promise in case of error', () => {
       kuzzle.internalEngine.get.rejects(new KuzzleInternalError('error'));
 
@@ -165,13 +158,6 @@ describe('Test: repositories/repository', () => {
           should(error.message).eql('Unable to find object with id \'-9999\'');
           done();
         });
-    });
-
-    it('should return null for an non existing id with returnNull to true', () => {
-      kuzzle.internalEngine.get.rejects(new NotFoundError('Not found'));
-
-      return repository.load(-9999, { returnNull: true })
-        .then(result => should(result).be.null());
     });
 
     it('should reject the promise in case of error', () => {

--- a/test/api/core/models/repositories/repository.test.js
+++ b/test/api/core/models/repositories/repository.test.js
@@ -31,14 +31,28 @@ describe('Test: repositories/repository', () => {
 
     repository = new Repository(kuzzle);
     repository.index = '%test';
-    repository.collection = 'repository';
+    repository.collection = 'objects';
     repository.init({});
     repository.ObjectConstructor = ObjectConstructor;
   });
 
   describe('#loadOneFromDatabase', () => {
-    it('should return null for an non existing id', () => {
-      return repository.loadOneFromDatabase(-9999)
+    it('should reject for an non existing id', done => {
+      kuzzle.internalEngine.get.rejects(new NotFoundError('Not found'));
+
+      repository.loadOneFromDatabase(-9999)
+        .then(() => done(new Error('Should reject with a NotFoundError')))
+        .catch(error => {
+          should(error).be.instanceOf(NotFoundError);
+          should(error.message).eql('Unable to find object with id \'-9999\'');
+          done();
+        });
+    });
+
+    it('should return null for an non existing id with returnNull to true', () => {
+      kuzzle.internalEngine.get.rejects(new NotFoundError('Not found'));
+
+      return repository.loadOneFromDatabase(-9999, { returnNull: true })
         .then(result => should(result).be.null());
     });
 
@@ -141,10 +155,22 @@ describe('Test: repositories/repository', () => {
   });
 
   describe('#load', () => {
-    it('should return null for an non-existing id', () => {
-      kuzzle.internalEngine.get.rejects(new NotFoundError('test'));
+    it('should reject for an non existing id', done => {
+      kuzzle.internalEngine.get.rejects(new NotFoundError('Not found'));
 
-      return repository.load(-999)
+      repository.load(-9999)
+        .then(() => done(new Error('Should reject with a NotFoundError')))
+        .catch(error => {
+          should(error).be.instanceOf(NotFoundError);
+          should(error.message).eql('Unable to find object with id \'-9999\'');
+          done();
+        });
+    });
+
+    it('should return null for an non existing id with returnNull to true', () => {
+      kuzzle.internalEngine.get.rejects(new NotFoundError('Not found'));
+
+      return repository.load(-9999, { returnNull: true })
         .then(result => should(result).be.null());
     });
 

--- a/test/mocks/fixtures.json
+++ b/test/mocks/fixtures.json
@@ -1,0 +1,24 @@
+{
+  "nyc-open-data": {
+    "yellow-taxi": [
+      { "index": {} },
+      { "name": "alyx" },
+      { "index": {} },
+      { "name": "gordon" }
+    ],
+    "green-taxi": [
+      { "index": {} },
+      { "data": "anti-citizen", "number": 1 },
+      { "index": {} },
+      { "data": "lambda-core", "number": 42 }
+    ]
+  },
+  "mtp-open-data": {
+    "yellow-bicycle": [
+      { "index": {} },
+      { "name": "kleiner" },
+      { "index": {} },
+      { "name": "eli" }
+    ]
+  }
+}

--- a/test/mocks/mappings.json
+++ b/test/mocks/mappings.json
@@ -1,0 +1,22 @@
+{
+  "nyc-open-data": {
+    "yellow-taxi": {
+      "properties": {
+        "name": { "type": "text" }
+      }
+    },
+    "green-taxi": {
+      "properties": {
+        "data": { "type": "text"},
+        "number": { "type": "integer" }
+      }
+    }
+  },
+  "mtp-open-data": {
+    "yellow-bicycle": {
+      "properties": {
+        "name": { "type": "text" }
+      }
+    }
+  }
+}

--- a/test/mocks/securities.json
+++ b/test/mocks/securities.json
@@ -1,0 +1,85 @@
+{
+  "roles": {
+    "driver": {
+      "controllers": {
+        "auth": {
+          "actions": {
+            "checkToken": true,
+            "getCurrentUser": true,
+            "getMyRights": true,
+            "login": true
+          }
+        },
+        "document": {
+          "actions": {
+            "*": true
+          }
+        }
+      }
+    },
+    "customer": {
+      "controllers": {
+        "auth": {
+          "actions": {
+            "checkToken": true,
+            "getCurrentUser": true,
+            "getMyRights": true,
+            "login": true
+          }
+        },
+        "document": {
+          "actions": {
+            "get": true,
+            "search": true
+          }
+        }
+      }
+    }
+  },
+  "profiles": {
+    "driver": {
+      "policies": [
+        {
+          "roleId": "driver",
+          "restrictedTo": [
+            { "index": "nyc-open-data", "collections": ["yellow-taxi"] }
+          ]
+        }
+      ]
+    },
+    "customer": {
+      "policies": [
+        {
+          "roleId": "customer",
+          "restrictedTo": [
+            { "index": "nyc-open-data", "collections": ["yellow-taxi"] }
+          ]
+        }
+      ]
+    }
+  },
+  "users": {
+    "gfreeman": {
+      "content": {
+        "profileIds": ["driver"]
+      },
+      "credentials": {
+        "local": {
+          "username": "gfreeman",
+          "password": "lambdacore"
+        }
+      }
+    },
+    "bcalhoun": {
+      "content": {
+        "profileIds": ["customer"]
+      },
+      "credentials": {
+        "local": {
+          "username": "bcalhoun",
+          "password": "blueshift"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do ?

This PR allow to load fixtures for users, profiles and roles at Kuzzle startup.  
The roles and profiles are loaded with `createOrReplace` and the users are first deleted with `mDeleteUsers` and then created with `createUser`.  

Documentation PR: https://github.com/kuzzleio/documentation/pull/521

The securities fixtures must have the following format: 

```json
{
  "roles": {
    "driver": {
      "controllers": {
        "auth": {
          "actions": {
            "checkToken": true,
            "getCurrentUser": true,
            "getMyRights": true,
            "login": true
          }
        },
        "document": {
          "actions": {
            "*": true
          }
        }
      }
    }
  },
  "profiles": {
    "driver": {
      "policies": [
        {
          "roleId": "driver",
          "restrictedTo": [
            { "index": "nyc-open-data", "collections": ["yellow-taxi"] }
          ]
        }
      ]
    }
  },
  "users": {
    "bcalhoun": {
      "content": {
        "profileIds": ["driver"]
      },
      "credentials": {
        "local": {
          "username": "bcalhoun",
          "password": "blueshift"
        }
      }
    }
  }
}
```

### How should this be manually tested?

  - Step 1 : Start only `elasticsearch` and `redis` with docker-compose (don't forget to expose the ports 9200 and 6379 respectively)
  - Step 2 : Run Kuzzle from the commande line: `./bin/kuzzle start --fixtures test/mocks/securities.json`
  - Step 3 : Check the roles, profiles and users presence in the admin console

### Other changes

  - Move mappings and fixtures loading to Janitor
  - Fix node inspector in docker-compose
  - Fix #1184 : Refactor a little the method `load` in the repositories to reject with an explicit `NotFoundError`. Some methods (`persistUser` generator from SecurityController and `load` from PluginRepository) needed to return `null` instead of rejecting with a 404 so I added an optional `returnNull` options to the `loadOneFromDatabase` method.