### PR TITLE
[WebSocket] Handle ping/pong packets

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -376,8 +376,14 @@
         // value of Access-Control-Allow-Origin header to answer the upgrade request
         "origins": "*:*"
       },
+      // * enabled:
+      //    Set to true to enable WebSocket support
+      // * heartbeat:
+      //    The time, in milliseconds, between the server's PING requests.
+      //    Setting this value to 0 disables PING/PONG requests entirely.
       "websocket": {
-        "enabled": true
+        "enabled": true,
+        "heartbeat": 60000
       }
     }
   },

--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -373,15 +373,16 @@
       },
       "socketio": {
         "enabled": true,
-        // value of Access-Control-Allow-Origin header to answer the upgrade request
+        // value of Access-Control-Allow-Origin header to answer the upgrade
+        // request
         "origins": "*:*"
       },
-      // * enabled:
-      //    Set to true to enable WebSocket support
-      // * heartbeat:
-      //    The time, in milliseconds, between the server's PING requests.
-      //    Setting this value to 0 disables PING/PONG requests entirely.
       "websocket": {
+        // * enabled:
+        //    Set to true to enable WebSocket support
+        // * heartbeat:
+        //    The time, in milliseconds, between the server's PING requests.
+        //    Setting this value to 0 disables PING/PONG requests entirely.
         "enabled": true,
         "heartbeat": 60000
       }

--- a/default.config.js
+++ b/default.config.js
@@ -202,7 +202,8 @@ module.exports = {
         origins: '*:*'
       },
       websocket: {
-        enabled: true
+        enabled: true,
+        heartbeat: 60000
       }
     }
   },

