### PR TITLE
Hotfix: correctly compute mUpdate notifications against the updated document

### DIFF
--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -1153,7 +1153,21 @@ class ElasticSearch extends Service {
       }
     }
 
-    return this._mexecute(esRequest, toImport, extracted.rejected);
+    return this._mexecute(esRequest, toImport, extracted.rejected)
+      .then(response => {
+        // with _source: true, ES returns the updated document in
+        // response.result.get._source
+        // => we replace response.result._source with it so that the notifier
+        // module can seamlessly process all kind of m* response*
+        let j; // NOSONAR
+        for (j = 0; j < response.result.length; j++) {
+          if (response.result[j].get && response.result[j].get._source) {
+            response.result[j]._source = response.result[j].get._source;
+          }
+        }
+
+        return response;
+      });
   }
 
   /**

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -1159,7 +1159,10 @@ class ElasticSearch extends Service {
         // response.result.get._source
         // => we replace response.result._source with it so that the notifier
         // module can seamlessly process all kind of m* response*
-        for (const result of response.result) {
+        let j; // NOSONAR
+        for (j = 0; j < response.result.length; j++) {
+          const result = response.result[j];
+
           if (result.get && result.get._source) {
             result._source = result.get._source;
           }

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -1159,10 +1159,9 @@ class ElasticSearch extends Service {
         // response.result.get._source
         // => we replace response.result._source with it so that the notifier
         // module can seamlessly process all kind of m* response*
-        let j; // NOSONAR
-        for (j = 0; j < response.result.length; j++) {
-          if (response.result[j].get && response.result[j].get._source) {
-            response.result[j]._source = response.result[j].get._source;
+        for (const result of response.result) {
+          if (result.get && result.get._source) {
+            result._source = result.get._source;
           }
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -6,15 +6,17 @@ const
   sinon = require('sinon'),
   rewire = require('rewire'),
   KuzzleMock = require('../../mocks/kuzzle.mock'),
-  Request = require('kuzzle-common-objects').Request,
   {
-    BadRequestError,
-    NotFoundError,
-    KuzzleError,
-    PreconditionError,
-    ExternalServiceError,
-    SizeLimitError
-  } = require('kuzzle-common-objects').errors,
+    Request,
+    errors: {
+      BadRequestError,
+      NotFoundError,
+      KuzzleError,
+      PreconditionError,
+      ExternalServiceError,
+      SizeLimitError
+    }
+  } = require('kuzzle-common-objects'),
   ESClientMock = require('../../mocks/services/elasticsearchClient.mock'),
   ES = rewire('../../../lib/services/elasticsearch');
 
@@ -2403,17 +2405,30 @@ describe('Test: ElasticSearch service', () => {
 
     it('should prevent updating documents to a non-existing index or collection', () => {
       elasticsearch.kuzzle.indexCache.exists.resolves(false);
-      request.input.body = {documents: [{_id: 'foo', body: {foo: 'bar'}}, {_id: 'bar', body: {bar: 'foo'}}]};
+      request.input.body = {
+        documents: [
+          {_id: 'foo', body: {foo: 'bar'}},
+          {_id: 'bar', body: {bar: 'foo'}}
+        ]
+      };
 
-      return should(elasticsearch.mupdate(request)).rejectedWith(PreconditionError);
+      return should(elasticsearch.mupdate(request))
+        .rejectedWith(PreconditionError);
     });
 
     it('should abort if the number of documents exceeds the configured limit', () => {
       elasticsearch.kuzzle.indexCache.exists.resolves(true);
       kuzzle.config.limits.documentsWriteCount = 1;
-      request.input.body = {documents: [{_id: 'foo', body: {foo: 'bar'}}, {_id: 'bar', body: {bar: 'foo'}}]};
+      request.input.body = {
+        documents: [
+          {_id: 'foo', body: {foo: 'bar'}},
+          {_id: 'bar', body: {bar: 'foo'}}
+        ]
+      };
 
-      return should(elasticsearch.mupdate(request)).rejectedWith(SizeLimitError, {message: 'Number of documents exceeds the server configured value (1)'});
+      return should(elasticsearch.mupdate(request)).rejectedWith(
+        SizeLimitError,
+        {message: 'Number of documents exceeds the server configured value (1)'});
     });
 
     it('should bulk import documents to be updated', () => {
@@ -2423,11 +2438,32 @@ describe('Test: ElasticSearch service', () => {
         took: 30,
         errors: false,
         items: [
-          {index: {_id: 'foo', status: 201}},
-          {index: {_id: 'bar', status: 201}}
+          {
+            index: {
+              _id: 'foo',
+              status: 201,
+              get: {
+                _source: {foo: 'bar', leftalone: true, _kuzzle_info: metadata}
+              }
+            }
+          },
+          {
+            index: {
+              _id: 'bar',
+              status: 201,
+              get: {
+                _source: {bar: 'foo', leftalone: true, _kuzzle_info: metadata}
+              }
+            }
+          }
         ]
       });
-      request.input.body = {documents: [{_id: 'foo', body: {foo: 'bar'}}, {_id: 'bar', body: {bar: 'foo'}}]};
+      request.input.body = {
+        documents: [
+          {_id: 'foo', body: {foo: 'bar'}},
+          {_id: 'bar', body: {bar: 'foo'}}
+        ]
+      };
 
       return elasticsearch.mupdate(request)
         .then(result => {
@@ -2443,14 +2479,22 @@ describe('Test: ElasticSearch service', () => {
           });
           should(result.error).be.an.Array().and.be.empty();
           should(result.result).match([
-            {_id: 'foo', _source: {foo: 'bar', _kuzzle_info: metadata}, _meta: metadata, status: 201},
-            {_id: 'bar', _source: {bar: 'foo', _kuzzle_info: metadata}, _meta: metadata, status: 201}
+            {
+              _id: 'foo',
+              _source: {foo: 'bar', leftalone: true, _kuzzle_info: metadata},
+              _meta: metadata,
+              status: 201
+            },
+            {
+              _id: 'bar',
+              _source: {bar: 'foo', leftalone: true, _kuzzle_info: metadata},
+              _meta: metadata,
+              status: 201
+            }
           ]);
 
           should(result.result[0]._meta.updatedAt).be.approximately(now, 100);
           should(result.result[1]._meta.updatedAt).be.approximately(now, 100);
-          should(result.result[0]._source._kuzzle_info.updatedAt).be.approximately(now, 100);
-          should(result.result[1]._source._kuzzle_info.updatedAt).be.approximately(now, 100);
         });
     });
 


### PR DESCRIPTION
# Description

When doing a `document:mUpdate`, real-time notifications are erroneously computed on the update query content, instead of the full updated document.

This is because for mUpdate we use Elasticsearch's `source` option, asking ES to return the updated document source, saving us from performing a `get` query for each updated document. But the returned source doesn't replace the `_source` property, which still contains only the update content. Instead, the full document source is put in `get._source`.

This PR correctly replaces _source with get._source before returning the result to the document controller.

# How to test

* Subscribe with the following filters: `{exists: 'foo'}`
* Create a document with the following body: `{foo: true, bar: 'baz'}`
* Use mUpdate to update it, **without** changing `foo`. Body example: `documents: [{_id: <documentId>, body: {bar: 'qux'}}]`

Without this fix, an `out` notification is sent, instead of an `in` one, because the notifier module thinks that the `foo` field has been removed and does not exist anymore.