### PR TITLE
Add a maximum ttl to auth:login

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -149,6 +149,10 @@
     //   * gracePeriod:
     //      Duration in ms during which a renewed jwt is still
     //      considered valid
+    //   * maxTTL:
+    //      Maximum duration in milliseconds a token can be requested
+    //      to be valid.
+    //      If set to -1 (default), no maximum duration is set.
     //   * secret:
     //      String or buffer data containing either the secret for HMAC
     //      algorithms, or the PEM encoded private key for RSA and ECDSA.
@@ -158,6 +162,7 @@
       "algorithm": "HS256",
       "expiresIn": "1h",
       "gracePeriod": 1000,
+      "maxTTL": -1,
       "secret": null
     },
     // [default]

--- a/default.config.js
+++ b/default.config.js
@@ -80,6 +80,7 @@ module.exports = {
       algorithm: 'HS256',
       expiresIn: '1h',
       gracePeriod: 1000,
+      maxTTL: -1,
       secret: null
     },
     default: {

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -29,7 +29,6 @@ const
   formatProcessing = require('../core/auth/formatProcessing'),
   { IncomingMessage } = require('http'),
   {
-    BadRequestError,
     InternalError: KuzzleInternalError,
     PluginImplementationError,
     KuzzleError,

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -29,6 +29,7 @@ const
   formatProcessing = require('../core/auth/formatProcessing'),
   { IncomingMessage } = require('http'),
   {
+    BadRequestError,
     InternalError: KuzzleInternalError,
     PluginImplementationError,
     KuzzleError,

--- a/lib/api/core/models/repositories/tokenRepository.js
+++ b/lib/api/core/models/repositories/tokenRepository.js
@@ -29,6 +29,7 @@ const
   Token = require('../security/token'),
   Repository = require('./repository'),
   {
+    BadRequestError,
     InternalError: KuzzleInternalError,
     UnauthorizedError
   } = require('kuzzle-common-objects').errors;
@@ -71,12 +72,10 @@ class TokenRepository extends Repository {
   /**
    * @param {User} user
    * @param {Request} request
-   * @param {object} opts
+   * @param {object} options
    * @returns {*}
    */
-  generateToken(user, request, opts) {
-    const options = opts || {};
-
+  generateToken(user, request, options = {}) {
     if (!user || user._id === null) {
       return Bluebird.reject(new KuzzleInternalError('Unknown User : cannot generate token'));
     }
@@ -94,6 +93,12 @@ class TokenRepository extends Repository {
     }
 
     const expiresIn = parseTimespan(options.expiresIn);
+
+    if (this.kuzzle.config.security.jwt.maxTTL > -1
+      && expiresIn > this.kuzzle.config.security.jwt.maxTTL) {
+      return Bluebird.reject(new BadRequestError('expiresIn value exceeds maximum allowed value'));
+    }
+
     let encodedToken;
 
     try {


### PR DESCRIPTION
## What does this PR do ?

Add a configurable maximum TTL to the login.

internal ref: https://jira.kaliop.net/browse/KZL-1126
