### PR TITLE
Logger plugin: Node.js 6 compatibility fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "1.6.0",
+  "version": "1.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {


### PR DESCRIPTION
:rotating_light: HOTFIX :rotating_light: 

# Description

Use the latest [logger plugin](https://github.com/kuzzleio/kuzzle-plugin-logger) version, fixing a problem with incompatible dependencies when installing Kuzzle using older versions of NPM (< 5).

# Why is this a hotfix?

Since the release of the `winston-syslog@2.1.0` module three days ago, all Kuzzle installations fail with NPM <5 (usually Node.js 6 environments)