### PR TITLE
remove dependency on elasticsearch for unit tests

### DIFF
--- a/test/api/core/pluginsManager/run.test.js
+++ b/test/api/core/pluginsManager/run.test.js
@@ -1,25 +1,34 @@
 'use strict';
 
 const
+  mockrequire = require('mock-require'),
   should = require('should'),
+  ElasticsearchClientMock = require('../../../mocks/services/elasticsearchClient.mock'),
   KuzzleMock = require('../../../mocks/kuzzle.mock'),
   sinon = require('sinon'),
   {
     KuzzleError,
     GatewayTimeoutError,
     PluginImplementationError
-  } = require('kuzzle-common-objects').errors,
-  PluginsManager = require('../../../../lib/api/core/plugins/pluginsManager');
+  } = require('kuzzle-common-objects').errors;
 
 describe('PluginsManager.run', () => {
   let
     plugin,
     pluginMock,
     kuzzle,
+    PluginsManager,
     pluginsManager;
 
   beforeEach(() => {
     kuzzle = new KuzzleMock();
+
+    mockrequire('elasticsearch', {Client: ElasticsearchClientMock});
+    mockrequire.reRequire('../../../../lib/services/internalEngine');
+    mockrequire.reRequire('../../../../lib/api/core/plugins/pluginContext');
+    mockrequire.reRequire('../../../../lib/api/core/plugins/privilegedPluginContext');
+    PluginsManager = mockrequire.reRequire('../../../../lib/api/core/plugins/pluginsManager');
+
     pluginsManager = new PluginsManager(kuzzle);
 
     plugin = {

--- a/test/api/core/pluginsManager/trigger.test.js
+++ b/test/api/core/pluginsManager/trigger.test.js
@@ -1,9 +1,17 @@
 const
-  KuzzleMock = require('../../../mocks/kuzzle.mock'),
-  PluginsManager = require('../../../../lib/api/core/plugins/pluginsManager');
+  mockrequire = require('mock-require'),
+  ElasticsearchClientMock = require('../../../mocks/services/elasticsearchClient.mock'),
+  KuzzleMock = require('../../../mocks/kuzzle.mock');
+
 
 describe('Test plugins manager trigger', () => {
   it('should trigger hooks with wildcard event', function (done) {
+    mockrequire('elasticsearch', {Client: ElasticsearchClientMock});
+    mockrequire.reRequire('../../../../lib/services/internalEngine');
+    mockrequire.reRequire('../../../../lib/api/core/plugins/pluginContext');
+    mockrequire.reRequire('../../../../lib/api/core/plugins/privilegedPluginContext');
+    const PluginsManager = mockrequire.reRequire('../../../../lib/api/core/plugins/pluginsManager');
+
     const
       kuzzle = new KuzzleMock(),
       pluginsManager = new PluginsManager(kuzzle);


### PR DESCRIPTION
## What does this PR do ?

This PR removes the current dependency on an Elasticsearch connection to run the unit tests.

### How should this be manually tested?

```
npm run unit-testing
```
