### PR TITLE
[KZL-522] Collection specifications methods cloisoned to a collection

### DIFF
--- a/features/kuzzle.feature
+++ b/features/kuzzle.feature
@@ -1775,12 +1775,21 @@ Feature: Kuzzle functional tests
     Then I put a valid specification for index "kuzzle-test-index" and collection "kuzzle-collection-test"
     And There is no error message
     And There is a specification for index "kuzzle-test-index" and collection "kuzzle-collection-test"
+    Then I put a not valid deprecated specification for index "kuzzle-test-index" and collection "kuzzle-collection-test"
+    And There is an error message
+    Then I put a valid deprecated specification for index "kuzzle-test-index" and collection "kuzzle-collection-test"
+    And There is no error message
+
 
   @validation
   Scenario: Validation - validateSpecification
     When I post a valid specification
     Then There is no error message
     When I post an invalid specification
+    Then There is an error message in the response body
+    When I post a valid deprecated specification
+    Then There is no error message
+    When I post an invalid deprecated specification
     Then There is an error message in the response body
 
   @validation

--- a/features/support/api/apiBase.js
+++ b/features/support/api/apiBase.js
@@ -1223,10 +1223,10 @@ class ApiBase {
     });
   }
 
-  updateSpecifications (specifications) {
+  updateSpecifications (index, collection, specifications) {
     return this.send({
-      index: null,
-      collection: null,
+      index,
+      collection,
       controller: 'collection',
       action : 'updateSpecifications',
       body: specifications
@@ -1267,10 +1267,10 @@ class ApiBase {
     });
   }
 
-  validateSpecifications (specifications) {
+  validateSpecifications (index, collection, specifications) {
     return this.send({
-      index: null,
-      collection: null,
+      index,
+      collection,
       controller: 'collection',
       action : 'validateSpecifications',
       body: specifications

--- a/features/support/api/http.js
+++ b/features/support/api/http.js
@@ -1188,9 +1188,9 @@ class HttpApi {
     return this.callApi(options);
   }
 
-  updateSpecifications (specifications) {
+  updateSpecifications (index, collection, specifications) {
     const options = {
-      url: this.apiPath('_specifications'),
+      url: this.apiPath(index ? `${index}/${collection}/_specifications` : '_specifications'),
       method: 'PUT',
       body: specifications
     };
@@ -1238,9 +1238,9 @@ class HttpApi {
     return this.callApi(options);
   }
 
-  validateSpecifications (specifications) {
+  validateSpecifications (index, collection, specifications) {
     const options = {
-      url: this.apiPath('_validateSpecifications'),
+      url: this.apiPath(index ? `${index}/${collection}/_validateSpecifications` : '_validateSpecifications'),
       method: 'POST',
       body: specifications
     };

--- a/lib/api/controllers/collectionController.js
+++ b/lib/api/controllers/collectionController.js
@@ -353,14 +353,14 @@ const formatSpecification = (index, collection, validation) => ({
  * @returns {Promise<Array>}
  */
 function createSpecificationList (request) {
-  const specifications = [];
   const { index, collection } = request.input.resource;
-
+  
   if (index && collection) {
     const specification = formatSpecification(index, collection, request.input.body);
     return Bluebird.resolve([ specification ]);
   }
-
+  
+  const specifications = [];
   _.forEach(request.input.body, (collections, _index) => {
     _.forEach(collections, (validation, _collection) => {
       specifications.push(formatSpecification(_index, _collection, validation));

--- a/lib/api/controllers/collectionController.js
+++ b/lib/api/controllers/collectionController.js
@@ -241,8 +241,6 @@ class CollectionController extends BaseController {
   validateSpecifications(request) {
     assertHasBody(request);
 
-    console.log('==========>', JSON.stringify(request));
-
     return createSpecificationList(request)
       .then(list => validateSpecificationList(this.kuzzle.validation, list));
   }

--- a/lib/api/controllers/collectionController.js
+++ b/lib/api/controllers/collectionController.js
@@ -241,6 +241,8 @@ class CollectionController extends BaseController {
   validateSpecifications(request) {
     assertHasBody(request);
 
+    console.log('==========>', JSON.stringify(request));
+
     return createSpecificationList(request)
       .then(list => validateSpecificationList(this.kuzzle.validation, list));
   }
@@ -334,18 +336,36 @@ class CollectionController extends BaseController {
 module.exports = CollectionController;
 
 /**
+ * @param {string} request
+ * @param {string} request
+ * @param {object} validation
+ * @returns {object}
+ */
+const formatSpecification = (index, collection, validation) => ({
+  _id: `${index}#${collection}`,
+  _source: {
+    validation,
+    index,
+    collection
+  }
+});
+
+/**
  * @param {Request} request
  * @returns {Promise<Array>}
  */
 function createSpecificationList (request) {
   const specifications = [];
+  const { index, collection } = request.input.resource;
 
-  _.forEach(request.input.body, (collections, index) => {
-    _.forEach(collections, (validation, collection) => {
-      specifications.push({
-        _id: `${index}#${collection}`,
-        _source: {validation, index, collection}
-      });
+  if (index && collection) {
+    const specification = formatSpecification(index, collection, request.input.body);
+    return Bluebird.resolve([ specification ]);
+  }
+
+  _.forEach(request.input.body, (collections, _index) => {
+    _.forEach(collections, (validation, _collection) => {
+      specifications.push(formatSpecification(_index, _collection, validation));
     });
   });
 

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -153,7 +153,10 @@ module.exports = [
   {verb: 'post', url: '/credentials/:strategy/_me/_create', controller: 'auth', action: 'createMyCredentials'},
   {verb: 'post', url: '/credentials/:strategy/_me/_validate', controller: 'auth', action: 'validateMyCredentials'},
 
+  /* DEPRECATED - will be removed in v2 */  
   {verb: 'post', url: '/_validateSpecifications', controller: 'collection', action: 'validateSpecifications'},
+
+  {verb: 'post', url: '/:index/:collection/_validateSpecifications', controller: 'collection', action: 'validateSpecifications'},
   {verb: 'post', url: '/validations/_search', controller: 'collection', action: 'searchSpecifications'},
 
   {verb: 'post', url: '/_bulk', controller: 'bulk', action: 'import'},
@@ -290,7 +293,10 @@ module.exports = [
 
   {verb: 'put', url: '/:index/:collection', controller: 'collection', action: 'create'},
   {verb: 'put', url: '/:index/:collection/_mapping', controller: 'collection', action: 'updateMapping'},
+
+  /* DEPRECATED - will be removed in v2 */
   {verb: 'put', url: '/_specifications', controller: 'collection', action: 'updateSpecifications'},
+  {verb: 'put', url: '/:index/:collection/_specifications', controller: 'collection', action: 'updateSpecifications'},
 
   {verb: 'put', url: '/:index/:collection/:_id', controller: 'document', action: 'createOrReplace'},
   {verb: 'put', url: '/:index/:collection/_mCreateOrReplace', controller: 'document', action: 'mCreateOrReplace'},

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -296,6 +296,7 @@ module.exports = [
 
   /* DEPRECATED - will be removed in v2 */
   {verb: 'put', url: '/_specifications', controller: 'collection', action: 'updateSpecifications'},
+  
   {verb: 'put', url: '/:index/:collection/_specifications', controller: 'collection', action: 'updateSpecifications'},
 
   {verb: 'put', url: '/:index/:collection/:_id', controller: 'document', action: 'createOrReplace'},

--- a/test/api/controllers/collectionController.test.js
+++ b/test/api/controllers/collectionController.test.js
@@ -225,10 +225,8 @@ describe('Test: collection controller', () => {
 
   describe('#updateSpecifications', () => {
     it('should create or replace specifications', () => {
-      index = 'myindex';
-      collection = 'mycollection';
-      request.input.resource.index = index;
-      request.input.resource.collection = collection;
+      request.input.resource.index = 'myindex';
+      request.input.resource.collection = 'mycollection';
       request.input.body = {
         myindex: {
           mycollection: {
@@ -252,16 +250,14 @@ describe('Test: collection controller', () => {
           should(kuzzle.internalEngine.refresh).be.calledOnce();
           should(kuzzle.validation.curateSpecification).be.called();
           should(kuzzle.internalEngine.createOrReplace).be.calledOnce();
-          should(kuzzle.internalEngine.createOrReplace).be.calledWithMatch('validations', `${index}#${collection}`);
+          should(kuzzle.internalEngine.createOrReplace).be.calledWithMatch('validations', 'myindex#mycollection');
           should(response).match(request.input.body);
         });
     });
 
     it('should rejects and do not create or replace specifications if the specs are wrong', () => {
-      index = 'myindex';
-      collection = 'mycollection';
-      request.input.resource.index = index;
-      request.input.resource.collection = collection;
+      request.input.resource.index = 'myindex';
+      request.input.resource.collection = 'mycollection';
       request.input.body = {
         myindex: {
           mycollection: {
@@ -284,8 +280,9 @@ describe('Test: collection controller', () => {
 
       return collectionController.updateSpecifications(request)
         .catch(error => {
-          should(kuzzle.pluginsManager.trigger).be.calledOnce();
-          should(kuzzle.pluginsManager.trigger.firstCall).be.calledWith('validation:error', 'Some errors with provided specifications.');
+          should(kuzzle.pluginsManager.trigger)
+            .be.calledOnce()
+            .be.calledWith('validation:error', 'Some errors with provided specifications.');
           should(kuzzle.internalEngine.refresh).not.be.called();
           should(kuzzle.validation.curateSpecification).not.be.called();
           should(kuzzle.internalEngine.createOrReplace).not.be.called();
@@ -323,8 +320,9 @@ describe('Test: collection controller', () => {
         .then(response => {
           should(kuzzle.internalEngine.refresh).be.calledOnce();
           should(kuzzle.validation.curateSpecification).be.called();
-          should(kuzzle.internalEngine.createOrReplace).be.calledOnce();
-          should(kuzzle.internalEngine.createOrReplace).be.calledWithMatch('validations', `${index}#${collection}`);
+          should(kuzzle.internalEngine.createOrReplace)
+            .be.calledOnce()
+            .be.calledWithMatch('validations', `${index}#${collection}`);
           should(response).match(request.input.body);
         });
     });
@@ -384,21 +382,29 @@ describe('Test: collection controller', () => {
         }
       };
 
+      const specifications = [{
+        _id: 'indexcollection',
+        _source: {
+          validation: 'validation',
+          index: 'index',
+          collection: 'collection'
+        }
+      }];
+
+      const createSpecificationList = sinon.stub().resolves(specifications);
+      const validateSpecificationList = sinon.stub().resolves({valid: true});
+
       CollectionController.__set__({
-        createSpecificationList: sinon.stub().resolves({
-          _id: 'indexcollection',
-          _source: {
-            validation: 'validation',
-            index: 'index',
-            collection: 'collection'
-          }
-        }),
-        validateSpecificationList: sinon.stub().resolves({valid: true})
+        createSpecificationList,
+        validateSpecificationList
       });
 
       return collectionController.validateSpecifications(request)
         .then(response => {
           should(response).match({valid: true});
+          should(validateSpecificationList)
+            .be.calledOnce()
+            .be.calledWith(kuzzle.validation, specifications);
         });
     });
 
@@ -422,21 +428,27 @@ describe('Test: collection controller', () => {
         }
       };
 
+      const specifications = [{
+        _id: 'indexcollection',
+        _source: {
+          validation: 'validation',
+          index: 'index',
+          collection: 'collection'
+        }
+      }];
+
+      const createSpecificationList = sinon.stub().resolves(specifications);
+      const validateSpecificationList = sinon.stub().resolves(errorResponse);
+
       CollectionController.__set__({
-        createSpecificationList: sinon.stub().resolves({
-          _id: 'indexcollection',
-          _source: {
-            validation: 'validation',
-            index: 'index',
-            collection: 'collection'
-          }
-        }),
-        validateSpecificationList: sinon.stub().resolves(errorResponse)
+        createSpecificationList,
+        validateSpecificationList
       });
 
       return collectionController.validateSpecifications(request)
         .then(response => {
           should(response).match(errorResponse);
+          should(validateSpecificationList).be.calledOnce();
         });
     });
 
@@ -458,21 +470,29 @@ describe('Test: collection controller', () => {
         }
       };
 
+      const specifications = [{
+        _id: 'indexcollection',
+        _source: {
+          validation: 'validation',
+          index: 'index',
+          collection: 'collection'
+        }
+      }];
+
+      const createSpecificationList = sinon.stub().resolves(specifications);
+      const validateSpecificationList = sinon.stub().resolves({valid: true});
+
       CollectionController.__set__({
-        createSpecificationList: sinon.stub().resolves({
-          _id: 'indexcollection',
-          _source: {
-            validation: 'validation',
-            index: 'index',
-            collection: 'collection'
-          }
-        }),
-        validateSpecificationList: sinon.stub().resolves({valid: true})
+        createSpecificationList,
+        validateSpecificationList
       });
 
       return collectionController.validateSpecifications(request)
         .then(response => {
           should(response).match({valid: true});
+          should(validateSpecificationList)
+            .be.calledOnce()
+            .be.calledWith(kuzzle.validation, specifications);
         });
     });
 
@@ -500,21 +520,27 @@ describe('Test: collection controller', () => {
         }
       };
 
+      const specifications = [{
+        _id: 'indexcollection',
+        _source: {
+          validation: 'validation',
+          index: 'index',
+          collection: 'collection'
+        }
+      }];
+
+      const createSpecificationList = sinon.stub().resolves(specifications);
+      const validateSpecificationList = sinon.stub().resolves(errorResponse);
+
       CollectionController.__set__({
-        createSpecificationList: sinon.stub().resolves({
-          _id: 'indexcollection',
-          _source: {
-            validation: 'validation',
-            index: 'index',
-            collection: 'collection'
-          }
-        }),
-        validateSpecificationList: sinon.stub().resolves(errorResponse)
+        createSpecificationList,
+        validateSpecificationList
       });
 
       return collectionController.validateSpecifications(request)
         .then(response => {
           should(response).match(errorResponse);
+          should(validateSpecificationList).be.calledOnce();
         });
     });
   });


### PR DESCRIPTION
## What does this PR do ?

Validate specifications:
- add new endpoint `http://kuzzle:7512/<index>/<collection>/_validateSpecifications`
- deprecate the previous endpoint `http://kuzzle:7512/_validateSpecifications`

Update specifications:
- add new endpoint `http://kuzzle:7512/<index>/<collection>/_specifications`
- deprecate the previous endpoint `http://kuzzle:7512/_specifications`

### How should this be manually tested?

- Step 1 : call the validate specifications with the new endpoint
- Step 2 : same with update specifications