### PR TITLE
Remove useless format property for winston logs

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -297,7 +297,6 @@
           "transport": "console",
           "level": "info",
           "stderrLevels": [],
-          "format": "simple",
           "silent": true
         }
       ],

--- a/default.config.js
+++ b/default.config.js
@@ -170,7 +170,6 @@ module.exports = {
           transport: 'console',
           level: 'info',
           stderrLevels: [],
-          format: 'simple',
           silent: true
         }
       ],


### PR DESCRIPTION
## What does this PR do ?

Remove unused `format: 'simple'` option from default config and kuzzlerc.

Fix #1228 
