### PR TITLE
Document HotelClerk's core events

### DIFF
--- a/doc/2/plugins/guides/events/core-hotelclerk-addSubscription/index.md
+++ b/doc/2/plugins/guides/events/core-hotelclerk-addSubscription/index.md
@@ -1,0 +1,28 @@
+---
+code: true
+type: page
+title: core:hotelClerk:addSubscription
+---
+
+# core:hotelClerk:addSubscription
+
+
+| Arguments  | Type              | Description                           |
+| ---------- | ----------------- | ------------------------------------- |
+| `subscription`     | <pre>object</pre> | Contains information about the added subscription |
+
+Triggered whenever a [subscription](/core/1/api/controllers/realtime/subscribe) is added.
+
+## subscription
+
+The provided `subscription` object has the following properties:
+
+| Properties     | Type                 | Description                                                                                                       |
+| -------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `roomId`       | <pre>string</pre>    | Room unique identifier                                                                                    |
+| `connectionId` | <pre>integer</pre>   | [ClientConnection](/core/1/protocols/api/context/clientconnection) unique identifier                          |
+| `index`        | <pre>string</pre>    | Index                                                                                                             |
+| `collection`   | <pre>string</pre>    | Collection                                                                                                        |
+| `filters`      | <pre>object</pre>    | Filters in [Koncorde's normalized format](https://www.npmjs.com/package/koncorde#filter-unique-identifier)  |
+
+---

--- a/doc/2/plugins/guides/events/core-hotelclerk-remove-room-for-customer/index.md
+++ b/doc/2/plugins/guides/events/core-hotelclerk-remove-room-for-customer/index.md
@@ -1,0 +1,29 @@
+---
+code: true
+type: page
+title: core:hotelClerk:removeRoomForCustomer
+---
+
+# core:hotelClerk:removeRoomForCustomer
+
+
+| Arguments        | Type              | Description                                                                                  |
+| -----------------| ----------------- | -------------------------------------------------------------------------------------------- |
+| `RequestContest` | <pre>object</pre> | [requestContext](https://docs.kuzzle.io/core/1/protocols/api/context/requestcontext/) object |
+| `room`           | <pre>object</pre> | Joined room information in Koncorde format                                                   |
+
+Triggered whenever a user is removed from a room. 
+
+---
+
+## room
+
+The provided `room` object has the following properties:
+
+| Properties     | Type                 | Description             |
+| -------------- | -------------------- | ----------------------- |
+| `id`           | <pre>string</pre>    | Room unique identifier  |
+| `index`        | <pre>string</pre>    | Index                   |
+| `collection`   | <pre>string</pre>    | Collection              |
+
+---

--- a/lib/api/core/hotelClerk.js
+++ b/lib/api/core/hotelClerk.js
@@ -52,6 +52,7 @@ class HotelClerk {
      *      },
      *      index: 'index', // -> the index name
      *      collection: 'collection', // -> the collection name
+     *      id: 'id', // -> the room unique identifier
      *    }
      *  }
      */


### PR DESCRIPTION
## What does this PR do ?

This PR adds documentation for `core:hotelClerk:addSubscription` and `core:hotelClerk:removeRoomForCustomers` events providing information about the payload

### How should this be manually tested?

<!--
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration
-->
  - Step 1 :
  - Step 2 :
  - Step 3 :  
  ...

### Other changes


Update commentary about `this.rooms` in `HotelClerk` class (field `id` was missing)