### PR TITLE
Allow "type" mapping property for nested objects

### DIFF
--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -35,7 +35,8 @@ const
 
 const scrollCachePrefix = '_docscroll_';
 
-const mappingProperties = ['properties', '_meta', 'dynamic', 'type'];
+const rootMappingProperties = ['properties', '_meta', 'dynamic'];
+const childMappingProperties = ['type'];
 
 /**
  * @property {Kuzzle} kuzzle
@@ -1598,7 +1599,11 @@ class ElasticSearch extends Service {
   }
 
   _checkMapping (mapping, path = [], check = true) {
-    const properties = Object.keys(mapping);
+    const
+      properties = Object.keys(mapping),
+      mappingProperties = path.length === 0
+        ? rootMappingProperties
+        : [...rootMappingProperties, ...childMappingProperties];
 
     for (const property of properties) {
       if (check && !mappingProperties.includes(property)) {

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -35,7 +35,7 @@ const
 
 const scrollCachePrefix = '_docscroll_';
 
-const mappingProperties = ['properties', '_meta', 'dynamic'];
+const mappingProperties = ['properties', '_meta', 'dynamic', 'type'];
 
 /**
  * @property {Kuzzle} kuzzle

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -2827,13 +2827,22 @@ describe('Test: ElasticSearch service', () => {
 
   describe('#_checkMapping', () => {
     it('should throw when a property is incorrect', () => {
-      const mapping = {
-        properties: {},
-        dinamic: 'false'
-      };
+      const
+        mapping2 = {
+          type: 'nested',
+          properties: {}
+        },
+        mapping = {
+          properties: {},
+          dinamic: 'false'
+        };
+
 
       should(() => elasticsearch._checkMapping(mapping))
         .throw({ message: 'Incorrect mapping property "mapping.dinamic". Did you mean "dynamic" ?' });
+
+      should(() => elasticsearch._checkMapping(mapping2))
+        .throw({ message: 'Incorrect mapping property "mapping.type".' });
     });
 
     it('should throw when a nested property is incorrect', () => {

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -2861,6 +2861,7 @@ describe('Test: ElasticSearch service', () => {
           name: { type: 'keyword' },
           car: {
             dynamic: 'false',
+            type: 'nested',
             properties: {
               brand: { type: 'keyword' }
             }


### PR DESCRIPTION
## What does this PR do ?

Allow to specify the `type` when declaring nested objects in mapping.  
This allow to have nested object with `type: "nested"` instead of the default `type: "object"`: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/nested.html

This PR allow users to define this kind of mappings:
```
{
  properties: {
    name: { type: 'keyword' },
    car: {
      dynamic: 'false',
      type: 'nested', // specify nested object type
      properties: {
        brand: { type: 'keyword' }
      }
    }
  }
}

```