### PR TITLE
doc: updated links to doc-v2 pages

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -40,7 +40,7 @@
     // * requestsBufferWarningThreshold:
     //      Number of buffered requests after
     //      which Kuzzle will throw 'core:overload' events
-    //      (see http://docs.kuzzle.io/plugin-reference/#core)
+    //      (see https://docs-v2.kuzzle.io/plugins/1/events/core-overload/)
     // * subscriptionConditionsCount
     //      Maximum number of conditions a subscription filter can contain
     //      NB: A condition is either a "simple" operator (anything but and, or and bool)
@@ -533,7 +533,7 @@
   // [validation]
   // Defines the specifications used to validate data.
   // Please refer to the guide for more information.
-  // (http://docs.kuzzle.io/guide/#data-validation)
+  // (https://docs-v2.kuzzle.io/guide/1/essentials/data-validation/)
   "validation": {
   },
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ We use most of the [NPM Coding Style](https://docs.npmjs.com/misc/coding-style) 
 
 ## General rules and principles we'd like you to follow
 
-* If you plan to add new features to Kuzzle, make sure that this is for a general improvement to benefit a majority of Kuzzle users. If not, consider making a plugin instead (check our [plugin documentation](http://docs.kuzzle.io/plugin-reference/))
+* If you plan to add new features to Kuzzle, make sure that this is for a general improvement to benefit a majority of Kuzzle users. If not, consider making a plugin instead (check our [plugin documentation](https://docs-v2.kuzzle.io/plugins/1/essentials/getting-started/))
 * Follow the [KISS Principle](https://en.wikipedia.org/wiki/KISS_principle)
 * Follow [The Boy Scout Rule](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
 
@@ -48,7 +48,7 @@ Everytime a modification is detected in the source files, the server is automati
 
 ## Create a plugin
 
-See our [plugins documentation](http://docs.kuzzle.io/plugin-reference/)
+See our [plugins documentation](https://docs-v2.kuzzle.io/plugins/1/essentials/getting-started/)
 
 ## Running Tests
    

--- a/README.md
+++ b/README.md
@@ -28,19 +28,19 @@ The easiest way to setup a kuzzle server for Linux-like systems without prerequi
 $ sudo bash -c "$(curl http://get.kuzzle.io/)"
 ```
 
-You can get detailed information about how to [start kuzzle with docker on docs.kuzzle.io](https://docs.kuzzle.io/guide/essentials/installing-kuzzle/#docker)
+You can get detailed information about how to [start kuzzle with docker on docs-v2.kuzzle.io](https://docs-v2.kuzzle.io/guide/1/essentials/installing-kuzzle/#docker)
 
 ### Manual install
 
-Check our [complete installation guide on docs.kuzzle.io](https://docs.kuzzle.io/guide/essentials/installing-kuzzle/#manually)
+Check our [complete installation guide on docs-v2.kuzzle.io](https://docs-v2.kuzzle.io/guide/1/essentials/installing-kuzzle/#manual-installation)
 
 ## Quick start with Kuzzle
 
-* [Install and start Kuzzle server](https://docs.kuzzle.io/guide/essentials/installing-kuzzle/)
-* [Choose a SDK](https://docs.kuzzle.io/sdk-reference/essentials/)
+* [Install and start Kuzzle server](https://docs-v2.kuzzle.io/guide/1/essentials/installing-kuzzle/)
+* [Choose a SDK](https://docs-v2.kuzzle.io/sdk-reference/)
 * Build your application without caring about your backend !
 
-Check the [**Getting started page on docs.kuzzle.io**](https://docs.kuzzle.io/guide/getting-started/)
+Check the [**Getting started page on docs-v2.kuzzle.io**](https://docs-v2.kuzzle.io/guide/1/getting-started/running-kuzzle/)
 
 ### NodeJS Sample
 
@@ -50,8 +50,9 @@ npm install kuzzle-sdk
 
 ```javascript
 const
-    Kuzzle = require('kuzzle-sdk'),
-    kuzzle = new Kuzzle('http://localhost:7512')
+    { Kuzzle, WebSocket } = require('kuzzle-sdk');
+
+const kuzzle = new Kuzzle(new WebSocket('http://localhost:7512'));
 
 const filter = {
     exists: {
@@ -60,25 +61,22 @@ const filter = {
 }
 
 // Subscribe to data changes in an app
-kuzzle
-    .collection('mycollection', 'myindex')
-    .subscribe(filter, function(error, result) {
+kuzzle.subscribe('mycollection', 'myindex', filter,
+  function(error, result) {
         // triggered each time a document is updated !
         console.log('message received from kuzzle:', result)
     })
 
 // Creating a document from another app will notify all subscribers
-kuzzle
-    .collection('mycollection', 'myindex')
-    .createDocument(document)
+kuzzle.document.createDocument('mycollection', 'myindex', document)
 ```
 
 ### Useful links
 
-* [Full documentation](https://docs.kuzzle.io/)
-* [SDK Reference](https://docs.kuzzle.io/sdk-reference/essentials/)
-* [API Documentation](https://docs.kuzzle.io/api-documentation/connecting-to-kuzzle/)  
-* [Data Validation Documentation](https://docs.kuzzle.io/validation-reference/schema/)
+* [Full documentation](https://docs-v2.kuzzle.io/)
+* [SDK Reference](https://docs-v2.kuzzle.io/sdk-reference/)
+* [API Documentation](https://docs-v2.kuzzle.io/api/1/essentials/connecting-to-kuzzle/)  
+* [Data Validation Documentation](https://docs-v2.kuzzle.io/guide/1/datavalidation/introduction/)
 * [View release notes](https://github.com/kuzzleio/kuzzle/releases)
 
 ## Contributing to Kuzzle

--- a/bin/commands/start.js
+++ b/bin/commands/start.js
@@ -68,7 +68,7 @@ function commandStart (options) {
           if (!res) {
             console.log(cout.warn('[!] [WARNING] There is no administrator user yet: everyone has administrator rights.'));
             console.log(cout.notice('[ℹ] You can use the CLI or the admin console to create the first administrator user.'));
-            console.log(cout.notice('    For more information: https://docs.kuzzle.io/guide/essentials/security'));
+            console.log(cout.notice('    For more information: https://docs-v2.kuzzle.io/guide/1/essentials/security/'));
           }
         });
     })


### PR DESCRIPTION
## What does this PR do ?
Updated all links to to equivalent pages in doc v2
Updated sample code to use NODE JS 

:warning: I left docs-v2 in the URL to track links that have been updated, 
we need to replace them once doc v2 is deployed on docs.kuzzle.io

:warning: Do not merge before doc v2 is deployed!