### PR TITLE
Fix typo in vault Decrypt Secrets command

### DIFF
--- a/bin/commands/decryptSecrets.js
+++ b/bin/commands/decryptSecrets.js
@@ -70,9 +70,9 @@ function commandDecryptSecrets (encryptedSecretsFile, options) {
 
     fs.writeFileSync(outputFile, JSON.stringify(secrets, null, 2));
 
-    console.log(cout.ok(`[✔] Secrets successfully encrypted: ${outputFile}`));
+    console.log(cout.ok(`[✔] Secrets successfully decrypted: ${outputFile}`));
   } catch (error) {
-    console.error(cout.error(`[ℹ] Can not encrypt secret file: ${error.message}`));
+    console.error(cout.error(`[ℹ] Can not decrypt secret file: ${error.message}`));
     process.exit(1);
   }
 }


### PR DESCRIPTION
<!--
  This template is optional.
  It simply serves to provide a guide to allow a better review of pull requests.
-->

<!--
  IMPORTANT
  Don't forget to add the corresponding "changelog:xxx" label to your PR.
  This is part of our release process in order to generate the change log.
-->


## What does this PR do ?
<!-- Please fill this section -->
Fix two typo errors in the decrypt secret command : The message was "Successfully encrypted" while it should be "Successfully decrypted"

