### PR TITLE
Remove error stack traces leaks in production environment

### DIFF
--- a/lib/api/core/entrypoints/embedded/index.js
+++ b/lib/api/core/entrypoints/embedded/index.js
@@ -48,7 +48,8 @@ const
   WinstonElasticsearch = require('winston-elasticsearch'),
   WinstonSyslog = require('winston-syslog'),
   Manifest = require('./manifest'),
-  ClientConnection = require('./clientConnection');
+  ClientConnection = require('./clientConnection'),
+  removeErrorStack = require('./removeErrorStack');
 
 const bearerRegexp = /^Bearer /i;
 
@@ -442,7 +443,7 @@ class EmbeddedEntryPoint extends EntryPoint {
 
       const response = result.response.toJSON();
 
-      cb(this.constructor._removeErrorStack(response));
+      cb(removeErrorStack(response));
     });
   }
 
@@ -476,7 +477,7 @@ class EmbeddedEntryPoint extends EntryPoint {
       const protocol = this.protocols[protoKey];
 
       try {
-        protocol.broadcast(this.constructor._removeErrorStack(data));
+        protocol.broadcast(removeErrorStack(data));
       }
       catch (e) {
         this.kuzzle.emit('log:error', `[broadcast] protocol ${protoKey} failed: ${e.message}\n${e.stack}`);
@@ -488,7 +489,7 @@ class EmbeddedEntryPoint extends EntryPoint {
     request.setError(new ServiceUnavailableError('Kuzzle is shutting down'));
     this.logAccess(request);
 
-    cb(this.constructor._removeErrorStack(request.response.toJSON()));
+    cb(removeErrorStack(request.response.toJSON()));
   }
 
   _notify (data) {
@@ -501,22 +502,11 @@ class EmbeddedEntryPoint extends EntryPoint {
     }
 
     try {
-      this.protocols[client.protocol].notify(this.constructor._removeErrorStack(data));
+      this.protocols[client.protocol].notify(removeErrorStack(data));
     }
     catch (e) {
       this.kuzzle.emit('log:error', `[notify] protocol ${client.protocol} failed: ${e.message}`);
     }
-  }
-
-  static _removeErrorStack (data) {
-    if (process.env.NODE_ENV !== 'development'
-      && data
-      && data.content
-      && data.content.error) {
-      delete data.content.error.stack;
-    }
-
-    return data;
   }
 }
 

--- a/lib/api/core/entrypoints/embedded/protocols/http.js
+++ b/lib/api/core/entrypoints/embedded/protocols/http.js
@@ -38,7 +38,8 @@ const
       SizeLimitError
     }
   } = require('kuzzle-common-objects'),
-  zlib = require('zlib');
+  zlib = require('zlib'),
+  removeErrorStack = require('../removeErrorStack');
 
 const
   defaultAllowedMethods = 'GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS',
