### PR TITLE
Provide a meaningful feedback when an invalid kuid is returned by a plugin

### DIFF
--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -519,8 +519,12 @@ class PluginsManager {
               throw new PluginImplementationError(`${errorPrefix} invalid authentication strategy result`);
             }
 
-            if (result.kuid && typeof result.kuid === 'string') {
-              return this.kuzzle.repositories.user.load(result.kuid);
+            if (result.kuid !== null && result.kuid !== undefined) {
+              if (typeof result.kuid === 'string') {
+                return this.kuzzle.repositories.user.load(result.kuid);
+              }
+
+              throw new PluginImplementationError(`${errorPrefix} invalid authentication kuid returned: expected a string, got a ${typeof result.kuid}`);
             }
 
             if (result.message && typeof result.message === 'string') {

--- a/test/api/core/pluginsManager/strategy.test.js
+++ b/test/api/core/pluginsManager/strategy.test.js
@@ -393,6 +393,23 @@ describe('PluginsManager: strategy management', () => {
       });
     });
 
+    it('should reject if the plugin resolves to a non-string kuid', done => {
+      plugin.object.verifyFunction.resolves({kuid: 123});
+      verifyAdapter('foo', 'bar', (err, res, msg) => {
+        try {
+          should(res).be.undefined();
+          should(msg).be.undefined();
+          should(err)
+            .instanceOf(PluginImplementationError)
+            .match({message: /\[some-plugin-name\] Strategy someStrategy: invalid authentication kuid returned: expected a string, got a number/});
+          done();
+        }
+        catch (e) {
+          done(e);
+        }
+      });
+    });
+
     it('should resolve to "false" if the plugins refuse the provided credentials', done => {
       plugin.object.verifyFunction.resolves(false);
       verifyAdapter((err, res, msg) => {


### PR DESCRIPTION
# Description

If an authentication plugin returns a non-null, non-string `kuid` value, then Kuzzle ignores it, ultimately leading to an `401 Unauthorized` error.
While not entirely wrong, this behavior makes it hard for users to debug a faulty authentication plugin.

This PR catches that case and throws a proper `PluginImplementationError` error whenever an invalid `kuid` value is returned by an authentication plugin.