### PR TITLE
[dockerhub] Fix docker image builder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -192,10 +192,7 @@ jobs:
     - stage: Deployments
       name: "Build & publish Docker images on Dockerhub"
 
-      if: type != pull_request AND branch =~ ^master|.?-dev$
+      if: type != pull_request AND branch =~ ^master|[1-9]+-dev$
 
       script:
         - MODE=production bash build-docker-images.sh
-
-
-

--- a/build-docker-images.sh
+++ b/build-docker-images.sh
@@ -97,9 +97,9 @@ if [[ "$TRAVIS_BRANCH" == *"-dev" ]]; then
     docker_push 'plugin-dev' 'develop'
     docker_push 'kuzzle' 'develop'
   fi
-elif [ ! -z "$RELEASE_TAG" ]; then
+elif [[ "$TRAVIS_BRANCH" == "master" ]]; then
+  RELEASE_TAG=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]')
   # Build triggered by a new release
-  # The build is triggered by Github webhook
   # Images are built in Travis
 
   docker_build 'plugin-dev' "$RELEASE_TAG"


### PR DESCRIPTION
## What does this PR do ?
~Use script to build docker images only on *-dev branches. For master branch and releases, use automated build on dockerhub~

Finally, this PR will fix the bash script used to build kuzzle images.

### How should this be manually tested?
Check Travis file