### PR TITLE
Fix timeouts on plugin action returing the request

### DIFF
--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -374,6 +374,17 @@ class FunnelController {
       .then(responseData => {
         modifiedRequest.setResult(responseData, {status: request.status === 102 ? 200 : request.status});
 
+        if (!this.isNativeController(modifiedRequest) && !modifiedRequest.response.raw) {
+          // check if the plugin response can be serialized
+          try {
+            JSON.stringify(modifiedRequest.response.toJSON());
+          }
+          catch (e) {
+            modifiedRequest.setResult(null);
+            throw new Error('Unable to serialize response. Are you trying to return the request?');
+          }
+        }
+
         return this.kuzzle.pluginsManager.trigger(this.getEventName(request, 'after'), modifiedRequest);
       })
       .then(newRequest => this.kuzzle.pluginsManager.trigger('request:onSuccess', newRequest))

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -377,11 +377,11 @@ class FunnelController {
         if (!this.isNativeController(modifiedRequest) && !modifiedRequest.response.raw) {
           // check if the plugin response can be serialized
           try {
-            JSON.stringify(modifiedRequest.response.toJSON());
+            JSON.stringify(responseData);
           }
           catch (e) {
             modifiedRequest.setResult(null);
-            throw new Error('Unable to serialize response. Are you trying to return the request?');
+            throw new PluginImplementationError('Unable to serialize response. Are you trying to return the request?');
           }
         }
 

--- a/test/api/controllers/funnelController/processRequest.test.js
+++ b/test/api/controllers/funnelController/processRequest.test.js
@@ -121,6 +121,23 @@ describe('funnelController.processRequest', () => {
       });
   });
 
+  it('should throw if a plugin action returns a non-serializable response', () => {
+    const
+      controller = 'fakePlugin/controller',
+      request = new Request({controller, action: 'succeed'}),
+      unserializable = {};
+    unserializable.self = unserializable;
+
+    funnel.pluginsControllers[controller].succeed.resolves(unserializable);
+
+    return funnel.processRequest(request)
+      .then(() => { throw new Error('Expected test to fail'); })
+      .catch(e => {
+        should(e).be.an.instanceOf(PluginImplementationError);
+        should(e.message).startWith('Unable to serialize response. Are you trying to return the request?');
+      });
+  });
+
   it('should resolve the promise if everything is ok', () => {
     const request = new Request({
       controller: 'fakeController',


### PR DESCRIPTION
## What does this PR do ?

This PR fixes the case where Kuzzle would timeout without error when/if a plugin controller action returns a non-serializable response.
This is notably the case if a controller action returns the origin request.
