### PR TITLE
Fix error codes generation

### DIFF
--- a/doc/1/plugins/guides/events/core-hotelclerk-addSubscription/index.md
+++ b/doc/1/plugins/guides/events/core-hotelclerk-addSubscription/index.md
@@ -1,0 +1,28 @@
+---
+code: true
+type: page
+title: core:hotelClerk:addSubscription
+---
+
+# core:hotelClerk:addSubscription
+
+
+| Arguments  | Type              | Description                           |
+| ---------- | ----------------- | ------------------------------------- |
+| `subscription`     | <pre>object</pre> | Contains information about the added subscription |
+
+Triggered whenever a [subscription](/core/1/api/controllers/realtime/subscribe) is added.
+
+## subscription
+
+The provided `subscription` object has the following properties:
+
+| Properties     | Type                 | Description                                                                                                       |
+| -------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `roomId`       | <pre>string</pre>   | Room unique identifier                                                                                    |
+| `connectionId` | <pre>integer</pre>   | [ClientConnection](/core/1/protocols/api/context/clientconnection) unique identifier                          |
+| `index`        | <pre>string</pre>    | Index                                                                                                             |
+| `collection`   | <pre>string</pre>    | Collection                                                                                                        |
+| `filters`      | <pre>object</pre>    | Filters in [Koncorde's normalized format](https://www.npmjs.com/package/koncorde#filter-unique-identifier)  |
+
+---

--- a/doc/1/plugins/guides/events/core-hotelclerk-remove-room-for-customer/index.md
+++ b/doc/1/plugins/guides/events/core-hotelclerk-remove-room-for-customer/index.md
@@ -1,0 +1,30 @@
+---
+code: true
+type: page
+title: core:hotelClerk:removeRoomForCustomer
+---
+
+# core:hotelClerk:removeRoomForCustomer
+
+
+| Arguments        | Type              | Description                                                                                  |
+| -----------------| ----------------- | -------------------------------------------------------------------------------------------- |
+| `RequestContest` | <pre>object</pre> | [requestContext](https://docs.kuzzle.io/core/1/protocols/api/context/requestcontext/) object |
+| `room`           | <pre>object</pre> | Joined room information in Koncorde format                                                   |
+
+Triggered whenever a user is removed from a room. 
+
+---
+
+## room
+
+The provided `room` object has the following properties:
+
+| Properties     | Type                 | Description             |
+| -------------- | -------------------- | ----------------------- |
+| `id`           | <pre>string</pre>    | Room unique identifier  |
+| `index`        | <pre>string</pre>    | Index                   |
+| `collection`   | <pre>string</pre>    | Collection              |
+
+---
+

--- a/lib/config/error-codes/throw.js
+++ b/lib/config/error-codes/throw.js
@@ -38,17 +38,18 @@ function getError (domain, subdomain, error, ...placeholders) {
     kuzzleError = _.get(errorCodes, `${domain}.subdomains.${subdomain}.errors.${error}`);
 
   if (! kuzzleError) {
-    return getError(
-      'internal',
-      'unexpected',
-      'unknown_error',
-      ...placeholders);
+    return getError('internal', 'unexpected', 'unknown_error', ...placeholders);
   }
 
-  const code =
-    (errorCodes[domain].code >> 24) |
-    (errorCodes[domain].subdomains[subdomain].code >> 16) |
-    errorCodes[domain].subdomains[subdomain].errors[error].code;
+  const codebuf = Buffer.allocUnsafe(4);
+
+  codebuf.writeUInt8(errorCodes[domain].code, 0);
+  codebuf.writeUInt8(errorCodes[domain].subdomains[subdomain].code, 1);
+  codebuf.writeUInt16BE(
+    errorCodes[domain].subdomains[subdomain].errors[error].code,
+    2);
+
+  const code = codebuf.toString('hex');
 
   const message = format(kuzzleError.message, ...placeholders);
 

--- a/lib/config/error-codes/throw.js
+++ b/lib/config/error-codes/throw.js
@@ -41,15 +41,9 @@ function getError (domain, subdomain, error, ...placeholders) {
     return getError('internal', 'unexpected', 'unknown_error', ...placeholders);
   }
 
-  const codebuf = Buffer.allocUnsafe(4);
-
-  codebuf.writeUInt8(errorCodes[domain].code, 0);
-  codebuf.writeUInt8(errorCodes[domain].subdomains[subdomain].code, 1);
-  codebuf.writeUInt16BE(
-    errorCodes[domain].subdomains[subdomain].errors[error].code,
-    2);
-
-  const code = codebuf.toString('hex');
+  const code = errorCodes[domain].code << 24
+    | errorCodes[domain].subdomains[subdomain].code << 16
+    | errorCodes[domain].subdomains[subdomain].errors[error].code;
 
   const message = format(kuzzleError.message, ...placeholders);
 

--- a/test/api/core/abstractManifest.test.js
+++ b/test/api/core/abstractManifest.test.js
@@ -50,7 +50,7 @@ describe('AbstractManifest class', () => {
 
     mockRequireManifest({ name: 'foobar' })(() => {
       should(() => manifest.load())
-        .throw(PluginImplementationError, { code: 39 });
+        .throw(PluginImplementationError, { code: parseInt('04010027', 16) });
     });
   });
 

--- a/test/api/kuzzle.test.js
+++ b/test/api/kuzzle.test.js
@@ -2,18 +2,7 @@ const
   sinon = require('sinon'),
   should = require('should'),
   rewire = require('rewire'),
-  errorsManager = require('../../lib/config/error-codes/throw'),
   Kuzzle = rewire('../../lib/api/kuzzle'),
-  {
-    errors: {
-      InternalError,
-      ExternalServiceError,
-      NotFoundError,
-      PreconditionError,
-      PartialError,
-      UnauthorizedError
-    }
-  } = require('kuzzle-common-objects'),
   KuzzleMock = require('../mocks/kuzzle.mock');
 
 describe('/lib/api/kuzzle.js', () => {
@@ -50,81 +39,6 @@ describe('/lib/api/kuzzle.js', () => {
   it('should build a kuzzle server object with emit and listen event', done => {
     kuzzle.on('event', done);
     kuzzle.emit('event');
-  });
-
-  describe('#throw', () => {
-    it('should throw an ExternalServiceError with right name, msg and code', () => {
-      should(() => errorsManager.throw('api', 'server', 'elasticsearch_down', '{"status":"red"}'))
-        .throw(
-          ExternalServiceError,
-          {
-            errorName: 'api.server.elasticsearch_down',
-            code: 1,
-            message: 'ElasticSearch is down: {"status":"red"}.'
-          }
-        );
-    });
-
-    it('should throw an InternalError with default name, msg and code', () => {
-      should(() => errorsManager.throw('api', 'server', 'fake_error', '{"status":"error"}'))
-        .throw(
-          InternalError,
-          {
-            errorName: 'internal.unexpected.unknown_error',
-            code: 1,
-            message: 'Unknown error: {"status":"error"}.'
-          }
-        );
-    });
-
-    it('should throw an NotFoundError with default name, msg and code', () => {
-      should(() => errorsManager.throw('api', 'admin', 'database_not_found', 'fake_database'))
-        .throw(
-          NotFoundError,
-          {
-            errorName: 'api.admin.database_not_found',
-            code: 1,
-            message: 'Database fake_database not found.'
-          }
-        );
-    });
-
-    it('should throw a PreconditionError with default name, msg and code', () => {
-      should(() => errorsManager.throw('api', 'admin', 'action_locked', 'Kuzzle is already shutting down'))
-        .throw(
-          PreconditionError,
-          {
-            errorName: 'api.admin.action_locked',
-            code: 2,
-            message: 'Lock action error: Kuzzle is already shutting down.'
-          }
-        );
-    });
-
-    it('should throw an UnauthorizedError with default name, msg and code', () => {
-      should(() => errorsManager.throw('api', 'auth', 'invalid_token'))
-        .throw(
-          UnauthorizedError,
-          {
-            errorName: 'api.auth.invalid_token',
-            code: 2,
-            message: 'Invalid token.'
-          }
-        );
-    });
-
-    it('should throw a PartialError with default name, msg and code', () => {
-      should(() => errorsManager.throw('api', 'bulk', 'document_creations_failed', ['foo', 'bar']))
-        .throw(
-          PartialError,
-          {
-            errorName: 'api.bulk.document_creations_failed',
-            errors: ['foo', 'bar'],
-            code: 1,
-            message: 'Some document creations failed: foo,bar.'
-          }
-        );
-    });
   });
 
   describe('#start', () => {

--- a/test/config/throw.test.js
+++ b/test/config/throw.test.js
@@ -1,0 +1,88 @@
+const
+  should = require('should'),
+  errorsManager = require('../../lib/config/error-codes/throw'),
+  {
+    errors: {
+      InternalError,
+      ExternalServiceError,
+      NotFoundError,
+      PreconditionError,
+      PartialError,
+      UnauthorizedError
+    }
+  } = require('kuzzle-common-objects');
+
+describe('#throw', () => {
+  it('should throw an ExternalServiceError with right name, msg and code', () => {
+    should(() => errorsManager.throw('api', 'server', 'elasticsearch_down', '{"status":"red"}'))
+      .throw(
+        ExternalServiceError,
+        {
+          errorName: 'api.server.elasticsearch_down',
+          code: '02020001',
+          message: 'ElasticSearch is down: {"status":"red"}.'
+        }
+      );
+  });
+
+  it('should throw an InternalError with default name, msg and code', () => {
+    should(() => errorsManager.throw('api', 'server', 'fake_error', '{"status":"error"}'))
+      .throw(
+        InternalError,
+        {
+          errorName: 'internal.unexpected.unknown_error',
+          code: '00000001',
+          message: 'Unknown error: {"status":"error"}.'
+        }
+      );
+  });
+
+  it('should throw an NotFoundError with default name, msg and code', () => {
+    should(() => errorsManager.throw('api', 'admin', 'database_not_found', 'fake_database'))
+      .throw(
+        NotFoundError,
+        {
+          errorName: 'api.admin.database_not_found',
+          code: '02040001',
+          message: 'Database fake_database not found.'
+        }
+      );
+  });
+
+  it('should throw a PreconditionError with default name, msg and code', () => {
+    should(() => errorsManager.throw('api', 'admin', 'action_locked', 'Kuzzle is already shutting down'))
+      .throw(
+        PreconditionError,
+        {
+          errorName: 'api.admin.action_locked',
+          code: '02040002',
+          message: 'Lock action error: Kuzzle is already shutting down.'
+        }
+      );
+  });
+
+  it('should throw an UnauthorizedError with default name, msg and code', () => {
+    should(() => errorsManager.throw('api', 'auth', 'invalid_token'))
+      .throw(
+        UnauthorizedError,
+        {
+          errorName: 'api.auth.invalid_token',
+          code: '02050002',
+          message: 'Invalid token.'
+        }
+      );
+  });
+
+  it('should throw a PartialError with default name, msg and code', () => {
+    should(() => errorsManager.throw('api', 'bulk', 'document_creations_failed', ['foo', 'bar']))
+      .throw(
+        PartialError,
+        {
+          errorName: 'api.bulk.document_creations_failed',
+          errors: ['foo', 'bar'],
+          code: '02080001',
+          message: 'Some document creations failed: foo,bar.'
+        }
+      );
+  });
+});

--- a/test/config/throw.test.js
+++ b/test/config/throw.test.js
@@ -19,7 +19,7 @@ describe('#throw', () => {
         ExternalServiceError,
         {
           errorName: 'api.server.elasticsearch_down',
-          code: '02020001',
+          code: 33685505,
           message: 'ElasticSearch is down: {"status":"red"}.'
         }
       );
@@ -31,7 +31,7 @@ describe('#throw', () => {
         InternalError,
         {
           errorName: 'internal.unexpected.unknown_error',
-          code: '00000001',
+          code: 1,
           message: 'Unknown error: {"status":"error"}.'
         }
       );
@@ -43,7 +43,7 @@ describe('#throw', () => {
         NotFoundError,
         {
           errorName: 'api.admin.database_not_found',
-          code: '02040001',
+          code: 33816577,
           message: 'Database fake_database not found.'
         }
       );
@@ -55,7 +55,7 @@ describe('#throw', () => {
         PreconditionError,
         {
           errorName: 'api.admin.action_locked',
-          code: '02040002',
+          code: 33816578,
           message: 'Lock action error: Kuzzle is already shutting down.'
         }
       );
@@ -67,7 +67,7 @@ describe('#throw', () => {
         UnauthorizedError,
         {
           errorName: 'api.auth.invalid_token',
-          code: '02050002',
+          code: 33882114,
           message: 'Invalid token.'
         }
       );
@@ -80,7 +80,7 @@ describe('#throw', () => {
         {
           errorName: 'api.bulk.document_creations_failed',
           errors: ['foo', 'bar'],
-          code: '02080001',
+          code: 34078721,
           message: 'Some document creations failed: foo,bar.'
         }
       );

--- a/test/config/throw.test.js
+++ b/test/config/throw.test.js
@@ -19,7 +19,7 @@ describe('#throw', () => {
         ExternalServiceError,
         {
           errorName: 'api.server.elasticsearch_down',
-          code: 33685505,
+          code: parseInt('02020001', 16),
           message: 'ElasticSearch is down: {"status":"red"}.'
         }
       );
@@ -31,7 +31,7 @@ describe('#throw', () => {
         InternalError,
         {
           errorName: 'internal.unexpected.unknown_error',
-          code: 1,
+          code: parseInt('00000001', 16),
           message: 'Unknown error: {"status":"error"}.'
         }
       );
@@ -43,7 +43,7 @@ describe('#throw', () => {
         NotFoundError,
         {
           errorName: 'api.admin.database_not_found',
-          code: 33816577,
+          code: parseInt('02040001', 16),
           message: 'Database fake_database not found.'
         }
       );
@@ -55,7 +55,7 @@ describe('#throw', () => {
         PreconditionError,
         {
           errorName: 'api.admin.action_locked',
-          code: 33816578,
+          code: parseInt('02040002', 16),
           message: 'Lock action error: Kuzzle is already shutting down.'
         }
       );
@@ -67,7 +67,7 @@ describe('#throw', () => {
         UnauthorizedError,
         {
           errorName: 'api.auth.invalid_token',
-          code: 33882114,
+          code: parseInt('02050002', 16),
           message: 'Invalid token.'
         }
       );
@@ -80,7 +80,7 @@ describe('#throw', () => {
         {
           errorName: 'api.bulk.document_creations_failed',
           errors: ['foo', 'bar'],
-          code: 34078721,
+          code: parseInt('02080001', 16),
           message: 'Some document creations failed: foo,bar.'
         }
       );


### PR DESCRIPTION
# Description

Error codes where improperly generated.

For instance, the following: domain=2, subdomain=8, error=245
gave the following code: `245`
instead of the expected (int32) 34078965 (hexadecimal: `0x020800f5`, can be verified with `Number(34078965).toString(16)`)

# Other changes

Moved config/throw.js unit tests from the test/api/kuzzle.test.js file to a new test/config/throw.test.js one