### PR TITLE
Fix wrong return value from collection truncate

### DIFF
--- a/lib/api/controllers/collectionController.js
+++ b/lib/api/controllers/collectionController.js
@@ -252,7 +252,8 @@ class CollectionController extends BaseController {
   truncate(request) {
     assertHasIndexAndCollection(request);
 
-    return this.engine.truncateCollection(request);
+    return this.engine.truncateCollection(request)
+      .then(() => ({ acknowledged: true }));
   }
 
   /**
@@ -260,20 +261,20 @@ class CollectionController extends BaseController {
    * @returns {Promise<Object>}
    */
   list(request) {
-    const
-      type = request.input.args.type ? request.input.args.type : 'all';
+    const type = request.input.args.type || 'all';
 
     assertHasIndex(request);
 
-    if (['all', 'stored', 'realtime'].indexOf(type) === -1) {
+    if (! ['all', 'stored', 'realtime'].includes(type)) {
       throw new BadRequestError(`must specify a valid type argument; Expected: "all", "stored" or "realtime"; Received: "${type}".`);
     }
 
     let collections = [];
 
     if (type === 'realtime' || type === 'all') {
-      collections = this.kuzzle.hotelClerk.getRealtimeCollections(request.input.resource.index)
-        .map(name => ({name, type: 'realtime'}));
+      collections =
+        this.kuzzle.hotelClerk.getRealtimeCollections(request.input.resource.index)
+          .map(name => ({ name, type: 'realtime' }));
     }
 
     return Bluebird.resolve()

--- a/test/api/controllers/collectionController.test.js
+++ b/test/api/controllers/collectionController.test.js
@@ -90,7 +90,7 @@ describe('Test: collection controller', () => {
           should(truncate).be.calledWith(request);
 
           should(response).be.instanceof(Object);
-          should(response).match(foo);
+          should(response).match({ acknowledged: true });
         });
     });
   });


### PR DESCRIPTION
## What does this PR do ?

Currently `collection:truncate` returns the list of deleted document IDs.  
This PR change the return value to match the documentation with `{ acknowledged: true }`
