### PR TITLE
[kzl-832] Document.count - body is optional

### DIFF
--- a/lib/api/controllers/documentController.js
+++ b/lib/api/controllers/documentController.js
@@ -137,8 +137,6 @@ class DocumentController {
    * @returns {Promise<Object>}
    */
   count(request) {
-    assertHasBody(request);
-
     return this.engine.count(request);
   }
 


### PR DESCRIPTION
## What does this PR do ?

This PR makes the `body` parameter optional for the `document.count` action.
If no `body` is provided, then the cardinal of the collection is returned.