### PR TITLE
fixes #1243 - improve validation error messages

### DIFF
--- a/lib/api/controllers/documentController.js
+++ b/lib/api/controllers/documentController.js
@@ -177,7 +177,7 @@ class DocumentController extends BaseController {
     assertHasIndexAndCollection(request);
     assertIdStartsNotUnderscore(request);
 
-    return this.kuzzle.validation.validationPromise(request, false)
+    return this.kuzzle.validation.validate(request, false)
       .then(newRequest => {
         modifiedRequest = newRequest;
 
@@ -219,7 +219,7 @@ class DocumentController extends BaseController {
     assertHasId(request);
     assertIdStartsNotUnderscore(request);
 
-    return this.kuzzle.validation.validationPromise(request, false)
+    return this.kuzzle.validation.validate(request, false)
       .then(newRequest => {
         modifiedRequest = newRequest;
 
@@ -267,7 +267,7 @@ class DocumentController extends BaseController {
     assertHasIndexAndCollection(request);
     assertHasId(request);
 
-    return this.kuzzle.validation.validationPromise(request, false)
+    return this.kuzzle.validation.validate(request, false)
       .then(newRequest => {
         modifiedRequest = newRequest;
 
@@ -305,7 +305,7 @@ class DocumentController extends BaseController {
     assertHasIndexAndCollection(request);
     assertHasId(request);
 
-    return this.kuzzle.validation.validationPromise(request, false)
+    return this.kuzzle.validation.validate(request, false)
       .then(newRequest => {
         modifiedRequest = newRequest;
 
@@ -407,7 +407,7 @@ class DocumentController extends BaseController {
     assertHasBody(request);
     assertHasIndexAndCollection(request);
 
-    return this.kuzzle.validation.validationPromise(request, true)
+    return this.kuzzle.validation.validate(request, true)
       .then(response => {
         if (!response.valid) {
           this.kuzzle.pluginsManager.trigger('validation:error', `The document does not comply with the ${request.input.resource.index} / ${request.input.resource.collection} : ${JSON.stringify(request.input.body)}`);

--- a/lib/api/controllers/realtimeController.js
+++ b/lib/api/controllers/realtimeController.js
@@ -118,7 +118,7 @@ class RealtimeController extends BaseController {
     assertHasBody(request);
     assertHasIndexAndCollection(request);
 
-    return this.kuzzle.validation.validationPromise(request, false)
+    return this.kuzzle.validation.validate(request, false)
       .then(newRequest => {
         newRequest.input.body._kuzzle_info = {
           // Wait for PR #1182 to be merged to have getUserId()

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -106,7 +106,7 @@ class PluginContext {
         get: () => {
           return {
             addType: kuzzle.validation.addType.bind(kuzzle.validation),
-            validate: kuzzle.validation.validationPromise.bind(kuzzle.validation)
+            validate: kuzzle.validation.validate.bind(kuzzle.validation)
           };
         }
       });

--- a/lib/api/core/validation/index.js
+++ b/lib/api/core/validation/index.js
@@ -84,22 +84,22 @@ class Validation {
   }
 
   /**
+   * Validates a document against its collection specifications
+   *
    * @param {Request} request
    * @param {boolean} [verbose]
    * @returns {Promise.<{documentBody: *, errorMessages:string[], valid: boolean}|KuzzleRequest>}
    */
-  validationPromise(request, verbose = false) {
+  validate(request, verbose = false) {
     const
-      id = request.input.resource._id;
+      id = request.input.resource._id,
+      index = request.input.resource.index,
+      collection = request.input.resource.collection,
+      collectionSpec = this.specification && this.specification[index] && this.specification[index][collection] || {};
+
     let
-      collectionSpec = {},
       updateBodyClone,
       isUpdate = false;
-
-    if (this.specification && this.specification[request.input.resource.index]
-      && this.specification[request.input.resource.index][request.input.resource.collection]) {
-      collectionSpec = this.specification[request.input.resource.index][request.input.resource.collection];
-    }
 
     return new Bluebird((resolve, reject) => {
       if (request.input.controller === 'document' && request.input.action === 'update') {
@@ -137,7 +137,7 @@ class Validation {
             catch (error) {
               if (error.message === 'strictness') {
                 // The strictness message can be received here only if it happens at the validation of the document's root
-                manageErrorMessage('document', errorMessages, 'The document validation is strict; it can not add unspecified sub-fields.', verbose);
+                manageErrorMessage('document', errorMessages, `The document validation is strict. Cannot add unspecified sub-field "${error.details.field}"`, verbose);
                 isValid = false;
               }
               else {
@@ -212,9 +212,16 @@ class Validation {
    * @param {boolean} verbose
    */
   recurseFieldValidation(documentSubset, collectionSpecSubset, strictness, errorMessages, verbose) {
-    if (strictness && !checkAllowedProperties(documentSubset, Object.keys(collectionSpecSubset))) {
-      // We use a throw to be able to provide information about the field or the document in whole
-      throw new BadRequestError('strictness');
+    if (strictness) {
+      for (const field of Object.keys(documentSubset)) {
+        if (!collectionSpecSubset[field]) {
+          const error = new BadRequestError('strictness');
+          error.details = {
+            field
+          };
+          throw error;
+        }
+      }
     }
 
     if (!verbose) {
@@ -308,7 +315,7 @@ class Validation {
           }
           catch (error) {
             if (error.message === 'strictness') {
-              manageErrorMessage(field.path, errorMessages, 'The field is set to "strict"; cannot add unspecified subField.', verbose);
+              manageErrorMessage(field.path, errorMessages, `The field is set to "strict"; cannot add unspecified sub-field "${error.details.field}".`, verbose);
             }
             else if (verbose) {
               manageErrorMessage(field.path, errorMessages, error.message, verbose);
@@ -677,6 +684,7 @@ class Validation {
 
     this.types[validationType.typeName] = validationType;
   }
+
 }
 
 /**
@@ -761,6 +769,7 @@ function getParent(structuredFields, fieldPath) {
 
   return pointer;
 }
+
 /**
  * @param {string} errorMessage
  * @param {boolean} doNotThrow

--- a/test/api/controllers/documentController.test.js
+++ b/test/api/controllers/documentController.test.js
@@ -223,7 +223,7 @@ describe('Test: document controller', () => {
       return documentController.create(request)
         .then(response => {
           try {
-            should(kuzzle.validation.validationPromise).be.calledOnce();
+            should(kuzzle.validation.validate).be.calledOnce();
 
             should(kuzzle.notifier.publish).be.calledOnce();
             should(kuzzle.notifier.publish).be.calledWith(request);
@@ -370,7 +370,7 @@ describe('Test: document controller', () => {
       return documentController.createOrReplace(request)
         .then(response => {
           try {
-            should(kuzzle.validation.validationPromise).be.calledOnce();
+            should(kuzzle.validation.validate).be.calledOnce();
 
             should(kuzzle.notifier.publish).be.calledOnce();
             should(kuzzle.notifier.publish).be.calledWith(request);
@@ -412,7 +412,7 @@ describe('Test: document controller', () => {
       return documentController.createOrReplace(request)
         .then(response => {
           try {
-            should(kuzzle.validation.validationPromise).be.calledOnce();
+            should(kuzzle.validation.validate).be.calledOnce();
 
             should(kuzzle.notifier.publish).be.calledOnce();
             should(kuzzle.notifier.publish).be.calledWith(request);
@@ -445,7 +445,7 @@ describe('Test: document controller', () => {
       return documentController.update(request)
         .then(response => {
           try {
-            should(kuzzle.validation.validationPromise).be.calledOnce();
+            should(kuzzle.validation.validate).be.calledOnce();
 
             should(engine.update).be.calledOnce();
             should(engine.update).be.calledWith(request);
@@ -480,7 +480,7 @@ describe('Test: document controller', () => {
       return documentController.replace(request)
         .then(response => {
           try {
-            should(kuzzle.validation.validationPromise).be.calledOnce();
+            should(kuzzle.validation.validate).be.calledOnce();
 
             should(kuzzle.notifier.publish).be.calledOnce();
             should(kuzzle.notifier.publish).be.calledWith(request);
@@ -617,13 +617,13 @@ describe('Test: document controller', () => {
       request.input.body = {};
 
       kuzzle.validation = {
-        validationPromise: sinon.stub().returns(Bluebird.resolve(expected))
+        validate: sinon.stub().returns(Bluebird.resolve(expected))
       };
 
       return documentController.validate(request)
         .then(response => {
           try {
-            should(kuzzle.validation.validationPromise).be.calledOnce();
+            should(kuzzle.validation.validate).be.calledOnce();
             should(response).be.instanceof(Object);
             should(response).match(expected);
 
@@ -656,12 +656,12 @@ describe('Test: document controller', () => {
       request.input.resource._id = 'document-id';
       request.input.body = {};
 
-      kuzzle.validation.validationPromise = sinon.stub().returns(Bluebird.resolve(expected));
+      kuzzle.validation.validate = sinon.stub().returns(Bluebird.resolve(expected));
 
       return documentController.validate(request)
         .then(response => {
           try {
-            should(kuzzle.validation.validationPromise).be.calledOnce();
+            should(kuzzle.validation.validate).be.calledOnce();
             should(response).be.instanceof(Object);
             should(response).match(expected);
 

--- a/test/api/controllers/realtimeController.test.js
+++ b/test/api/controllers/realtimeController.test.js
@@ -170,7 +170,7 @@ describe('Test: subscribe controller', () => {
       return realtimeController.publish(request)
         .then(response => {
           try {
-            should(kuzzle.validation.validationPromise).be.calledOnce();
+            should(kuzzle.validation.validate).be.calledOnce();
 
             should(kuzzle.notifier.publish).be.calledOnce();
             should(kuzzle.notifier.publish).be.calledWith(request);

--- a/test/api/core/pluginContext/pluginContext.test.js
+++ b/test/api/core/pluginContext/pluginContext.test.js
@@ -222,7 +222,7 @@ describe('Plugin Context', () => {
       const validation = context.accessors.validation;
 
       should(validation.addType).be.eql(kuzzle.validation.addType.bind(kuzzle.validation));
-      should(validation.validate).be.eql(kuzzle.validation.validationPromise.bind(kuzzle.validation));
+      should(validation.validate).be.eql(kuzzle.validation.validate.bind(kuzzle.validation));
     });
 
     it('should expose an API execution accessor', () => {

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -352,7 +352,6 @@ class KuzzleMock extends Kuzzle {
       curateSpecification: this.sandbox.stub().resolves(),
       isValidSpecification: this.sandbox.stub().resolves({isValid: false}),
       validate: this.sandbox.stub().callsFake((...args) => Bluebird.resolve(args[0])),
-      validationPromise: this.sandbox.stub().callsFake((...args) => Bluebird.resolve(args[0])),
       addType: this.sandbox.spy()
     };
 


### PR DESCRIPTION
## What does this PR do ?

This PR is a dirty fix for https://github.com/kuzzleio/kuzzle/issues/1243 but I could not figure out any cleaner way to proceed.

### How should this be manually tested?

You can use [this script](https://gist.github.com/benoitvidis/221335b714babdb726ddb07e9128f685)

### Other changes

- rename `validationPromise` to `validate`