### PR TITLE
Expose new admin:load* routes

### DIFF
--- a/features/kuzzle.feature
+++ b/features/kuzzle.feature
@@ -1,5 +1,4 @@
 Feature: Kuzzle functional tests
-
   @http
   Scenario: Send a request compressed with gzip
     Given a request compressed with "gzip"
@@ -1831,3 +1830,68 @@ Feature: Kuzzle functional tests
     Then I'm able to find a default role with id "admin" equivalent to role "admin"
     And I'm able to find a default role with id "default" equivalent to role "default"
     And I'm able to find a default role with id "anonymous" equivalent to role "anonymous"
+
+  Scenario: Load Mappings
+    Given I load the mappings '{"kuzzle-test-index-new": {"kuzzle-collection-test": {}}}'
+    When I check if index "kuzzle-test-index-new" exists
+    Then The result should match the json true
+    When I check if collection "kuzzle-collection-test" exists on index "kuzzle-test-index-new"
+    Then The result should match the json true
+    Then I'm able to delete the index named "kuzzle-test-index-new"
+
+  Scenario: Load Fixtures
+    When I load the fixtures
+    """
+    {
+      "kuzzle-test-index": {
+        "kuzzle-collection-test": [
+          {"create": {"_id": "foo"}},
+          {}
+        ]
+      },
+      "kuzzle-test-index-alt": {
+        "kuzzle-collection-test": [
+          {"create": {"_id": "bar"}},
+          {}
+        ]
+      }
+    }
+    """
+    Then I find a document with "foo" in field "_id" in index "kuzzle-test-index"
+    And I find a document with "bar" in field "_id" in index "kuzzle-test-index-alt"
+
+  Scenario: Load Securities
+    When I load the securities
+    """
+    {
+      "roles": {
+        "#prefix#fakeRole": {
+          "controllers": {
+            "*": {
+              "actions": {
+                "*" : true
+              }
+            }
+          }
+        }
+      },
+      "profiles": {
+        "#prefix#fakeProfile": {
+          "policies": [
+            {"roleId": "#prefix#fakeRole"}
+          ]
+        }
+      },
+      "users": {
+        "#prefix#fakeUser": {
+          "content": {
+            "profileIds": ["#prefix#fakeProfile"]
+          }
+        }
+      }
+    }
+    """
+    # the following tests assume the prefix #prefix# automatically
+    Then I'm able to find a role with id "fakeRole"
+    And I'm able to find the profile with id "fakeProfile"
+    And I am able to get the user "fakeUser"

--- a/features/step_definitions/adminController.js
+++ b/features/step_definitions/adminController.js
@@ -1,0 +1,14 @@
+const { Given, When } = require('cucumber');
+
+Given('I load the mappings {string}', function (mappings) {
+  return this.api.loadMappings(JSON.parse(mappings));
+});
+
+When('I load the fixtures', function (fixtures) {
+  return this.api.loadFixtures(JSON.parse(fixtures));
+});
+
+When('I load the securities', function (securities) {
+  const parsed = JSON.parse(securities.replace(/#prefix#/g, this.idPrefix));
+  return this.api.loadSecurities(parsed);
+});

--- a/features/support/api/apiBase.js
+++ b/features/support/api/apiBase.js
@@ -1293,6 +1293,33 @@ class ApiBase {
       action: 'resetDatabase'
     });
   }
+
+  loadMappings (body) {
+    return this.send({
+      body,
+      controller: 'admin',
+      action: 'loadMappings',
+      refresh: 'wait_for'
+    });
+  }
+
+  loadFixtures (body) {
+    return this.send({
+      body,
+      controller: 'admin',
+      action: 'loadFixtures',
+      refresh: 'wait_for'
+    });
+  }
+
+  loadSecurities (body) {
+    return this.send({
+      body,
+      controller: 'admin',
+      action: 'loadSecurities',
+      refresh: 'wait_for'
+    });
+  }
 }
 
 

--- a/features/support/api/http.js
+++ b/features/support/api/http.js
@@ -1276,6 +1276,36 @@ class HttpApi {
     return this.callApi(options);
   }
 
