### PR TITLE
Document HotelClerk's core events

### DIFF
--- a/doc/1/plugins/guides/events/core-hotelclerk-addSubscription/index.md
+++ b/doc/1/plugins/guides/events/core-hotelclerk-addSubscription/index.md
@@ -13,7 +13,7 @@ title: core:hotelClerk:addSubscription
 
 Triggered whenever a [subscription](/core/1/api/controllers/realtime/subscribe) is added.
 
-## diff
+## subscription
 
 The provided `diff` object has the following properties:
 

--- a/doc/1/plugins/guides/events/core-hotelclerk-addSubscription/index.md
+++ b/doc/1/plugins/guides/events/core-hotelclerk-addSubscription/index.md
@@ -15,7 +15,7 @@ Triggered whenever a [subscription](/core/1/api/controllers/realtime/subscribe) 
 
 ## subscription
 
-The provided `diff` object has the following properties:
+The provided `subscription` object has the following properties:
 
 | Properties     | Type                 | Description                                                                                                       |
 | -------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------- |

--- a/doc/1/plugins/guides/events/core-hotelclerk-addSubscription/index.md
+++ b/doc/1/plugins/guides/events/core-hotelclerk-addSubscription/index.md
@@ -19,7 +19,7 @@ The provided `diff` object has the following properties:
 
 | Properties     | Type                 | Description                                                                                                       |
 | -------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `roomId`       | <pre>integer</pre>   | The new room unique identifier                                                                                    |
+| `roomId`       | <pre>integer</pre>   | New room unique identifier                                                                                    |
 | `connectionId` | <pre>integer</pre>   | The [ClientConnection](/core/1/protocols/api/context/clientconnection) unique identifier                          |
 | `index`        | <pre>string</pre>    | Index                                                                                                             |
 | `collection`   | <pre>string</pre>    | Collection                                                                                                        |

--- a/doc/1/plugins/guides/events/core-hotelclerk-addSubscription/index.md
+++ b/doc/1/plugins/guides/events/core-hotelclerk-addSubscription/index.md
@@ -20,7 +20,7 @@ The provided `diff` object has the following properties:
 | Properties     | Type                 | Description                                                                                                       |
 | -------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `roomId`       | <pre>integer</pre>   | New room unique identifier                                                                                    |
