### PR TITLE
Fix controllers action leak

### DIFF
--- a/lib/api/controllers/adminController.js
+++ b/lib/api/controllers/adminController.js
@@ -39,8 +39,7 @@ const _locks = {};
  */
 class AdminController extends BaseController {
   constructor(kuzzle) {
-    super(kuzzle);
-    this.actions = new Set([
+    super(kuzzle, [
       'dump',
       'resetCache',
       'resetDatabase',
@@ -48,18 +47,6 @@ class AdminController extends BaseController {
       'resetSecurity',
       'shutdown'
     ]);
-  }
-
-  /**
-   * Check if the provided action name exists within that controller.
-   * This check's purpose is to prevent actions leak by making actions exposure
-   * explicit.
-   *
-   * @param  {string} name
-   * @return {boolean}
-   */
-  isAction(name) {
-    return this.actions.has(name);
   }
 
   /**

--- a/lib/api/controllers/adminController.js
+++ b/lib/api/controllers/adminController.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const
+  BaseController = require('./controller'),
   Bluebird = require('bluebird'),
   {
     BadRequestError,
@@ -36,9 +37,29 @@ const _locks = {};
  * @class AdminController
  * @param {Kuzzle} kuzzle
  */
-class AdminController {
+class AdminController extends BaseController {
   constructor(kuzzle) {
-    this.kuzzle = kuzzle;
+    super(kuzzle);
+    this.actions = new Set([
+      'dump',
+      'resetCache',
+      'resetDatabase',
+      'resetKuzzleData',
+      'resetSecurity',
+      'shutdown'
+    ]);
+  }
+
+  /**
+   * Check if the provided action name exists within that controller.
+   * This check's purpose is to prevent actions leak by making actions exposure
+   * explicit.
+   *
+   * @param  {string} name
+   * @return {boolean}
+   */
+  isAction(name) {
+    return this.actions.has(name);
   }
 
   /**

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -53,9 +53,7 @@ class AuthController extends BaseController {
    * @constructor
    */
   constructor(kuzzle) {
-    super(kuzzle);
-
-    this.actions = new Set([
+    super(kuzzle, [
       'checkToken',
       'createMyCredentials',
       'credentialsExist',
@@ -70,18 +68,6 @@ class AuthController extends BaseController {
       'updateSelf',
       'validateMyCredentials'
     ]);
-  }
-
-  /**
-   * Check if the provided action name exists within that controller.
-   * This check's purpose is to prevent actions leak by making actions exposure
-   * explicit.
-   *
-   * @param  {string} name
-   * @return {boolean}
-   */
-  isAction(name) {
-    return this.actions.has(name);
   }
 
   /**

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -24,11 +24,10 @@
 const
   Bluebird = require('bluebird'),
   _ = require('lodash'),
+  BaseController = require('./controller'),
   User = require('../core/models/security/user'),
   formatProcessing = require('../core/auth/formatProcessing'),
-  {
-    IncomingMessage
-  } = require('http'),
+  { IncomingMessage } = require('http'),
   {
     InternalError: KuzzleInternalError,
     PluginImplementationError,
@@ -48,13 +47,41 @@ const
  * @class AuthController
  * @param {Kuzzle} kuzzle
  */
-class AuthController {
+class AuthController extends BaseController {
   /**
    * @param {Kuzzle} kuzzle
    * @constructor
    */
   constructor(kuzzle) {
-    this.kuzzle = kuzzle;
+    super(kuzzle);
+
+    this.actions = new Set([
+      'checkToken',
+      'createMyCredentials',
+      'credentialsExist',
+      'deleteMyCredentials',
+      'getCurrentUser',
+      'getMyCredentials',
+      'getMyRights',
+      'getStrategies',
+      'login',
+      'logout',
+      'updateMyCredentials',
+      'updateSelf',
+      'validateMyCredentials'
+    ]);
+  }
+
+  /**
+   * Check if the provided action name exists within that controller.
+   * This check's purpose is to prevent actions leak by making actions exposure
+   * explicit.
+   *
+   * @param  {string} name
+   * @return {boolean}
+   */
+  isAction(name) {
+    return this.actions.has(name);
   }
 
   /**

--- a/lib/api/controllers/bulkController.js
+++ b/lib/api/controllers/bulkController.js
@@ -32,20 +32,8 @@ const
  */
 class BulkController extends BaseController {
   constructor (kuzzle) {
-    super(kuzzle);
+    super(kuzzle, ['import']);
     this.engine = kuzzle.services.list.storageEngine;
-  }
-
-  /**
-   * Check if the provided action name exists within that controller.
-   * This check's purpose is to prevent actions leak by making actions exposure
-   * explicit.
-   *
-   * @param  {string} name
-   * @return {boolean}
-   */
-  isAction(name) {
-    return name === 'import';
   }
 
   /**

--- a/lib/api/controllers/collectionController.js
+++ b/lib/api/controllers/collectionController.js
@@ -22,12 +22,16 @@
 'use strict';
 
 const
+  BaseController = require('./controller'),
   _ = require('lodash'),
   Bluebird = require('bluebird'),
   {
-    BadRequestError,
-    PreconditionError,
-    SizeLimitError} = require('kuzzle-common-objects').errors,
+    errors: {
+      BadRequestError,
+      PreconditionError,
+      SizeLimitError
+    }
+  } = require('kuzzle-common-objects'),
   {
     assertHasBody,
     assertHasIndex,
@@ -40,14 +44,37 @@ const
  * @param {Kuzzle} kuzzle
  * @constructor
  */
-class CollectionController {
+class CollectionController extends BaseController {
   constructor(kuzzle) {
-    /** @type Kuzzle */
-    this.kuzzle = kuzzle;
-    /** @type ElasticSearch */
+    super(kuzzle);
     this.engine = kuzzle.services.list.storageEngine;
-    /** @type InternalEngine */
     this.internalEngine = kuzzle.internalEngine;
+    this.actions = new Set([
+      'create',
+      'deleteSpecifications',
+      'exists',
+      'getMapping',
+      'getSpecifications',
+      'list',
+      'scrollSpecifications',
+      'searchSpecifications',
+      'truncate',
+      'updateMapping',
+      'updateSpecifications',
+      'validateSpecifications'
+    ]);
+  }
+
+  /**
+   * Check if the provided action name exists within that controller.
+   * This check's purpose is to prevent actions leak by making actions exposure
+   * explicit.
+   *
+   * @param  {string} name
+   * @return {boolean}
+   */
+  isAction(name) {
+    return this.actions.has(name);
   }
 
   /**

--- a/lib/api/controllers/collectionController.js
+++ b/lib/api/controllers/collectionController.js
@@ -46,10 +46,7 @@ const
  */
 class CollectionController extends BaseController {
   constructor(kuzzle) {
-    super(kuzzle);
-    this.engine = kuzzle.services.list.storageEngine;
-    this.internalEngine = kuzzle.internalEngine;
-    this.actions = new Set([
+    super(kuzzle, [
       'create',
       'deleteSpecifications',
       'exists',
@@ -63,18 +60,9 @@ class CollectionController extends BaseController {
       'updateSpecifications',
       'validateSpecifications'
     ]);
-  }
 
-  /**
-   * Check if the provided action name exists within that controller.
-   * This check's purpose is to prevent actions leak by making actions exposure
-   * explicit.
-   *
-   * @param  {string} name
-   * @return {boolean}
-   */
-  isAction(name) {
-    return this.actions.has(name);
+    this.engine = kuzzle.services.list.storageEngine;
+    this.internalEngine = kuzzle.internalEngine;
   }
 
   /**

--- a/lib/api/controllers/controller.js
+++ b/lib/api/controllers/controller.js
@@ -19,21 +19,17 @@
  * limitations under the License.
  */
 
-'use strict';
-
 const
-  BaseController = require('./controller'),
-  {errors: {PartialError}} = require('kuzzle-common-objects'),
-  {assertHasBody, assertBodyHasAttribute} = require('../../util/requestAssertions');
+  {
+    errors: {
+      InternalError: KuzzleInternalError
+    }
+  } = require('kuzzle-common-objects');
 
-/**
- * @class BulkController
- * @param {Kuzzle} kuzzle
- */
-class BulkController extends BaseController {
-  constructor (kuzzle) {
-    super(kuzzle);
-    this.engine = kuzzle.services.list.storageEngine;
+// Base class for all controllers (except the funnel one)
+class BaseController {
+  constructor(kuzzle) {
+    this.kuzzle = kuzzle;
   }
 
   /**
@@ -45,28 +41,9 @@ class BulkController extends BaseController {
    * @return {boolean}
    */
   isAction(name) {
-    return name === 'import';
-  }
-
-  /**
-   * Perform a bulk import
-   *
-   * @param {Request} request
-   * @returns {Promise}
-   */
-  import(request) {
-    assertHasBody(request);
-    assertBodyHasAttribute(request, 'bulkData');
-
-    return this.engine.import(request)
-      .then(response => {
-        if (response.partialErrors && response.partialErrors.length > 0) {
-          request.setError(new PartialError('Some data was not imported.', response.partialErrors));
-        }
-
-        return response;
-      });
+    throw new KuzzleInternalError(
+      `Call to incomplete controller when invoking the action ${name}`);
   }
 }
 
-module.exports = BulkController;
+module.exports = BaseController;

--- a/lib/api/controllers/controller.js
+++ b/lib/api/controllers/controller.js
@@ -19,17 +19,11 @@
  * limitations under the License.
  */
 
-const
-  {
-    errors: {
-      InternalError: KuzzleInternalError
-    }
-  } = require('kuzzle-common-objects');
-
-// Base class for all controllers (except the funnel one)
+// Base class for all API controllers
 class BaseController {
-  constructor(kuzzle) {
+  constructor(kuzzle, actions = []) {
     this.kuzzle = kuzzle;
+    this._actions = new Set(actions);
   }
 
   /**
@@ -41,8 +35,11 @@ class BaseController {
    * @return {boolean}
    */
   isAction(name) {
-    throw new KuzzleInternalError(
-      `Call to incomplete controller when invoking the action ${name}`);
+    return this.actions.has(name);
+  }
+
+  get actions() {
+    return this._actions;
   }
 }
 

--- a/lib/api/controllers/documentController.js
+++ b/lib/api/controllers/documentController.js
@@ -22,11 +22,14 @@
 'use strict';
 
 const
+  BaseController = require('./controller'),
   {
-    BadRequestError,
-    SizeLimitError,
-    PartialError
-  } = require('kuzzle-common-objects').errors,
+    errors: {
+      BadRequestError,
+      SizeLimitError,
+      PartialError
+    }
+  } = require('kuzzle-common-objects'),
   {
     assertHasBody,
     assertHasId,
@@ -41,10 +44,41 @@ const
  * @class DocumentController
  * @param {Kuzzle} kuzzle
  */
-class DocumentController {
+class DocumentController extends BaseController {
   constructor(kuzzle) {
+    super(kuzzle);
     this.engine = kuzzle.services.list.storageEngine;
-    this.kuzzle = kuzzle;
+    this.actions = new Set([
+      'count',
+      'create',
+      'createOrReplace',
+      'delete',
+      'deleteByQuery',
+      'get',
+      'mCreate',
+      'mCreateOrReplace',
+      'mDelete',
+      'mGet',
+      'mReplace',
+      'mUpdate',
+      'replace',
+      'scroll',
+      'search',
+      'update',
+      'validate'
+    ]);
+  }
+
+  /**
+   * Check if the provided action name exists within that controller.
+   * This check's purpose is to prevent actions leak by making actions exposure
+   * explicit.
+   *
+   * @param  {string} name
+   * @return {boolean}
+   */
+  isAction(name) {
+    return this.actions.has(name);
   }
 
   /**

--- a/lib/api/controllers/documentController.js
+++ b/lib/api/controllers/documentController.js
@@ -46,9 +46,7 @@ const
  */
 class DocumentController extends BaseController {
   constructor(kuzzle) {
-    super(kuzzle);
-    this.engine = kuzzle.services.list.storageEngine;
-    this.actions = new Set([
+    super(kuzzle, [
       'count',
       'create',
       'createOrReplace',
@@ -68,18 +66,8 @@ class DocumentController extends BaseController {
       'update',
       'validate'
     ]);
-  }
 
-  /**
-   * Check if the provided action name exists within that controller.
-   * This check's purpose is to prevent actions leak by making actions exposure
-   * explicit.
-   *
-   * @param  {string} name
-   * @return {boolean}
-   */
-  isAction(name) {
-    return this.actions.has(name);
+    this.engine = kuzzle.services.list.storageEngine;
   }
 
   /**

--- a/lib/api/controllers/documentController.js
+++ b/lib/api/controllers/documentController.js
@@ -54,6 +54,7 @@ class DocumentController extends BaseController {
       'createOrReplace',
       'delete',
       'deleteByQuery',
+      'exists',
       'get',
       'mCreate',
       'mCreateOrReplace',

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -355,7 +355,7 @@ class FunnelController {
    * @return {Promise}
    */
   processRequest(request) {
-    const controllers = this.getControllers(request);
+    const controller = this.getController(request);
 
     this.kuzzle.statistics.startRequest(request);
     this.concurrentRequests++;
@@ -366,7 +366,7 @@ class FunnelController {
       .then(newRequest => {
         modifiedRequest = newRequest;
 
-        return callController(controllers, newRequest);
+        return doAction(controller, newRequest);
       })
       .then(responseData => {
         modifiedRequest.setResult(responseData, {status: request.status === 102 ? 200 : request.status});
@@ -378,7 +378,7 @@ class FunnelController {
         this.kuzzle.statistics.completedRequest(request);
         return newRequest;
       })
-      .catch(error => this.handleProcessRequestError(modifiedRequest, request, controllers, error))
+      .catch(error => this.handleProcessRequestError(modifiedRequest, request, error))
       .finally(() => {
         this.concurrentRequests--;
       });
@@ -397,21 +397,18 @@ class FunnelController {
    */
   executePluginRequest(request) {
     return Bluebird.resolve()
-      .then(() => {
-        const controllers = this.getControllers(request);
-        return callController(controllers, request);
-      })
+      .then(() => doAction(this.getController(request), request))
       .catch(e => {
         this.handleErrorDump(e);
         return Bluebird.reject(e);
       });
   }
 
-  handleProcessRequestError(modifiedRequest, request, controllers, error) {
+  handleProcessRequestError(modifiedRequest, request, error) {
     let _error = error;
     const eventError = this.getEventName(modifiedRequest, 'error');
 
-    if (controllers === this.pluginsControllers && !(error instanceof KuzzleError)) {
+    if (!this.isNativeController(request) && !(error instanceof KuzzleError)) {
       _error = new PluginImplementationError(error);
     }
     modifiedRequest.setError(_error);
@@ -429,7 +426,8 @@ class FunnelController {
       .catch(customError => {
         _error = customError;
 
-        if (controllers === this.pluginsControllers && !(customError instanceof KuzzleError)) {
+        if (!this.isNativeController(request)
+          && !(customError instanceof KuzzleError)) {
           _error = new PluginImplementationError(customError);
         }
 
@@ -478,33 +476,44 @@ class FunnelController {
   }
 
   /**
-   * Returns the controllers object corresponding to the action asked
-   * by the request
+   * Return the controller corresponding to the action asked by the request
    *
    * @param  {Request} request
-   * @return {Object} controllers object
+   * @return {Object} controller object
    * @throws {BadRequestError} If the asked controller or action is unknown
    */
-  getControllers(request) {
-    let controllers;
+  getController(request) {
+    const {controller, action} = request.input;
 
-    if (this.controllers[request.input.controller]) {
-      controllers = this.controllers;
-    }
-    else if (this.pluginsControllers[request.input.controller]) {
-      controllers = this.pluginsControllers;
-    }
-    else {
-      throw new BadRequestError(`Unknown controller ${request.input.controller}`);
-    }
+    let target;
 
-    const action = controllers[request.input.controller][request.input.action];
-
-    if (!action || typeof action !== 'function') {
-      throw new BadRequestError(`No corresponding action ${request.input.action} in controller ${request.input.controller}`);
+    if (this.controllers[controller]) {
+      if (this.controllers[controller].isAction(action)) {
+        target = this.controllers[controller];
+      }
+    } else if (this.pluginsControllers[controller]) {
+      if (this.pluginsControllers[controller][action]) {
+        target = this.pluginsControllers[controller];
+      }
+    } else {
+      throw new BadRequestError(`Unknown controller ${controller}`);
     }
 
-    return controllers;
+    if (!target) {
+      throw new BadRequestError(
+        `No corresponding action ${action} in controller ${controller}`);
+    }
+
+    return target;
+  }
+
+  /**
+   * Tell if the request accesses to a native controller or not
+   * @param  {Request}  request
+   * @return {Boolean}
+   */
+  isNativeController(request) {
+    return Boolean(this.controllers[request.input.controller]);
   }
 
   /**
@@ -580,18 +589,18 @@ function capitalizeFirstLetter(string) {
 }
 
 /**
- * Invoke a controller function, checking that its return
+ * Execute a controller action, checking that its return
  * value is a Promise. If not, wraps the returned value
  * in a rejected Promise and returns it.
  *
  * Used to make Kuzzle safe from badly implemented plugins
  *
- * @param  {Object} controllers
+ * @param  {Object} controller
  * @param  {Request} request
  * @return {Promise}
  */
-function callController(controllers, request) {
-  const ret = controllers[request.input.controller][request.input.action](request);
+function doAction(controller, request) {
+  const ret = controller[request.input.action](request);
 
   if (!ret || typeof ret.then !== 'function') {
     return Bluebird.reject(new PluginImplementationError(`Unexpected return value from action ${request.input.controller}/${request.input.action}: expected a Promise`));

--- a/lib/api/controllers/indexController.js
+++ b/lib/api/controllers/indexController.js
@@ -39,9 +39,7 @@ const
  */
 class IndexController extends BaseController {
   constructor(kuzzle) {
-    super(kuzzle);
-    this.engine = this.kuzzle.services.list.storageEngine;
-    this.actions = new Set([
+    super(kuzzle, [
       'create',
       'delete',
       'exists',
@@ -52,17 +50,8 @@ class IndexController extends BaseController {
       'refreshInternal',
       'setAutoRefresh'
     ]);
-  }
 
-  /**
-   * Return the action corresponding to the provided name.
-   * Prevent accidental functions leak to the API.
-   *
-   * @param  {string} name
-   * @return {Function}
-   */
-  isAction(name) {
-    return this.actions.has(name);
+    this.engine = this.kuzzle.services.list.storageEngine;
   }
 
   /**

--- a/lib/api/controllers/indexController.js
+++ b/lib/api/controllers/indexController.js
@@ -22,9 +22,10 @@
 'use strict';
 
 const
+  BaseController = require('./controller'),
   _ = require('lodash'),
   Bluebird = require('bluebird'),
-  Request = require('kuzzle-common-objects').Request,
+  { Request } = require('kuzzle-common-objects'),
   {
     assertHasBody,
     assertBodyHasAttribute,
@@ -36,13 +37,32 @@ const
  * @class IndexController
  * @param {Kuzzle} kuzzle
  */
-class IndexController {
+class IndexController extends BaseController {
   constructor(kuzzle) {
-    /** @type Kuzzle */
-    this.kuzzle = kuzzle;
+    super(kuzzle);
+    this.engine = this.kuzzle.services.list.storageEngine;
+    this.actions = new Set([
+      'create',
+      'delete',
+      'exists',
+      'getAutoRefresh',
+      'list',
+      'mDelete',
+      'refresh',
+      'refreshInternal',
+      'setAutoRefresh'
+    ]);
+  }
 
-    /** @type ElasticSearch */
-    this.engine = kuzzle.services.list.storageEngine;
+  /**
+   * Return the action corresponding to the provided name.
+   * Prevent accidental functions leak to the API.
+   *
+   * @param  {string} name
+   * @return {Function}
+   */
+  isAction(name) {
+    return this.actions.has(name);
   }
 
   /**

--- a/lib/api/controllers/memoryStorageController.js
+++ b/lib/api/controllers/memoryStorageController.js
@@ -22,7 +22,8 @@
 'use strict';
 
 const
-  BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
+  BaseController = require('./controller'),
+  {errors: {BadRequestError}} = require('kuzzle-common-objects'),
   kassert = require('../../util/requestAssertions');
 
 let mapping;
@@ -31,17 +32,31 @@ let mapping;
  * @class MemoryStorageController
  * @param {Kuzzle} kuzzle
  */
-class MemoryStorageController {
+class MemoryStorageController extends BaseController {
   constructor(kuzzle) {
-    this.kuzzle = kuzzle;
+    super(kuzzle);
 
     initMapping();
 
+    this.actions = new Set();
+
     Object.keys(mapping).forEach(command => {
+      this.actions.add(command);
       this[command] = request => kuzzle.services.list.memoryStorage[command](...extractArgumentsFromRequest(command, request));
     });
   }
 
+  /**
+   * Check if the provided action name exists within that controller.
+   * This check's purpose is to prevent actions leak by making actions exposure
+   * explicit.
+   *
+   * @param  {string} name
+   * @return {boolean}
+   */
+  isAction(name) {
+    return this.actions.has(name);
+  }
 }
 
 module.exports = MemoryStorageController;

--- a/lib/api/controllers/memoryStorageController.js
+++ b/lib/api/controllers/memoryStorageController.js
@@ -38,24 +38,10 @@ class MemoryStorageController extends BaseController {
 
     initMapping();
 
-    this.actions = new Set();
-
     Object.keys(mapping).forEach(command => {
       this.actions.add(command);
       this[command] = request => kuzzle.services.list.memoryStorage[command](...extractArgumentsFromRequest(command, request));
     });
-  }
-
-  /**
-   * Check if the provided action name exists within that controller.
-   * This check's purpose is to prevent actions leak by making actions exposure
-   * explicit.
-   *
-   * @param  {string} name
-   * @return {boolean}
-   */
-  isAction(name) {
-    return this.actions.has(name);
   }
 }
 

--- a/lib/api/controllers/realtimeController.js
+++ b/lib/api/controllers/realtimeController.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const
+  BaseController = require('./controller'),
   {
     assertHasBody,
     assertBodyHasAttribute,
@@ -33,10 +34,31 @@ const
  * @class RealtimeController
  * @param {Kuzzle} kuzzle
  */
-class RealtimeController {
+class RealtimeController extends BaseController {
   constructor(kuzzle) {
-    /** @type Kuzzle */
-    this.kuzzle = kuzzle;
+    super(kuzzle);
+
+    this.actions = new Set([
+      'count',
+      'join',
+      'list',
+      'publish',
+      'subscribe',
+      'unsubscribe',
+      'validate'
+    ]);
+  }
+
+  /**
+   * Check if the provided action name exists within that controller.
+   * This check's purpose is to prevent actions leak by making actions exposure
+   * explicit.
+   *
+   * @param  {string} name
+   * @return {boolean}
+   */
+  isAction(name) {
+    return this.actions.has(name);
   }
 
   /**

--- a/lib/api/controllers/realtimeController.js
+++ b/lib/api/controllers/realtimeController.js
@@ -36,9 +36,7 @@ const
  */
 class RealtimeController extends BaseController {
   constructor(kuzzle) {
-    super(kuzzle);
-
-    this.actions = new Set([
+    super(kuzzle, [
       'count',
       'join',
       'list',
@@ -47,18 +45,6 @@ class RealtimeController extends BaseController {
       'unsubscribe',
       'validate'
     ]);
-  }
-
-  /**
-   * Check if the provided action name exists within that controller.
-   * This check's purpose is to prevent actions leak by making actions exposure
-   * explicit.
-   *
-   * @param  {string} name
-   * @return {boolean}
-   */
-  isAction(name) {
-    return this.actions.has(name);
   }
 
   /**

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -245,7 +245,7 @@ class SecurityController extends BaseController {
    * @return {boolean}
    */
   isAction(name) {
-    this.actions.has(name);
+    return this.actions.has(name);
   }
 
   /**

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -25,17 +25,20 @@ const
   _ = require('lodash'),
   uuid = require('uuid/v4'),
   Bluebird = require('bluebird'),
+  BaseController = require('./controller'),
   formatProcessing = require('../core/auth/formatProcessing'),
-  Request = require('kuzzle-common-objects').Request,
   {
-    NotFoundError,
-    BadRequestError,
-    PluginImplementationError,
-    PartialError,
-    PreconditionError,
-    InternalError: KuzzleInternalError,
-    SizeLimitError
-  } = require('kuzzle-common-objects').errors,
+    Request,
+    errors: {
+      NotFoundError,
+      BadRequestError,
+      PluginImplementationError,
+      PartialError,
+      PreconditionError,
+      InternalError: KuzzleInternalError,
+      SizeLimitError
+    }
+  } = require('kuzzle-common-objects'),
   {
     assertHasBody,
     assertBodyHasAttribute,
@@ -181,10 +184,68 @@ const persistUser = Bluebird.coroutine(function* persistUserGenerator (kuzzle, r
  * @constructor
  * @property {Kuzzle} kuzzle
  */
-class SecurityController {
+class SecurityController extends BaseController {
   constructor(kuzzle) {
-    /** @type Kuzzle */
-    this.kuzzle = kuzzle;
+    super(kuzzle);
+
+    this.actions = new Set([
+      'createCredentials',
+      'createFirstAdmin',
+      'createOrReplaceProfile',
+      'createOrReplaceRole',
+      'createProfile',
+      'createRestrictedUser',
+      'createRole',
+      'createUser',
+      'deleteCredentials',
+      'deleteProfile',
+      'deleteRole',
+      'deleteUser',
+      'getAllCredentialFields',
+      'getCredentialFields',
+      'getCredentials',
+      'getCredentialsById',
+      'getProfile',
+      'getProfileMapping',
+      'getProfileRights',
+      'getRole',
+      'getRoleMapping',
+      'getUser',
+      'getUserMapping',
+      'getUserRights',
+      'hasCredentials',
+      'mDeleteProfiles',
+      'mDeleteRoles',
+      'mDeleteUsers',
+      'mGetProfiles',
+      'mGetRoles',
+      'replaceUser',
+      'scrollProfiles',
+      'scrollUsers',
+      'searchProfiles',
+      'searchRoles',
+      'searchUsers',
+      'updateCredentials',
+      'updateProfile',
+      'updateProfileMapping',
+      'updateRole',
+      'updateRoleMapping',
+      'updateUser',
+      'updateUserMapping',
+      'validateCredentials'
+    ]);
+  }
+
+  /**
+   * Check if the provided action name exists within that controller.
+   * This check's purpose is to prevent actions leak by making actions exposure
+   * explicit.
+   *
+   * @param  {string} name
+   * @return {boolean}
+   */
+  isAction(name) {
+    this.actions.has(name);
   }
 
   /**

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -186,9 +186,7 @@ const persistUser = Bluebird.coroutine(function* persistUserGenerator (kuzzle, r
  */
 class SecurityController extends BaseController {
   constructor(kuzzle) {
-    super(kuzzle);
-
-    this.actions = new Set([
+    super(kuzzle, [
       'createCredentials',
       'createFirstAdmin',
       'createOrReplaceProfile',
@@ -234,18 +232,6 @@ class SecurityController extends BaseController {
       'updateUserMapping',
       'validateCredentials'
     ]);
-  }
-
-  /**
-   * Check if the provided action name exists within that controller.
-   * This check's purpose is to prevent actions leak by making actions exposure
-   * explicit.
-   *
-   * @param  {string} name
-   * @return {boolean}
-   */
-  isAction(name) {
-    return this.actions.has(name);
   }
 
   /**

--- a/lib/api/controllers/serverController.js
+++ b/lib/api/controllers/serverController.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const
+  BaseController = require('./controller'),
   Bluebird = require('bluebird'),
   os = require('os'),
   {
@@ -33,9 +34,31 @@ const
  * @class ServerController
  * @param {Kuzzle} kuzzle
  */
-class ServerController {
+class ServerController extends BaseController {
   constructor(kuzzle) {
-    this.kuzzle = kuzzle;
+    super(kuzzle);
+
+    this.actions = new Set([
+      'adminExists',
+      'getAllStats',
+      'getConfig',
+      'getLastStats',
+      'getStats',
+      'info',
+      'now'
+    ]);
+  }
+
+  /**
+   * Check if the provided action name exists within that controller.
+   * This check's purpose is to prevent actions leak by making actions exposure
+   * explicit.
+   *
+   * @param  {string} name
+   * @return {boolean}
+   */
+  isAction(name) {
+    return this.actions.has(name);
   }
 
   /**

--- a/lib/api/controllers/serverController.js
+++ b/lib/api/controllers/serverController.js
@@ -44,6 +44,7 @@ class ServerController extends BaseController {
       'getConfig',
       'getLastStats',
       'getStats',
+      'healthCheck',
       'info',
       'now'
     ]);

--- a/lib/api/controllers/serverController.js
+++ b/lib/api/controllers/serverController.js
@@ -36,9 +36,7 @@ const
  */
 class ServerController extends BaseController {
   constructor(kuzzle) {
-    super(kuzzle);
-
-    this.actions = new Set([
+    super(kuzzle, [
       'adminExists',
       'getAllStats',
       'getConfig',
@@ -48,18 +46,6 @@ class ServerController extends BaseController {
       'info',
       'now'
     ]);
-  }
-
-  /**
-   * Check if the provided action name exists within that controller.
-   * This check's purpose is to prevent actions leak by making actions exposure
-   * explicit.
-   *
-   * @param  {string} name
-   * @return {boolean}
-   */
-  isAction(name) {
-    return this.actions.has(name);
   }
 
   /**

--- a/test/api/controllers/adminController.test.js
+++ b/test/api/controllers/adminController.test.js
@@ -27,9 +27,15 @@ describe('Test: admin controller', () => {
     request.input.args.refresh = 'wait_for';
   });
 
-  describe('#constructor', () => {
+  describe('#base', () => {
     it('should inherit the base constructor', () => {
       should(adminController).instanceOf(BaseController);
+    });
+
+    it('should properly override the isAction method', () => {
+      adminController._foobar = () => {};
+      should(adminController.isAction('dump')).be.true();
+      should(adminController.isAction('_foobar')).be.false();
     });
   });
 

--- a/test/api/controllers/adminController.test.js
+++ b/test/api/controllers/adminController.test.js
@@ -27,15 +27,9 @@ describe('Test: admin controller', () => {
     request.input.args.refresh = 'wait_for';
   });
 
-  describe('#base', () => {
+  describe('#constructor', () => {
     it('should inherit the base constructor', () => {
       should(adminController).instanceOf(BaseController);
-    });
-
-    it('should properly override the isAction method', () => {
-      adminController._foobar = () => {};
-      should(adminController.isAction('dump')).be.true();
-      should(adminController.isAction('_foobar')).be.false();
     });
   });
 

--- a/test/api/controllers/adminController.test.js
+++ b/test/api/controllers/adminController.test.js
@@ -3,12 +3,15 @@ const
   should = require('should'),
   sinon = require('sinon'),
   {
-    BadRequestError,
-    PreconditionError
-  } = require('kuzzle-common-objects').errors,
+    Request,
+    errors: {
+      BadRequestError,
+      PreconditionError
+    }
+  } = require('kuzzle-common-objects'),
   KuzzleMock = require('../../mocks/kuzzle.mock'),
-  Request = require('kuzzle-common-objects').Request,
-  AdminController = rewire('../../../lib/api/controllers/adminController');
+  AdminController = rewire('../../../lib/api/controllers/adminController'),
+  BaseController = require('../../../lib/api/controllers/controller');
 
 describe('Test: admin controller', () => {
   let
@@ -22,6 +25,12 @@ describe('Test: admin controller', () => {
     adminController = new AdminController(kuzzle);
     request = new Request({ controller: 'admin' });
     request.input.args.refresh = 'wait_for';
+  });
+
+  describe('#constructor', () => {
+    it('should inherit the base constructor', () => {
+      should(adminController).instanceOf(BaseController);
+    });
   });
 
   describe('#resetCache', () => {

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -3,18 +3,20 @@ const
   should = require('should'),
   jwt = require('jsonwebtoken'),
   Bluebird = require('bluebird'),
-  /** @type KuzzleConfiguration */
   AuthController = require('../../../lib/api/controllers/authController'),
   KuzzleMock = require('../../mocks/kuzzle.mock'),
-  Request = require('kuzzle-common-objects').Request,
   Token = require('../../../lib/api/core/models/security/token'),
   User = require('../../../lib/api/core/models/security/user'),
   {
-    UnauthorizedError,
-    BadRequestError,
-    InternalError: KuzzleInternalError,
-    PluginImplementationError
-  } = require('kuzzle-common-objects').errors;
+    Request,
+    errors: {
+      UnauthorizedError,
+      BadRequestError,
+      InternalError: KuzzleInternalError,
+      PluginImplementationError
+    }
+  } = require('kuzzle-common-objects'),
+  BaseController = require('../../../lib/api/controllers/controller');
 
 describe('Test the auth controller', () => {
   let
@@ -41,6 +43,12 @@ describe('Test the auth controller', () => {
     });
 
     authController = new AuthController(kuzzle);
+  });
+
+  describe('#constructor', () => {
+    it('should inherit the base constructor', () => {
+      should(authController).instanceOf(BaseController);
+    });
   });
 
   describe('#login', () => {

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -45,9 +45,15 @@ describe('Test the auth controller', () => {
     authController = new AuthController(kuzzle);
   });
 
-  describe('#constructor', () => {
+  describe('#base', () => {
     it('should inherit the base constructor', () => {
       should(authController).instanceOf(BaseController);
+    });
+
+    it('should properly override the isAction method', () => {
+      authController._foobar = () => {};
+      should(authController.isAction('login')).be.true();
+      should(authController.isAction('_foobar')).be.false();
     });
   });
 

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -45,15 +45,9 @@ describe('Test the auth controller', () => {
     authController = new AuthController(kuzzle);
   });
 
-  describe('#base', () => {
+  describe('#constructor', () => {
     it('should inherit the base constructor', () => {
       should(authController).instanceOf(BaseController);
-    });
-
-    it('should properly override the isAction method', () => {
-      authController._foobar = () => {};
-      should(authController.isAction('login')).be.true();
-      should(authController.isAction('_foobar')).be.false();
     });
   });
 

--- a/test/api/controllers/baseController.test.js
+++ b/test/api/controllers/baseController.test.js
@@ -1,11 +1,6 @@
 const
   should = require('should'),
-  BaseController = require('../../../lib/api/controllers/controller'),
-  {
-    errors: {
-      InternalError: KuzzleInternalError
-    }
-  } = require('kuzzle-common-objects');
+  BaseController = require('../../../lib/api/controllers/controller');
 
 describe('#base controller', () => {
   it('should expose a kuzzle property', () => {
@@ -14,11 +9,13 @@ describe('#base controller', () => {
     should(base).have.properties({kuzzle: 'foobar'});
   });
 
-  it('should throw if the isAction method has not been overridden', () => {
-    const base = new BaseController();
+  it('should initialize its actions list from the constructor', () => {
+    const base = new BaseController('foobar', ['foo', 'bar']);
 
-    should(() => base.isAction('foo')).throw(
-      KuzzleInternalError,
-      {message: 'Call to incomplete controller when invoking the action foo'});
+    base.qux = () => {};
+
+    should(base.isAction('foo')).be.true();
+    should(base.isAction('bar')).be.true();
+    should(base.isAction('qux')).be.false();
   });
 });

--- a/test/api/controllers/baseController.test.js
+++ b/test/api/controllers/baseController.test.js
@@ -1,0 +1,24 @@
+const
+  should = require('should'),
+  BaseController = require('../../../lib/api/controllers/controller'),
+  {
+    errors: {
+      InternalError: KuzzleInternalError
+    }
+  } = require('kuzzle-common-objects');
+
+describe('#base controller', () => {
+  it('should expose a kuzzle property', () => {
+    const base = new BaseController('foobar');
+
+    should(base).have.properties({kuzzle: 'foobar'});
+  });
+
+  it('should throw if the isAction method has not been overridden', () => {
+    const base = new BaseController();
+
+    should(() => base.isAction('foo')).throw(
+      KuzzleInternalError,
+      {message: 'Call to incomplete controller when invoking the action foo'});
+  });
+});

--- a/test/api/controllers/bulkController.test.js
+++ b/test/api/controllers/bulkController.test.js
@@ -22,15 +22,9 @@ describe('Test the bulk controller', () => {
     controller = new BulkController(kuzzle);
   });
 
-  describe('#base', () => {
+  describe('#constructor', () => {
     it('should inherit the base constructor', () => {
       should(controller).instanceOf(BaseController);
-    });
-
-    it('should properly override the isAction method', () => {
-      controller._foobar = () => {};
-      should(controller.isAction('import')).be.true();
-      should(controller.isAction('_foobar')).be.false();
     });
   });
 

--- a/test/api/controllers/bulkController.test.js
+++ b/test/api/controllers/bulkController.test.js
@@ -1,9 +1,12 @@
 const
   should = require('should'),
   BulkController = require('../../../lib/api/controllers/bulkController'),
-  Request = require('kuzzle-common-objects').Request,
-  PartialError = require('kuzzle-common-objects').errors.PartialError,
-  KuzzleMock = require('../../mocks/kuzzle.mock');
+  {
+    Request,
+    errors: { PartialError }
+  } = require('kuzzle-common-objects'),
+  KuzzleMock = require('../../mocks/kuzzle.mock'),
+  BaseController = require('../../../lib/api/controllers/controller');
 
 describe('Test the bulk controller', () => {
   let
@@ -17,6 +20,12 @@ describe('Test the bulk controller', () => {
     kuzzle = new KuzzleMock();
     stub = kuzzle.services.list.storageEngine.import;
     controller = new BulkController(kuzzle);
+  });
+
+  describe('#constructor', () => {
+    it('should inherit the base constructor', () => {
+      should(controller).instanceOf(BaseController);
+    });
   });
 
   it('should trigger the proper methods and resolve to a valid response', () => {

--- a/test/api/controllers/bulkController.test.js
+++ b/test/api/controllers/bulkController.test.js
@@ -22,9 +22,15 @@ describe('Test the bulk controller', () => {
     controller = new BulkController(kuzzle);
   });
 
-  describe('#constructor', () => {
+  describe('#base', () => {
     it('should inherit the base constructor', () => {
       should(controller).instanceOf(BaseController);
+    });
+
+    it('should properly override the isAction method', () => {
+      controller._foobar = () => {};
+      should(controller.isAction('import')).be.true();
+      should(controller.isAction('_foobar')).be.false();
     });
   });
 

--- a/test/api/controllers/collectionController.test.js
+++ b/test/api/controllers/collectionController.test.js
@@ -36,15 +36,9 @@ describe('Test: collection controller', () => {
     request = new Request(data);
   });
 
-  describe('#base', () => {
+  describe('#constructor', () => {
     it('should inherit the base constructor', () => {
       should(collectionController).instanceOf(BaseController);
-    });
-
-    it('should properly override the isAction method', () => {
-      collectionController._foobar = () => {};
-      should(collectionController.isAction('list')).be.true();
-      should(collectionController.isAction('_foobar')).be.false();
     });
   });
 

--- a/test/api/controllers/collectionController.test.js
+++ b/test/api/controllers/collectionController.test.js
@@ -11,7 +11,8 @@ const
       PreconditionError
     }
   } = require('kuzzle-common-objects'),
-  KuzzleMock = require('../../mocks/kuzzle.mock');
+  KuzzleMock = require('../../mocks/kuzzle.mock'),
+  BaseController = require('../../../lib/api/controllers/controller');
 
 describe('Test: collection controller', () => {
   let
@@ -33,6 +34,12 @@ describe('Test: collection controller', () => {
     engine = kuzzle.services.list.storageEngine;
     collectionController = new CollectionController(kuzzle);
     request = new Request(data);
+  });
+
+  describe('#constructor', () => {
+    it('should inherit the base constructor', () => {
+      should(collectionController).instanceOf(BaseController);
+    });
   });
 
   describe('#updateMapping', () => {

--- a/test/api/controllers/collectionController.test.js
+++ b/test/api/controllers/collectionController.test.js
@@ -36,9 +36,15 @@ describe('Test: collection controller', () => {
     request = new Request(data);
   });
 
-  describe('#constructor', () => {
+  describe('#base', () => {
     it('should inherit the base constructor', () => {
       should(collectionController).instanceOf(BaseController);
+    });
+
+    it('should properly override the isAction method', () => {
+      collectionController._foobar = () => {};
+      should(collectionController.isAction('list')).be.true();
+      should(collectionController.isAction('_foobar')).be.false();
     });
   });
 

--- a/test/api/controllers/documentController.test.js
+++ b/test/api/controllers/documentController.test.js
@@ -35,9 +35,15 @@ describe('Test: document controller', () => {
     });
   });
 
-  describe('#constructor', () => {
+  describe('#base', () => {
     it('should inherit the base constructor', () => {
       should(documentController).instanceOf(BaseController);
+    });
+
+    it('should properly override the isAction method', () => {
+      documentController._foobar = () => {};
+      should(documentController.isAction('create')).be.true();
+      should(documentController.isAction('_foobar')).be.false();
     });
   });
 

--- a/test/api/controllers/documentController.test.js
+++ b/test/api/controllers/documentController.test.js
@@ -5,13 +5,16 @@ const
   sinon = require('sinon'),
   Bluebird = require('bluebird'),
   KuzzleMock = require('../../mocks/kuzzle.mock'),
-  Request = require('kuzzle-common-objects').Request,
   DocumentController = require('../../../lib/api/controllers/documentController'),
   {
-    InternalError: KuzzleInternalError,
-    NotFoundError,
-    PartialError
-  } = require('kuzzle-common-objects').errors;
+    Request,
+    errors: {
+      InternalError: KuzzleInternalError,
+      NotFoundError,
+      PartialError
+    }
+  } = require('kuzzle-common-objects'),
+  BaseController = require('../../../lib/api/controllers/controller');
 
 describe('Test: document controller', () => {
   const foo = {foo: 'bar'};
@@ -25,7 +28,17 @@ describe('Test: document controller', () => {
     kuzzle = new KuzzleMock();
     engine = kuzzle.services.list.storageEngine;
     documentController = new DocumentController(kuzzle);
-    request = new Request({controller: 'document', index: '%test', collection: 'unit-test-documentController'});
+    request = new Request({
+      controller: 'document',
+      index: '%test',
+      collection: 'unit-test-documentController'
+    });
+  });
+
+  describe('#constructor', () => {
+    it('should inherit the base constructor', () => {
+      should(documentController).instanceOf(BaseController);
+    });
   });
 
   describe('#search', () => {

--- a/test/api/controllers/documentController.test.js
+++ b/test/api/controllers/documentController.test.js
@@ -35,15 +35,9 @@ describe('Test: document controller', () => {
     });
   });
 
-  describe('#base', () => {
+  describe('#constructor', () => {
     it('should inherit the base constructor', () => {
       should(documentController).instanceOf(BaseController);
-    });
-
-    it('should properly override the isAction method', () => {
-      documentController._foobar = () => {};
-      should(documentController.isAction('create')).be.true();
-      should(documentController.isAction('_foobar')).be.false();
     });
   });
 

--- a/test/api/controllers/funnelController/processRequest.test.js
+++ b/test/api/controllers/funnelController/processRequest.test.js
@@ -2,12 +2,17 @@
 
 const
   should = require('should'),
-  sinon = require('sinon'),
-  Bluebird = require('bluebird'),
-  Request = require('kuzzle-common-objects').Request,
   FunnelController = require('../../../../lib/api/controllers/funnelController'),
   KuzzleMock = require('../../../mocks/kuzzle.mock'),
-  {BadRequestError, PluginImplementationError} = require('kuzzle-common-objects').errors;
+  ControllerMock = require('../../../mocks/controller.mock'),
+  {
+    Request,
+    errors: {
+      BadRequestError,
+      PluginImplementationError,
+      InternalError: KuzzleInternalError
+    }
+  } = require('kuzzle-common-objects');
 
 describe('funnelController.processRequest', () => {
   let
@@ -18,74 +23,95 @@ describe('funnelController.processRequest', () => {
     kuzzle = new KuzzleMock();
     funnel = new FunnelController(kuzzle);
 
-    // injects fake controllers for unit tests
-    funnel.controllers = {
-      'fakeController': {
-        ok: sinon.stub().returns(Bluebird.resolve()),
-        fail: sinon.stub()
-      }
-    };
-
-    funnel.pluginsControllers = {
-      'fakePlugin/controller': {
-        ok: sinon.stub().returns(Bluebird.resolve()),
-        fail: sinon.stub()
-      }
-    };
+    // inject fake controllers for unit tests
+    funnel.controllers.fakeController = new ControllerMock(kuzzle);
+    funnel.pluginsControllers['fakePlugin/controller'] =
+      new ControllerMock(kuzzle);
   });
 
   it('should throw if no controller is specified', () => {
     const request = new Request({action: 'create'});
 
-    should(() => funnel.processRequest(request)).throw(BadRequestError, {message: 'Unknown controller null'});
-    should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
-    should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.false();
+    should(() => funnel.processRequest(request))
+      .throw(BadRequestError, {message: 'Unknown controller null'});
+    should(kuzzle.pluginsManager.trigger)
+      .not.calledWith('request:onSuccess', request);
+    should(kuzzle.pluginsManager.trigger)
+      .not.calledWith('request:onError', request);
     should(kuzzle.statistics.startRequest).not.be.called();
   });
 
   it('should throw if no action is specified', () => {
     const request = new Request({controller: 'fakeController'});
 
-    should(() => funnel.processRequest(request)).throw(BadRequestError, {message: 'No corresponding action null in controller fakeController'});
-    should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
-    should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.false();
+    should(() => funnel.processRequest(request))
+      .throw(BadRequestError, {
+        message: 'No corresponding action null in controller fakeController'
+      });
+    should(kuzzle.pluginsManager.trigger)
+      .not.calledWith('request:onSuccess', request);
+    should(kuzzle.pluginsManager.trigger)
+      .not.calledWith('request:onError', request);
     should(kuzzle.statistics.startRequest).not.be.called();
   });
 
-  it('should throw if the action doesn\'t exist', () => {
-    const request = new Request({controller: 'fakeController', action: 'create'});
+  it('should throw if the action does not exist', () => {
+    const request = new Request({
+      controller: 'fakeController',
+      action: 'create'
+    });
 
-    should(() => funnel.processRequest(request)).throw(BadRequestError, {message: 'No corresponding action create in controller fakeController'});
-    should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
-    should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.false();
-    should(kuzzle.pluginsManager.trigger.calledWithMatch('fakeController:errorCreate', request)).be.false();
+    should(() => funnel.processRequest(request))
+      .throw(BadRequestError, {
+        message: 'No corresponding action create in controller fakeController'
+      });
+    should(kuzzle.pluginsManager.trigger)
+      .not.calledWith('request:onSuccess', request);
+    should(kuzzle.pluginsManager.trigger)
+      .not.calledWith('request:onError', request);
+    should(kuzzle.pluginsManager.trigger)
+      .not.calledWith('fakeController:errorCreate', request);
     should(kuzzle.statistics.startRequest).not.be.called();
   });
 
   it('should throw if a plugin action does not exist', () => {
-    const request = new Request({controller: 'fakePlugin/controller', action: 'create'});
+    const
+      controller = 'fakePlugin/controller',
+      request = new Request({controller, action: 'create'});
 
-    should(() => funnel.processRequest(request)).throw(BadRequestError, {message: 'No corresponding action create in controller fakePlugin/controller'});
-    should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
-    should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.false();
-    should(kuzzle.pluginsManager.trigger.calledWithMatch('fakePlugin/controller:errorCreate', request)).be.false();
+    should(() => funnel.processRequest(request))
+      .throw(BadRequestError, {
+        message: `No corresponding action create in controller ${controller}`
+      });
+    should(kuzzle.pluginsManager.trigger)
+      .not.calledWith('request:onSuccess', request);
+    should(kuzzle.pluginsManager.trigger)
+      .not.calledWith('request:onError', request);
+    should(kuzzle.pluginsManager.trigger)
+      .not.calledWith('fakePlugin/controller:errorCreate', request);
     should(kuzzle.statistics.startRequest).not.be.called();
   });
 
   it('should throw if a plugin action returns a non-thenable object', done => {
-    const request = new Request({controller: 'fakePlugin/controller', action: 'ok'});
+    const
+      controller = 'fakePlugin/controller',
+      request = new Request({controller, action: 'succeed'});
 
-    funnel.pluginsControllers['fakePlugin/controller'].ok.returns('foobar');
+    funnel.pluginsControllers[controller].succeed.returns('foobar');
 
     funnel.processRequest(request)
-      .then(() => done('Expected test to fail'))
+      .then(() => done(new Error('Expected test to fail')))
       .catch(e => {
         try {
           should(e).be.instanceOf(PluginImplementationError);
-          should(e.message).startWith('Unexpected return value from action fakePlugin/controller/ok: expected a Promise');
-          should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
-          should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.true();
-          should(kuzzle.pluginsManager.trigger.calledWithMatch('fakePlugin/controller:errorOk', request)).be.true();
+          should(e.message).startWith(
+            `Unexpected return value from action ${controller}/succeed: expected a Promise`);
+          should(kuzzle.pluginsManager.trigger)
+            .not.calledWith('request:onSuccess', request);
+          should(kuzzle.pluginsManager.trigger)
+            .calledWith('request:onError', request);
+          should(kuzzle.pluginsManager.trigger)
+            .calledWith(`${controller}:errorSucceed`, request);
           should(kuzzle.statistics.startRequest).be.called();
           done();
         }
@@ -98,21 +124,26 @@ describe('funnelController.processRequest', () => {
   it('should resolve the promise if everything is ok', () => {
     const request = new Request({
       controller: 'fakeController',
-      action: 'ok'
+      action: 'succeed'
     });
 
-    return should(funnel.processRequest(request)
+    return funnel.processRequest(request)
       .then(response => {
         should(response).be.exactly(request);
-        should(kuzzle.pluginsManager.trigger).calledWith('fakeController:beforeOk');
-        should(kuzzle.pluginsManager.trigger).calledWith('fakeController:afterOk');
-        should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.true();
-        should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.false();
-        should(kuzzle.pluginsManager.trigger.calledWithMatch('fakeController:errorOk', request)).be.false();
+        should(kuzzle.pluginsManager.trigger)
+          .calledWith('fakeController:beforeSucceed');
+        should(kuzzle.pluginsManager.trigger)
+          .calledWith('fakeController:afterSucceed');
+        should(kuzzle.pluginsManager.trigger)
+          .calledWith('request:onSuccess', request);
+        should(kuzzle.pluginsManager.trigger)
+          .not.calledWith('request:onError', request);
+        should(kuzzle.pluginsManager.trigger)
+          .not.calledWith('fakeController:errorSucceed', request);
         should(kuzzle.statistics.startRequest).be.called();
         should(kuzzle.statistics.completedRequest).be.called();
         should(kuzzle.statistics.failedRequest).not.be.called();
-      })).be.fulfilled();
+      });
   });
 
   it('should reject the promise if a controller action fails', done => {
@@ -121,19 +152,22 @@ describe('funnelController.processRequest', () => {
       action: 'fail',
     });
 
-    funnel.controllers.fakeController.fail.rejects(new Error('rejected'));
-
     funnel.processRequest(request)
-      .then(() => done('Expected test to fail'))
+      .then(() => done(new Error('Expected test to fail')))
       .catch(e => {
         try {
-          should(e).be.instanceOf(Error);
-          should(e.message).be.eql('rejected');
-          should(kuzzle.pluginsManager.trigger).calledWith('fakeController:beforeFail');
-          should(kuzzle.pluginsManager.trigger).not.be.calledWith('fakeController:afterFail');
-          should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
-          should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.true();
-          should(kuzzle.pluginsManager.trigger.calledWithMatch('fakeController:errorFail', request)).be.true();
+          should(e).be.instanceOf(KuzzleInternalError);
+          should(e.message).be.eql('rejected action');
+          should(kuzzle.pluginsManager.trigger)
+            .calledWith('fakeController:beforeFail');
+          should(kuzzle.pluginsManager.trigger)
+            .not.be.calledWith('fakeController:afterFail');
+          should(kuzzle.pluginsManager.trigger)
+            .not.calledWith('request:onSuccess', request);
+          should(kuzzle.pluginsManager.trigger)
+            .calledWith('request:onError', request);
+          should(kuzzle.pluginsManager.trigger)
+            .calledWith('fakeController:errorFail', request);
           should(kuzzle.statistics.startRequest).be.called();
           should(kuzzle.statistics.completedRequest).not.be.called();
           should(kuzzle.statistics.failedRequest).be.called();
@@ -146,24 +180,28 @@ describe('funnelController.processRequest', () => {
   });
 
   it('should wrap a Node error on a plugin action failure', done => {
-    const request = new Request({
-      controller: 'fakePlugin/controller',
-      action: 'fail',
-    });
+    const
+      controller = 'fakePlugin/controller',
+      request = new Request({controller, action: 'fail'});
 
-    funnel.pluginsControllers['fakePlugin/controller'].fail.rejects(new Error('rejected'));
+    funnel.pluginsControllers[controller].fail.rejects(new Error('foobar'));
 
     funnel.processRequest(request)
-      .then(() => done('Expected test to fail'))
+      .then(() => done(new Error('Expected test to fail')))
       .catch(e => {
         try {
           should(e).be.instanceOf(PluginImplementationError);
-          should(e.message).startWith('rejected');
-          should(kuzzle.pluginsManager.trigger).calledWith('fakePlugin/controller:beforeFail');
-          should(kuzzle.pluginsManager.trigger).not.be.calledWith('fakePlugin/controller:afterFail');
-          should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onSuccess', request)).be.false();
-          should(kuzzle.pluginsManager.trigger.calledWithMatch('request:onError', request)).be.true();
-          should(kuzzle.pluginsManager.trigger.calledWithMatch('fakePlugin/controller:errorFail', request)).be.true();
+          should(e.message).startWith('foobar');
+          should(kuzzle.pluginsManager.trigger)
+            .calledWith(`${controller}:beforeFail`);
+          should(kuzzle.pluginsManager.trigger)
+            .not.be.calledWith(`${controller}:afterFail`);
+          should(kuzzle.pluginsManager.trigger)
+            .not.calledWith('request:onSuccess', request);
+          should(kuzzle.pluginsManager.trigger)
+            .calledWith('request:onError', request);
+          should(kuzzle.pluginsManager.trigger)
+            .calledWith('fakePlugin/controller:errorFail', request);
           should(kuzzle.statistics.startRequest).be.called();
           should(kuzzle.statistics.completedRequest).not.be.called();
           should(kuzzle.statistics.failedRequest).be.called();

--- a/test/api/controllers/indexController.test.js
+++ b/test/api/controllers/indexController.test.js
@@ -30,15 +30,9 @@ describe('Test: index controller', () => {
     request = new Request(data);
   });
 
-  describe('#base', () => {
+  describe('#constructor', () => {
     it('should inherit the base constructor', () => {
       should(indexController).instanceOf(BaseController);
-    });
-
-    it('should properly override the isAction method', () => {
-      indexController._foobar = () => {};
-      should(indexController.isAction('list')).be.true();
-      should(indexController.isAction('_foobar')).be.false();
     });
   });
 

--- a/test/api/controllers/indexController.test.js
+++ b/test/api/controllers/indexController.test.js
@@ -30,9 +30,15 @@ describe('Test: index controller', () => {
     request = new Request(data);
   });
 
-  describe('#constructor', () => {
+  describe('#base', () => {
     it('should inherit the base constructor', () => {
       should(indexController).instanceOf(BaseController);
+    });
+
+    it('should properly override the isAction method', () => {
+      indexController._foobar = () => {};
+      should(indexController.isAction('list')).be.true();
+      should(indexController.isAction('_foobar')).be.false();
     });
   });
 

--- a/test/api/controllers/indexController.test.js
+++ b/test/api/controllers/indexController.test.js
@@ -2,8 +2,11 @@ const
   should = require('should'),
   sinon = require('sinon'),
   IndexController = require('../../../lib/api/controllers/indexController'),
-  Request = require('kuzzle-common-objects').Request,
-  BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
+  {
+    Request,
+    errors: { BadRequestError }
+  } = require('kuzzle-common-objects'),
+  BaseController = require('../../../lib/api/controllers/controller'),
   KuzzleMock = require('../../mocks/kuzzle.mock');
 
 describe('Test: index controller', () => {
@@ -25,6 +28,12 @@ describe('Test: index controller', () => {
 
     indexController = new IndexController(kuzzle);
     request = new Request(data);
+  });
+
+  describe('#constructor', () => {
+    it('should inherit the base constructor', () => {
+      should(indexController).instanceOf(BaseController);
+    });
   });
 
   describe('#mDelete', () => {

--- a/test/api/controllers/memoryStorageController.test.js
+++ b/test/api/controllers/memoryStorageController.test.js
@@ -5,8 +5,11 @@ const
   rewire = require('rewire'),
   KuzzleMock = require('../../mocks/kuzzle.mock'),
   RedisClientMock = require('../../mocks/services/redisClient.mock'),
-  BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
-  Request = require('kuzzle-common-objects').Request,
+  BaseController = require('../../../lib/api/controllers/controller'),
+  {
+    Request,
+    errors: { BadRequestError }
+  } = require('kuzzle-common-objects'),
   MemoryStorageController = rewire('../../../lib/api/controllers/memoryStorageController.js');
 
 describe('Test: memoryStorage controller', () => {
@@ -116,6 +119,10 @@ describe('Test: memoryStorage controller', () => {
       allowed.forEach(command => {
         should(msController[command]).be.a.Function();
       });
+    });
+
+    it('should inherit the base constructor', () => {
+      should(msController).instanceOf(BaseController);
     });
   });
 

--- a/test/api/controllers/memoryStorageController.test.js
+++ b/test/api/controllers/memoryStorageController.test.js
@@ -124,6 +124,12 @@ describe('Test: memoryStorage controller', () => {
     it('should inherit the base constructor', () => {
       should(msController).instanceOf(BaseController);
     });
+
+    it('should properly override the isAction method', () => {
+      msController._foobar = () => {};
+      should(msController.isAction('flushdb')).be.true();
+      should(msController.isAction('_foobar')).be.false();
+    });
   });
 
   describe('#extractArgumentsFromRequest', () => {

--- a/test/api/controllers/realtimeController.test.js
+++ b/test/api/controllers/realtimeController.test.js
@@ -29,9 +29,15 @@ describe('Test: subscribe controller', () => {
     kuzzle.repositories.user.anonymous = sinon.stub();
   });
 
-  describe('#constructor', () => {
+  describe('#base', () => {
     it('should inherit the base constructor', () => {
       should(realtimeController).instanceOf(BaseController);
+    });
+
+    it('should properly override the isAction method', () => {
+      realtimeController._foobar = () => {};
+      should(realtimeController.isAction('subscribe')).be.true();
+      should(realtimeController.isAction('_foobar')).be.false();
     });
   });
 

--- a/test/api/controllers/realtimeController.test.js
+++ b/test/api/controllers/realtimeController.test.js
@@ -3,8 +3,11 @@ const
   sinon = require('sinon'),
   KuzzleMock = require('../../mocks/kuzzle.mock'),
   RealtimeController = require('../../../lib/api/controllers/realtimeController'),
-  Request = require('kuzzle-common-objects').Request,
-  BadRequestError = require('kuzzle-common-objects').errors.BadRequestError;
+  {
+    Request,
+    errors: { BadRequestError }
+  } = require('kuzzle-common-objects'),
+  BaseController = require('../../../lib/api/controllers/controller');
 
 describe('Test: subscribe controller', () => {
   let
@@ -16,8 +19,20 @@ describe('Test: subscribe controller', () => {
   beforeEach(() => {
     kuzzle = new KuzzleMock();
     realtimeController = new RealtimeController(kuzzle);
-    request = new Request({index: 'test', collection: 'collection', controller: 'realtime', body: {}}, {user: {_id: '42'}});
+    request = new Request({
+      index: 'test',
+      collection: 'collection',
+      controller: 'realtime',
+      body: {}
+    }, {user: {_id: '42'}});
+
     kuzzle.repositories.user.anonymous = sinon.stub();
+  });
+
+  describe('#constructor', () => {
+    it('should inherit the base constructor', () => {
+      should(realtimeController).instanceOf(BaseController);
+    });
   });
 
   describe('#subscribe', () => {

--- a/test/api/controllers/realtimeController.test.js
+++ b/test/api/controllers/realtimeController.test.js
@@ -29,15 +29,9 @@ describe('Test: subscribe controller', () => {
     kuzzle.repositories.user.anonymous = sinon.stub();
   });
 
-  describe('#base', () => {
+  describe('#constructor', () => {
     it('should inherit the base constructor', () => {
       should(realtimeController).instanceOf(BaseController);
-    });
-
-    it('should properly override the isAction method', () => {
-      realtimeController._foobar = () => {};
-      should(realtimeController.isAction('subscribe')).be.true();
-      should(realtimeController.isAction('_foobar')).be.false();
     });
   });
 

--- a/test/api/controllers/securityController/createFirstAdmin.test.js
+++ b/test/api/controllers/securityController/createFirstAdmin.test.js
@@ -17,6 +17,11 @@ describe('Test: security controller - createFirstAdmin', () => {
   beforeEach(() => {
     kuzzle = new KuzzleMock();
     adminController = new SecurityController(kuzzle);
+    kuzzle.funnel.controllers = {
+      server: {
+        adminExists: sinon.stub()
+      }
+    };
   });
 
   describe('#createFirstAdmin', () => {

--- a/test/api/controllers/securityController/index.js
+++ b/test/api/controllers/securityController/index.js
@@ -32,6 +32,14 @@ describe('/api/controllers/security', () => {
     it('should inherit the base constructor', () => {
       should(new SecurityController(kuzzle)).instanceOf(BaseController);
     });
+
+    it('should properly override the isAction method', () => {
+      const securityController = new SecurityController(kuzzle);
+
+      securityController._foobar = () => {};
+      should(securityController.isAction('createUser')).be.true();
+      should(securityController.isAction('_foobar')).be.false();
+    });
   });
 
   describe('#mDelete', () => {

--- a/test/api/controllers/securityController/index.js
+++ b/test/api/controllers/securityController/index.js
@@ -6,14 +6,17 @@ const
   Bluebird = require('bluebird'),
   FunnelController = require('../../../../lib/api/controllers/funnelController'),
   KuzzleMock = require('../../../mocks/kuzzle.mock'),
-  Request = require('kuzzle-common-objects').Request,
+  BaseController = require('../../../../lib/api/controllers/controller'),
   SecurityController = rewire('../../../../lib/api/controllers/securityController'),
   {
-    BadRequestError,
-    ServiceUnavailableError,
-    InternalError: KuzzleInternalError,
-    PartialError
-  } = require('kuzzle-common-objects').errors;
+    Request,
+    errors: {
+      BadRequestError,
+      ServiceUnavailableError,
+      InternalError: KuzzleInternalError,
+      PartialError
+    }
+  } = require('kuzzle-common-objects');
 
 describe('/api/controllers/security', () => {
   let
@@ -23,6 +26,12 @@ describe('/api/controllers/security', () => {
   beforeEach(() => {
     kuzzle = new KuzzleMock();
     funnelController = new FunnelController(kuzzle);
+  });
+
+  describe('#constructor', () => {
+    it('should inherit the base constructor', () => {
+      should(new SecurityController(kuzzle)).instanceOf(BaseController);
+    });
   });
 
   describe('#mDelete', () => {

--- a/test/api/controllers/securityController/index.js
+++ b/test/api/controllers/securityController/index.js
@@ -32,14 +32,6 @@ describe('/api/controllers/security', () => {
     it('should inherit the base constructor', () => {
       should(new SecurityController(kuzzle)).instanceOf(BaseController);
     });
-
-    it('should properly override the isAction method', () => {
-      const securityController = new SecurityController(kuzzle);
-
-      securityController._foobar = () => {};
-      should(securityController.isAction('createUser')).be.true();
-      should(securityController.isAction('_foobar')).be.false();
-    });
   });
 
   describe('#mDelete', () => {

--- a/test/api/controllers/serverController.test.js
+++ b/test/api/controllers/serverController.test.js
@@ -1,8 +1,11 @@
 const
   should = require('should'),
   ServerController = require('../../../lib/api/controllers/serverController'),
-  Request = require('kuzzle-common-objects').Request,
-  ServiceUnavailableError = require('kuzzle-common-objects').errors.ServiceUnavailableError,
+  {
+    Request,
+    errors: { ServiceUnavailableError }
+  } = require('kuzzle-common-objects'),
+  BaseController = require('../../../lib/api/controllers/controller'),
   KuzzleMock = require('../../mocks/kuzzle.mock');
 
 describe('Test: server controller', () => {
@@ -23,6 +26,12 @@ describe('Test: server controller', () => {
     kuzzle = new KuzzleMock();
     serverController = new ServerController(kuzzle);
     request = new Request(data);
+  });
+
+  describe('#constructor', () => {
+    it('should inherit the base constructor', () => {
+      should(serverController).instanceOf(BaseController);
+    });
   });
 
   describe('#getStats', () => {

--- a/test/api/controllers/serverController.test.js
+++ b/test/api/controllers/serverController.test.js
@@ -28,9 +28,15 @@ describe('Test: server controller', () => {
     request = new Request(data);
   });
 
-  describe('#constructor', () => {
+  describe('#base', () => {
     it('should inherit the base constructor', () => {
       should(serverController).instanceOf(BaseController);
+    });
+
+    it('should properly override the isAction method', () => {
+      serverController._foobar = () => {};
+      should(serverController.isAction('info')).be.true();
+      should(serverController.isAction('_foobar')).be.false();
     });
   });
 

--- a/test/api/controllers/serverController.test.js
+++ b/test/api/controllers/serverController.test.js
@@ -28,15 +28,9 @@ describe('Test: server controller', () => {
     request = new Request(data);
   });
 
-  describe('#base', () => {
+  describe('#constructor', () => {
     it('should inherit the base constructor', () => {
       should(serverController).instanceOf(BaseController);
-    });
-
-    it('should properly override the isAction method', () => {
-      serverController._foobar = () => {};
-      should(serverController.isAction('info')).be.true();
-      should(serverController.isAction('_foobar')).be.false();
     });
   });
 

--- a/test/api/core/entrypoints/embedded/index.test.js
+++ b/test/api/core/entrypoints/embedded/index.test.js
@@ -60,6 +60,7 @@ describe('lib/core/api/core/entrypoints/embedded/index', () => {
     mockrequire('../../../../../lib/api/core/entrypoints/embedded/protocols/http', initStub);
     mockrequire('../../../../../lib/api/core/entrypoints/embedded/protocols/websocket', initStub);
     mockrequire('../../../../../lib/api/core/entrypoints/embedded/protocols/socketio', initStub);
+    mockrequire('../../../../../lib/api/core/entrypoints/embedded/protocols/mqtt', initStub);
 
     mockrequire('http', httpMock);
     mockrequire('winston', {
@@ -120,6 +121,10 @@ describe('lib/core/api/core/entrypoints/embedded/index', () => {
     }
   });
 
+  after(() => {
+    mockrequire.stopAll();
+  });
+
   describe('#dispatch', () => {
     it('should call _notify', () => {
       const data = {foo: 'bar'};
@@ -151,7 +156,7 @@ describe('lib/core/api/core/entrypoints/embedded/index', () => {
 
   describe('#execute', () => {
     it('should call the funnel and log the response', (done) => {
-      kuzzle.funnel.execute = (request, cb) => cb(null, request);
+      kuzzle.funnel.execute.callsFake((request, cb) => cb(null, request));
       entrypoint.logAccess = sinon.spy();
 
       const request = new Request({});
@@ -173,7 +178,7 @@ describe('lib/core/api/core/entrypoints/embedded/index', () => {
 
     it('should try to return an error if one received without any response', (done) => {
       const error = new KuzzleInternalError('test');
-      kuzzle.funnel.execute = (request, cb) => cb(error, request);
+      kuzzle.funnel.execute.callsFake((request, cb) => cb(error, request));
 
       const request = new Request({});
       entrypoint.execute(request, response => {

--- a/test/api/core/entrypoints/embedded/protocols/mqtt.test.js
+++ b/test/api/core/entrypoints/embedded/protocols/mqtt.test.js
@@ -10,33 +10,32 @@ const
 
 describe('/lib/api/core/entrypoints/embedded/protocols/mqtt', () => {
   const moscaOnMock = sinon.stub();
-  moscaOnMock
-    .withArgs('ready')
-    .yields();
-
   const moscaMock = function (config) {
     this.config = config;
     this.on = moscaOnMock;
     this.publish = sinon.spy();
   };
 
-  mockrequire('mosca', {
-    Server: moscaMock
-  });
-  const MqttProtocol = mockrequire.reRequire('../../../../../../lib/api/core/entrypoints/embedded/protocols/mqtt');
-
   let
-    clock,
     entrypoint,
     kuzzle,
-    protocol;
+    protocol,
+    MqttProtocol;
 
   before(() => {
-    clock = sinon.useFakeTimers();
+    moscaOnMock
+      .withArgs('ready')
+      .yields();
+
+    mockrequire('mosca', {
+      Server: moscaMock
+    });
+
+    MqttProtocol = mockrequire.reRequire('../../../../../../lib/api/core/entrypoints/embedded/protocols/mqtt');
   });
 
   after(() => {
-    clock.restore();
+    mockrequire.stopAll();
   });
 
   beforeEach(() => {
@@ -101,7 +100,6 @@ describe('/lib/api/core/entrypoints/embedded/protocols/mqtt', () => {
           .be.calledOnce()
           .be.calledWith('packet', 'client');
       }
-
     });
   });
 
@@ -279,7 +277,9 @@ describe('/lib/api/core/entrypoints/embedded/protocols/mqtt', () => {
     });
 
     it('should remove the connection', () => {
-      const client = {};
+      const
+        clock = sinon.useFakeTimers(),
+        client = {};
 
       protocol.connections.set(client, {id: 'id'});
       protocol.connectionsById = {
@@ -292,6 +292,8 @@ describe('/lib/api/core/entrypoints/embedded/protocols/mqtt', () => {
       should(entrypoint.removeConnection)
         .be.calledOnce()
         .be.calledWith('id');
+
+      clock.restore();
     });
 
   });

--- a/test/mocks/controller.mock.js
+++ b/test/mocks/controller.mock.js
@@ -1,0 +1,30 @@
+const
+  BaseController = require('../../lib/api/controllers/controller'),
+  {
+    errors: {
+      InternalError: KuzzleInternalError
+    }
+  } = require('kuzzle-common-objects'),
+  sinon = require('sinon');
+
+class MockController extends BaseController {
+  constructor(kuzzle) {
+    super(kuzzle);
+
+    this.failResult = new KuzzleInternalError('rejected action');
+    this.fail = sinon.stub().rejects(this.failResult);
+
+    // we need to use "callsFake" instead of "resolvesArg" because, for some
+    // reason, .resolves and .resolvesArg behaviors are not overwritten
+    // when we do "this.succeed.returns('another value')": in that case,
+    // "another value" is resolved as a promise result, which is not the
+    // desired result
+    this.succeed = sinon.stub().callsFake(foo => Promise.resolve(foo));
+  }
+
+  isAction(name) {
+    return name === 'succeed' || name === 'fail';
+  }
+}
+
+module.exports = MockController;

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -51,24 +51,13 @@ class KuzzleMock extends Kuzzle {
     };
 
     this.funnel = {
-      controllers: {
-        server: {
-          adminExists: this.sandbox.stub(),
-        },
-        security: {
-          createFirstAdmin: sinon.spy(),
-          deleteUser: sinon.spy(),
-          deleteProfile: sinon.spy(),
-          deleteRole: sinon.spy()
-        }
-      },
-      pluginsControllers: {
-      },
+      controllers: {},
+      pluginsControllers: {},
       init: this.sandbox.spy(),
       loadPluginControllers: this.sandbox.spy(),
       getRequestSlot: this.sandbox.stub().returns(true),
       handleErrorDump: this.sandbox.spy(),
-      execute: this.sandbox.spy(),
+      execute: this.sandbox.stub(),
       mExecute: this.sandbox.stub(),
       processRequest: this.sandbox.stub().resolves(),
       checkRights: this.sandbox.stub(),


### PR DESCRIPTION
# Description

Controllers actions were implicitly exposed: whenever an API request is submitted, the funnel checks if the requested action is exposed as a function by the requested controller, and if so, the action was allowed to be executed.
This means that internal methods, which are obviously not API actions, are executable too.

Hopefully, I've extensively tested this, and it appears that *for now* this has little consequence. But this is a major bug that needs to be fixed ASAP, just in case.

This PR does that, by making controllers action exposure explicit. 

# Other changes

* Entrypoints unit test: solve a randomly failing test because of a mock-require leakage

# How to test it

We can execute the `_mChanges` internal method from the document controller, just by sending the following request:

```json
{"controller":"document","action":"_mChanges","body":{"documents":[] },"index":"foo","collection":"bar"}
```

With this PR active, we get a `BadRequestError` instead, with the following message: `No corresponding action _mChanges in controller document`
