### PR TITLE
Make the Kuzzle return a BadRequestException if it receives an invalid Content-Type header

### DIFF
--- a/lib/api/core/entrypoints/embedded/protocols/http.js
+++ b/lib/api/core/entrypoints/embedded/protocols/http.js
@@ -221,14 +221,15 @@ class HttpProtocol extends Protocol {
       raw: true,
       content: JSON.stringify(error)
     };
+    const kerr = error instanceof KuzzleError ? error : new BadRequestError(error);
 
-    debug('[%s] replyWithError: %a', connection.id, error);
+    debug('[%s] replyWithError: %a', connection.id, kerr);
 
     this.entryPoint.logAccess(
-      new Request(proxyRequest, {error, connectionId: connection.id}),
+      new Request(proxyRequest, {kerr, connectionId: connection.id}),
       proxyRequest);
 
-    response.writeHead(error.status, {
+    response.writeHead(kerr.status, {
       'Content-Type': 'application/json',
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': defaultAllowedMethods,
@@ -359,13 +360,18 @@ class HttpProtocol extends Protocol {
     if (request.headers['content-type'] &&
       !request.headers['content-type'].startsWith('application/json')
     ) {
-      return new HttpFormDataStream(
-        {
-          headers: request.headers,
-          limits: { fileSize: this.maxFormFileSize }
-        },
-        proxyRequest,
-        request);
+      try {
+        return new HttpFormDataStream(
+          {
+            headers: request.headers,
+            limits: { fileSize: this.maxFormFileSize }
+          },
+          proxyRequest,
+          request);
+      }
+      catch (error) {
+        throw new BadRequestError(error.message);
+      }
     }
 
     const maxRequestSize = this.maxRequestSize; // prevent context mismatch

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {


### PR DESCRIPTION

## What does this PR do ?
Make the Kuzzle returning a BadRequestException if it receives an invalid Content-Type header.

### How should this be manually tested?

* Try to send an HTTP request with a wrong `Content-Type` header such as:
```
$ curl -H 'Content-Type: application/LULZ' http://localhost:7512
```

Expected behavior:
* From Kuzzle 1.8.0 to 1.8.2, Kuzzle server will stop.
* With this patch, Kuzzle returns a BadRequestException


### Other changes

Add a specific unit test to prevents regression.

