### PR TITLE
Provide a copy of Kuzzle's configuration to plugins

### DIFF
--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -161,12 +161,17 @@ class PluginsManager {
         } = this.config.common;
 
 
-      debug('[%s] starting plugin in "%s" mode', plugin.manifest.name, plugin.config.privileged ? 'privileged' : 'standard');
+      debug(
+        '[%s] starting plugin in "%s" mode',
+        plugin.manifest.name,
+        plugin.config.privileged ? 'privileged' : 'standard');
 
-      return Bluebird.resolve(plugin.object.init(
-        plugin.config,
-        plugin.config.privileged ? new PrivilegedPluginContext(this.kuzzle, plugin.manifest.name) : new PluginContext(this.kuzzle, plugin.manifest.name)
-      ))
+      return Bluebird
+        .resolve(plugin.object.init(
+          plugin.config,
+          plugin.config.privileged
+            ? new PrivilegedPluginContext(this.kuzzle, plugin.manifest.name)
+            : new PluginContext(this.kuzzle, plugin.manifest.name)))
         .timeout(initTimeout)
         .then(initStatus => {
           if (initStatus === false) {
@@ -875,7 +880,9 @@ class PluginsManager {
         plugin = {
           manifest,
           object: null,
-          config: this.config[manifest.name] || {}
+          config: this.config[manifest.name]
+            ? JSON.parse(JSON.stringify(this.config[manifest.name]))
+            : {}
         };
 
       // load plugin object

--- a/test/api/core/pluginsManager/init.test.js
+++ b/test/api/core/pluginsManager/init.test.js
@@ -88,8 +88,9 @@ describe('PluginsManager', () => {
           return true;
         }
       });
-      should(() => pluginsManager.init())
-        .throw(PluginImplementationError, {message:  /\[\/kuzzle\/plugins\/enabled\/kuzzle-plugin-test\] No package\.json file found\./});
+      should(() => pluginsManager.init()).throw(
+        PluginImplementationError,
+        {message:  /\[\/kuzzle\/plugins\/enabled\/kuzzle-plugin-test\] No package\.json file found\./});
       should(pluginsManager.plugins).be.empty();
     });
 
@@ -103,39 +104,45 @@ describe('PluginsManager', () => {
       });
       mockrequire('/kuzzle/plugins/enabled/kuzzle-plugin-test', pluginStub);
       mockrequire('/kuzzle/plugins/enabled/another-plugin', pluginStub);
-      mockrequire('/kuzzle/plugins/enabled/kuzzle-plugin-test/manifest.json', { name: instanceName, kuzzleVersion: '^1.x'});
-      mockrequire('/kuzzle/plugins/enabled/another-plugin/manifest.json', { name: instanceName, kuzzleVersion: '^1.x'});
+      mockrequire(
+        '/kuzzle/plugins/enabled/kuzzle-plugin-test/manifest.json',
+        { name: instanceName, kuzzleVersion: '^1.x'});
+      mockrequire(
+        '/kuzzle/plugins/enabled/another-plugin/manifest.json',
+        { name: instanceName, kuzzleVersion: '^1.x'});
 
       PluginsManager = mockrequire.reRequire('../../../../lib/api/core/plugins/pluginsManager');
 
-      should(() => pluginsManager.init())
-        .throw(PluginImplementationError, {message: /A plugin named kuzzle-plugin-test already exists/});
+      should(() => pluginsManager.init()).throw(
+        PluginImplementationError,
+        {message: /A plugin named kuzzle-plugin-test already exists/});
     });
 
     it('should throw if a plugin does not expose a "init" method', () => {
       const instanceName = 'kuzzle-plugin-test';
       pluginsManager = new PluginsManager(kuzzle);
       fsStub.readdirSync.returns(['kuzzle-plugin-test']);
-      fsStub.statSync.returns({
-        isDirectory: () => true
-      });
+      fsStub.statSync.returns({ isDirectory: () => true });
       mockrequire('/kuzzle/plugins/enabled/kuzzle-plugin-test', function () {
         return {};
       });
-      mockrequire('/kuzzle/plugins/enabled/kuzzle-plugin-test/manifest.json', { name: instanceName, kuzzleVersion: '^1.x'});
+      mockrequire(
+        '/kuzzle/plugins/enabled/kuzzle-plugin-test/manifest.json',
+        { name: instanceName, kuzzleVersion: '^1.x'});
       PluginsManager = mockrequire.reRequire('../../../../lib/api/core/plugins/pluginsManager');
 
-      should(() => pluginsManager.init())
-        .throw(PluginImplementationError, {message: /\[kuzzle-plugin-test\] No "init" method found\./});
+      should(() => pluginsManager.init()).throw(
+        PluginImplementationError,
+        {message: /\[kuzzle-plugin-test\] No "init" method found\./});
     });
 
     it('should return a well-formed plugin instance if a valid requirable plugin is enabled', () => {
       const instanceName = 'kuzzle-plugin-test';
+
       pluginsManager = new PluginsManager(kuzzle);
       fsStub.readdirSync.returns(['kuzzle-plugin-test']);
-      fsStub.statSync.returns({
-        isDirectory: () => true
-      });
+      fsStub.statSync.returns({ isDirectory: () => true });
+
       mockrequire('/kuzzle/plugins/enabled/kuzzle-plugin-test', pluginStub);
       mockrequire('/kuzzle/plugins/enabled/kuzzle-plugin-test/manifest.json', {
         name: 'kuzzle-plugin-test',
@@ -144,8 +151,9 @@ describe('PluginsManager', () => {
       PluginsManager = mockrequire.reRequire('../../../../lib/api/core/plugins/pluginsManager');
 
       should(() => pluginsManager.init()).not.throw();
-      should(pluginsManager.plugins[instanceName]).be.Object();
-      should(pluginsManager.plugins[instanceName]).have.keys('object', 'config', 'manifest');
+      should(pluginsManager.plugins[instanceName])
+        .be.an.Object()
+        .and.have.keys('object', 'config', 'manifest');
       should(pluginsManager.plugins[instanceName].config).be.eql({});
       should(pluginsManager.plugins[instanceName].manifest)
         .instanceOf(Manifest)
@@ -156,6 +164,29 @@ describe('PluginsManager', () => {
           path: '/kuzzle/plugins/enabled/kuzzle-plugin-test'
         });
       should(pluginsManager.plugins[instanceName].object).be.ok();
+    });
+
+    it('should provide a copy of kuzzle\'s configuration to prevent plugins to alter it', () => {
+      const name = 'kuzzle-plugin-test';
+
+      pluginsManager = new PluginsManager(kuzzle);
+      fsStub.readdirSync.returns([name]);
+      fsStub.statSync.returns({ isDirectory: () => true });
+
+      mockrequire(`/kuzzle/plugins/enabled/${name}`, pluginStub);
+      mockrequire(`/kuzzle/plugins/enabled/${name}/manifest.json`, {
+        name,
+        kuzzleVersion: '^1.x'
+      });
+      PluginsManager = mockrequire.reRequire('../../../../lib/api/core/plugins/pluginsManager');
+
+      const config = { foo: 'bar' };
+      kuzzle.config.plugins[name] = config;
+
+      should(() => pluginsManager.init()).not.throw();
+      should(pluginsManager.plugins[name].config)
+        .match(config)
+        .and.not.exactly(config);
     });
 
     it('should reject plugin initialization if a plugin requires another version of kuzzle core', () => {


### PR DESCRIPTION
# Description

The configuration object provided to plugins' init functions is the one maintained by Kuzzle. Plugins modifying this object will also modify Kuzzle's object, altering the output of the `server:getConfig` API route result.

This PR makes sure that only a copy of the configuration file is provided to plugins.