@@ -219,9 +220,12 @@ class HttpProtocol extends Protocol {
   _replyWithError(connection, proxyRequest, response, error) {
     const result = {
       raw: true,
-      content: JSON.stringify(error)
+      content: JSON.stringify(removeErrorStack(error))
     };
-    const kerr = error instanceof KuzzleError ? error : new BadRequestError(error);
+
+    const kerr = error instanceof KuzzleError
+      ? error
+      : new BadRequestError(error);
 
     debug('[%s] replyWithError: %a', connection.id, kerr);
 
@@ -250,7 +254,7 @@ class HttpProtocol extends Protocol {
    * @return {Buffer}
    */
   _getResponseData(request, proxyRequest) {
-    let data = request.response.toJSON();
+    let data = removeErrorStack(request.response.toJSON());
 
     if (proxyRequest.requestId !== data.requestId) {
       data.requestId = proxyRequest.requestId;

--- a/lib/api/core/entrypoints/embedded/protocols/mqtt.js
+++ b/lib/api/core/entrypoints/embedded/protocols/mqtt.js
@@ -24,13 +24,16 @@
 const
   Bluebird = require('bluebird'),
   debug = require('../../../../../kuzzleDebug')('kuzzle:entry-point:protocols:mqtt'),
-  Request = require('kuzzle-common-objects').Request,
   ClientConnection = require('../clientConnection'),
   Protocol = require('./protocol'),
   mosca = require('mosca'),
   {
-    BadRequestError,
-  } = require('kuzzle-common-objects').errors;
+    Request,
+    errors: {
+      BadRequestError
+    }
+  } = require('kuzzle-common-objects'),
+  removeErrorStack = require('../removeErrorStack');
 
 /**
  * @class MqttProtocol
@@ -162,7 +165,10 @@ class MqttProtocol extends Protocol {
     debug('[mqtt] onConnection: %s', client.id);
 
     try {
-      const connection = new ClientConnection(this.name, [client.connection.stream.remoteAddress], {});
+      const connection = new ClientConnection(
+        this.name,
+        [client.connection.stream.remoteAddress],
+        {});
       this.entryPoint.newConnection(connection);
 
       this.connections.set(client, connection);
@@ -216,7 +222,9 @@ class MqttProtocol extends Protocol {
           protocol: this.name
         });
 
-        return this.entryPoint.execute(request, response => this._respond(client, response));
+        return this.entryPoint.execute(
+          request,
+          response => this._respond(client, response));
       } catch (error) {
         return this._respondError(client, error);
       }
@@ -231,7 +239,12 @@ class MqttProtocol extends Protocol {
       });
     }
 
-    client.forward(this.config.responseTopic, JSON.stringify(response.content), {}, this.config.responseTopic, 0);
+    client.forward(
+      this.config.responseTopic,
+      JSON.stringify(response.content),
+      {},
+      this.config.responseTopic,
+      0);
   }
 
   _respondError (client, error) {
@@ -242,7 +255,7 @@ class MqttProtocol extends Protocol {
       error: new BadRequestError(error.message)
     });
 
-    this._respond(client, errReq.response.toJSON());
+    this._respond(client, removeErrorStack(errReq.response.toJSON()));
   }
 
 }

--- a/lib/api/core/entrypoints/embedded/protocols/protocol.js
+++ b/lib/api/core/entrypoints/embedded/protocols/protocol.js
@@ -79,7 +79,6 @@ class Protocol {
     // do nothing by default
   }
 
-
   /**
    * Extract and return the list of IP addresses from a request made to a
    * protocol.

--- a/lib/api/core/entrypoints/embedded/protocols/websocket.js
+++ b/lib/api/core/entrypoints/embedded/protocols/websocket.js
@@ -33,7 +33,8 @@ const
       BadRequestError,
       InternalError: KuzzleInternalError
     }
-  } = require('kuzzle-common-objects');
+  } = require('kuzzle-common-objects'),
+  removeErrorStack = require('../removeErrorStack');
 
 // Used by the broadcast method to build JSON payloads while limiting the
 // number of JSON serializations
@@ -221,8 +222,16 @@ class WebSocketProtocol extends Protocol {
        So... the error is forwarded to the client, hoping they know
        what to do with it.
        */
+      const errRequest = new Request(
+        {},
+        {
+          connection,
+          error: new BadRequestError(e.message)
+        });
+
       return this._send(
-        connection.id, JSON.stringify(new BadRequestError(e.message)));
+        connection.id,
+        JSON.stringify(removeErrorStack(errRequest.response.toJSON()).content));
     }
 
     try {

--- a/lib/api/core/entrypoints/embedded/removeErrorStack.js
+++ b/lib/api/core/entrypoints/embedded/removeErrorStack.js
@@ -1,0 +1,45 @@
+/*
+ * Kuzzle, a backend software, self-hostable and ready to use
+ * to power modern apps
+ *
+ * Copyright 2015-2018 Kuzzle
+ * mailto: support AT kuzzle.io
+ * website: http://kuzzle.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const util = require('util');
+
+/**
+ * utility method: must be invoked by all protocols to remove stack traces
+ * from payloads before sending them
+ * @param  {Error|Object} data - expected: plain error object or serialized
+ *                               request response
+ * @return {*} return the data minus the stack trace
+ */
+module.exports = data => {
+  if (process.env.NODE_ENV !== 'development') {
+    if (util.isError(data)) {
+      delete data.stack;
+    } else if (
+      data &&
+      data.content &&
+      data.content.error
+    ) {
+      delete data.content.error.stack;
+    }
+  }
+
+  return data;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {

--- a/test/api/core/entrypoints/embedded/protocols/http.test.js
+++ b/test/api/core/entrypoints/embedded/protocols/http.test.js
@@ -9,7 +9,6 @@ const
   {
     Request,
     errors: {
-      KuzzleError,
       SizeLimitError,
       BadRequestError
     }

--- a/test/api/core/entrypoints/embedded/protocols/websocket.test.js
+++ b/test/api/core/entrypoints/embedded/protocols/websocket.test.js
@@ -6,7 +6,8 @@ const
   sinon = require('sinon'),
   { IncomingMessage } = require('http'),
   EntryPoint = require(`${root}/lib/api/core/entrypoints/embedded`),
-  KuzzleMock = require(`${root}/test/mocks/kuzzle.mock`);
+  KuzzleMock = require(`${root}/test/mocks/kuzzle.mock`),
+  errorMatcher = require(`${root}/test/util/errorMatcher`);
 
 describe('/lib/api/core/entrypoints/embedded/protocols/websocket', () => {
   let
@@ -284,6 +285,29 @@ describe('/lib/api/core/entrypoints/embedded/protocols/websocket', () => {
     it('should do nothing if no data is given or if the connection is unknown', () => {
       protocol.onClientMessage({id: 'foo'});
       should(entrypoint.execute).have.callCount(0);
+    });
+
+    it('should handle invalid messages format', () => {
+      const nodeEnv = process.env.NODE_ENV;
+      // depending on NODE_ENV, errors can have a stacktrace or not
+      ['development', '', 'production'].forEach(env => {
+        process.env.NODE_ENV = env;
+
+        protocol.onClientMessage(connection, 'ohnoes');
+
+        const matcher = errorMatcher.fromMessage(
+          'BadRequestError',
+          'Unexpected token o in JSON at position 0');
+
+        should(entrypoint.execute).not.be.called();
+        should(protocol._send)
+          .calledOnce()
+          .calledWith(connection.id, sinon.match(matcher));
+
+        protocol._send.resetHistory();
+      });
+
+      process.env.NODE_ENV = nodeEnv;
     });
 
     it('should call entrypoint execute', () => {

--- a/test/util/errorMatcher.js
+++ b/test/util/errorMatcher.js
@@ -1,0 +1,77 @@
+const
+  stableStringify = require('json-stable-stringify'),
+  {
+    Request,
+    errors
+  } = require('kuzzle-common-objects');
+
+/**
+ * Returns a sinon matcher tailored-made to match error API responses depending
+ * on the current process.env.NODE_ENV environment variable.
+ */
+module.exports = {
+  fromMessage: (className, message) => {
+    let expectedError = new Request(
+      {},
+      {
+        error: new errors[className](message)
+      });
+
+    expectedError = expectedError.response.toJSON().content;
+
+    delete expectedError.requestId;
+
+    expectedError.error.stack = process.env.NODE_ENV === 'development'
+      ? 'stacktrace'
+      : undefined;
+
+    return function (value) {
+      let compared = typeof value === 'string' || Buffer.isBuffer(value)
+        ? JSON.parse(value)
+        : value;
+
+      let expectedStr;
+
+      if (compared.content) { // api response object
+        if (compared.content.error.stack) {
+          compared.content.error.stack = 'stacktrace';
+        }
+
+        compared = compared.content;
+        expectedStr = stableStringify(expectedError);
+      } else if (compared.error) { // stringified api response
+        if (compared.error.stack) {
+          compared.error.stack = 'stacktrace';
+        }
+
+        expectedStr = stableStringify(expectedError);
+      } else { // error object (HTTP)
+        if (compared.stack) {
+          compared.stack = 'stacktrace';
+        }
+        expectedStr = stableStringify(expectedError.error);
+      }
+
+      delete compared.requestId;
+
+      const
+        comparedStr = stableStringify(compared),
+        res = comparedStr === expectedStr;
+
+      // makes debugging easier, since sinon do not have the expectedError
+      // object
+      if (!res) {
+        // eslint-disable-next-line no-console
+        console.error(`Error: error objects do not match (env = ${process.env.NODE_ENV})
+Expected:
+${expectedStr}
+===
+Got:
+${comparedStr}
+`);
+      }
+
+      return res;
+    };
+  },
+};


### PR DESCRIPTION
# Description

Error stack traces are removed from the API responses, but there are some cases where they leak.

This is a minor security issue, resolved by removing stack traces directly at protocol levels, instead of doing it in the entrypoint class.

Caught leaks:
* HTTP:  as this protocol only marginally resort to the entrypoint class because of its specificities, response sent by it contained stack traces
* WebSocket & MQTT: parsing errors were generated by the protocol itself due to being caught before going to the entrypoint, and thus stack traces were leaked that way
* socket.io is unaffected

# How to test

* start a kuzzle instance with the `NODE_ENV` environment variable not set to `development`
* execute the following command: `curl 'http://localhost:7512/foobar'`

Without this fix, the response contains the error stack trace.