### PR TITLE
KZL-997/Restrict index and collection list

### DIFF
--- a/features/kuzzle.feature
+++ b/features/kuzzle.feature
@@ -1,4 +1,22 @@
 Feature: Kuzzle functional tests
+
+  @security
+  Scenario: List collection with restriction
+    Given I create a new role "restrictedRole" with id "restrictedRole"
+    And I create a new profile "restrictedProfile" with id "restrictedProfile"
+    And I create a user "restrictedUser" with id "restrictedUser-id"
+    When I log in as restrictedUser:password expiring in 1h
+    And I list "stored" data collections in index "kuzzle-test-index"
+    Then I can not find a stored collection kuzzle-collection-test-alt
+
+  @security
+  Scenario: List index with restriction
+    Given I create a new role "restrictedRole" with id "restrictedRole"
+    And I create a new profile "restrictedProfile" with id "restrictedProfile"
+    And I create a user "restrictedUser" with id "restrictedUser-id"
+    When I log in as restrictedUser:password expiring in 1h
+    Then I'm not able to find the index named "kuzzle-test-index-alt" in index list
+
   Scenario: Create a collection
     When I create a collection "kuzzle-test-index":"my-collection1"
     Then The mapping properties field of "kuzzle-test-index":"my-collection1" is "the default value"

--- a/features/step_definitions/collections.js
+++ b/features/step_definitions/collections.js
@@ -38,16 +38,19 @@ Then(/^I can ?(not)* find a ?(.*?) collection ?(.*)$/, function (not, type, coll
       return callback('Collection list is empty, expected collections to be listed');
     }
   }
-
   if (this.result.collections.filter(item => item.type === type && item.name === collection).length !== 0) {
     if (not) {
       return callback('Expected collection ' + collection + ' not to appear in the collection list');
     }
 
-    return callback();
-  }
+    callback();
+  } else {
+    if (not) {
+      return callback();
+    }
 
-  callback('Expected to find the collection <' + collection + '> in this collections list: ' + JSON.stringify(this.result.collections));
+    callback('Expected to find the collection <' + collection + '> in this collections list: ' + JSON.stringify(this.result.collections));
+  }
 });
 
 Then(/^I change the mapping(?: in index "([^"]*)")?$/, function (index, callback) {

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -231,6 +231,34 @@ class KWorld {
             }
           }
         }
+      },
+      restrictedRole: {
+        controllers: {
+          auth: {
+            actions: {
+              getCurrentUser: true,
+              getMyCredentials: true,
+              getMyRights: true,
+              logout: true
+            }
+          },
+          collection: {
+            actions: {
+              getMapping: true,
+              list: true
+            }
+          },
+          document: {
+            actions: {
+              '*': true
+            }
+          },
+          index: {
+            actions: {
+              list: true
+            }
+          }
+        }
       }
     };
 
@@ -306,6 +334,14 @@ class KWorld {
       },
       anonymousfoo: {
         policies: [{roleId: 'anonymous'}, {roleId: this.idPrefix +'foo'}]
+      },
+      restrictedProfile: {
+        policies: [
+          {
+            roleId: this.idPrefix + 'restrictedRole',
+            restrictedTo: [{ index: this.fakeIndex, collections: [this.fakeCollection] }]
+          }
+        ]
       }
     };
 
@@ -438,7 +474,18 @@ class KWorld {
           },
           profileIds: [null]
         }
-      }
+      },
+      restrictedUser: {
+        content: {
+          profileIds: [this.idPrefix + 'restrictedProfile']
+        },
+        credentials: {
+          local: {
+            username: this.idPrefix + 'restrictedUser',
+            password: 'password'
+          }
+        }
+      },
     };
 
     this.credentials = {

--- a/lib/api/controllers/collectionController.js
+++ b/lib/api/controllers/collectionController.js
@@ -299,6 +299,27 @@ class CollectionController extends BaseController {
           return a.name < b.name ? -1 : 1;
         });
 
+        return request.context.user.getRights();
+      })
+      .then(rights => {
+        const allowedCollections = [];
+
+        for (const key of Object.keys(rights)) {
+          const { index, collection, value } = rights[key];
+
+          if (allowedCollections.indexOf(collection) === -1 
+              && value === 'allowed'
+              && (index === request.input.resource.index || index === '*')) {
+            allowedCollections.push(collection);
+          }
+        }
+
+        if (allowedCollections.indexOf('*') !== -1) {
+          return paginateCollections(request, {type, collections});
+        }
+
+        collections = collections.filter(collection => allowedCollections.indexOf(collection.name) !== -1);
+
         return paginateCollections(request, {type, collections});
       });
   }

--- a/lib/api/controllers/indexController.js
+++ b/lib/api/controllers/indexController.js
@@ -143,8 +143,29 @@ class IndexController extends BaseController {
   /**
    * @returns {Promise<Object>}
    */
-  list() {
-    return this.engine.listIndexes();
+  list(request) {
+    return request.context.user.getRights()
+      .then(rights => {
+        const allowedIndexes = [];
+        
+        for (const key of Object.keys(rights)) {
+          const { index, value } = rights[key];
+
+          if (allowedIndexes.indexOf(index) === -1 && value === 'allowed') {
+            allowedIndexes.push(index);
+          }
+        }
+
+        const response = this.engine.listIndexes();
+
+        if (allowedIndexes.indexOf('*') !== -1) {
+          return response;
+        }
+
+        return response
+          .then(({ indexes }) => indexes.filter(index => allowedIndexes.indexOf(index) !== -1))
+          .then(filteredIndexes => ({ indexes: filteredIndexes }));          
+      });
   }
 
   /**


### PR DESCRIPTION
## What does this PR do ?

Take the profiles restrictions into account for `index:list` and `collection:list`.  

### How should this be manually tested?

  - Step 1 : Create a user with a profile restricted to one particular index and one collection
  - Step 2 : Log as this user and then call `index:list` and `collection:list`.  
  - Step 3 : You should see only the index and collection allowed for this user