+  loadMappings (body) {
+    const options = {
+      url : this.apiPath('admin/_loadMappings?refresh=wait_for'),
+      method: 'POST',
+      body
+    };
+
+    return this.callApi(options);
+  }
+
+  loadFixtures (body) {
+    const options = {
+      url : this.apiPath('admin/_loadFixtures?refresh=wait_for'),
+      method: 'POST',
+      body
+    };
+
+    return this.callApi(options);
+  }
+
+  loadSecurities (body) {
+    const options = {
+      url : this.apiPath('admin/_loadSecurities?refresh=wait_for'),
+      method: 'POST',
+      body
+    };
+
+    return this.callApi(options);
+  }
+
   encode(algorithm) {
     checkAlgorithm(algorithm);
     this.encoding = algorithm;

--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -59,6 +59,7 @@ AfterAll(function () {
 
 After(function () {
   return this.api.truncateCollection()
+    .then(() => this.api.truncateCollection(this.fakeAltIndex))
     .then(() => this.api.refreshIndex(this.fakeIndex))
     .then(() => this.api.disconnect());
 });

--- a/lib/api/controllers/adminController.js
+++ b/lib/api/controllers/adminController.js
@@ -25,11 +25,16 @@ const
   BaseController = require('./controller'),
   Bluebird = require('bluebird'),
   {
-    BadRequestError,
-    PreconditionError
-  } = require('kuzzle-common-objects').errors,
-  Request = require('kuzzle-common-objects').Request,
-  assertArgsHasAttribute = require('../../util/requestAssertions').assertArgsHasAttribute;
+    Request,
+    errors: {
+      BadRequestError,
+      PreconditionError
+    }
+  } = require('kuzzle-common-objects'),
+  {
+    assertHasBody,
+    assertArgsHasAttribute
+  } = require('../../util/requestAssertions');
 
 const _locks = {};
 
@@ -180,11 +185,9 @@ class AdminController extends BaseController {
   }
 
   loadFixtures (request) {
-    const fixtures = request.input.body;
+    assertHasBody(request);
 
-    if (fixtures === null) {
-      throw new BadRequestError('Cannot load null fixtures');
-    }
+    const fixtures = request.input.body;
 
     const promise = this.kuzzle.janitor.loadFixtures(fixtures);
 
@@ -192,11 +195,9 @@ class AdminController extends BaseController {
   }
 
   loadMappings (request) {
-    const mappings = request.input.body;
+    assertHasBody(request);
 
-    if (mappings === null) {
-      throw new BadRequestError('Cannot load null mappings');
-    }
+    const mappings = request.input.body;
 
     const promise = this.kuzzle.janitor.loadMappings(mappings);
 
@@ -204,11 +205,9 @@ class AdminController extends BaseController {
   }
 
   loadSecurities (request) {
-    const securities = request.input.body;
+    assertHasBody(request);
 
-    if (securities === null) {
-      throw new BadRequestError('Cannot load null securities');
-    }
+    const securities = request.input.body;
 
     const promise = this.kuzzle.janitor.loadSecurities(securities);
 

--- a/lib/api/controllers/adminController.js
+++ b/lib/api/controllers/adminController.js
@@ -41,6 +41,9 @@ class AdminController extends BaseController {
   constructor(kuzzle) {
     super(kuzzle, [
       'dump',
+      'loadFixtures',
+      'loadMappings',
+      'loadSecurities',
       'resetCache',
       'resetDatabase',
       'resetKuzzleData',
@@ -179,6 +182,10 @@ class AdminController extends BaseController {
   loadFixtures (request) {
     const fixtures = request.input.body;
 
+    if (fixtures === null) {
+      throw new BadRequestError('Cannot load null fixtures');
+    }
+
     const promise = this.kuzzle.janitor.loadFixtures(fixtures);
 
     return this._waitForAction(request, promise, { acknowledge: true });
@@ -187,6 +194,10 @@ class AdminController extends BaseController {
   loadMappings (request) {
     const mappings = request.input.body;
 
+    if (mappings === null) {
+      throw new BadRequestError('Cannot load null mappings');
+    }
+
     const promise = this.kuzzle.janitor.loadMappings(mappings);
 
     return this._waitForAction(request, promise, { acknowledge: true });
@@ -194,6 +205,10 @@ class AdminController extends BaseController {
 
   loadSecurities (request) {
     const securities = request.input.body;
+
+    if (securities === null) {
+      throw new BadRequestError('Cannot load null securities');
+    }
 
     const promise = this.kuzzle.janitor.loadSecurities(securities);
 

--- a/lib/api/core/janitor.js
+++ b/lib/api/core/janitor.js
@@ -481,7 +481,7 @@ class Janitor {
   }
 
   _createSecurity (action, objects) {
-    if (objects === undefined) {
+    if (! objects) {
       return Bluebird.resolve();
     }
 

--- a/lib/api/core/janitor.js
+++ b/lib/api/core/janitor.js
@@ -25,12 +25,15 @@
 
 const
   Bluebird = require('bluebird'),
-  Request = require('kuzzle-common-objects').Request,
   {
-    PreconditionError,
-    InternalError: KuzzleInternalError,
-    PartialError
-  } = require('kuzzle-common-objects').errors,
+    Request,
+    errors: {
+      PreconditionError,
+      InternalError: KuzzleInternalError,
+      PartialError
+    }
+  } = require('kuzzle-common-objects'),
+  { assertIsObject } = require('../../util/requestAssertions'),
   pm2 = require('pm2'),
   path = require('path'),
   fs = require('fs-extra'),
@@ -55,8 +58,12 @@ class Janitor {
    * @param {object} securities
    * @returns {Promise}
    */
-  loadSecurities (securities) {
-    return this._createSecurity('createOrReplaceRole', securities.roles)
+  loadSecurities (securities = {}) {
+    return Bluebird.resolve()
+      .then(() => {
+        assertIsObject(securities);
+        return this._createSecurity('createOrReplaceRole', securities.roles);
+      })
       .then(() => this._createSecurity('createOrReplaceProfile', securities.profiles))
       .then(() => this._deleteUsers(securities.users))
       .then(() => this._createSecurity('createUser', securities.users));
@@ -68,22 +75,29 @@ class Janitor {
    * @param {String} fixtures
    * @returns {Promise}
    */
-  loadFixtures (fixtures) {
-    const requests = [];
+  loadFixtures (fixtures = {}) {
+    return Bluebird.resolve()
+      .then(() => {
+        assertIsObject(fixtures);
 
-    for (const index of Object.keys(fixtures)) {
-      for (const collection of Object.keys(fixtures[index])) {
-        requests.push(new Request({
-          index,
-          collection,
-          body: {
-            bulkData: fixtures[index][collection]
+        const requests = [];
+
+        for (const index of Object.keys(fixtures)) {
+          assertIsObject(fixtures[index]);
+
+          for (const collection of Object.keys(fixtures[index])) {
+            requests.push(new Request({
+              index,
+              collection,
+              body: {
+                bulkData: fixtures[index][collection]
+              }
+            }));
           }
-        }));
-      }
-    }
+        }
 
-    return Bluebird.resolve(requests)
+        return requests;
+      })
       .each(request => {
         return this.kuzzle.services.list.storageEngine.import(request)
           .then(res => {
@@ -105,20 +119,27 @@ class Janitor {
    * @param {String} mappings
    * @returns {Promise}
    */
-  loadMappings (mappings) {
-    const requests = [];
+  loadMappings (mappings = {}) {
+    return Bluebird.resolve()
+      .then(() => {
+        assertIsObject(mappings);
 
-    for (const index of Object.keys(mappings)) {
-      for (const collection of Object.keys(mappings[index])) {
-        requests.push(new Request({
-          index,
-          collection,
-          body: mappings[index][collection]
-        }));
-      }
-    }
+        const requests = [];
 
-    return Bluebird.resolve(requests)
+        for (const index of Object.keys(mappings)) {
+          assertIsObject(mappings[index]);
+
+          for (const collection of Object.keys(mappings[index])) {
+            requests.push(new Request({
+              index,
+              collection,
+              body: mappings[index][collection]
+            }));
+          }
+        }
+
+        return requests;
+      })
       .each(request => {
         const
           index = request.input.resource.index,
@@ -460,11 +481,19 @@ class Janitor {
   }
 
   _createSecurity (action, objects) {
-    if (! objects) {
+    if (objects === undefined) {
       return Bluebird.resolve();
     }
 
+    try {
+      assertIsObject(objects);
+    } catch (e) {
+      return Bluebird.reject(e);
+    }
+
     return Bluebird.map(Object.keys(objects), _id => {
+      assertIsObject(objects[_id]);
+
       const request = new Request({
         action,
         _id,

--- a/lib/api/core/janitor.js
+++ b/lib/api/core/janitor.js
@@ -55,7 +55,7 @@ class Janitor {
    * @param {object} securities
    * @returns {Promise}
    */
-  loadSecurities (securities = {}) {
+  loadSecurities (securities) {
     return this._createSecurity('createOrReplaceRole', securities.roles)
       .then(() => this._createSecurity('createOrReplaceProfile', securities.profiles))
       .then(() => this._deleteUsers(securities.users))
@@ -68,7 +68,7 @@ class Janitor {
    * @param {String} fixtures
    * @returns {Promise}
    */
-  loadFixtures (fixtures = {}) {
+  loadFixtures (fixtures) {
     const requests = [];
 
     for (const index of Object.keys(fixtures)) {
@@ -105,7 +105,7 @@ class Janitor {
    * @param {String} mappings
    * @returns {Promise}
    */
-  loadMappings (mappings = {}) {
+  loadMappings (mappings) {
     const requests = [];
 
     for (const index of Object.keys(mappings)) {

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -42,6 +42,9 @@ module.exports = [
   {verb: 'post', url: '/admin/_resetKuzzleData/', controller: 'admin', action: 'resetKuzzleData'},
   {verb: 'post', url: '/admin/_dump', controller: 'admin', action: 'dump'},
   {verb: 'post', url: '/admin/_shutdown/', controller: 'admin', action: 'shutdown'},
+  {verb: 'post', url: '/admin/_loadFixtures/', controller: 'admin', action: 'loadFixtures'},
+  {verb: 'post', url: '/admin/_loadMappings/', controller: 'admin', action: 'loadMappings'},
+  {verb: 'post', url: '/admin/_loadSecurities/', controller: 'admin', action: 'loadSecurities'},
 
   /* DEPRECATED - will be removed in v2 */
   {verb: 'get', url: '/:index/_list/:type', controller: 'collection', action: 'list'},

--- a/lib/util/requestAssertions.js
+++ b/lib/util/requestAssertions.js
@@ -20,14 +20,20 @@
  */
 
 const
-  {BadRequestError, InternalError: KuzzleInternalError, UnauthorizedError} = require('kuzzle-common-objects').errors;
+  {
+    errors: {
+      BadRequestError,
+      InternalError: KuzzleInternalError,
+      UnauthorizedError
+    }
+  } = require('kuzzle-common-objects');
 
 module.exports = {
   /**
    * @param {Request} request
    */
   assertHasBody: request => {
-    if (!request.input.body) {
+    if (request.input.body === undefined || request.input.body === null) {
       throw new BadRequestError('The request must specify a body.');
     }
   },
@@ -237,6 +243,16 @@ module.exports = {
   assertIsStrategyRegistered: (kuzzle, request) => {
     if (kuzzle.pluginsManager.listStrategies().indexOf(request.input.args.strategy) === -1) {
       throw new BadRequestError(`The strategy "${request.input.args.strategy}" is not a known strategy.`);
+    }
+  },
+
+  /**
+   * @param  {*} value
+   * @throws {BadRequestError} If the value is not an object
+   */
+  assertIsObject: value => {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+      throw new BadRequestError(`Expected '${value}' to be an object`);
     }
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {

--- a/test/api/core/janitor.test.js
+++ b/test/api/core/janitor.test.js
@@ -4,7 +4,12 @@ const
   sinon = require('sinon'),
   path = require('path'),
   should = require('should'),
-  PreconditionError = require('kuzzle-common-objects').errors.PreconditionError,
+  {
+    errors: {
+      BadRequestError,
+      PreconditionError
+    }
+  } = require('kuzzle-common-objects'),
   KuzzleMock = require('../../mocks/kuzzle.mock');
 
 function rewireJanitor() {
@@ -37,53 +42,46 @@ describe('Test: core/janitor', () => {
   });
 
   describe('#loadSecurities', () => {
-    const
-      securities = require('../../mocks/securities.json');
+    const securities = require('../../mocks/securities.json');
 
     beforeEach(() => {
       Janitor = mockrequire.reRequire('../../../lib/api/core/janitor');
     });
 
-    it('create or replace roles', done => {
+    afterEach(() => {
+      mockrequire.stopAll();
+    });
+
+    it('should create or replace roles', () => {
       kuzzle.funnel.processRequest.resolves(true);
 
-      janitor.loadSecurities({ roles: securities.roles })
+      return janitor.loadSecurities({ roles: securities.roles })
         .then(() => {
           should(kuzzle.funnel.processRequest.callCount).be.eql(2);
 
           should(kuzzle.funnel.processRequest.getCall(1).args[0].input.action).be.eql('createOrReplaceRole');
           should(kuzzle.funnel.processRequest.getCall(0).args[0].input.resource._id).be.eql('driver');
           should(kuzzle.funnel.processRequest.getCall(0).args[0].input.body.controllers.document.actions['*']).be.eql(true);
-
-          done();
-        })
-        .catch(error => {
-          done(error);
         });
     });
 
-    it('create or replace profiles', done => {
+    it('should create or replace profiles', () => {
       kuzzle.funnel.processRequest.resolves(true);
 
-      janitor.loadSecurities({ profiles: securities.profiles })
+      return janitor.loadSecurities({ profiles: securities.profiles })
         .then(() => {
           should(kuzzle.funnel.processRequest.callCount).be.eql(2);
 
           should(kuzzle.funnel.processRequest.getCall(1).args[0].input.action).be.eql('createOrReplaceProfile');
           should(kuzzle.funnel.processRequest.getCall(1).args[0].input.resource._id).be.eql('customer');
           should(kuzzle.funnel.processRequest.getCall(1).args[0].input.body.policies[0].roleId).be.eql('customer');
-
-          done();
-        })
-        .catch(error => {
-          done(error);
         });
     });
 
-    it('delete then create users', done => {
+    it('should delete then create users', () => {
       kuzzle.funnel.processRequest.resolves(true);
 
-      janitor.loadSecurities({ users: securities.users })
+      return janitor.loadSecurities({ users: securities.users })
         .then(() => {
           should(kuzzle.funnel.processRequest.callCount).be.eql(3);
 
@@ -93,62 +91,128 @@ describe('Test: core/janitor', () => {
           should(kuzzle.funnel.processRequest.getCall(1).args[0].input.action).be.eql('createUser');
           should(kuzzle.funnel.processRequest.getCall(1).args[0].input.resource._id).be.eql('gfreeman');
           should(kuzzle.funnel.processRequest.getCall(1).args[0].input.body.content.profileIds).be.eql(['driver']);
-
-          done();
-        })
-        .catch(error => {
-          done(error);
         });
     });
 
+    it('should reject if the roles object is null', () => {
+      return should(janitor.loadSecurities({
+        roles: null,
+        profiles: securities.profiles,
+        users: securities.users
+      }))
+        .rejectedWith(
+          BadRequestError,
+          {message: 'Expected \'null\' to be an object'}
+        );
+    });
+
+    it('should reject if roles contains non-object properties', () => {
+      return should(janitor.loadSecurities({
+        roles: { foo: 123},
+        profiles: securities.profiles,
+        users: securities.users
+      }))
+        .rejectedWith(
+          BadRequestError,
+          {message: 'Expected \'123\' to be an object'}
+        );
+    });
+
+    it('should reject if the profiles object is null', () => {
+      return should(janitor.loadSecurities({
+        roles: securities.roles,
+        profiles: null,
+        users: securities.users
+      }))
+        .rejectedWith(
+          BadRequestError,
+          {message: 'Expected \'null\' to be an object'}
+        );
+    });
+
+    it('should reject if profiles contains non-object properties', () => {
+      return should(janitor.loadSecurities({
+        roles: securities.roles,
+        profiles: { foo: 123},
+        users: securities.users
+      }))
+        .rejectedWith(
+          BadRequestError,
+          {message: 'Expected \'123\' to be an object'}
+        );
+    });
+
+    it('should reject if the users object is null', () => {
+      return should(janitor.loadSecurities({
+        roles: securities.roles,
+        profiles: securities.profiles,
+        users: null
+      }))
+        .rejectedWith(
+          BadRequestError,
+          {message: 'Expected \'null\' to be an object'}
+        );
+    });
+
+    it('should reject if users contains non-object properties', () => {
+      return should(janitor.loadSecurities({
+        roles: securities.roles,
+        profiles: securities.profiles,
+        users: { foo: 123},
+      }))
+        .rejectedWith(
+          BadRequestError,
+          {message: 'Expected \'123\' to be an object'}
+        );
+    });
   });
 
   describe('#loadFixtures', () => {
-    const
-      fixtures = require('../../mocks/fixtures.json');
+    const fixtures = require('../../mocks/fixtures.json');
 
     beforeEach(() => {
       janitor = new Janitor(kuzzle);
     });
 
-    it('create index and collection that does not exists', done => {
+    it('create index and collection that does not exists', () => {
       const storageEngine = kuzzle.services.list.storageEngine;
       storageEngine.import.onCall(0).resolves(false);
       storageEngine.import.onCall(1).resolves(true);
       storageEngine.import.onCall(2).resolves(false);
 
-      janitor.loadFixtures(fixtures)
+      return janitor.loadFixtures(fixtures)
         .then(() => {
           should(storageEngine.import.callCount).be.eql(3);
           should(storageEngine.import.getCall(0).args[0].input.resource.index).be.eql('nyc-open-data');
           should(storageEngine.import.getCall(0).args[0].input.resource.collection).be.eql('yellow-taxi');
           should(storageEngine.import.getCall(0).args[0].input.body.bulkData[1]).be.eql({ name: 'alyx' });
-
           should(storageEngine.refreshIndex.callCount).be.eql(3);
-
-          done();
-        })
-        .catch(error => {
-          done(error);
         });
+    });
+
+    it('should reject if fixtures contain non-object properties', () => {
+      return should(janitor.loadFixtures({foo: 123}))
+        .rejectedWith(
+          BadRequestError,
+          {message: 'Expected \'123\' to be an object'}
+        );
     });
   });
 
   describe('#loadMappings', () => {
-    const
-      mappings = require('../../mocks/mappings.json');
+    const mappings = require('../../mocks/mappings.json');
 
     beforeEach(() => {
       janitor = new Janitor(kuzzle);
     });
 
-    it('create index and collection that does not exists', done => {
+    it('create index and collection that does not exists', () => {
       const storageEngine = kuzzle.services.list.storageEngine;
       storageEngine.indexExists.onCall(0).resolves(false);
       storageEngine.indexExists.onCall(1).resolves(true);
       storageEngine.indexExists.onCall(2).resolves(false);
 
-      janitor.loadMappings(mappings)
+      return janitor.loadMappings(mappings)
         .then(() => {
           should(storageEngine.indexExists.callCount).be.eql(3);
           should(storageEngine.createIndex.callCount).be.eql(2);
@@ -161,12 +225,15 @@ describe('Test: core/janitor', () => {
           should(storageEngine.refreshIndex.callCount).be.eql(3);
 
           should(kuzzle.indexCache.add.callCount).be.eql(3);
-
-          done();
-        })
-        .catch(error => {
-          done(error);
         });
+    });
+
+    it('should reject if a mapping contains non-object properties', () => {
+      return should(janitor.loadMappings({foo: 123}))
+        .rejectedWith(
+          BadRequestError,
+          {message: 'Expected \'123\' to be an object'}
+        );
     });
   });
 

--- a/test/api/core/janitor.test.js
+++ b/test/api/core/janitor.test.js
@@ -94,12 +94,8 @@ describe('Test: core/janitor', () => {
         });
     });
 
-    it('should reject if the roles object is null', () => {
-      return should(janitor.loadSecurities({
-        roles: null,
-        profiles: securities.profiles,
-        users: securities.users
-      }))
+    it('should reject if the securities object is null', () => {
+      return should(janitor.loadSecurities(null))
         .rejectedWith(
           BadRequestError,
           {message: 'Expected \'null\' to be an object'}
@@ -118,18 +114,6 @@ describe('Test: core/janitor', () => {
         );
     });
 
-    it('should reject if the profiles object is null', () => {
-      return should(janitor.loadSecurities({
-        roles: securities.roles,
-        profiles: null,
-        users: securities.users
-      }))
-        .rejectedWith(
-          BadRequestError,
-          {message: 'Expected \'null\' to be an object'}
-        );
-    });
-
     it('should reject if profiles contains non-object properties', () => {
       return should(janitor.loadSecurities({
         roles: securities.roles,
@@ -139,18 +123,6 @@ describe('Test: core/janitor', () => {
         .rejectedWith(
           BadRequestError,
           {message: 'Expected \'123\' to be an object'}
-        );
-    });
-
-    it('should reject if the users object is null', () => {
-      return should(janitor.loadSecurities({
-        roles: securities.roles,
-        profiles: securities.profiles,
-        users: null
-      }))
-        .rejectedWith(
-          BadRequestError,
-          {message: 'Expected \'null\' to be an object'}
         );
     });
 

--- a/test/api/kuzzle.test.js
+++ b/test/api/kuzzle.test.js
@@ -5,7 +5,7 @@ const
   Kuzzle = rewire('../../lib/api/kuzzle'),
   KuzzleMock = require('../mocks/kuzzle.mock');
 
-describe.only('/lib/api/kuzzle.js', () => {
+describe('/lib/api/kuzzle.js', () => {
   let kuzzle;
 
   beforeEach(() => {

--- a/test/api/kuzzle.test.js
+++ b/test/api/kuzzle.test.js
@@ -5,7 +5,7 @@ const
   Kuzzle = rewire('../../lib/api/kuzzle'),
   KuzzleMock = require('../mocks/kuzzle.mock');
 
-describe('/lib/api/kuzzle.js', () => {
+describe.only('/lib/api/kuzzle.js', () => {
   let kuzzle;
 
   beforeEach(() => {
@@ -84,7 +84,7 @@ describe('/lib/api/kuzzle.js', () => {
         processOnSpy = sinon.spy(),
         processRemoveAllListenersSpy = sinon.spy();
 
-      Kuzzle.__with__({
+      return Kuzzle.__with__({
         console: {
           error: sinon.spy()
         },
@@ -117,29 +117,30 @@ describe('/lib/api/kuzzle.js', () => {
 
         kuzzle.config.dump.enabled = true;
 
-        kuzzle.start();
+        return kuzzle.start();
+      })
+        .then(() => {
+          should(processRemoveAllListenersSpy.getCall(0).args[0]).be.exactly('unhandledRejection');
+          should(processOnSpy.getCall(0).args[0]).be.exactly('unhandledRejection');
 
-        should(processRemoveAllListenersSpy.getCall(0).args[0]).be.exactly('unhandledRejection');
-        should(processOnSpy.getCall(0).args[0]).be.exactly('unhandledRejection');
+          should(processRemoveAllListenersSpy.getCall(1).args[0]).be.exactly('uncaughtException');
+          should(processOnSpy.getCall(1).args[0]).be.exactly('uncaughtException');
 
-        should(processRemoveAllListenersSpy.getCall(1).args[0]).be.exactly('uncaughtException');
-        should(processOnSpy.getCall(1).args[0]).be.exactly('uncaughtException');
+          should(processRemoveAllListenersSpy.getCall(2).args[0]).be.exactly('SIGQUIT');
+          should(processOnSpy.getCall(2).args[0]).be.exactly('SIGQUIT');
 
-        should(processRemoveAllListenersSpy.getCall(2).args[0]).be.exactly('SIGQUIT');
-        should(processOnSpy.getCall(2).args[0]).be.exactly('SIGQUIT');
+          should(processRemoveAllListenersSpy.getCall(3).args[0]).be.exactly('SIGABRT');
+          should(processOnSpy.getCall(3).args[0]).be.exactly('SIGABRT');
 
-        should(processRemoveAllListenersSpy.getCall(3).args[0]).be.exactly('SIGABRT');
-        should(processOnSpy.getCall(3).args[0]).be.exactly('SIGABRT');
+          should(processRemoveAllListenersSpy.getCall(4).args[0]).be.exactly('SIGTRAP');
+          should(processOnSpy.getCall(4).args[0]).be.exactly('SIGTRAP');
 
-        should(processRemoveAllListenersSpy.getCall(4).args[0]).be.exactly('SIGTRAP');
-        should(processOnSpy.getCall(4).args[0]).be.exactly('SIGTRAP');
+          should(processRemoveAllListenersSpy.getCall(5).args[0]).be.exactly('SIGINT');
+          should(processOnSpy.getCall(5).args[0]).be.exactly('SIGINT');
 
-        should(processRemoveAllListenersSpy.getCall(5).args[0]).be.exactly('SIGINT');
-        should(processOnSpy.getCall(5).args[0]).be.exactly('SIGINT');
-
-        should(processRemoveAllListenersSpy.getCall(6).args[0]).be.exactly('SIGTERM');
-        should(processOnSpy.getCall(6).args[0]).be.exactly('SIGTERM');
-      });
+          should(processRemoveAllListenersSpy.getCall(6).args[0]).be.exactly('SIGTERM');
+          should(processOnSpy.getCall(6).args[0]).be.exactly('SIGTERM');
+        });
     });
 
     it('should not start if it fails initializing its internal storage', () => {

--- a/test/bin/commands/start.test.js
+++ b/test/bin/commands/start.test.js
@@ -1,5 +1,6 @@
 const
   mockRequire = require('mock-require'),
+  rewire = require('rewire'),
   sinon = require('sinon'),
   should = require('should'),
   KuzzleMock = require('../../mocks/kuzzle.mock');
@@ -11,7 +12,18 @@ describe('bin/commands/start.js', () => {
   beforeEach(() => {
     mockRequire('../../../bin/commands/loadJson', sinon.stub().resolves({}));
     mockRequire('../../../lib/api/kuzzle', KuzzleMock);
-    start = require('../../../bin/commands/start');
+    start = rewire('../../../bin/commands/start');
+
+    start.__set__({
+      console: {
+        log: sinon.stub(),
+        error: sinon.stub()
+      }
+    });
+  });
+
+  afterEach(() => {
+    mockRequire.stopAll();
   });
 
   it('should start kuzzle with proper params', () => {


### PR DESCRIPTION
# Description

The new API routes `admin:loadFixtures`, `admin:loadMappings` and `admin:loadSecurities` weren't exposed.

* expose these 3 API routes to the funnel
* add the appropriate HTTP URLs for these 3 API routes 
* properly reject improperly formatted bodies for these routes, instead of returning unhandled errors to the requesting users
* add unit & functional tests to make sure that these 3 routes behave correctly

# Boyscout

* Fix a kuzzle.start unit test that didn't properly wait for a promise to be resolved
* Simplify some of the existing `admin:load*` unit tests to make them return a promise instead of using mocha's `done` callback
* Hide console messages when running unit tests on the CLI `start` command

# Why a hotfix?

These 3 routes have been announced in the changelog, and documented in the official documentation, so it doesn't seem right to wait for a new kuzzle version to release them.
