### PR TITLE
Make "collection:getSpecifications" error messages meaningful

### DIFF
--- a/lib/api/controllers/collectionController.js
+++ b/lib/api/controllers/collectionController.js
@@ -24,7 +24,10 @@
 const
   _ = require('lodash'),
   Bluebird = require('bluebird'),
-  {BadRequestError, SizeLimitError} = require('kuzzle-common-objects').errors,
+  {
+    BadRequestError,
+    PreconditionError,
+    SizeLimitError} = require('kuzzle-common-objects').errors,
   {
     assertHasBody,
     assertHasIndex,
@@ -84,8 +87,32 @@ class CollectionController {
   getSpecifications(request) {
     assertHasIndexAndCollection(request);
 
-    return this.internalEngine.get('validations', `${request.input.resource.index}#${request.input.resource.collection}`)
-      .then(response => Bluebird.resolve(response._source));
+    const {index, collection} = request.input.resource;
+
+    return this.kuzzle.indexCache.exists(index)
+      .then(exists => {
+        if (!exists) {
+          throw new PreconditionError(`The index '${index}' does not exist`);
+        }
+
+        return this.kuzzle.indexCache.exists(index, collection);
+      })
+      .then(exists => {
+        if (!exists) {
+          throw new PreconditionError(
+            `The collection '${collection}' does not exist`);
+        }
+
+        return this.internalEngine.get('validations', `${index}#${collection}`);
+      })
+      .then(response => response._source)
+      .catch(error => {
+        if (error.status === 404) {
+          error.message = `No specifications defined for index ${index} and collection ${collection}`;
+        }
+
+        throw error;
+      });
   }
 
   /**


### PR DESCRIPTION
# Description

Upon executing the `collection:getSpecifications` API route, a plain "Not Found" error is returned when one of the following does not exist: index, collection, specifications

This makes very hard for users to understand what's going on when they receive that error.

This PR makes that API route return different error messages to allow the requesting client understand why they do not receive the asked specifications.