### PR TITLE
Es aliases compatibility

### DIFF
--- a/lib/api/core/indexCache.js
+++ b/lib/api/core/indexCache.js
@@ -95,6 +95,12 @@ class IndexCache {
         }
 
         return Bluebird.all(promises);
+      })
+      .then(() => engine.listAliases())
+      .then(aliases => {
+        for (const alias of Object.keys(aliases)) {
+          this.indexes[alias] = this.indexes[aliases[alias]];
+        }
       });
   }
 
@@ -217,7 +223,7 @@ class IndexCache {
           return false;
         }
 
-        return this.kuzzle.internalEngine.updateMapping(collection, this.commonMapping, index)
+        return this.kuzzle.internalEngine.updateMapping(collection, {properties: this.commonMapping}, index)
           .then(() => this.add(index, collection, true));
       });
   }

--- a/lib/services/internalEngine/index.js
+++ b/lib/services/internalEngine/index.js
@@ -441,6 +441,31 @@ class InternalEngine {
   }
 
   /**
+   * Get a map of existing aliases in elasticsearch
+   * {
+   *    alias1: index,
+   *    alias2: index2,
+   *    [..]
+   * }
+   *
+   * @returns {Promise<object>}
+   */
+  listAliases() {
+    return this.client.cat.aliases({
+      format: 'json'
+    })
+      .then(aliases => {
+        const aliasMap = {};
+
+        for (const entry of aliases) {
+          aliasMap[entry.alias] = entry.index;
+        }
+
+        return aliasMap;
+      });
+  }
+
+  /**
    * Get the list of existing indexes in elasticsearch
    *
    * @returns {Promise}

--- a/test/api/core/indexCache.test.js
+++ b/test/api/core/indexCache.test.js
@@ -6,6 +6,7 @@ const
 
 describe('Test: core/indexCache', () => {
   var
+    listAliasesStub,
     listIndexesStub,
     listCollectionsStub,
     getMappingStub,
@@ -25,6 +26,7 @@ describe('Test: core/indexCache', () => {
       }
     };
 
+    listAliasesStub = kuzzle.internalEngine.listAliases.resolves({alias: 'foo', alias2: 'foo'});
     listIndexesStub = kuzzle.internalEngine.listIndexes.resolves(['foo']);
     listCollectionsStub = kuzzle.internalEngine.listCollections.resolves(['bar', 'baz', 'qux']);
     getMappingStub = kuzzle.internalEngine.getMapping.resolves(internalMapping);
@@ -38,10 +40,13 @@ describe('Test: core/indexCache', () => {
 
       return indexCache.init()
         .then(() => {
+          should(listAliasesStub).be.calledOnce();
           should(listIndexesStub.calledOnce).be.true();
           should(listCollectionsStub.calledOnce).be.true();
-          should(indexCache.indexes).be.an.Object().and.have.keys('foo');
+          should(indexCache.indexes).be.an.Object().and.have.keys('alias', 'alias2', 'foo');
           should(indexCache.indexes.foo).be.an.Array().and.match(['bar', 'baz', 'qux']);
+          should(indexCache.indexes.alias).be.exactly(indexCache.indexes.foo);
+          should(indexCache.indexes.alias2).be.exactly(indexCache.indexes.foo);
         });
     });
 

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -139,6 +139,7 @@ class KuzzleMock extends Kuzzle {
       index: 'internalIndex',
       init: this.sandbox.stub().resolves(),
       listCollections: this.sandbox.stub(),
+      listAliases: this.sandbox.stub().resolves([]),
       listIndexes: this.sandbox.stub(),
       persist: this.sandbox.stub().resolves(),
       refresh: this.sandbox.stub().resolves(),


### PR DESCRIPTION
## What does this PR do ?

This PR adds a minimal level of compatibility with Elasticsearch aliases. 
This PR **does not** implement management of aliases