--- a/lib/api/core/entrypoints/embedded/index.js
+++ b/lib/api/core/entrypoints/embedded/index.js
@@ -97,24 +97,15 @@ class EmbeddedEntryPoint extends EntryPoint {
     this.httpServer = http.createServer();
     this.httpServer.listen(this.config.port, this.config.host);
 
-    if (this.config.protocols.http.enabled) {
-      this.protocols.http = new HttpProtocol();
-      this.protocols.http.init(this);
-    }
+    this.protocols = {
+      http: new HttpProtocol(),
+      mqtt: new MqttProtocol(),
+      websocket: new WebSocketProtocol(),
+      socketio: new SocketIoProtocol()
+    };
 
-    if (this.config.protocols.mqtt.enabled) {
-      this.protocols.mqtt = new MqttProtocol();
-      this.protocols.mqtt.init(this);
-    }
-
-    if (this.config.protocols.websocket.enabled) {
-      this.protocols.websocket = new WebSocketProtocol();
-      this.protocols.websocket.init(this);
-    }
-
-    if (this.config.protocols.socketio.enabled) {
-      this.protocols.socketio = new SocketIoProtocol();
-      this.protocols.socketio.init(this);
+    for (const protocol of Object.keys(this.protocols)) {
+      this.protocols[protocol].init(this);
     }
 
     return this.kuzzle.repositories.user.anonymous()

--- a/lib/api/core/entrypoints/embedded/protocols/mqtt.js
+++ b/lib/api/core/entrypoints/embedded/protocols/mqtt.js
@@ -50,12 +50,12 @@ class MqttProtocol extends Protocol {
   }
 
   init (entryPoint) {
-    super.init(entryPoint);
-    debug('initializing MQTT Server with config: %a', entryPoint.config.protocols.mqtt);
-
     if (!entryPoint.config.protocols.mqtt.enabled) {
       return;
     }
+
+    super.init(entryPoint);
+    debug('initializing MQTT Server with config: %a', entryPoint.config.protocols.mqtt);
 
     this.entryPoint = entryPoint;
     this.kuzzle = this.entryPoint.kuzzle;

--- a/lib/api/core/entrypoints/embedded/protocols/socketio.js
+++ b/lib/api/core/entrypoints/embedded/protocols/socketio.js
@@ -45,12 +45,12 @@ class SocketIoProtocol extends Protocol {
   }
 
   init(entryPoint) {
-    super.init(entryPoint);
-    debug('initializing socketIo Server with config: %a', entryPoint.config.socketio);
-
     if (!entryPoint.config.protocols.socketio.enabled) {
       return;
     }
+
+    super.init(entryPoint);
+    debug('initializing socketIo Server with config: %a', entryPoint.config.socketio);
 
     this.kuzzle = this.entryPoint.kuzzle;
 

--- a/lib/api/core/entrypoints/embedded/protocols/websocket.js
+++ b/lib/api/core/entrypoints/embedded/protocols/websocket.js
@@ -44,6 +44,7 @@ class WebsocketProtocol extends Protocol {
     this.server = null;
     this.protocol = 'websocket';
     this.kuzzle = null;
+    this.heartbeatInterval = null;
   }
 
   /**
@@ -52,10 +53,25 @@ class WebsocketProtocol extends Protocol {
    */
   init (entryPoint) {
     super.init(entryPoint);
-    debug('initializing WebSocket Server with config: %a', entryPoint.config.websocket);
 
     if (!entryPoint.config.protocols.websocket.enabled) {
       return;
+    }
+
+    debug(
+      'initializing WebSocket Server with config: %a',
+      entryPoint.config.protocols.websocket);
+
+    const heartbeat = entryPoint.config.protocols.websocket.heartbeat;
+
+    if (!Number.isInteger(heartbeat) || heartbeat < 0) {
+      throw new KuzzleInternalError(`WebSocket: invalid heartbeat value ${heartbeat}`);
+    }
+
+    if (heartbeat > 0) {
+      this.heartbeatInterval = setInterval(
+        () => this._doHeartbeat(),
+        heartbeat);
     }
 
     this.kuzzle = this.entryPoint.kuzzle;
@@ -66,17 +82,23 @@ class WebsocketProtocol extends Protocol {
       perMessageDeflate: false
     });
 
-    this.server.on('connection', (socket, request) => this.onConnection(socket, request));
+    this.server.on(
+      'connection',
+      (socket, request) => this.onConnection(socket, request));
+
     this.server.on('error', error => this.onServerError(error));
   }
 
   onServerError(error) {
-    this.kuzzle.pluginsManager.trigger('log:error', `[websocket] An error has occured "${error.message}":\n${error.stack}`);
+    this.kuzzle.pluginsManager.trigger(
+      'log:error',
+      `[websocket] An error has occured "${error.message}":\n${error.stack}`);
   }
 
   onConnection(clientSocket, request) {
     if (request.url && request.url.startsWith('/socket.io/')) {
-      // Discarding request management here: let socket.io protocol manage this connection
+      // Discarding request management here: let socket.io protocol manage
+      // this connection
       return false;
     }
 
@@ -107,18 +129,23 @@ class WebsocketProtocol extends Protocol {
     };
 
     clientSocket.on('close', () => {
-      debug('[%s] receiving a `close` event', connection.id);
+      debug('[%s] received a `close` event', connection.id);
       this.onClientDisconnection(connection.id);
     });
 
     clientSocket.on('error', () => {
-      debug('[%s] receiving a `error` event', connection.id);
+      debug('[%s] received an `error` event', connection.id);
       this.onClientDisconnection(connection.id);
     });
 
     clientSocket.on('message', data => {
-      debug('[%s] receiving a `message` event', connection.id);
+      debug('[%s] received a `message` event', connection.id);
       this.onClientMessage(connection, data);
+    });
+
+    clientSocket.on('pong', () => {
+      debug('[%s] received a `pong` event', connection.id);
+      this.connectionPool[connection.id].alive = true;
     });
 
     return true;
@@ -294,6 +321,20 @@ class WebsocketProtocol extends Protocol {
 
     if (connection && connection.alive && connection.socket.readyState === connection.socket.OPEN) {
       connection.socket.send(data);
+    }
+  }
+
+  _doHeartbeat() {
+    debug('[WebSocket] Heartbeat');
+    for (const id of Object.keys(this.connectionPool)) {
+      // did not respond since we last sent a PING request
+      if (this.connectionPool[id].alive === false) {
+        // correctly triggers the 'close' event handler on that socket
+        this.connectionPool[id].socket.terminate();
+      } else {
+        this.connectionPool[id].alive = false;
+        this.connectionPool[id].socket.ping();
+      }
     }
   }
 }

--- a/lib/api/core/entrypoints/embedded/protocols/websocket.js
+++ b/lib/api/core/entrypoints/embedded/protocols/websocket.js
@@ -52,11 +52,11 @@ class WebsocketProtocol extends Protocol {
    * @param {EmbeddedEntryPoint} entryPoint
    */
   init (entryPoint) {
-    super.init(entryPoint);
-
     if (!entryPoint.config.protocols.websocket.enabled) {
       return;
     }
+
+    super.init(entryPoint);
 
     debug(
       'initializing WebSocket Server with config: %a',

--- a/test/api/core/entrypoints/embedded/protocols/websocket.test.js
+++ b/test/api/core/entrypoints/embedded/protocols/websocket.test.js
@@ -79,6 +79,8 @@ describe('/lib/api/core/entrypoints/embedded/protocols/websocket', () => {
       clock.tick(1000);
 
       should(heartbeatSpy).be.calledTwice();
+
+      clock.restore();
     });
 
     it('should disable heartbeats if set to 0', () => {


### PR DESCRIPTION
# Description

PING/PONG packets are described in the WebSocket specifications, and are used to:
* efficiently detect and clean up dead sockets (a socket can stay opened indefinitly if the client couldn't send a socket closed packet)
* keep idle sockets alive

This PR:
* adds a new `heartbeat` configuration under the `protocols.websocket` part of the .kuzzlerc file
* adds a heartbeat to the WebSocket protocol, sending PING packets to client sockets, and mark them as "dead" until a PONG response is received
* destroys and cleans up sockets that stayed dead after the heartbeat delay

# Other change

Deduplicated the test made on the `enabled` part of a protocol configuration: the test was made in each protocol implementation, AND in the global entrypoint object during protocols initialization.

# How to test

An easy way to test this is to use `wscat`:
* (if not already done) install it with `npm -g wscat`
* connect it to your local kuzzle stack: `wscat --connect http://localhost:7512`
* suspend it with a SIGSTOP signal (e.g. Ctrl+Z on the terminal)

Without this PR: you can go have a lunch, return to your terminal and wake wscat up (with `fg`), and you can use it again as if nothing happend, even if the socket should have been marked as dead by Kuzzle since it can never respond to any request.

With this PR: if you wait at least 2 minutes by default, and wake wscat up with `fg`, it will exit immediately with the following message: `disconnected`
(you need to wait for 2 heartbeats before the socket is disconnected: the 1st one to mark the socket temporarily as "dead", and the second one to clean up the dead socket)

```
$ wscat --connect http://localhost:7512
connected (press CTRL+C to quit)
> 
[1]  + 24777 suspended  wscat --connect http://localhost:7512
$ fg
[1]  + 24777 continued  wscat --connect http://localhost:7512
disconnected
$
```

You can follow what happens with this test using debug messages (set the `DEBUG` environment variable to `kuzzle:entry-point:protocols:websocket` before starting Kuzzle):

```
  kuzzle:entry-point:protocols:websocket [090cacd2-8ca5-49b1-bf8a-8b9b37b5882d] creating Websocket connection +4s
  kuzzle:entry-point:protocols:websocket [WebSocket] Heartbeat +56s
  kuzzle:entry-point:protocols:websocket [WebSocket] Heartbeat +60s
  kuzzle:entry-point:protocols:websocket [090cacd2-8ca5-49b1-bf8a-8b9b37b5882d] received a `close` event +2ms
  kuzzle:entry-point:protocols:websocket [090cacd2-8ca5-49b1-bf8a-8b9b37b5882d] onClientDisconnection +1ms
```

These logs show that the 2nd heartbeat after the wscat connection correctly force closes the socket, since it couldn't respond to the PING packet in time.