### PR TITLE
fix truncated object name in error messages

### DIFF
--- a/lib/api/core/models/repositories/repository.js
+++ b/lib/api/core/models/repositories/repository.js
@@ -24,7 +24,6 @@
 const
   Bluebird = require('bluebird'),
   {
-    BadRequestError,
     InternalError: KuzzleInternalError,
     NotFoundError
   } = require('kuzzle-common-objects').errors;
@@ -103,7 +102,7 @@ class Repository {
       })
       .catch(error => {
         if (error.status === 404) {
-          throw new NotFoundError(`Unable to find ${this._objectName()} with id '${id}'`);
+          throw new NotFoundError(`Unable to find ${this.collection} with id '${id}'`);
         }
 
         throw error;
@@ -117,7 +116,7 @@ class Repository {
    */
   loadMultiFromDatabase (ids) {
     if (!Array.isArray(ids)) {
-      return Bluebird.reject(new KuzzleInternalError(`Bad argument: ${ids.toString()} is not an array.`));
+      return Bluebird.reject(new KuzzleInternalError(`Bad argument: ${ids} is not an array.`));
     }
 
     return this.databaseEngine.mget(this.collection, ids)
@@ -247,11 +246,11 @@ class Repository {
    */
   delete (object, options = {}) {
     if (! object) {
-      return Bluebird.reject(new NotFoundError(`Unable to find ${this._objectName()}`));
+      return Bluebird.reject(new KuzzleInternalError(`Repository ${this.collection}: nothing to delete`));
     }
 
     if (! object._id) {
-      return Bluebird.reject(new BadRequestError(`Missing ${this._objectName()} id`));
+      return Bluebird.reject(new KuzzleInternalError(`Repository ${this.collection}: missing _id`));
     }
 
     const promises = [];
@@ -496,20 +495,6 @@ class Repository {
 
     return Bluebird.resolve(result);
   }
-
-  /**
-   * Return the name of the object managed by the repository
-   * @returns {string}
-   * @private
-   */
-  _objectName () {
-    if (this.collection) {
-      return this.collection.slice(0, -1);
-    }
-
-    return 'object';
-  }
-
 }
 
 module.exports = Repository;

--- a/test/api/core/models/repositories/profileRepository.test.js
+++ b/test/api/core/models/repositories/profileRepository.test.js
@@ -60,16 +60,11 @@ describe('Test: repositories/profileRepository', () => {
         });
     });
 
-    it('should reject if the profile does not exist', done => {
+    it('should reject if the profile does not exist', () => {
       kuzzle.internalEngine.get.rejects(new NotFoundError('Not found'));
 
-      profileRepository.load('idontexist')
-        .then(() => done(new Error('Should reject with NotFoundError')))
-        .catch(error => {
-          should(error).be.instanceOf(NotFoundError);
-          should(error.message).eql('Unable to find profile with id \'idontexist\'');
-          done();
-        });
+      return should(profileRepository.load('idontexist'))
+        .rejectedWith(NotFoundError, {message: 'Unable to find profiles with id \'idontexist\''});
     });
 
     it('should load a profile from the db', () => {

--- a/test/api/core/models/repositories/repository.test.js
+++ b/test/api/core/models/repositories/repository.test.js
@@ -2,7 +2,6 @@ const
   should = require('should'),
   KuzzleMock = require('../../../../mocks/kuzzle.mock'),
   {
-    BadRequestError,
     InternalError: KuzzleInternalError,
     NotFoundError
   } = require('kuzzle-common-objects').errors,
@@ -19,7 +18,6 @@ describe('Test: repositories/repository', () => {
     cachePojo = {_id: 'someId', some: 'source'};
 
   before(() => {
-
     /**
      * @constructor
      */
@@ -37,22 +35,18 @@ describe('Test: repositories/repository', () => {
   });
 
   describe('#loadOneFromDatabase', () => {
-    it('should reject for an non existing id', done => {
+    it('should reject for an non existing id', () => {
       kuzzle.internalEngine.get.rejects(new NotFoundError('Not found'));
 
-      repository.loadOneFromDatabase(-9999)
-        .then(() => done(new Error('Should reject with a NotFoundError')))
-        .catch(error => {
-          should(error).be.instanceOf(NotFoundError);
-          should(error.message).eql('Unable to find object with id \'-9999\'');
-          done();
-        });
+      return should(repository.loadOneFromDatabase(-9999))
+        .rejectedWith(NotFoundError, {message: 'Unable to find objects with id \'-9999\''});
     });
 
     it('should reject the promise in case of error', () => {
       kuzzle.internalEngine.get.rejects(new KuzzleInternalError('error'));
 
-      return should(repository.loadOneFromDatabase('error')).be.rejectedWith(KuzzleInternalError);
+      return should(repository.loadOneFromDatabase('error'))
+        .rejectedWith(KuzzleInternalError, {message: 'error'});
     });
 
     it('should return a valid ObjectConstructor instance if found', () => {
@@ -74,7 +68,8 @@ describe('Test: repositories/repository', () => {
     });
 
     it('should reject the promise in case of error', () => {
-      return should(repository.loadMultiFromDatabase('error')).be.rejectedWith(KuzzleInternalError);
+      return should(repository.loadMultiFromDatabase('error')).
+        rejectedWith(KuzzleInternalError, {message: 'Bad argument: error is not an array.'});
     });
 
     it('should return a list of plain object', () => {
@@ -126,13 +121,15 @@ describe('Test: repositories/repository', () => {
     it('should reject the promise in case of error', () => {
       kuzzle.services.list.internalCache.get.rejects(new KuzzleInternalError('error'));
 
-      return should(repository.loadFromCache('error')).be.rejectedWith(KuzzleInternalError);
+      return should(repository.loadFromCache('error')).
+        rejectedWith(KuzzleInternalError, {message: 'error'});
     });
 
     it('should reject the promise when loading an incorrect object', () => {
       kuzzle.services.list.internalCache.get.resolves('bad type');
 
-      return should(repository.loadFromCache('string')).be.rejectedWith(KuzzleInternalError);
+      return should(repository.loadFromCache('string'))
+        .rejectedWith(KuzzleInternalError, {message: 'Unexpected token b in JSON at position 0'});
     });
 
     it('should return a valid ObjectConstructor instance if found', () => {
@@ -148,28 +145,25 @@ describe('Test: repositories/repository', () => {
   });
 
   describe('#load', () => {
-    it('should reject for an non existing id', done => {
+    it('should reject for an non existing id', () => {
       kuzzle.internalEngine.get.rejects(new NotFoundError('Not found'));
 
-      repository.load(-9999)
-        .then(() => done(new Error('Should reject with a NotFoundError')))
-        .catch(error => {
-          should(error).be.instanceOf(NotFoundError);
-          should(error.message).eql('Unable to find object with id \'-9999\'');
-          done();
-        });
+      return should(repository.load(-9999))
+        .rejectedWith(NotFoundError, {message: 'Unable to find objects with id \'-9999\''});
     });
 
     it('should reject the promise in case of error', () => {
       kuzzle.internalEngine.get.rejects(new KuzzleInternalError('test'));
 
-      return should(repository.load('error')).be.rejectedWith(KuzzleInternalError);
+      return should(repository.load('error'))
+        .rejectedWith(KuzzleInternalError, {message: 'test'});
     });
 
     it('should reject the promise when loading an incorrect object', () => {
       kuzzle.services.list.internalCache.get.resolves('bad type');
 
-      return should(repository.load('string')).be.rejectedWith(KuzzleInternalError);
+      return should(repository.load('string'))
+        .rejectedWith(KuzzleInternalError, {message: 'Unexpected token b in JSON at position 0'});
     });
 
     it('should return a valid ObjectConstructor instance if found', () => {
@@ -263,24 +257,16 @@ describe('Test: repositories/repository', () => {
   });
 
   describe('#delete', () => {
-    it('should throw an error when no object id is given', done => {
+    it('should throw an error when no object id is given', () => {
       const someObject = { name: 'barney' };
 
-      repository.delete(someObject)
-        .then(() => done(new Error('should throw error')))
-        .catch(error => {
-          should(error).be.instanceOf(BadRequestError);
-          done();
-        });
+      return should(repository.delete(someObject))
+        .rejectedWith(KuzzleInternalError, {message: 'Repository objects: missing _id'});
     });
 
-    it('should return a 404 if the given object is not present', done => {
-      repository.delete(null)
-        .then(() => done(new Error('should throw error')))
-        .catch(error => {
-          should(error).be.instanceOf(NotFoundError);
-          done();
-        });
+    it('should return a 404 if the given object is not present', () => {
+      return should(repository.delete(null))
+        .rejectedWith(KuzzleInternalError, {message: 'Repository objects: nothing to delete'});
     });
 
     it('should delete an object from both cache and database when pertinent', () => {

--- a/test/api/core/models/repositories/userRepository.test.js
+++ b/test/api/core/models/repositories/userRepository.test.js
@@ -189,13 +189,9 @@ describe('Test: repositories/userRepository', () => {
   });
 
   describe('#delete', () => {
-    it('should throw an error when no user id is given', done => {
-      userRepository.delete({ profileIds: [], name: 'gordon' })
-        .then(() => done(new Error('should throw error')))
-        .catch(error => {
-          should(error).be.instanceOf(BadRequestError);
-          done();
-        });
+    it('should throw an error when no user id is given', () => {
+      return should(userRepository.delete({ profileIds: [], name: 'gordon' }))
+        .rejectedWith(KuzzleInternalError, {message: 'Repository users: missing _id'});
     });
 
     it('should delete user from both cache and database', () => {


### PR DESCRIPTION
# Description

Some error messages invoving repositories had a truncated object name.

Example: `NotFoundError: Unable to find faceboo with id '1923186077761337'`

This is due to a new `_objectName` method introduced recently, aiming at providing intelligible error messages. I found that method more harmful than anything, so I replaced it with improved error messages using the raw `this.collection` repository property, which should never be null (if it is, then we still have the stack trace to debug the problem).

Also, repository errors triggered because of invalid arguments have been changed from `NotFoundError` or `BadRequestError` to `KuzzleInternalError`, since repositories are internal objects, used only by Kuzzle's core. We shouldn't even test arguments in the first place.

# Boyscout

* Improved unit tests triggering unhandled promise rejection on failure, instead of reporting the failure to mocha
* Improved some unit tests by forcing tests to test error messages, and not only error types, to make sure the test is verifying the right error