-| `connectionId` | <pre>integer</pre>   | The [ClientConnection](/core/1/protocols/api/context/clientconnection) unique identifier                          |
+| `connectionId` | <pre>integer</pre>   | [ClientConnection](/core/1/protocols/api/context/clientconnection) unique identifier                          |
 | `index`        | <pre>string</pre>    | Index                                                                                                             |
 | `collection`   | <pre>string</pre>    | Collection                                                                                                        |
 | `filters`      | <pre>object</pre>    | [Filters](https://docs.kuzzle.io/core/1/guides/cookbooks/realtime-api/terms/) to match with                       |

--- a/doc/1/plugins/guides/events/core-hotelclerk-addSubscription/index.md
+++ b/doc/1/plugins/guides/events/core-hotelclerk-addSubscription/index.md
@@ -24,6 +24,5 @@ The provided `subscription` object has the following properties:
 | `index`        | <pre>string</pre>    | Index                                                                                                             |
 | `collection`   | <pre>string</pre>    | Collection                                                                                                        |
 | `filters`      | <pre>object</pre>    | Filters in [Koncorde's normalized format](https://www.npmjs.com/package/koncorde#filter-unique-identifier)  |
-| `changed`      | <pre>boolean</pre>   | Indicates if a channel was associated to the current `roomId` or if the room was associated to the `connectionId` |
 
 ---

--- a/doc/1/plugins/guides/events/core-hotelclerk-addSubscription/index.md
+++ b/doc/1/plugins/guides/events/core-hotelclerk-addSubscription/index.md
@@ -9,7 +9,7 @@ title: core:hotelClerk:addSubscription
 
 | Arguments  | Type              | Description                           |
 | ---------- | ----------------- | ------------------------------------- |
-| `diff`     | <pre>object</pre> | Contains information about subscription |
+| `subscription`     | <pre>object</pre> | Contains information about the added subscription |
 
 Triggered whenever a [subscription](/core/1/api/controllers/realtime/subscribe) is added.
 

--- a/doc/1/plugins/guides/events/core-hotelclerk-addSubscription/index.md
+++ b/doc/1/plugins/guides/events/core-hotelclerk-addSubscription/index.md
@@ -9,7 +9,7 @@ title: core:hotelClerk:addSubscription
 
 | Arguments  | Type              | Description                           |
 | ---------- | ----------------- | ------------------------------------- |
-| `diff`     | <pre>object</pre> | Contains information for subscription |
+| `diff`     | <pre>object</pre> | Contains information about subscription |
 
 Triggered whenever a [subscription](/core/1/api/controllers/realtime/subscribe) is added.
 

--- a/doc/1/plugins/guides/events/core-hotelclerk-addSubscription/index.md
+++ b/doc/1/plugins/guides/events/core-hotelclerk-addSubscription/index.md
@@ -23,7 +23,7 @@ The provided `subscription` object has the following properties:
 | `connectionId` | <pre>integer</pre>   | [ClientConnection](/core/1/protocols/api/context/clientconnection) unique identifier                          |
 | `index`        | <pre>string</pre>    | Index                                                                                                             |
 | `collection`   | <pre>string</pre>    | Collection                                                                                                        |
-| `filters`      | <pre>object</pre>    | [Filters](https://docs.kuzzle.io/core/1/guides/cookbooks/realtime-api/terms/) to match with                       |
+| `filters`      | <pre>object</pre>    | Filters in [Koncorde's normalized format](https://www.npmjs.com/package/koncorde#filter-unique-identifier)  |
 | `changed`      | <pre>boolean</pre>   | Indicates if a channel was associated to the current `roomId` or if the room was associated to the `connectionId` |
 
 ---

--- a/doc/1/plugins/guides/events/core-hotelclerk-addSubscription/index.md
+++ b/doc/1/plugins/guides/events/core-hotelclerk-addSubscription/index.md
@@ -1,0 +1,29 @@
+---
+code: true
+type: page
+title: core:hotelClerk:addSubscription
+---
+
+# core:hotelClerk:addSubscription
+
+
+| Arguments  | Type              | Description                           |
+| ---------- | ----------------- | ------------------------------------- |
+| `diff`     | <pre>object</pre> | Contains information for subscription |
+
+Triggered whenever a [subscription](/core/1/api/controllers/realtime/subscribe) is added.
+
+## diff
+
+The provided `diff` object has the following properties:
+
+| Properties     | Type                 | Description                                                                                                       |
+| -------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `roomId`       | <pre>integer</pre>   | The new room unique identifier                                                                                    |
+| `connectionId` | <pre>integer</pre>   | The [ClientConnection](/core/1/protocols/api/context/clientconnection) unique identifier                          |
+| `index`        | <pre>string</pre>    | Index                                                                                                             |
+| `collection`   | <pre>string</pre>    | Collection                                                                                                        |
+| `filters`      | <pre>object</pre>    | [Filters](https://docs.kuzzle.io/core/1/guides/cookbooks/realtime-api/terms/) to match with                       |
+| `changed`      | <pre>boolean</pre>   | Indicates if a channel was associated to the current `roomId` or if the room was associated to the `connectionId` |
+
+---

--- a/doc/1/plugins/guides/events/core-hotelclerk-addSubscription/index.md
+++ b/doc/1/plugins/guides/events/core-hotelclerk-addSubscription/index.md
@@ -19,7 +19,7 @@ The provided `subscription` object has the following properties:
 
 | Properties     | Type                 | Description                                                                                                       |
 | -------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `roomId`       | <pre>integer</pre>   | New room unique identifier                                                                                    |
+| `roomId`       | <pre>string</pre>   | Room unique identifier                                                                                    |
 | `connectionId` | <pre>integer</pre>   | [ClientConnection](/core/1/protocols/api/context/clientconnection) unique identifier                          |
 | `index`        | <pre>string</pre>    | Index                                                                                                             |
 | `collection`   | <pre>string</pre>    | Collection                                                                                                        |

--- a/doc/1/plugins/guides/events/core-hotelclerk-remove-room-for-customer/index.md
+++ b/doc/1/plugins/guides/events/core-hotelclerk-remove-room-for-customer/index.md
@@ -10,8 +10,21 @@ title: core:hotelClerk:removeRoomForCustomer
 | Arguments        | Type              | Description                                                                                  |
 | -----------------| ----------------- | -------------------------------------------------------------------------------------------- |
 | `RequestContest` | <pre>object</pre> | [requestContext](https://docs.kuzzle.io/core/1/protocols/api/context/requestcontext/) object |
-| `room`           | <pre>object</pre> | Joined room information in Koncorde format                                                                     |
+| `room`           | <pre>object</pre> | Joined room information in Koncorde format                                                   |
 
 Triggered whenever a user is removed from a room. 
 
 ---
+
+## room
+
+The provided `room` object has the following properties:
+
+| Properties     | Type                 | Description             |
+| -------------- | -------------------- | ----------------------- |
+| `id`           | <pre>string</pre>    | Room unique identifier  |
+| `index`        | <pre>string</pre>    | Index                   |
+| `collection`   | <pre>string</pre>    | Collection              |
+
+---
+

--- a/doc/1/plugins/guides/events/core-hotelclerk-remove-room-for-customer/index.md
+++ b/doc/1/plugins/guides/events/core-hotelclerk-remove-room-for-customer/index.md
@@ -1,0 +1,17 @@
+---
+code: true
+type: page
+title: core:hotelClerk:removeRoomForCustomer
+---
+
+# core:hotelClerk:removeRoomForCustomer
+
+
+| Arguments        | Type              | Description                                                                                  |
+| -----------------| ----------------- | -------------------------------------------------------------------------------------------- |
+| `RequestContest` | <pre>object</pre> | [requestContext](https://docs.kuzzle.io/core/1/protocols/api/context/requestcontext/) object |
+| `room`           | <pre>object</pre> | Joined room information                                                                      |
+
+Triggered whenever a user is removed from a room. 
+
+---

--- a/doc/1/plugins/guides/events/core-hotelclerk-remove-room-for-customer/index.md
+++ b/doc/1/plugins/guides/events/core-hotelclerk-remove-room-for-customer/index.md
@@ -10,7 +10,7 @@ title: core:hotelClerk:removeRoomForCustomer
 | Arguments        | Type              | Description                                                                                  |
 | -----------------| ----------------- | -------------------------------------------------------------------------------------------- |
 | `RequestContest` | <pre>object</pre> | [requestContext](https://docs.kuzzle.io/core/1/protocols/api/context/requestcontext/) object |
-| `room`           | <pre>object</pre> | Joined room information                                                                      |
+| `room`           | <pre>object</pre> | Joined room information in Koncorde format                                                                     |
 
 Triggered whenever a user is removed from a room. 
 

--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -52,6 +52,7 @@ class HotelClerk {
      *      },
      *      index: 'index', // -> the index name
      *      collection: 'collection', // -> the collection name
+     *      id: 'id', // -> the room unique identifier
      *    }
      *  }
      */


### PR DESCRIPTION
## What does this PR do ?

This PR adds documentation for `core:hotelClerk:addSubscription` and `core:hotelClerk:removeRoomForCustomers` events providing information about the payload

### How should this be manually tested?

<!--
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration
-->
  - Step 1 :
  - Step 2 :
  - Step 3 :  
  ...

### Other changes


Update commentary about `this.rooms` in `HotelClerk` class (field `id` was missing)