### PR TITLE
Remove superfluous protocols related directories

### DIFF
--- a/plugins/protocols/available/.gitignore
+++ b/plugins/protocols/available/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/plugins/protocols/enabled/.gitignore
+++ b/plugins/protocols/enabled/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore


### PR DESCRIPTION
# Description

Remove the `plugins/protocols` directory, as it is superfluous and misleading (protocols are to be installed in the `protocols/` directory)