### PR TITLE
KZL 46 - Add metadata to published documents

### DIFF
--- a/lib/api/controllers/realtimeController.js
+++ b/lib/api/controllers/realtimeController.js
@@ -111,7 +111,15 @@ class RealtimeController {
     assertHasIndexAndCollection(request);
 
     return this.kuzzle.validation.validationPromise(request, false)
-      .then(newRequest => this.kuzzle.notifier.publish(newRequest, 'in', 'done'));
+      .then(newRequest => {
+        newRequest.input.body._kuzzle_info = {
+          // Wait for PR #1182 to be merged to have getUserId()
+          author: request.context.user._id ? String(request.context.user._id) : null,
+          createdAt: Date.now()
+        };
+
+        return this.kuzzle.notifier.publish(newRequest, 'in', 'done');
+      });
   }
 
   /**

--- a/test/api/controllers/realtimeController.test.js
+++ b/test/api/controllers/realtimeController.test.js
@@ -170,5 +170,20 @@ describe('Test: subscribe controller', () => {
           }
         });
     });
+
+    it('should add basic metadata to body', () => {
+      request.input.resource.index = '%test';
+      request.input.resource.collection = 'test-collection';
+
+      return realtimeController.publish(request)
+        .then(() => {
+          should(kuzzle.notifier.publish).be.calledOnce();
+
+          const req = kuzzle.notifier.publish.getCall(0).args[0];
+          should(req.input.body._kuzzle_info).be.instanceof(Object);
+          should(req.input.body._kuzzle_info.author).be.eql('42');
+          should(req.input.body._kuzzle_info.createdAt).be.approximately(Date.now(), 100);
+        });
+    });
   });
 });


### PR DESCRIPTION
## What does this PR do ?

This PR inject basic metadata to published documents.  
Not all standard metadata are present because some of them are irrelevant, the injected metadata are: 
  - `createdAt`
  - `author`

Documentation: https://github.com/kuzzleio/documentation/pull/523

### How should this be manually tested?

  - Step 1 : Create `my-index` and `my-collection`
  - Step 2 : Subscribe to `my-collection` without filters
  - Step 3 :  Use this code to publish a document: [publish.js](https://gist.github.com/Aschen/f79ab5a48ffabf83af80ee4b6464e577)
  - Step 4 : Check metadata presence in admin console
