### PR TITLE
update dependency: use https to get kuzzle-sdk from git

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3700,6 +3700,13 @@
         "uuid": "3.3.2"
       }
     },
+    "kuzzle-sdk": {
+      "version": "git+https://github.com/kuzzleio/sdk-javascript.git#6a416bf7d855b25b583f1af367ff952572f2a733",
+      "requires": {
+        "min-req-promise": "1.0.1",
+        "uws": "10.148.0"
+      }
+    },
     "lazy": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/lazy/-/lazy-1.0.11.tgz",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "jsonwebtoken": "^8.3.0",
     "koncorde": "^1.2.0",
     "kuzzle-common-objects": "^3.0.13",
-    "kuzzle-sdk": "git://github.com/kuzzleio/sdk-javascript.git#6-beta",
+    "kuzzle-sdk": "https://github.com/kuzzleio/sdk-javascript.git#6-beta",
     "lodash": "4.17.11",
     "moment": "^2.22.2",
     "ms": "^2.1.1",


### PR DESCRIPTION
Nitpicking: use https instead of SSH to git clone `kuzzle-sdk` dependency

This enables to run `npm install` behind a proxy without having to setup git config for it
The user just have to set its `https_proxy` environment variable 