### PR TITLE
Fix return values authorized for pipes

### DIFF
--- a/lib/api/core/notifier.js
+++ b/lib/api/core/notifier.js
@@ -19,7 +19,6 @@
  * limitations under the License.
  */
 
-
 const
   _ = require('lodash'),
   Bluebird = require('bluebird'),

--- a/lib/api/core/notifier.js
+++ b/lib/api/core/notifier.js
@@ -19,6 +19,7 @@
  * limitations under the License.
  */
 
+
 const
   _ = require('lodash'),
   Bluebird = require('bluebird'),
@@ -115,7 +116,8 @@ class NotifierController {
       this.kuzzle.pluginsManager.trigger('notify:server', notification)
         .then(updatedNotification => {
           this._dispatch(channels, updatedNotification, connectionId);
-        });
+        })
+        .catch(error => this.kuzzle.pluginsManager.trigger('log:error', error));
     }
   }
 
@@ -411,7 +413,8 @@ class NotifierController {
           connectionId,
           payload: updatedNotification
         });
-      });
+      })
+      .catch(error => this.kuzzle.pluginsManager.trigger('log:error', error));
   }
 
   /**
@@ -449,7 +452,8 @@ class NotifierController {
       const notification = new Notification.Document(request, scope, state, action, content);
 
       this.kuzzle.pluginsManager.trigger('notify:document', notification)
-        .then(updatedNotification => this._dispatch(channels, updatedNotification));
+        .then(updatedNotification => this._dispatch(channels, updatedNotification))
+        .catch(error => this.kuzzle.pluginsManager.trigger('log:error', error));
     }
   }
 
@@ -481,7 +485,8 @@ class NotifierController {
       const notification = new Notification.User(request, scope, content);
 
       this.kuzzle.pluginsManager.trigger('notify:user', notification)
-        .then(updatedNotification => this._dispatch(channels, updatedNotification));
+        .then(updatedNotification => this._dispatch(channels, updatedNotification))
+        .catch(error => this.kuzzle.pluginsManager.trigger('log:error', error));
     }
   }
 

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -21,6 +21,7 @@
 
 'use strict';
 
+
 const
   debug = require('../../../kuzzleDebug')('kuzzle:plugins'),
   PluginContext = require('./pluginContext'),
@@ -31,13 +32,10 @@ const
   _ = require('lodash'),
   fs = require('fs'),
   {
-    Request,
-    errors: {
-      KuzzleError,
-      GatewayTimeoutError,
-      PluginImplementationError
-    }
-  } = require('kuzzle-common-objects'),
+    KuzzleError,
+    GatewayTimeoutError,
+    PluginImplementationError
+  } = require('kuzzle-common-objects').errors,
   Manifest = require('./manifest');
 
 /**
@@ -377,7 +375,7 @@ class PluginsManager {
         }, warnDelay);
       }
 
-      let errorMsg = `Timeout error. Plugin ${name} pipe for event '${event}' exceeded ${timeoutDelay}ms to execute. Aborting.`;
+      const errorMsg = `Timeout error. Plugin ${name} pipe for event '${event}' exceeded ${timeoutDelay}ms to execute. Aborting.`;
       if (timeoutDelay) {
         pipeTimeoutTimer = setTimeout(() => {
           this.trigger('log:error', errorMsg);
@@ -387,19 +385,16 @@ class PluginsManager {
         }, timeoutDelay);
       }
 
-      const cb = (err, request) => {
+      const cb = (err, pipeResponse) => {
         if (pipeWarnTimer !== undefined) {
           clearTimeout(pipeWarnTimer);
         }
         if (pipeTimeoutTimer !== undefined) {
           clearTimeout(pipeTimeoutTimer);
         }
-        if (!err && !(request instanceof Request)) {
-          return callback(new PluginImplementationError(`Plugin ${name} pipe for event '${event}' must resolve to a valid Request object.`));
-        }
 
         if (!timedOut) {
-          callback(err, request);
+          callback(err, pipeResponse);
         }
       };
 
@@ -420,8 +415,6 @@ class PluginsManager {
           pipeResponse
             .then(request => cb(null, request))
             .catch(error => cb(error));
-        } else {
-          errorMsg = `Plugin ${name} pipe for event '${event}' must return a valid promise.`;
         }
       }
       catch (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {

--- a/test/api/core/pluginsManager/run.test.js
+++ b/test/api/core/pluginsManager/run.test.js
@@ -346,6 +346,21 @@ describe('PluginsManager.run', () => {
       });
   });
 
+  it('should accept promises that resolve to anything for pipes', () => {
+    plugin.object.pipes = {
+      'foo:bar': 'foo'
+    };
+
+    plugin.object.foo = sinon.stub().resolves({ result: 'flavie' });
+
+    return pluginsManager.run()
+      .then(() => pluginsManager.trigger('foo:bar'))
+      .then(response => {
+        should(plugin.object.foo).be.calledOnce();
+        should(response.result).eql('flavie');
+      });
+  });
+
   it('should attach controller actions with method name', () => {
     plugin.object.controllers = {
       'foo': {


### PR DESCRIPTION
## What does this PR do ?

Fix a regression introduced by https://github.com/kuzzleio/kuzzle/pull/1229.

This regression force pipe return value to be a promise resolving to a `Request` object but pipes could also return `DocumentNotification` or event custom JS objects (See [auth:strategyAuthenticated](https://docs.kuzzle.io/plugins/1/events/auth-strategy-authenticated/) )

### How should this be manually tested?

  - Step 1: Add a pipe on `notify:document` that returns the original `notification` received
  - Step 2 : Subscribe 
```
const {
  Kuzzle,
  WebSocket
} = require('kuzzle-sdk');

const kuzzle = new Kuzzle(new WebSocket('localhost', { port: 7512 }));

  kuzzle.on('networkError', error => {
    console.error(`Network Error: ${error.message}`);
  });

(async () => {

  try {
    await kuzzle.connect()

    await kuzzle.realtime.subscribe('nyc-open-data', 'yellow-taxi', {}, notif => console.log(notif))
  } catch (error) {
    console.error(error.message);
  }

})()
```
  - Step 3 :  Publish
```
const {
  Kuzzle,
  WebSocket
} = require('kuzzle-sdk');

const kuzzle = new Kuzzle(new WebSocket('localhost', { port: 7512 }));

kuzzle.on('networkError', error => {
  console.error(`Network Error: ${error.message}`);
});

(async () => {

  try {
    await kuzzle.connect()

    await kuzzle.realtime.publish('nyc-open-data', 'yellow-taxi', { toto: 42 })

    console.log('Success');
  } catch (error) {
    console.error(error.message);
  } finally {
    kuzzle.disconnect()
  }

})()
```

### Other changes

 - catch and log promise rejection on `notify:*` events
