### PR TITLE
KZL 1032 - Throw an error when the realtime controller is invoked by plugin developers

### DIFF
--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -236,6 +236,15 @@ function execute (kuzzle, request, callback) {
     return deferred;
   }
 
+  if (request.input.controller === 'realtime') {
+    error = new PluginImplementationError('Realtime controller is not available in plugins. You should use plugin hooks instead');
+    if (callback) {
+      return callback(error);
+    }
+    return Bluebird.reject(error);
+  }
+
+
   request.clearError();
   request.status = 102;
 

--- a/lib/api/core/sdk/funnelProtocol.js
+++ b/lib/api/core/sdk/funnelProtocol.js
@@ -22,10 +22,12 @@
 'use strict';
 
 const
+  Bluebird = require('bluebird'),
   {
     Request,
     errors: {
-      InternalError: KuzzleInternalError
+      InternalError: KuzzleInternalError,
+      PluginImplementationError
     }
   } = require('kuzzle-common-objects'),
   User = require('../models/security/user'),
@@ -56,6 +58,10 @@ class FunnelProtocol extends KuzzleEventEmitter {
       connection: { protocol: 'funnel' },
       user: this.user
     });
+
+    if (kuzzleRequest.input.controller === 'realtime') {
+      return Bluebird.reject(new PluginImplementationError('Realtime controller is not available in plugins. You should use plugin hooks instead'));
+    }
 
     return this.funnel.executePluginRequest(kuzzleRequest)
       .then(result => ({ result }));

--- a/test/api/core/pluginContext/pluginContext.test.js
+++ b/test/api/core/pluginContext/pluginContext.test.js
@@ -445,6 +445,14 @@ describe('Plugin Context', () => {
           .be.rejectedWith({message: /^Invalid argument: Expected callback to be a function, received "string"/});
 
       });
+
+      it('should reject if trying to call the realtime controller', () => {
+        return should(context.accessors.execute(new Request({
+          controller: 'realtime',
+          action: 'publish'
+        })))
+          .be.rejectedWith(/Realtime controller is not available in plugins\. You should use plugin hooks instead/);
+      });
     });
 
     describe('#strategies', () => {

--- a/test/api/core/sdk/funnelProtocol.test.js
+++ b/test/api/core/sdk/funnelProtocol.test.js
@@ -78,5 +78,13 @@ describe('Test: sdk/funnelProtocol', () => {
           should(response.result.context.user).be.eql(user);
         });
     });
+
+    it('should reject if trying to call the realtime controller', () => {
+      return should(funnelProtocol.query({
+        controller: 'realtime',
+        action: 'publish'
+      }))
+        .be.rejectedWith(/Realtime controller is not available in plugins\. You should use plugin hooks instead/);
+    });
   });
 });


### PR DESCRIPTION
## What does this PR do ?

This PR makes Kuzzle throw an error when the realtime controller is invoked from within a plugin.

>The realtime controller can be accessed by plugin developers with:
>
> - the execute method
> - the realtime controller exposed in the SDK object
> - the query low-level method exposed in the SDK object
>
>The realtime controller cannot work for plugin developers: it needs a physical network connection so that it can send notifications to subscribers.
>
>To prevent questions and hard to debug errors, we need to throw a PluginImplementationError exception whenever the realtime controller is invoked by a plugin developper using one of the 3 ways listed above.
>The error message must make it clear why an exception has been thrown, explaining that the realtime controller cannot be used by plugins.

