### PR TITLE
[fix] Use request:onUnauthorized on bad credentials

### DIFF
--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -447,8 +447,8 @@ class FunnelController {
 
         modifiedRequest.setError(_error);
         this.kuzzle.statistics.failedRequest(request);
-
-        return this.kuzzle.pluginsManager.trigger('request:onError', modifiedRequest)
+        const kuzzleEvent = customError.status === 401 ? 'request:onUnauthorized' : 'request:onError';
+        return this.kuzzle.pluginsManager.trigger(kuzzleEvent, modifiedRequest)
           .then(modifiedRequestError => {
             if (modifiedRequestError !== modifiedRequest) {
               return modifiedRequestError;


### PR DESCRIPTION
## What does this PR do ?
Before this PR, use login with bad credentials triggered a `request:onError` event instead of `request:onUnauthorized` as it should be according to [documentation](https://docs.kuzzle.io/plugins/1/events/request-on-unauthorized/).

I know this fix is so ugly. But I'm open to any remark to improve it. :slightly_smiling_face: 

### How should this be manually tested?
* Launch staging Kuzzle stack with debug mode on to see triggered events. 
* Try this simple curl command:
```bash
curl -X POST -H 'Content-Type: application/json' --data '{"username":"test","password":"test"}' http://localhost:7512/_login/local
```
* Look at the triggered events:
```bash
kuzzle_1         | 0|KuzzleServer  | 2019-05-22T01:19:36.828Z kuzzle:plugins trigger "http:post" event                                                                                                                                    
kuzzle_1         | 0|KuzzleServer  | 2019-05-22T01:19:36.831Z kuzzle:plugins trigger "request:onAuthorized" event                                                                                                                         
kuzzle_1         | 0|KuzzleServer  | 2019-05-22T01:19:36.832Z kuzzle:plugins trigger "auth:beforeLogin" event                                                                                                                             
kuzzle_1         | 0|KuzzleServer  | 2019-05-22T01:19:36.845Z kuzzle:plugins trigger "auth:errorLogin" event                                                                                                                              
kuzzle_1         | 0|KuzzleServer  | 2019-05-22T01:19:36.845Z kuzzle:plugins trigger "log:info" event                                                                                                                                     
kuzzle_1         | 0|KuzzleServer  | 2019-05-22T01:19:36.845Z kuzzle:plugins trigger "request:onError" event  
```

Repeat previous steps with current PR Kuzzle stack.