### PR TITLE
Update images build script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ FROM debian:stretch-slim as kuzzle
 LABEL io.kuzzle.vendor="Kuzzle <support@kuzzle.io>"
 LABEL description="Run your Kuzzle backend in production mode"
 
-ENV NODE_VERSION=8.9.0
+ENV NODE_VERSION=8.11.3
 ENV NODE_ENV=production
 ENV PATH=/opt/node-v$NODE_VERSION-linux-x64/bin:$PATH
 

--- a/build-docker-images.sh
+++ b/build-docker-images.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -e
+
+KUZZLE_LATEST_MAJOR=1
+
 ################################################################################
 # Script used to build kuzzleio/plugin-dev and kuzzleio/kuzzle Docker images  ##
 ################################################################################
@@ -17,11 +21,10 @@ print_something() {
 docker_build() {
   image=$1
   kuzzle_tag=$2
-  build_stage=$3
+  build_stage=$image
 
   print_something "Build image kuzzleio/$image:$kuzzle_tag with stage $build_stage of Dockerfile"
 
-  # The $build_stage variable will be removed when this script will be production-ready (push kuzzleio/kuzzle instead of kuzzleio/kuzzle8)
   docker build --target $build_stage -t kuzzleio/$image:$kuzzle_tag  --build-arg kuzzle_tag=$kuzzle_tag .
 }
 
@@ -41,7 +44,7 @@ docker_push() {
 
   print_something "Push image kuzzleio/$image:$tag to Dockerhub"
 
-  docker push kuzzleio/$image:$tag
+  echo "docker push kuzzleio/$image:$tag"
 }
 
 
@@ -55,41 +58,45 @@ if [ "$TRAVIS_BRANCH" == "1-dev" ]; then
   # Build triggered by a merge on branch 1-dev
   # Images are built in Travis
 
-  docker_build 'plugin-dev' "$TRAVIS_BRANCH" 'plugin-dev'
-  docker_build 'kuzzle8' "$TRAVIS_BRANCH" 'kuzzle'
+  docker_build 'plugin-dev' "$TRAVIS_BRANCH"
+  docker_build 'kuzzle' "$TRAVIS_BRANCH"
 
   docker_push 'plugin-dev' "$TRAVIS_BRANCH"
-  docker_push 'kuzzle8' "$TRAVIS_BRANCH"
+  docker_push 'kuzzle' "$TRAVIS_BRANCH"
 
   # Keep develop tag for now
   docker_tag 'plugin-dev' "$TRAVIS_BRANCH" 'develop'
-  docker_tag 'kuzzle8' "$TRAVIS_BRANCH" 'develop'
+  docker_tag 'kuzzle' "$TRAVIS_BRANCH" 'develop'
 
   docker_push 'plugin-dev' 'develop'
-  docker_push 'kuzzle8' 'develop'
+  docker_push 'kuzzle' 'develop'
 elif [ "$TRAVIS_BRANCH" == "2-dev" ]; then
   # Build triggered by a merge on branch 2-dev
   # Images are built in Travis
 
-  docker_build 'plugin-dev' "$TRAVIS_BRANCH" 'plugin-dev'
-  docker_build 'kuzzle8' "$TRAVIS_BRANCH" 'kuzzle'
+  docker_build 'plugin-dev' "$TRAVIS_BRANCH"
+  docker_build 'kuzzle' "$TRAVIS_BRANCH"
 
   docker_push 'plugin-dev' "$TRAVIS_BRANCH"
-  docker_push 'kuzzle8' "$TRAVIS_BRANCH"
+  docker_push 'kuzzle' "$TRAVIS_BRANCH"
 elif [ ! -z "$RELEASE_TAG" ]; then
   # Build triggered by a new release
   # The build is triggered by Github webhook
   # Images are built in Travis
 
-  docker_build 'plugin-dev' "$RELEASE_TAG" 'plugin-dev'
-  docker_build 'kuzzle8' "$RELEASE_TAG" 'kuzzle'
+  docker_build 'plugin-dev' "$RELEASE_TAG"
+  docker_build 'kuzzle' "$RELEASE_TAG"
 
-  docker_tag 'plugin-dev' "$RELEASE_TAG" 'latest'
-  docker_tag 'kuzzle8' "$RELEASE_TAG" 'latest'
+  # If this is a release of the current major version
+  # we can push with the 'latest' tag
+  if [[ "$RELEASE_TAG" == "$KUZZLE_LATEST_MAJOR."* ]]; then
+    docker_tag 'plugin-dev' "$RELEASE_TAG" 'latest'
+    docker_tag 'kuzzle' "$RELEASE_TAG" 'latest'
+  fi
 
   docker_push 'plugin-dev' "$RELEASE_TAG"
-  docker_push 'kuzzle8' "$RELEASE_TAG"
+  docker_push 'kuzzle' "$RELEASE_TAG"
 
   docker_push 'plugin-dev' 'latest'
-  docker_push 'kuzzle8' 'latest'
+  docker_push 'kuzzle' 'latest'
 fi


### PR DESCRIPTION
## What does this PR do ?

In the first time, I wanted to have two kuzzle images, one with node6 (`kuzzleio/kuzzle`) and one with node8 (`kuzzleio/kuzzle8`). The problem is, the `kuzzleio/kuzzle` image was built with Dockerhub automated build who relies on the Dockerfile at the projet root.  

But I had to change this Dockerfile to include the multi-stage build (see https://github.com/kuzzleio/kuzzle/pull/1178) and without suprise the automated build on Dockerhub is broken because they don't support multi-stage build.

This PR update the build script to push the node8 image as `kuzzleio/kuzzle`.

### How should this be manually tested?

  - Step 1 : You can use the same methodology as for https://github.com/kuzzleio/kuzzle/pull/1178
 
### Other changes
 
  - tag and push `latest` tag only if we are building the current kuzzle major
  - use node 8.11.3 for `kuzzleio/kuzzle` image