### PR TITLE
Add '--enable-plugins' option to 'start' CLI command

### DIFF
--- a/bin/commands/indexRestore.js
+++ b/bin/commands/indexRestore.js
@@ -122,7 +122,7 @@ async function indexRestore (dumpDirectory, options) {
     batchSize = options.batchSize || 200,
     cout = new ColorOutput(opts);
 
-  const sdk = await getSdk(options, 'websocket')
+  const sdk = await getSdk(options, 'websocket');
 
   cout.ok(`[✔] Start importing dump from ${dumpDirectory}`);
 

--- a/bin/commands/start.js
+++ b/bin/commands/start.js
@@ -63,6 +63,10 @@ function commandStart (options = {}) {
       }));
   }
 
+  if (options.enablePlugins) {
+    kuzzleParams.additionalPlugins = options.enablePlugins.split(',').map(x => x.trim());
+  }
+
   return Promise.all(promises)
     .then(() => kuzzle.start(kuzzleParams))
     .then(() => {

--- a/bin/kuzzle
+++ b/bin/kuzzle
@@ -112,11 +112,12 @@ bindOption(
   program
     .command('start')
     .description('start a Kuzzle instance')
-    .option('    --fixtures <file>', 'import data from file')
-    .option('    --mappings <file>', 'apply mappings from file')
-    .option('    --securities <file>', 'import roles, profiles and users from file')
+    .option('    --fixtures <file>', 'Import data from file')
+    .option('    --mappings <file>', 'Apply mappings from file')
+    .option('    --securities <file>', 'Import roles, profiles and users from file')
     .option('    --vault-key <vaultKey>', 'Vault key used to decrypt secrets')
     .option('    --secrets-file <secretsFile>', 'Output file to write decrypted secrets')
+    .option('    --enable-plugins <plugins>', 'Enable plugins from `plugins/available` directory')
     .action(requireCommand('start'))
 );
 
@@ -186,10 +187,10 @@ bindOption(
 // $ kuzzle indexRestore
 bindOption(
   program
-  .command('indexRestore <path>')
-  .option('    --batch-size <batchSize>', 'Maximum batch size (see limits.documentsWriteCount config)')
-  .description('restore the content of a previously dumped index')
-  .action(requireCommand('indexRestore'))
+    .command('indexRestore <path>')
+    .option('    --batch-size <batchSize>', 'Maximum batch size (see limits.documentsWriteCount config)')
+    .description('restore the content of a previously dumped index')
+    .action(requireCommand('indexRestore'))
 );
 
 // Run user command

--- a/doc/1/guides/essentials/cli/index.md
+++ b/doc/1/guides/essentials/cli/index.md
@@ -225,6 +225,7 @@ This call the action [admin#shutdown](/core/1/api/controllers/admin/shutdown)
 #          --securities <file>           import roles, profiles and users from file
 #          --vault-key <vaultKey>        Vault key used to decrypt secrets
 #          --secrets-file <secretsFile>  Output file to write decrypted secrets
+#          --enable-plugins <plugins>    Enable given plugins (separated with comma)
 
 ```
 
@@ -430,6 +431,16 @@ The roles, profiles and users definition follow the same structure as in the bod
   }
 }
 ```
+
+#### `--enable--plugins`
+<SinceBadge version="1.10.0" />
+
+```bash
+./bin/kuzzle start --enable-plugins kuzzle-custom-plugin-one,kuzzle-custom-plugin-two
+```
+Enable given plugins. If several names are given, they need to be separated with comma.
+Provided plugins need to be located in `plugins/available` directory.
+
 
 ---
 

--- a/doc/1/guides/essentials/cli/index.md
+++ b/doc/1/guides/essentials/cli/index.md
@@ -433,13 +433,14 @@ The roles, profiles and users definition follow the same structure as in the bod
 ```
 
 #### `--enable--plugins`
-<SinceBadge version="1.10.0" />
+<SinceBadge version="1.9.3" />
 
 ```bash
 ./bin/kuzzle start --enable-plugins kuzzle-custom-plugin-one,kuzzle-custom-plugin-two
 ```
-Enable given plugins. If several names are given, they need to be separated with comma.
-Provided plugins need to be located in `plugins/available` directory.
+
+Enable given plugins. If several names are given, they need to be separated with commas.
+Provided strings must match plugin directory names located in the `plugins/available` directory.
 
 
 ---

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -73,12 +73,13 @@ class PluginsManager {
   }
 
   /**
-   * Load plugin located in "plugins/enabled" folder
-   *
+   * Load plugin located in "plugins/enabled" folder and from CLI arguments
+   * 
+   * @param  {Array.<string>} plugins - Plugins passed as CLI arguments
    * @throws PluginImplementationError - Throws when an error occurs when loading a plugin
    */
-  init() {
-    this.plugins = this.load();
+  init(additionalPlugins = []) {
+    this.plugins = this.load(additionalPlugins);
   }
 
   /**
@@ -998,10 +999,17 @@ class PluginsManager {
    *
    * @returns {object} list of loaded plugin
    */
-  load() {
-    const loadedPlugins = {};
+  load(additionalPlugins = []) {
+    const 
+      loadedPlugins = {},
+      getPluginDir = plugin => {
+        return additionalPlugins.includes(plugin)
+          ? path.resolve(path.join(this.kuzzle.rootPath, 'plugins/available'))
+          : this.pluginsDir;
+      };
 
     let plugins = [];
+
     try {
       plugins = fs.readdirSync(this.pluginsDir);
     } catch (e) {
@@ -1013,8 +1021,16 @@ class PluginsManager {
         e.message);
     }
 
+    // Add CLI enabled plugins.
+    // See CLI `start` command `--enable-plugins` option.
+    plugins = additionalPlugins
+      .filter(plugin => !plugins.includes(plugin))
+      .concat(plugins);
+
     for (const plugin of plugins) {
-      const pluginPath = path.join(this.pluginsDir, plugin);
+      const
+        pluginDir = getPluginDir(plugin),
+        pluginPath = path.join(pluginDir, plugin);
 
       try {
         fs.statSync(pluginPath).isDirectory();
@@ -1032,7 +1048,8 @@ class PluginsManager {
 
     for (const relativePluginPath of plugins) {
       const
-        pluginPath = path.resolve(this.pluginsDir, relativePluginPath),
+        pluginDir = getPluginDir(relativePluginPath),
+        pluginPath = path.resolve(pluginDir, relativePluginPath),
         manifest = new Manifest(this.kuzzle, pluginPath);
 
       manifest.load();

--- a/lib/api/kuzzle.js
+++ b/lib/api/kuzzle.js
@@ -161,7 +161,7 @@ class Kuzzle extends EventEmitter {
       .then(() => this.funnel.init())
       .then(() => this.janitor.loadMappings(params.mappings))
       .then(() => this.janitor.loadFixtures(params.fixtures))
-      .then(() => this.pluginsManager.init())
+      .then(() => this.pluginsManager.init(params.additionalPlugins))
       .then(() => this.pluginsManager.run())
       .then(() => {
         this.log.info('Services Initialized');

--- a/test/bin/commands/start.test.js
+++ b/test/bin/commands/start.test.js
@@ -33,7 +33,8 @@ describe('bin/commands/start.js', () => {
     return start({
       mappings: 'mappings.json',
       fixtures: 'fixtures.json',
-      securities: 'securities.json'
+      securities: 'securities.json',
+      enablePlugins: 'kuzzle-plugin-fake,kuzzle-plugin-fake2'
     })
       .then(() => {
         should(KuzzleMock.instance().start)
@@ -41,7 +42,8 @@ describe('bin/commands/start.js', () => {
           .be.calledWith({
             mappings: {},
             fixtures: {},
-            securities: {}
+            securities: {},
+            additionalPlugins: ['kuzzle-plugin-fake','kuzzle-plugin-fake2']
           });
       });
   });


### PR DESCRIPTION
## What does this PR do ?
Add a new action to `kuzzle start` CLI command. This new option allow users to load 'on the fly' plugins disabled ('not in `plugins/enabled` directory) but saved in `plugins/available`.

### How should this be manually tested?
* Read https://deploy-preview-1409--doc-kuzzle.netlify.com/guides/essentials/cli/
* Try to enable plugin using CLI

### Other changes
Add documentation for this new CLI action

### Boyscout
Fix LGTM alert on `bin/indexRestore.js`