### PR TITLE
[KZL-291] pipes & hooks: wildcarded event

### DIFF
--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -831,10 +831,7 @@ class PluginsManager {
  * @returns {Promise}
  */
 function triggerHooks(emitter, event, data) {
-  const wildcardEvents = getWildcardEvents(event)
-    // filter events like 'foo:*' because EventEmitter2 
-    // already have this wildcard feature
-    .filter(e => e[0] !== '*' && e.split(':')[1] !== '*');
+  const wildcardEvents = getWildcardEvents(event);
 
   emitter.emit(event, data);
 
@@ -894,24 +891,26 @@ function triggerPipes(pipes, event, data) {
  * @param {String} event
  * @returns {Array<String>} wildcard events
  */
-function getWildcardEvents (event) {
-  const [scope, name] = event.split(':');
-
-  if (!name) {
+const getWildcardEvents = _.memoize(event => {
+  const delimIndex = event.lastIndexOf(':');
+  
+  if (delimIndex === -1) {
     return null;
   }
-
-  const wildcardEvents = ['*:*', `${scope}:*`];
-
+  
+  const scope = event.slice(0, delimIndex);
+  const name = event.slice(delimIndex + 1);
+  const wildcardEvents = ['*'];
+  
   ['before', 'after'].forEach(prefix => {
-    if (name.startsWith(prefix)) {
-      wildcardEvents.push(`${scope}:${prefix}*`);
-      wildcardEvents.push(`*:${prefix}*`);
+    if (!name.startsWith(prefix)) {
+      return;
     }
+    wildcardEvents.push(`${prefix}*`);
   });
 
-  return wildcardEvents;
-}
+  return wildcardEvents.map(e => `${scope}:${e}`);
+});
 
 /**
  * Test if the provided argument is a constructor or not

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -834,7 +834,7 @@ function triggerHooks(emitter, event, data) {
   const wildcardEvents = getWildcardEvents(event)
     // filter events like 'foo:*' because EventEmitter2 
     // already have this wildcard feature
-    .filter(e => /[^*]+:[^:*]+\*/.test(e));
+    .filter(e => e[0] !== '*' && e.split(':')[1] !== '*');
 
   emitter.emit(event, data);
 

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -831,7 +831,14 @@ class PluginsManager {
  * @returns {Promise}
  */
 function triggerHooks(emitter, event, data) {
+  const wildcardEvents = getWildcardEvents(event)
+    // filter events like 'foo:*' because EventEmitter2 
+    // already have this wildcard feature
+    .filter(e => /[^*]+:[^:*]+\*/.test(e));
+
   emitter.emit(event, data);
+
+  wildcardEvents.forEach(wildcardEvent => emitter.emit(wildcardEvent, data));
 
   return Bluebird.resolve(data);
 }
@@ -845,15 +852,19 @@ function triggerHooks(emitter, event, data) {
  * @returns {Promise}
  */
 function triggerPipes(pipes, event, data) {
-  let preparedPipes = [];
-  const wildcardEvent = getWildcardEvent(event);
+  const preparedPipes = [];
+  const wildcardEvents = getWildcardEvents(event);
 
   if (pipes && pipes[event] && pipes[event].length) {
-    preparedPipes = pipes[event];
+    preparedPipes.push(...pipes[event]);
   }
 
-  if (wildcardEvent && pipes && pipes[wildcardEvent] && pipes[wildcardEvent].length) {
-    preparedPipes = preparedPipes.concat(pipes[wildcardEvent]);
+  if (wildcardEvents && pipes) {
+    wildcardEvents.forEach(wildcardEvent => {
+      if (pipes[wildcardEvent] && pipes[wildcardEvent].length) {
+        preparedPipes.push(...pipes[wildcardEvent]);
+      }
+    });
   }
 
   if (preparedPipes.length === 0) {
@@ -876,19 +887,30 @@ function triggerPipes(pipes, event, data) {
 }
 
 /**
- * For a specific event, return the corresponding wildcard
+ * For a specific event, return the correspondings wildcards
  * @example
- *  getWildcardEvent('data:create') // return 'data:*'
- * @param {string} event
- * @returns {String} wildcard event
+ *  getWildcardEvents('data:create') // return ['data:*']
+ *  getWildcardEvents('data:beforeCreate') // return ['data:*', 'data:before*']
+ * @param {String} event
+ * @returns {Array<String>} wildcard events
  */
-function getWildcardEvent (event) {
-  const indexDelimiter = event.indexOf(':');
-  if (indexDelimiter !== 1) {
-    return event.substring(0, indexDelimiter+1) + '*';
+function getWildcardEvents (event) {
+  const [scope, name] = event.split(':');
+
+  if (!name) {
+    return null;
   }
 
-  return null;
+  const wildcardEvents = ['*:*', `${scope}:*`];
+
+  ['before', 'after'].forEach(prefix => {
+    if (name.startsWith(prefix)) {
+      wildcardEvents.push(`${scope}:${prefix}*`);
+      wildcardEvents.push(`*:${prefix}*`);
+    }
+  });
+
+  return wildcardEvents;
 }
 
 /**

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -823,6 +823,35 @@ class PluginsManager {
 }
 
 /**
+ * For a specific event, return the correspondings wildcards
+ * @example
+ *  getWildcardEvents('data:create') // return ['data:*']
+ *  getWildcardEvents('data:beforeCreate') // return ['data:*', 'data:before*']
+ * @param {String} event
+ * @returns {Array<String>} wildcard events
+ */
+const getWildcardEvents = _.memoize(event => {
+  const delimIndex = event.lastIndexOf(':');
+  
+  if (delimIndex === -1) {
+    return [];
+  }
+  
+  const scope = event.slice(0, delimIndex);
+  const name = event.slice(delimIndex + 1);
+  const wildcardEvents = ['*'];
+  
+  ['before', 'after'].forEach(prefix => {
+    if (!name.startsWith(prefix)) {
+      return;
+    }
+    wildcardEvents.push(`${prefix}*`);
+  });
+
+  return wildcardEvents.map(e => `${scope}:${e}`);
+});
+
+/**
  * Emit event
  *
  * @param {EventEmitter} emitter
@@ -880,35 +909,6 @@ function triggerPipes(pipes, event, data) {
     });
   });
 }
-
-/**
- * For a specific event, return the correspondings wildcards
- * @example
- *  getWildcardEvents('data:create') // return ['data:*']
- *  getWildcardEvents('data:beforeCreate') // return ['data:*', 'data:before*']
- * @param {String} event
- * @returns {Array<String>} wildcard events
- */
-const getWildcardEvents = _.memoize(event => {
-  const delimIndex = event.lastIndexOf(':');
-  
-  if (delimIndex === -1) {
-    return [];
-  }
-  
-  const scope = event.slice(0, delimIndex);
-  const name = event.slice(delimIndex + 1);
-  const wildcardEvents = ['*'];
-  
-  ['before', 'after'].forEach(prefix => {
-    if (!name.startsWith(prefix)) {
-      return;
-    }
-    wildcardEvents.push(`${prefix}*`);
-  });
-
-  return wildcardEvents.map(e => `${scope}:${e}`);
-});
 
 /**
  * Test if the provided argument is a constructor or not

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -841,7 +841,7 @@ const getWildcardEvents = _.memoize(event => {
   const name = event.slice(delimIndex + 1);
   const wildcardEvents = ['*'];
   
-  ['before', 'after'].forEach(prefix => {
+  ['before', 'after', 'error'].forEach(prefix => {
     if (!name.startsWith(prefix)) {
       return;
     }

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -856,13 +856,11 @@ function triggerPipes(pipes, event, data) {
     preparedPipes.push(...pipes[event]);
   }
 
-  if (wildcardEvents && pipes) {
-    wildcardEvents.forEach(wildcardEvent => {
-      if (pipes[wildcardEvent] && pipes[wildcardEvent].length) {
-        preparedPipes.push(...pipes[wildcardEvent]);
-      }
-    });
-  }
+  wildcardEvents.forEach(wildcardEvent => {
+    if (pipes[wildcardEvent] && pipes[wildcardEvent].length) {
+      preparedPipes.push(...pipes[wildcardEvent]);
+    }
+  });
 
   if (preparedPipes.length === 0) {
     return Bluebird.resolve(data);
@@ -895,7 +893,7 @@ const getWildcardEvents = _.memoize(event => {
   const delimIndex = event.lastIndexOf(':');
   
   if (delimIndex === -1) {
-    return null;
+    return [];
   }
   
   const scope = event.slice(0, delimIndex);

--- a/lib/api/kuzzle.js
+++ b/lib/api/kuzzle.js
@@ -22,7 +22,7 @@
 'use strict';
 
 const
-  EventEmitter = require('eventemitter2').EventEmitter2,
+  EventEmitter = require('eventemitter3'),
   config = require('../config'),
   path = require('path'),
   murmur = require('murmurhash-native').murmurHash128,
@@ -55,12 +55,7 @@ const
  */
 class Kuzzle extends EventEmitter {
   constructor() {
-    super({
-      verboseMemoryLeak: true,
-      wildcard: true,
-      maxListeners: 30,
-      delimiter: ':'
-    });
+    super();
 
     /** @type {KuzzleConfiguration} */
     this.config = config;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dumpme": "^1.0.2",
     "easy-circular-list": "^1.0.13",
     "elasticsearch": "^15.4.1",
-    "eventemitter2": "^5.0.1",
+    "eventemitter3": "^3.1.2",
     "fs-extra": "^7.0.1",
     "glob": "^7.1.3",
     "ioredis": "^4.9.0",

--- a/test/api/core/pluginsManager/run.test.js
+++ b/test/api/core/pluginsManager/run.test.js
@@ -61,10 +61,8 @@ describe('PluginsManager.run', () => {
     pluginMock.expects('bar').never();
 
     return pluginsManager.run()
-      .then(() => {
-        kuzzle.emit('foo:bar');
-        pluginMock.verify();
-      });
+      .then(() => pluginsManager.trigger('foo:bar'))
+      .then(() => pluginMock.verify());
   });
 
   it('should attach event hook with function', () => {
@@ -78,9 +76,8 @@ describe('PluginsManager.run', () => {
     };
 
     return pluginsManager.run()
+      .then(() => pluginsManager.trigger('foo:bar'))
       .then(() => {
-        kuzzle.emit('foo:bar');
-
         should(bar).be.calledOnce();
         should(foo).not.be.called();
       });
@@ -101,10 +98,8 @@ describe('PluginsManager.run', () => {
     pluginMock.expects('baz').never();
 
     return pluginsManager.run()
-      .then(() => {
-        kuzzle.emit('foo:bar');
-        pluginMock.verify();
-      });
+      .then(() => pluginsManager.trigger('foo:bar'))
+      .then(() => pluginMock.verify());
   });
 
   it('should attach multi-target hook with function', () => {
@@ -119,9 +114,8 @@ describe('PluginsManager.run', () => {
     };
 
     return pluginsManager.run()
+      .then(() => pluginsManager.trigger('foo:bar'))
       .then(() => {
-        kuzzle.emit('foo:bar');
-
         should(bar).be.calledOnce();
         should(foo).be.calledOnce();
         should(baz).not.be.called();
@@ -142,10 +136,8 @@ describe('PluginsManager.run', () => {
     pluginMock.expects('bar').never();
 
     return pluginsManager.run()
-      .then(() => {
-        kuzzle.emit('foo:bar');
-        pluginMock.verify();
-      });
+      .then(() => pluginsManager.trigger('foo:bar'))
+      .then(() => pluginMock.verify());
   });
 
   it('should throw if a hook target is not a function and not a method name', () => {

--- a/test/api/core/pluginsManager/trigger.test.js
+++ b/test/api/core/pluginsManager/trigger.test.js
@@ -106,7 +106,7 @@ describe('Test plugins manager trigger', () => {
       }
     }];
 
-    pluginsManager.run()
+    return pluginsManager.run()
       .then(() => pluginsManager.trigger('foo:bar'))
       .then(() => {
         should(pluginsManager.plugins[0].object.myFunc).be.calledOnce();
@@ -129,7 +129,7 @@ describe('Test plugins manager trigger', () => {
       }
     }];
 
-    pluginsManager.run()
+    return pluginsManager.run()
       .then(() => pluginsManager.trigger('foo:beforeBar'))
       .then(() => {
         should(pluginsManager.plugins[0].object.myFunc).be.calledOnce();
@@ -152,7 +152,7 @@ describe('Test plugins manager trigger', () => {
       }
     }];
 
-    pluginsManager.run()
+    return pluginsManager.run()
       .then(() => pluginsManager.trigger('foo:afterBar'))
       .then(() => {
         should(pluginsManager.plugins[0].object.myFunc).be.calledOnce();

--- a/test/api/core/pluginsManager/trigger.test.js
+++ b/test/api/core/pluginsManager/trigger.test.js
@@ -1,12 +1,14 @@
 const
   mockrequire = require('mock-require'),
   should = require('should'),
+  sinon = require('sinon'),
   ElasticsearchClientMock = require('../../../mocks/services/elasticsearchClient.mock'),
   KuzzleMock = require('../../../mocks/kuzzle.mock'),
   {
     errors: {
       PluginImplementationError
-    }
+    },
+    Request: KuzzleRequest
   } = require('kuzzle-common-objects');
 
 describe('Test plugins manager trigger', () => {
@@ -41,6 +43,119 @@ describe('Test plugins manager trigger', () => {
     pluginsManager.run()
       .then(() => {
         pluginsManager.trigger('foo:bar');
+      });
+  });
+
+  it('should trigger hooks with before wildcard event', done => {
+    pluginsManager.plugins = [{
+      object: {
+        init: () => {},
+        hooks: {
+          'foo:before*': 'myFunc'
+        },
+        myFunc: done
+      },
+      config: {},
+      activated: true,
+      manifest: {
+        name: 'foo'
+      }
+    }];
+
+    pluginsManager.run()
+      .then(() => {
+        pluginsManager.trigger('foo:beforeBar');
+      });
+  });
+
+  it('should trigger hooks with after wildcard event', done => {
+    pluginsManager.plugins = [{
+      object: {
+        init: () => {},
+        hooks: {
+          'foo:after*': 'myFunc'
+        },
+        myFunc: done
+      },
+      config: {},
+      activated: true,
+      manifest: {
+        name: 'foo'
+      }
+    }];
+
+    pluginsManager.run()
+      .then(() => {
+        pluginsManager.trigger('foo:afterBar');
+      });
+  });
+
+  it('should trigger pipes with wildcard event', () => {
+    pluginsManager.plugins = [{
+      object: {
+        init: () => {},
+        pipes: {
+          'foo:*': 'myFunc'
+        },
+        myFunc: sinon.stub().callsArgWith(1, null, new KuzzleRequest({}))
+      },
+      config: {},
+      activated: true,
+      manifest: {
+        name: 'foo'
+      }
+    }];
+
+    pluginsManager.run()
+      .then(() => pluginsManager.trigger('foo:bar'))
+      .then(() => {
+        should(pluginsManager.plugins[0].object.myFunc).be.calledOnce();
+      });
+  });
+
+  it('should trigger pipes with before wildcard event', () => {
+    pluginsManager.plugins = [{
+      object: {
+        init: () => {},
+        pipes: {
+          'foo:before*': 'myFunc'
+        },
+        myFunc: sinon.stub().callsArgWith(1, null, new KuzzleRequest({}))
+      },
+      config: {},
+      activated: true,
+      manifest: {
+        name: 'foo'
+      }
+    }];
+
+    pluginsManager.run()
+      .then(() => pluginsManager.trigger('foo:beforeBar'))
+      .then(() => {
+        should(pluginsManager.plugins[0].object.myFunc).be.calledOnce();
+      });
+  });
+
+  it('should trigger pipes with after wildcard event', () => {
+    pluginsManager.plugins = [{
+      object: {
+        init: () => {},
+        pipes: {
+          'foo:after*': 'myFunc'
+        },
+        myFunc: sinon.stub().callsArgWith(1, null, new KuzzleRequest({}))
+      },
+      config: {},
+      activated: true,
+      manifest: {
+        name: 'foo'
+      }
+    }];
+
+    pluginsManager.run()
+      .then(() => pluginsManager.trigger('foo:afterBar'))
+      .then(() => {
+        should(pluginsManager.plugins[0].object.myFunc).be.calledOnce();
       });
   });
 

--- a/test/mocks/services/redisClient.mock.js
+++ b/test/mocks/services/redisClient.mock.js
@@ -1,5 +1,5 @@
 const
-  EventEmitter = require('eventemitter2').EventEmitter2,
+  EventEmitter = require('eventemitter3'),
   IORedis = require('ioredis'),
   getBuiltinCommands = (new IORedis({lazyConnect: true})).getBuiltinCommands,
   Bluebird = require('bluebird');
@@ -10,7 +10,7 @@ const
  */
 class RedisClientMock extends EventEmitter {
   constructor (err) {
-    super({verboseMemoryLeak: true});
+    super();
 
     this.getBuiltinCommands = getBuiltinCommands;
 
@@ -46,7 +46,7 @@ class RedisClientMock extends EventEmitter {
         this.emit('end', true);
       }, 50);
     };
-    Stream.prototype = new EventEmitter({verboseMemoryLeak: true});
+    Stream.prototype = new EventEmitter();
 
     return new Stream();
   }


### PR DESCRIPTION
## What does this PR do ?

- pipes & hooks can now trigger wildcarded events like this:
`'foo:*'`
`'foo:after*'`
`'foo:before*'`

### How should this be manually tested?

  - Step 1 : create a plugin and declare some wildcarded events handler
  - Step 2 : trigger events