### PR TITLE
Update docker build script for new branch name 1-dev

### DIFF
--- a/build-docker-images.sh
+++ b/build-docker-images.sh
@@ -51,8 +51,8 @@ if [ -z "$DOCKER_PASSWORD" ]; then
 fi
 docker login -u kuzzleteam -p $DOCKER_PASSWORD
 
-if [ "$TRAVIS_BRANCH" == "1.x" ]; then
-  # Build triggered by a merge on branch 1.x
+if [ "$TRAVIS_BRANCH" == "1-dev" ]; then
+  # Build triggered by a merge on branch 1-dev
   # Images are built in Travis
 
   docker_build 'plugin-dev' "$TRAVIS_BRANCH" 'plugin-dev'
@@ -67,8 +67,8 @@ if [ "$TRAVIS_BRANCH" == "1.x" ]; then
 
   docker_push 'plugin-dev' 'develop'
   docker_push 'kuzzle8' 'develop'
-elif [ "$TRAVIS_BRANCH" == "2.x" ]; then
-  # Build triggered by a merge on branch 2.x
+elif [ "$TRAVIS_BRANCH" == "2-dev" ]; then
+  # Build triggered by a merge on branch 2-dev
   # Images are built in Travis
 
   docker_build 'plugin-dev' "$TRAVIS_BRANCH" 'plugin-dev'

--- a/lib/api/core/abstractManifest.js
+++ b/lib/api/core/abstractManifest.js
@@ -53,7 +53,7 @@ class AbstractManifest {
 
     if (_.isNil(this.raw.kuzzleVersion)) {
       console.warn(`[${this.path}/manifest.json] No "kuzzleVersion" property found: assuming the target is Kuzzle v1`);
-      // Only Kuzzle 1.x should support plugins or protocols
+      // Only Kuzzle v1 should support plugins or protocols
       // without a kuzzleVersion property set
       this.kuzzleVersion = '>=1.0.0 <2.0.0';
     } else {

--- a/lib/services/index.js
+++ b/lib/services/index.js
@@ -74,7 +74,7 @@ class Services {
         // @deprecated - "internalBroker" was an internal service until Kuzzle 1.4.0
         // Filtering this configuration allows users to upgrade their Kuzzle from pre-1.4.0
         // without generating a breaking change because of an old configuration file
-        // This filter can be removed as soon as Kuzzle v1.x support ends
+        // This filter can be removed as soon as Kuzzle v1 support ends
         if (key === 'internalBroker') {
           // eslint-disable-next-line no-console
           console.warn('[WARN] Ignoring the "internalBroker" service entry found in the kuzzlerc file. This service is deprecated and its corresponding entry in custom configuration files should be removed.');

--- a/test/api/core/abstractManifest.test.js
+++ b/test/api/core/abstractManifest.test.js
@@ -49,7 +49,7 @@ describe('AbstractManifest class', () => {
     });
   });
 
-  it('should complain and default the Kuzzle target version to 1.x if no kuzzleVersion property is found', () => {
+  it('should complain and default the Kuzzle target version to v1 if no kuzzleVersion property is found', () => {
     mockRequireManifest({name: 'foobar'})(() => {
       const manifest = new Manifest(kuzzle, pluginPath);
       manifest.load();


### PR DESCRIPTION
## What does this PR do ?

Since we use the name `1-dev` instead of `1.x` for the development branch, I had to update the script used to build docker images. (See https://github.com/kuzzleio/kuzzle/pull/1178)

I also update DockerHub since we still use it to build `kuzzle` image: https://hub.docker.com/r/kuzzleio/kuzzle/~/settings/automated-builds/