### PR TITLE
fix regression injected by #1263

### DIFF
--- a/bin/commands/start.js
+++ b/bin/commands/start.js
@@ -40,7 +40,7 @@ function commandStart (options) {
       console.log(cout.kuz('[✔] Kuzzle server ready'));
       return kuzzle.internalEngine.bootstrap.adminExists()
         .then(res => {
-          if (res) {
+          if (!res) {
             console.log(cout.warn('[!] [WARNING] There is no administrator user yet: everyone has administrator rights.'));
             console.log(cout.notice('[ℹ] You can use the CLI or the admin console to create the first administrator user.'));
             console.log(cout.notice('    For more information: https://docs.kuzzle.io/guide/essentials/security'));


### PR DESCRIPTION
We must log a warning message if there is no admin user,
that means if the result of `kuzzle.internalEngine.bootstrap.adminExists()` is falsy.

(see https://github.com/kuzzleio/kuzzle/pull/1263/files#diff-ae4b049d55a80c7c724d5a42038576d6R43 )