### PR TITLE
[http] Allow configuration of CORS methods & headers

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -11,8 +11,14 @@
     // * accessControlAllowOrigin:
     //    sets the default Access-Control-Allow-Origin HTTP
     //    header used to send responses to the client
-    //    (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS)
-    "accessControlAllowOrigin": "*"
+    // * accessControlAllowMethods:
+    //    sets the default Access-Control-Allow-Method header
+    // * accessControlAllowHeaders:
+    //    sets the default Access-Control-Allow-Headers
+    // (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS)
+    "accessControlAllowOrigin": "*",
+    "accessControlAllowMethods": "GET,POST,PUT,DELETE,OPTIONS,HEAD",
+    "accessControlAllowHeaders": "Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding, Content-Length, X-Kuzzle-Volatile"
   },
 
   // Kuzzle configured limits

--- a/default.config.js
+++ b/default.config.js
@@ -38,7 +38,9 @@ module.exports = {
    */
   http: {
     routes: require('./lib/config/httpRoutes'),
-    accessControlAllowOrigin: '*'
+    accessControlAllowOrigin: '*',
+    accessControlAllowMethods: 'GET,POST,PUT,DELETE,OPTIONS,HEAD',
+    accessControlAllowHeaders: 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding, Content-Length, X-Kuzzle-Volatile'
   },
 
   limits: {

--- a/lib/api/core/httpRouter/index.js
+++ b/lib/api/core/httpRouter/index.js
@@ -53,9 +53,9 @@ class Router {
     this.defaultHeaders = {
       'content-type': 'application/json',
       'Accept-Encoding': 'identity',
-      'Access-Control-Allow-Origin': kuzzle.config.http.accessControlAllowOrigin || '*',
-      'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS,HEAD',
-      'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding, Content-Length, X-Kuzzle-Volatile'
+      'Access-Control-Allow-Origin': kuzzle.config.http.accessControlAllowOrigin,
+      'Access-Control-Allow-Methods': kuzzle.config.http.accessControlAllowMethods,
+      'Access-Control-Allow-Headers': kuzzle.config.http.accessControlAllowHeaders
     };
 
     if (this.kuzzle.config.server.protocols.http.allowCompression === true) {

--- a/test/api/controllers/routerController/httpRequest.test.js
+++ b/test/api/controllers/routerController/httpRequest.test.js
@@ -20,7 +20,9 @@ describe('Test: routerController.httpRequest', () => {
       config: {
         http: {
           routes: require('../../../../lib/config/httpRoutes'),
-          accessControlAllowOrigin: 'foobar'
+          accessControlAllowOrigin: 'foobar',
+          accessControlAllowMethods: 'GET,HEAD,PUT,POST,OPTIONS',
+          accessControlAllowHeaders: 'headers'
         },
         server: {
           protocols: {

--- a/test/api/core/httpRouter/httpRouter.test.js
+++ b/test/api/core/httpRouter/httpRouter.test.js
@@ -94,29 +94,19 @@ describe('core/httpRouter', () => {
       });
     });
 
-    it('should set the default allow-origin header to "*" if undefined in the config', () => {
-      delete kuzzleMock.config.http.accessControlAllowOrigin;
-      router = new Router(kuzzleMock);
-
-      should(router.defaultHeaders).eql({
-        'content-type': 'application/json',
-        'Accept-Encoding': 'gzip,deflate,identity',
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS,HEAD',
-        'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding, Content-Length, X-Kuzzle-Volatile'
-      });
-    });
-
-    it('should take the value of the allow-origin header from the config file, if set', () => {
+    it('should take the value of the CORS headers from the config file, if set', () => {
       kuzzleMock.config.http.accessControlAllowOrigin = 'foobar';
+      kuzzleMock.config.http.accessControlAllowMethods = 'METHOD';
+      kuzzleMock.config.http.accessControlAllowHeaders = 'headers';
+
       router = new Router(kuzzleMock);
 
       should(router.defaultHeaders).eql({
         'content-type': 'application/json',
         'Accept-Encoding': 'gzip,deflate,identity',
         'Access-Control-Allow-Origin': 'foobar',
-        'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS,HEAD',
-        'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding, Content-Length, X-Kuzzle-Volatile'
+        'Access-Control-Allow-Methods': 'METHOD',
+        'Access-Control-Allow-Headers': 'headers'
       });
     });
   });


### PR DESCRIPTION
This PR makes the CORS headers `Accept-Control-Allow-Methods` and `Accept-Control-Allow-Headers` configurable. 

Related issue: https://github.com/kuzzleio/kuzzle/issues/1258