### PR TITLE
Do not check for a connection existence if none is set

### DIFF
--- a/doc/1/plugins/guides/events/generic-document-events/index.md
+++ b/doc/1/plugins/guides/events/generic-document-events/index.md
@@ -1,0 +1,305 @@
+---
+type: page
+code: false
+title: Generic Events
+order: 150
+---
+
+# Generic Document Events
+
+Some actions in the document controller trigger generic events. Generic events are used to apply modifications on the documents in the request or result of these actions.
+
+Generic "before" events (`generic:document:before*`) are triggered **before** the regular `document:before*` event.  
+Generic "after" events (`generic:document:after*`) are triggered **after** the regular `document:after*` event.
+
+All the pipes triggered by generic events have the same signature and should return the array of the updated documents from parameters.
+
+```javascript
+class PipePlugin {
+
+  init(customConfig, context) {
+    this.pipes = {
+      'generic:document:<event>': (documents, request) => {
+        // some random change on documents
+
+        return documents;
+      }
+    };
+  }
+
+}
+```
+
+---
+
+## generic:document:beforeWrite
+
+| Arguments | Type                                                           | Description                |
+| --------- | -------------------------------------------------------------- | -------------------------- |
+| documents | `Array` | Array of documents (containing a document's `_id` and `_source` fields) |
+| request | `Request` | [Kuzzle API Request](/core/1/plugins/plugin-context/constructors/request/#request) |
+
+`generic:document:beforeWrite` generic events allow to intercept the Request lifecycle before all the actions related to document writing.
+
+### Example
+
+```javascript
+class PipePlugin {
+
+  init(customConfig, context) {
+    this.pipes = {
+      'generic:document:beforeWrite': documents => {
+        // some random change
+        documents[0]._source.foo = 'bar';
+
+        return documents;
+      }
+    };
+  }
+
+}
+```
+
+### Associated controller actions:
+- [document:create](/core/1/api/controllers/document/create/)
+- [document:createOrReplace](/core/1/api/controllers/document/create-or-replace/)
+- [document:mCreate](/core/1/api/controllers/document/m-create/)
+- [document:mCreateOrReplace](/core/1/api/controllers/document/m-create-or-replace/)
+- [document:mReplace](/core/1/api/controllers/document/m-replace/)
+- [document:replace](/core/1/api/controllers/document/replace/)
+
+## generic:document:afterWrite
+
+| Arguments | Type                                                           | Description                |
+| --------- | -------------------------------------------------------------- | -------------------------- |
+| documents | `Array` | Array of documents (containing a document `_id` and `_source` fields) |
+| request | `Request` | [Kuzzle API Request](/core/1/plugins/plugin-context/constructors/request/#request) |
+
+`generic:document:afterWrite` generic events allow to intercept the request lifecycle after all the actions related to document writing.
+
+### Example
+
+```javascript
+class PipePlugin {
+
+  init(customConfig, context) {
+    this.pipes = {
+      'generic:document:afterWrite': documents => {
+        // some random change
+        documents[0]._source.foo = 'bar';
+
+        return documents;
+      }
+    };
+  }
+
+}
+```
+
+### Associated controller actions:
+- [document:create](/core/1/api/controllers/document/create/)
+- [document:createOrReplace](/core/1/api/controllers/document/create-or-replace/)
+- [document:mCreate](/core/1/api/controllers/document/m-create/)
+- [document:mCreateOrReplace](/core/1/api/controllers/document/m-create-or-replace/)
+- [document:mReplace](/core/1/api/controllers/document/m-replace/)
+- [document:replace](/core/1/api/controllers/document/replace/)
+
+
+## generic:document:beforeUpdate
+
+| Arguments | Type                                                           | Description                |
+| --------- | -------------------------------------------------------------- | -------------------------- |
+| documents | `Array` | Array of documents (containing a document `_id` and `_source` fields) |
+| request | `Request` | [Kuzzle API Request](/core/1/plugins/plugin-context/constructors/request/#request) |
+
+`generic:document:beforeUpdate` generic events allow to intercept the Request lifecycle before all the actions related to document updating.
+
+### Example
+
+```javascript
+class PipePlugin {
+
+  init(customConfig, context) {
+    this.pipes = {
+      'generic:document:beforeUpdate': documents => {
+        // some random change
+        documents[0]._source.foo = 'bar';
+
+        return documents;
+      }
+    };
+  }
+
+}
+```
+
+### Associated controller actions:
+- [document:update](/core/1/api/controllers/document/update/)
+- [document:mUpdate](/core/1/api/controllers/document/m-update/)
+
+
+## generic:document:afterUpdate
+
+| Arguments | Type                                                           | Description                |
+| --------- | -------------------------------------------------------------- | -------------------------- |
+| documents | `Array` | Array of documents (containing a document `_id` and `_source` fields) |
+| request | `Request` | [Kuzzle API Request](/core/1/plugins/plugin-context/constructors/request/#request) |
+
+`generic:document:afterUpdate` generic events allos to intercept the Request lifecycle after all the actions related to document updating.
+
+### Example
+
+```javascript
+class PipePlugin {
+
+  init(customConfig, context) {
+    this.pipes = {
+      'generic:document:afterUpdate': documents => {
+        // some random change
+        documents[0]._source.foo = 'bar';
+
+        return documents;
+      }
+    };
+  }
+
+}
+```
+
+### Associated controller actions:
+- [document:update](/core/1/api/controllers/document/update/)
+- [document:mUpdate](/core/1/api/controllers/document/m-update/)
+
+
+## generic:document:beforeDelete
+
+| Arguments | Type                                                           | Description                |
+| --------- | -------------------------------------------------------------- | -------------------------- |
+| documents | `Array` | Array of documents (containing document `_id`) |
+| request | `Request` | [Kuzzle API Request](/core/1/plugins/plugin-context/constructors/request/#request) |
+
+`generic:document:beforeDelete` generic events allow to intercept the Request lifecycle before all the actions related to document deleting.
+
+### Example
+
+```javascript
+class PipePlugin {
+
+  init(customConfig, context) {
+    this.pipes = {
+      'generic:document:beforeDelete': documents => {
+        // some random change
+        documents[0]._id += 'foo';
+
+        return documents;
+      }
+    };
+  }
+
+}
+```
+
+### Associated controller actions:
+- [document:delete](/core/1/api/controllers/document/delete/)
+- [document:mDelete](/core/1/api/controllers/document/m-delete/)
+
+
+## generic:document:afterDelete
+
+| Arguments | Type                                                           | Description                |
+| --------- | -------------------------------------------------------------- | -------------------------- |
+| documents | `Array` | Array of documents (containing document `_id`) |
+| request | `Request` | [Kuzzle API Request](/core/1/plugins/plugin-context/constructors/request/#request) |
+
+`generic:document:afterDelete` generic events allow to intercept the Request lifecycle after all the actions related to document deleting.
+
+### Example
+
+```javascript
+class PipePlugin {
+
+  init(customConfig, context) {
+    this.pipes = {
+      'generic:document:afterDelete': documents => {
+        // some random change
+        documents[0]._id += 'foo';
+
+        return documents;
+      }
+    };
+  }
+
+}
+```
+
+### Associated controller actions:
+- [document:delete](/core/1/api/controllers/document/delete/)
+- [document:mDelete](/core/1/api/controllers/document/m-delete/)
+- [document:deleteByQuery](/core/1/api/controllers/document/delete-by-query/)
+
+
+## generic:document:beforeGet
+
+| Arguments | Type                                                           | Description                |
+| --------- | -------------------------------------------------------------- | -------------------------- |
+| documents | `Array` | Array of documents (containing document `_id`) |
+| request | `Request` | [Kuzzle API Request](/core/1/plugins/plugin-context/constructors/request/#request) |
+
+`generic:document:beforeGet` generic events allow to intercept the Request liecycle before all the actions related to document getting.
+
+### Example
+
+```javascript
+class PipePlugin {
+
+  init(customConfig, context) {
+    this.pipes = {
+      'generic:document:beforeGet': documents => {
+        // some random change
+        documents[0]._id += 'foo';
+
+        return documents;
+      }
+    };
+  }
+
+}
+```
+
+### Associated controller actions:
+- [document:get](/core/1/api/controllers/document/get/)
+- [document:mGet](/core/1/api/controllers/document/m-get/)
+
+
+## generic:document:afterGet
+
+| Arguments | Type                                                           | Description                |
+| --------- | -------------------------------------------------------------- | -------------------------- |
+| documents | `Array` | Array of documents (containing document `_id`) |
+| request | `Request` | [Kuzzle API Request](/core/1/plugins/plugin-context/constructors/request/#request) |
+
+`generic:document:afterGet` generic events allow to intercept the Request lifecycle after all the actions related to document getting.
+
+### Example
+
+```javascript
+class PipePlugin {
+
+  init(customConfig, context) {
+    this.pipes = {
+      'generic:document:beforeGet': documents => {
+        // some random change
+        documents[0]._id += 'foo';
+
+        return documents;
+      }
+    };
+  }
+
+}
+```
+
+### Associated controller actions:
+- [document:get](/core/1/api/controllers/document/get/)
+- [document:mGet](/core/1/api/controllers/document/m-get/)
+- [document:search](/core/1/api/controllers/document/search/)

--- a/doc/doc.sh
+++ b/doc/doc.sh
@@ -20,8 +20,14 @@ fi
 
 case $1 in
   prepare)
-    echo "Clone documentation framework"
-    git clone --depth 10 --single-branch --branch master https://github.com/kuzzleio/documentation.git framework/
+    if [ -d "framework" ]
+    then
+      echo "Pulling latest framework version"
+      bash -c "cd framework && git reset --hard HEAD~ && git pull"
+    else
+      echo "Clone documentation framework"
+      git clone --depth 10 --single-branch --branch master https://github.com/kuzzleio/documentation.git framework/
+    fi
 
     echo "Link local doc for dead links checking"
     rm framework/src$DOC_PATH

--- a/doc/doc.sh
+++ b/doc/doc.sh
@@ -20,14 +20,10 @@ fi
 
 case $1 in
   prepare)
-    if [ -d "framework" ]
-    then
-      echo "Pulling latest framework version"
-      bash -c "cd framework && git reset --hard HEAD~ && git pull"
-    else
-      echo "Clone documentation framework"
-      git clone --depth 10 --single-branch --branch master https://github.com/kuzzleio/documentation.git framework/
-    fi
+    rm -rf framework
+
+    echo "Clone documentation framework"
+    git clone --depth 10 --single-branch --branch master https://github.com/kuzzleio/documentation.git framework/
 
     echo "Link local doc for dead links checking"
     rm framework/src$DOC_PATH

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -231,6 +231,7 @@ class FunnelController {
     // if the connection is closed there is no need to execute the request
     // => discarding it
     if (!this.kuzzle.router.isConnectionAlive(request.context)) {
+      callback(new BadRequestError('Client connection dropped'));
       return 0;
     }
 

--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -85,7 +85,7 @@ class RouterController {
     // not have one)
     return requestContext.connection.id === null
       || requestContext.connection.misc.proxy === true
-      || this.connections.has(requestContext.connection.id) !== undefined;
+      || this.connections.has(requestContext.connection.id);
   }
 
   /**

--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -23,7 +23,7 @@
 
 const
   HttpRouter = require('../core/httpRouter'),
-  PluginImplementationError = require('kuzzle-common-objects').errors.PluginImplementationError,
+  { errors: { PluginImplementationError } } = require('kuzzle-common-objects'),
   generateSwagger = require('../core/swagger'),
   jsonToYaml = require('json2yaml');
 

--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -35,7 +35,7 @@ const
 class RouterController {
   constructor(kuzzle) {
     this.kuzzle = kuzzle;
-    this.connections = {};
+    this.connections = new Map();
     this.http = new HttpRouter(kuzzle);
   }
 
@@ -46,12 +46,11 @@ class RouterController {
    */
   newConnection(requestContext) {
     if (!requestContext.connection.id || !requestContext.connection.protocol) {
-      this.kuzzle.log.error(new PluginImplementationError('Rejected new connection - invalid arguments:' + JSON.stringify(requestContext)));
+      this.kuzzle.log.error(new PluginImplementationError(`Rejected new connection - invalid arguments: ${JSON.stringify(requestContext)}`));
     }
     else {
-      this.connections[requestContext.connection.id] = requestContext;
-
-      this.kuzzle.statistics.newConnection(this.connections[requestContext.connection.id]);
+      this.connections.set(requestContext.connection.id, requestContext);
+      this.kuzzle.statistics.newConnection(requestContext);
     }
   }
 
@@ -62,14 +61,14 @@ class RouterController {
    */
   removeConnection(requestContext) {
     if (!requestContext.connection.id || !requestContext.connection.protocol) {
-      return this.kuzzle.log.error(new PluginImplementationError('Unable to remove connection - invalid arguments:' + JSON.stringify(requestContext.context)));
+      return this.kuzzle.log.error(new PluginImplementationError(`Unable to remove connection - invalid arguments: ${JSON.stringify(requestContext.context)}`));
     }
 
-    if (!this.connections[requestContext.connection.id]) {
-      return this.kuzzle.log.error(new PluginImplementationError('Unable to remove connection - unknown connection identifier:' + JSON.stringify(requestContext.connection.id)));
+    if (!this.connections.has(requestContext.connection.id)) {
+      return this.kuzzle.log.error(new PluginImplementationError(`Unable to remove connection - unknown connection identifier: ${JSON.stringify(requestContext.connection.id)}`));
     }
 
-    delete this.connections[requestContext.connection.id];
+    this.connections.delete(requestContext.connection.id);
 
     this.kuzzle.hotelClerk.removeCustomerFromAllRooms(requestContext);
 
@@ -85,7 +84,8 @@ class RouterController {
     // Check only defined connection identifiers (some protocols might
     // not have one)
     return requestContext.connection.id === null
-      || this.connections[requestContext.connection.id] !== undefined;
+      || requestContext.connection.misc.proxy === true
+      || this.connections.has(requestContext.connection.id) !== undefined;
   }
 
   /**

--- a/lib/api/controllers/routerController.js
+++ b/lib/api/controllers/routerController.js
@@ -82,12 +82,10 @@ class RouterController {
    * @param  {RequestContext} requestContext
    */
   isConnectionAlive(requestContext) {
-    // We only care about connections that stay open
-    if (requestContext.connection.protocol === 'http') {
-      return true;
-    }
-
-    return this.connections[requestContext.connection.id] !== undefined;
+    // Check only defined connection identifiers (some protocols might
+    // not have one)
+    return requestContext.connection.id === null
+      || this.connections[requestContext.connection.id] !== undefined;
   }
 
   /**

--- a/lib/api/core/entrypoints/proxy/index.js
+++ b/lib/api/core/entrypoints/proxy/index.js
@@ -87,6 +87,9 @@ class ProxyEntryPoint extends Entrypoint {
    */
   onRequest (data) {
     const request = new Request(data.data, data.options);
+
+    request.context.connection.misc.proxy = true;
+
     debug('[%s] received request from proxy: %a', request.id, data);
 
     this.kuzzle.funnel.execute(request, (error, result) => {

--- a/lib/api/core/entrypoints/proxy/index.js
+++ b/lib/api/core/entrypoints/proxy/index.js
@@ -108,7 +108,10 @@ class ProxyEntryPoint extends Entrypoint {
         }
       }
 
-      debug('[%s] sending request response to proxy: %a', response.requestId, response);
+      debug(
+        '[%s] sending request response to proxy: %O',
+        response.requestId,
+        response);
 
       this.proxy.send('response', response);
     });
@@ -140,6 +143,8 @@ class ProxyEntryPoint extends Entrypoint {
    */
   onHttpRequest (message) {
     debug('received HTTP request from proxy: %a', message);
+
+    message.proxy = true;
 
     this.kuzzle.router.http.route(message, result => {
       const response = result.response.toJSON();

--- a/lib/api/core/httpRouter/index.js
+++ b/lib/api/core/httpRouter/index.js
@@ -22,14 +22,17 @@
 'use strict';
 
 const
+  debug = require('../../../kuzzleDebug')('kuzzle:http:router'),
   RoutePart = require('./routePart'),
-  Request = require('kuzzle-common-objects').Request,
   {
-    KuzzleError,
-    InternalError: KuzzleInternalError,
-    BadRequestError,
-    NotFoundError
-  } = require('kuzzle-common-objects').errors;
+    Request,
+    errors: {
+      KuzzleError,
+      InternalError: KuzzleInternalError,
+      BadRequestError,
+      NotFoundError
+    }
+  } = require('kuzzle-common-objects');
 
 const
   LeadingSlashRegex = /\/+$/,
@@ -147,10 +150,16 @@ class Router {
   route(httpRequest, cb) {
     let request;
 
+    debug('Routing request: %a', httpRequest);
+
     if (!this.routes[httpRequest.method]) {
       // the http protocol uses the requestId as connection id
-      const requestContext = this.kuzzle.router.connections[httpRequest.requestId];
-      request = new Request({requestId: httpRequest.requestId}, requestContext && requestContext.toJSON());
+      const requestContext = this.kuzzle.router.connections.get(
+        httpRequest.requestId);
+
+      request = new Request(
+        { requestId: httpRequest.requestId },
+        requestContext && requestContext.toJSON());
       request.response.setHeaders(this.defaultHeaders);
 
       if (httpRequest.method.toUpperCase() === 'OPTIONS') {
@@ -167,14 +176,19 @@ class Router {
         return;
       }
 
-      replyWithError(cb, request, new BadRequestError(`Unrecognized HTTP method ${httpRequest.method}`));
+      replyWithError(
+        cb,
+        request,
+        new BadRequestError(`Unrecognized HTTP method ${httpRequest.method}`));
+
       return;
     }
 
     httpRequest.url = httpRequest.url.replace(LeadingSlashRegex, '');
 
     try {
-      const routeHandler = this.routes[httpRequest.method].getHandler(httpRequest);
+      const routeHandler = this.routes[httpRequest.method].getHandler(
+        httpRequest);
 
       request = routeHandler.getRequest();
       request.response.setHeaders(this.defaultHeaders);

--- a/lib/api/core/httpRouter/routeHandler.js
+++ b/lib/api/core/httpRouter/routeHandler.js
@@ -102,7 +102,8 @@ class RouteHandler {
         protocol: 'http',
         url: this.url,
         headers: this.httpRequest.headers,
-        ips: this.httpRequest.ips
+        ips: this.httpRequest.ips,
+        proxy: this.httpRequest.proxy
       }
     });
 

--- a/test/api/controllers/funnelController/execute.test.js
+++ b/test/api/controllers/funnelController/execute.test.js
@@ -4,8 +4,13 @@ const
   should = require('should'),
   sinon = require('sinon'),
   Bluebird = require('bluebird'),
-  Request = require('kuzzle-common-objects').Request,
-  ServiceUnavailableError = require('kuzzle-common-objects').errors.ServiceUnavailableError,
+  {
+    Request,
+    errors: {
+      BadRequestError,
+      ServiceUnavailableError
+    }
+  } = require('kuzzle-common-objects'),
   KuzzleMock = require('../../../mocks/kuzzle.mock'),
   rewire = require('rewire'),
   FunnelController = rewire('../../../../lib/api/controllers/funnelController');
@@ -52,7 +57,8 @@ describe('funnelController.execute', () => {
       funnel.execute(request, (err, res) => {
         try {
           should(err).be.null();
-          // 102 is the default status of a request, it should be 200 when coming out from the execute
+          // 102 is the default status of a request, it should be 200 when
+          // coming out from the execute
           should(res.status).be.exactly(102);
           should(res).be.instanceOf(Request);
           should(funnel.processRequest).be.calledOnce();
@@ -80,7 +86,7 @@ describe('funnelController.execute', () => {
   });
 
   describe('#core:overload hook', () => {
-    it('should fire the hook the first time Kuzzle is in overloaded state', /** @this {Mocha} */ () => {
+    it('should fire the hook the first time Kuzzle is in overloaded state', () => {
       funnel.overloaded = true;
       funnel.requestsCacheQueue = Array(kuzzle.config.limits.requestsBufferWarningThreshold + 1);
 
@@ -201,7 +207,10 @@ describe('funnelController.execute', () => {
 
       should(funnel.execute(request, cb)).be.eql(0);
       should(funnel.checkRights).not.be.called();
-      should(cb).not.be.called();
+      should(cb)
+        .calledOnce()
+        .calledWith(sinon.match.instanceOf(BadRequestError));
+      should(cb.firstCall.args[0].message).eql('Client connection dropped');
     });
   });
 

--- a/test/api/controllers/routerController/routerController.test.js
+++ b/test/api/controllers/routerController/routerController.test.js
@@ -116,11 +116,11 @@ describe('Test: routerController', () => {
       should(routerController.isConnectionAlive(requestContext)).be.false();
     });
 
-    it('should always return true on HTTP connections', () => {
+    it('should always return true for connections without an id', () => {
       const context = new RequestContext({
         connection: {
-          id: connectionId,
-          protocol: 'http'
+          id: null,
+          protocol: 'foobar'
         }
       });
       should(routerController.isConnectionAlive(context)).be.true();

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -260,7 +260,7 @@ class KuzzleMock extends Kuzzle {
     this.rootPath = '/kuzzle';
 
     this.router = {
-      connections: {},
+      connections: new Map(),
       execute: this.sandbox.stub().resolves(foo),
       isConnectionAlive: this.sandbox.stub().returns(true),
       init: this.sandbox.spy(),


### PR DESCRIPTION
# Description

The router "controller", amongst other tasks, manages connections, to allow skipping requests from dead connections.

This PR fixes 2 minor problems:
* some protocols cannot maintain a connection identifier (e.g. UDP, MODBUS, ...): the router now only checks the connection identifier if one is set
* the check always returns `true` for the HTTP protocol, because requests from Kuzzle Proxy cannot declare new connections beforehand. But this makes Kuzzle execute all HTTP requests, even useless ones from dropped HTTP connections. So this has been changed so that request coming from the proxy now have a special flag in the request.connection.misc object, and the router controller now relies on that flag to let pass proxy requests

It also fixes a leak occuring when requests are dropped by the funnel controller because its associated connection has been killed: the funnel now answers to protocols (embedded or not) with an appropriate error when that happens, allowing protocols to clean up resources if necessary.

# Other change

* Connections managed by the router controller are now stored in a map, which is a lot more suited for storing highly volatile keys (better performances)
* The documentation `doc.sh prepare` script fails if the framework repository is already there. This is fixed by force-pulling the repository instead of trying to clone it if it already exists.