### PR TITLE
[bulk] fix an error when trying a non-partial bulk update

### DIFF
--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -721,7 +721,12 @@ class ElasticSearch extends Service {
           } else if (lastAction === 'index' || lastAction === 'create') {
             item._kuzzle_info = kuzzleMetaCreated;
           } else if (lastAction === 'update') {
-            item.doc._kuzzle_info = kuzzleMetaUpdated;
+            // we can only update metadata on a partial update, or on an upsert
+            for (const prop of ['doc', 'upsert']) {
+              if (_.isPlainObject(item[prop])) {
+                item[prop]._kuzzle_info = kuzzleMetaUpdated;
+              }
+            }
           }
         }
 
@@ -729,6 +734,7 @@ class ElasticSearch extends Service {
       })
       .then(response => this.refreshIndexIfNeeded(esRequest, response))
       .then(result => {
+
         // If some errors occured during the Bulk, we send a "Partial Error" response :
         if (result.errors) {
           result.partialErrors = [];

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -1017,8 +1017,12 @@ describe('Test: ElasticSearch service', () => {
           {create: {_id: 3, _type: collection, _index: index}},
           {firstName: 'gordon'},
           {update: {_id: 1, _type: collection, _index: index}},
-          {doc: {firstName: 'foobar'}},
-          {delete: {_id: 2, _type: collection, _index: index}}
+          {doc: {firstName: 'foobar'}, upsert: {firstName: 'john'}},
+          {delete: {_id: 2, _type: collection, _index: index}},
+          // this update triggers a crash if the case of an update without
+          // "doc" nor "upsert" is submitted
+          {update: {_id: 42}},
+          {script: 'can I has a cheezburgscript?'}
         ]
       };
 
@@ -1048,6 +1052,13 @@ describe('Test: ElasticSearch service', () => {
           should(body[7].doc._kuzzle_info).be.type('object');
           should(body[7].doc._kuzzle_info.updater).be.exactly('test');
           should(body[7].doc._kuzzle_info.updatedAt).not.be.null();
+          should(body[7].upsert._kuzzle_info).be.type('object');
+          should(body[7].upsert._kuzzle_info.updater).be.exactly('test');
+          should(body[7].upsert._kuzzle_info.updatedAt).not.be.null();
+
+          // Bulk action: script update
+          // (just verifying that this hasn't been filtered)
+          should(body[10].script).eql('can I has a cheezburgscript?');
         });
     });
 


### PR DESCRIPTION
# Description

Attempting a bulk update without a `doc` property results in the following error received by the client: `Cannot set property '_kuzzle_info' of undefined`

That error message is misleading, either because the bulk update is invalid, or if it is a script update.

This PR fixes that by checking if the `doc` property exists before trying to inject metadata.

# Other change

Inject metadata in the `upsert` property of a bulk update, if there is one

# How to test

Send the following body to a bulk import API request: 

```js
{
	"bulkData": [
		{"update": {"_id": "foobar"}},
		{"foo": "qux"}
	]
}
```