### PR TITLE
Add ps dependency to plugin-dev Docker image for pm2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN  set -x \
        libfontconfig \
        libkrb5-dev \
        libzmq3-dev \
+       procps \
        wget \
   && tar xf /tmp/node-v$NODE_VERSION-linux-x64.tar.gz -C /opt/ \
   && rm /tmp/node-v$NODE_VERSION-linux-x64.tar.gz \


### PR DESCRIPTION
## What does this PR do ?

pm2 has an optional [dependency on `ps` tool](https://github.com/Unitech/pm2/blob/64c1ac82eb27774d1ac9612633fd10b03bb8b0c4/lib/TreeKill.js#L33).
When pm2 tries to restart a process, for instance if a watched file changes, we get an exception in the log trace (but still manages to restart the service):

```
{ Error: spawn ps ENOENT
    at _errnoException (util.js:992:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:190:19)
    at onErrorNT (internal/child_process.js:372:16)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickDomainCallback (internal/process/next_tick.js:218:9)
  code: 'ENOENT',
  errno: 'ENOENT',
  syscall: 'spawn ps',
  path: 'ps',
  spawnargs: [ '-o', 'pid', '--no-headers', '--ppid', 92 ] } 
```

### How should this be manually tested?

1. Build the image locally

```bash
docker build -t kuzzleio/plugin-dev:latest --target plugin-dev .
```
2. Test the plugin boiler plate does not throw errors anymore on file change detection.
