### PR TITLE
Fix SDK constructor in CLI's sendAction

### DIFF
--- a/bin/commands/sendAction.js
+++ b/bin/commands/sendAction.js
@@ -48,7 +48,7 @@ function sendAction (query, options) {
     };
   }
 
-  const kuzzle = new Kuzzle('websocket', {host: config.host, port: config.port });
+  const kuzzle = new Kuzzle(new WebSocket(config.host, { port: config.port }));
 
   return kuzzle.connect()
     .then(() => {

--- a/bin/commands/sendAction.js
+++ b/bin/commands/sendAction.js
@@ -19,7 +19,7 @@
  * limitations under the License.
  */
 
-const { Kuzzle } = require('kuzzle-sdk');
+const { Kuzzle, WebSocket } = require('kuzzle-sdk');
 
 /**
  *  Send an action through the API


### PR DESCRIPTION
Fixes call to SDK constructor in `sendAction`, used by the CLI.

### How should this be manually tested?
- Launch Kuzzle
- shut it down with `./bin/kuzzle shutdown`