### PR TITLE
[bugfix] scan keys on redis cluster

### DIFF
--- a/lib/services/redis.js
+++ b/lib/services/redis.js
@@ -166,7 +166,7 @@ class Redis extends Service {
   searchKeys(pattern) {
     if (this._client instanceof IORedis.Cluster) {
       let keys = [];
-      let promises = [];
+      const promises = [];
 
       for (const node of this._client.nodes('master')) {
         promises.push(this._searchNodeKeys(node, pattern)

--- a/lib/services/redis.js
+++ b/lib/services/redis.js
@@ -164,18 +164,22 @@ class Redis extends Service {
    * @returns {Promise} promise resolving to an array of keys
    */
   searchKeys(pattern) {
-    return new Bluebird(resolve => {
+    if (this._client instanceof IORedis.Cluster) {
       let keys = [];
-      const stream = this._client.scanStream({match: pattern});
+      let promises = [];
 
-      stream.on('data', resultKeys => {
-        keys = keys.concat(resultKeys);
-      });
+      for (const node of this._client.nodes('master')) {
+        promises.push(this._searchNodeKeys(node, pattern)
+          .then(nodeKeys => {
+            keys = keys.concat(nodeKeys);
+          }));
+      }
 
-      stream.on('end', () => {
-        resolve(_.uniq(keys));
-      });
-    });
+      return Bluebird.all(promises)
+        .then(() => _.uniq(keys));
+    }
+
+    return this._searchNodeKeys(this._client, pattern);
   }
 
   /**
@@ -205,6 +209,23 @@ class Redis extends Service {
 
     return this._client.mget(_args);
   }
+
+  _searchNodeKeys(node, pattern) {
+    return new Bluebird(resolve => {
+      let keys = [];
+      const stream = node.scanStream({match: pattern});
+
+      stream.on('data', resultKeys => {
+        keys = keys.concat(resultKeys);
+      });
+
+      stream.on('end', () => {
+        resolve(_.uniq(keys));
+      });
+    });
+
+  }
+
 }
 
 module.exports = Redis;

--- a/lib/services/redis.js
+++ b/lib/services/redis.js
@@ -170,7 +170,7 @@ class Redis extends Service {
 
       for (const node of this._client.nodes('master')) {
         promises.push(this._searchNodeKeys(node, pattern)
-          .then(nodeKeys => {
+          .then(nodeKeys => { // eslint-disable-line no-loop-func
             keys = keys.concat(nodeKeys);
           }));
       }


### PR DESCRIPTION
## What does this PR do ?

Fixes Kuzzle way of fetching keys when redis is running in cluster mode. 
cf: https://github.com/luin/ioredis/issues/175 

### How should this be manually tested?

An easy way to test this method is to call `server:getStats`.
You can get a ready-to-use redis cluster from the cluster development stack.