### PR TITLE
Fix createFirstAdmin HTTP route

### DIFF
--- a/features/support/api/http.js
+++ b/features/support/api/http.js
@@ -305,7 +305,7 @@ class HttpApi {
     };
 
     if (id !== undefined) {
-      options.url = this.apiPath('_createFirstAdmin/' + id);
+      options.url = this.apiPath(`_createFirstAdmin/${id}`);
     }
 
     if (reset) {

--- a/features/support/api/http.js
+++ b/features/support/api/http.js
@@ -299,13 +299,13 @@ class HttpApi {
 
   createFirstAdmin (body, id, reset) {
     const options = {
-      url: this.apiPath('/_createFirstAdmin'),
+      url: this.apiPath('_createFirstAdmin'),
       method: 'POST',
       body
     };
 
     if (id !== undefined) {
-      options.url = this.apiPath('/' + id + '/_createFirstAdmin');
+      options.url = this.apiPath('_createFirstAdmin/' + id);
     }
 
     if (reset) {

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -173,8 +173,12 @@ module.exports = [
   {verb: 'post', url: '/:index/:collection/_mCreate', controller: 'document', action: 'mCreate'},
   {verb: 'post', url: '/:index/:collection/_validate', controller: 'document', action: 'validate'},
 
-  {verb: 'post', url: '/:_id/_createFirstAdmin', controller: 'security', action: 'createFirstAdmin'},
+  {verb: 'post', url: '/_createFirstAdmin/:_id', controller: 'security', action: 'createFirstAdmin'},
   {verb: 'post', url: '/_createFirstAdmin', controller: 'security', action: 'createFirstAdmin'},
+
+  /* DEPRECATED - will be removed in v2 */
+  {verb: 'post', url: '/:_id/_createFirstAdmin', controller: 'security', action: 'createFirstAdmin'},
+
   {verb: 'post', url: '/credentials/:strategy/:_id/_create', controller: 'security', action: 'createCredentials'},
   {verb: 'post', url: '/profiles/:_id/_create', controller: 'security', action: 'createProfile'},
   {verb: 'post', url: '/roles/:_id/_create', controller: 'security', action: 'createRole'},


### PR DESCRIPTION
## What does this PR do ?

Old HTTP route for createFirstAdmin (`:_id/_createFirstAdmin`) had a conflict with other routes.
For example, we could not create an admin user with `admin` uid, because `/admin/_createFirstAdmin` failed.

This PR fixes that isse by renaming the route in  `/_createFirstAdmin/:_id`... and keep the old one as deprecated

### How should this be manually tested?

In an empty Kuzzle instance, call the following CURL request and verify that the admin user is created:

```
curl --request GET \
  --url http://<kuzzlehost>:<kuzzleport>/_createFirstAdmin/admin \
  --header 'content-type: application/json' \
  --data '{
  "content": {
    "name": "John Doe"
  },
  "credentials": {
    "local": {
      "username": "userAdmin", 
      "password": "myPassword"
    }
  }
}'
```
