### PR TITLE
Fixes document.validate requiring an id

### DIFF
--- a/lib/api/controllers/documentController.js
+++ b/lib/api/controllers/documentController.js
@@ -385,7 +385,6 @@ class DocumentController {
   validate(request) {
     assertHasBody(request);
     assertHasIndexAndCollection(request);
-    assertHasId(request);
 
     return this.kuzzle.validation.validationPromise(request, true)
       .then(response => {


### PR DESCRIPTION
This PR fixes the document.validate action by removing the constraint on giving an id.