### PR TITLE
[bugfix] allows bulk inserts on aliases

### DIFF
--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -665,11 +665,22 @@ class ElasticSearch extends Service {
       updatedAt: dateNow
     };
 
+    const esCache = {};
+
     return this.client.indices.getMapping()
-      .then(mappings => {
-        // Keep a local cache of existents index/collections on elasticsearch
-        const reducer = (indexes, index) => Object.assign(indexes, { [index]: Object.keys(mappings[index].mappings) });
-        const esCache = Object.keys(mappings).reduce(reducer, {});
+      .then(raw => {
+        for (const index of Object.keys(raw)) {
+          esCache[index] = Object.keys(raw[index].mappings);
+        }
+
+        return this.client.cat.aliases({
+          format: 'json'
+        });
+      })
+      .then(aliases => {
+        for (const entry of aliases) {
+          esCache[entry.alias] = esCache[entry.index];
+        }
 
         // set missing index & type if possible and add metadata
         let lastAction; // NOSONAR

--- a/test/mocks/services/elasticsearchClient.mock.js
+++ b/test/mocks/services/elasticsearchClient.mock.js
@@ -25,6 +25,7 @@ class ElasticsearchClientMock {
     this.scroll = sinon.stub().resolves();
 
     this.cat = {
+      aliases: sinon.stub().resolves(),
       indices: sinon.stub().resolves()
     };
 


### PR DESCRIPTION
## What does this PR do ?

This PR fixes the case where a bulk operation would fail on an elasticsearch index alias.

### How should this be manually tested?

```bash
#!/bin/bash
  
set -x
  
es_container=kuz_elasticsearch_1
  
es=$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$es_container"):9200
kuzzle="localhost:7512"
  
curl -XPOST $kuzzle/index/_create
curl -XPUT $kuzzle/index/collection
  
curl -d '{"actions": {"add": {"index": "index", "alias": "alias"}}}' $es/_aliases
  
curl -H "Content-type: application/json" -d '{
    "bulkData": [
      {"index": {"_type": "collection", "_index": "alias"}},
      {"foo": "bar"}
    ]
}' $kuzzle/_bulk
```