### PR TITLE
Fix a crash occuring when trying to ping dead sockets

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,7 +47,7 @@
     "quotes": [2, "single"],
     "semi": [2, "always"],
     "space-before-blocks": 2,
-    "space-in-parens": [2, "never"],
+    "space-in-parens": [0, "never"],
     "vars-on-top": 2,
     "yoda": [2, "never"]
   },

--- a/lib/api/core/entrypoints/embedded/protocols/websocket.js
+++ b/lib/api/core/entrypoints/embedded/protocols/websocket.js
@@ -383,8 +383,9 @@ class WebSocketProtocol extends Protocol {
 
     const connection = this.connectionPool.get(id);
 
-    if (connection && connection.alive &&
-      connection.socket.readyState === connection.socket.OPEN
+    if ( connection
+      && connection.alive
+      && connection.socket.readyState === connection.socket.OPEN
     ) {
       connection.socket.send(data);
     }
@@ -420,25 +421,15 @@ class WebSocketProtocol extends Protocol {
       lastActivityThreshold = this.activityTimestamp - this.config.heartbeat;
 
     for (const connection of this.connectionPool.values()) {
-      if (connection.alive === false) {
-        // if still marked as "not alive", then the socket did not respond
-        // to the last emitted PING request
-        // (this correctly triggers the 'close' event handler on that socket)
+      if ( connection.alive === false
+        || connection.socket.readyState !== connection.socket.OPEN
+      ) {
         connection.socket.terminate();
       } else if (connection.lastActivity < lastActivityThreshold) {
         // emit a PING request only if the socket has been inactive for longer
         // than the heartbeat value
         connection.alive = false;
-
-        try {
-          connection.socket.ping();
-        }
-        catch (e) {
-          // might happen if the socket has just been closed, and if a heartbeat
-          // happens before its 'closed' handled has been processed
-          connection.alive = false;
-          connection.socket.terminate();
-        }
+        connection.socket.ping();
       }
     }
   }

--- a/lib/api/core/entrypoints/embedded/protocols/websocket.js
+++ b/lib/api/core/entrypoints/embedded/protocols/websocket.js
@@ -429,7 +429,16 @@ class WebSocketProtocol extends Protocol {
         // emit a PING request only if the socket has been inactive for longer
         // than the heartbeat value
         connection.alive = false;
-        connection.socket.ping();
+
+        try {
+          connection.socket.ping();
+        }
+        catch (e) {
+          // might happen if the socket has just been closed, and if a heartbeat
+          // happens before its 'closed' handled has been processed
+          connection.alive = false;
+          connection.socket.terminate();
+        }
       }
     }
   }

--- a/test/api/core/entrypoints/embedded/protocols/websocket.test.js
+++ b/test/api/core/entrypoints/embedded/protocols/websocket.test.js
@@ -652,6 +652,49 @@ describe('/lib/api/core/entrypoints/embedded/protocols/websocket', () => {
       should(activeConnection.socket.terminate).not.be.called();
       should(activeConnection.socket.ping).not.be.called();
     });
+
+    it('should mark a socket as dead if an exception is triggered on PING', () => {
+      const
+        Connection = function (alive, lastActivity) {
+          return {
+            alive,
+            lastActivity,
+            socket: {
+              terminate: sinon.stub(),
+              ping: sinon.stub()
+            }
+          };
+        };
+
+      protocol.connectionPool = new Map([
+        ['ahAhAhAhStayinAliveStayinAlive', new Connection(true, 0)],
+        ['I just met you, and this is cr...gargl', new Connection(true, 0)],
+        ['ahAhAhAhStayinAliiiiiiiiive', new Connection(true, 0)]
+      ]);
+
+      const deadConnection = protocol.connectionPool.get('I just met you, and this is cr...gargl');
+      deadConnection.socket.ping.throws(new Error('dead socket is dead :-('));
+
+      protocol.config.heartbeat = 1000;
+      protocol._doHeartbeat();
+
+      // inactive sockets are pinged
+      for (const id of [
+        'ahAhAhAhStayinAliveStayinAlive',
+        'ahAhAhAhStayinAliiiiiiiiive'
+      ]) {
+        const connection = protocol.connectionPool.get(id);
+
+        should(connection.alive).be.false();
+        should(connection.socket.terminate).not.be.called();
+        should(connection.socket.ping).be.calledOnce();
+      }
+
+      // dead sockets are terminated
+      should(deadConnection.socket.ping).be.called();
+      should(deadConnection.alive).be.false();
+      should(deadConnection.socket.terminate).be.calledOnce();
+    });
   });
 
   describe('#IdleTimeout', () => {

--- a/test/api/core/entrypoints/embedded/protocols/websocket.test.js
+++ b/test/api/core/entrypoints/embedded/protocols/websocket.test.js
@@ -660,6 +660,8 @@ describe('/lib/api/core/entrypoints/embedded/protocols/websocket', () => {
             alive,
             lastActivity,
             socket: {
+              OPEN: 'OPEN',
+              readyState: 'OPEN',
               terminate: sinon.stub(),
               ping: sinon.stub()
             }
@@ -673,7 +675,7 @@ describe('/lib/api/core/entrypoints/embedded/protocols/websocket', () => {
       ]);
 
       const deadConnection = protocol.connectionPool.get('I just met you, and this is cr...gargl');
-      deadConnection.socket.ping.throws(new Error('dead socket is dead :-('));
+      deadConnection.socket.readyState = 'CLOSED';
 
       protocol.config.heartbeat = 1000;
       protocol._doHeartbeat();
@@ -691,8 +693,7 @@ describe('/lib/api/core/entrypoints/embedded/protocols/websocket', () => {
       }
 
       // dead sockets are terminated
-      should(deadConnection.socket.ping).be.called();
-      should(deadConnection.alive).be.false();
+      should(deadConnection.socket.ping).not.be.called();
       should(deadConnection.socket.terminate).be.calledOnce();
     });
   });

--- a/test/api/core/entrypoints/embedded/protocols/websocket.test.js
+++ b/test/api/core/entrypoints/embedded/protocols/websocket.test.js
@@ -653,7 +653,7 @@ describe('/lib/api/core/entrypoints/embedded/protocols/websocket', () => {
       should(activeConnection.socket.ping).not.be.called();
     });
 
-    it('should mark a socket as dead if an exception is triggered on PING', () => {
+    it('should mark a socket as dead if not available for PING', () => {
       const
         Connection = function (alive, lastActivity) {
           return {


### PR DESCRIPTION
# Description

Fix a rare crash that might occur within the WebSocket entrypoint, when a socket is closed just before a heartbeat occurs. If that happens at just the "right" time, then a heartbeat can start before that socket "close" event is processed and before that socket is marked as dead.

If that happens, pinging that socket results in an exception being thrown. Since it is not caught, this results in an unhandled exception, trapped by Kuzzle and triggering a graceful shutdown.