### PR TITLE
Add event on new/removed connection

### DIFF
--- a/doc/1/plugins/guides/events/connection-new/index.md
+++ b/doc/1/plugins/guides/events/connection-new/index.md
@@ -1,0 +1,32 @@
+---
+code: true
+type: page
+title: connection:new
+---
+
+# connection:new
+
+
+
+| Arguments | Type              | Description             |
+| --------- | ----------------- | ----------------------- |
+| `connection`    | <pre>object</pre> | Connection information |
+
+Triggered whenever a new connection is made to Kuzzle.
+
+:::info
+Pipes cannot listen to that event, only hooks can.
+:::
+
+---
+
+## connection
+
+The provided `connection` object has the following properties:
+
+| Properties   | Type              | Description                    |
+| ------------ | ----------------- | ------------------------------ |
+| `id`      | <pre>string</pre> | Connection unique ID              |
+| `protocol` | <pre>string</pre> | Protocol name (eg: `websocket`, `http`, etc.)      |
+| `headers` | <pre>object</pre> | Protocol specific headers                |
+| `ips`      | <pre>array</pre> | Array of ips addresses              |

--- a/doc/1/plugins/guides/events/connection-remove/index.md
+++ b/doc/1/plugins/guides/events/connection-remove/index.md
@@ -1,0 +1,30 @@
+---
+code: true
+type: page
+title: connection:remove
+---
+
+# connection:remove
+
+| Arguments | Type              | Description             |
+| --------- | ----------------- | ----------------------- |
+| `connection`    | <pre>object</pre> | Connection information |
+
+Triggered whenever a connection is removed from Kuzzle.
+
+:::info
+Pipes cannot listen to that event, only hooks can.
+:::
+
+---
+
+## connection
+
+The provided `connection` object has the following properties:
+
+| Properties   | Type              | Description                    |
+| ------------ | ----------------- | ------------------------------ |
+| `id`      | <pre>string</pre> | Connection unique ID              |
+| `protocol` | <pre>string</pre> | Protocol name (eg: `websocket`, `http`, etc.)      |
+| `headers` | <pre>object</pre> | Protocol specific headers                |
+| `ips`      | <pre>array</pre> | Array of ips addresses              |

--- a/lib/api/core/entrypoints/embedded/clientConnection.js
+++ b/lib/api/core/entrypoints/embedded/clientConnection.js
@@ -44,8 +44,11 @@ class ClientConnection {
     if (headers && typeof headers === 'object') {
       this.headers = headers;
     }
-  }
 
+    Object.freeze(this.headers);
+    Object.freeze(this.ips);
+    Object.freeze(this);
+  }
 }
 
 module.exports = ClientConnection;

--- a/lib/api/core/entrypoints/embedded/index.js
+++ b/lib/api/core/entrypoints/embedded/index.js
@@ -488,11 +488,9 @@ class EmbeddedEntryPoint extends EntryPoint {
   newConnection (connection) {
     this.clients[connection.id] = connection;
 
-    this.kuzzle.emit('connection:new', JSON.parse(JSON.stringify(connection)));
+    this.kuzzle.emit('connection:new', connection);
 
-    this.kuzzle.router.newConnection(
-      new RequestContext({connection})
-    );
+    this.kuzzle.router.newConnection(new RequestContext({ connection }));
   }
 
   /**
@@ -502,8 +500,10 @@ class EmbeddedEntryPoint extends EntryPoint {
     const connection = this.clients[connectionId];
 
     if (connection) {
-      this.kuzzle.emit('connection:remove', JSON.parse(JSON.stringify(connection)));
-      this.kuzzle.router.removeConnection(new RequestContext({connection}));
+      this.kuzzle.emit('connection:remove', connection);
+
+      this.kuzzle.router.removeConnection(new RequestContext({ connection }));
+
       delete this.clients[connectionId];
     }
   }

--- a/lib/api/core/entrypoints/embedded/index.js
+++ b/lib/api/core/entrypoints/embedded/index.js
@@ -90,7 +90,7 @@ class EmbeddedEntryPoint extends EntryPoint {
   init () {
     // We need to verify the port ourselves, to make sure Node.js won't open
     // a named pipe if the provided port number is a string
-    if (!Number.isInteger(this.config.port)) {
+    if (! Number.isInteger(this.config.port)) {
       errorsManager.throw(
         'network',
         'entrypoint',
@@ -487,6 +487,9 @@ class EmbeddedEntryPoint extends EntryPoint {
    */
   newConnection (connection) {
     this.clients[connection.id] = connection;
+
+    this.kuzzle.emit('connection:new', JSON.parse(JSON.stringify(connection)));
+
     this.kuzzle.router.newConnection(
       new RequestContext({connection})
     );
@@ -499,6 +502,7 @@ class EmbeddedEntryPoint extends EntryPoint {
     const connection = this.clients[connectionId];
 
     if (connection) {
+      this.kuzzle.emit('connection:remove', JSON.parse(JSON.stringify(connection)));
       this.kuzzle.router.removeConnection(new RequestContext({connection}));
       delete this.clients[connectionId];
     }

--- a/lib/api/core/entrypoints/embedded/protocols/http.js
+++ b/lib/api/core/entrypoints/embedded/protocols/http.js
@@ -114,7 +114,10 @@ class HttpProtocol extends Protocol {
         requestId: connection.id,
         url: request.url,
         method: request.method,
-        headers: request.headers,
+        headers: Object.assign(
+          {},
+          request.headers,
+          { 'content-type': 'application/json' }),
         content: ''
       };
 
@@ -168,7 +171,6 @@ class HttpProtocol extends Protocol {
 
     stream.on('finish', () => {
       debug('[%s] End Request', connection.id);
-      proxyRequest.headers['content-type'] = 'application/json';
       this._sendRequest(connection, response, proxyRequest);
     });
   }
@@ -194,12 +196,12 @@ class HttpProtocol extends Protocol {
 
       this._compress(data, response, proxyRequest.headers, (err, deflated) => {
         if (err) {
-          const kuzerr = err instanceof KuzzleError 
+          const kuzerr = err instanceof KuzzleError
             ? err
             : errorsManager.getError('http_request_error', err.message);
           this._replyWithError(connection, proxyRequest, response, kuzerr);
           return;
-          
+
         }
 
         request.response.setHeader('Content-Length', String(deflated.length));

--- a/test/api/core/entrypoints/embedded/clientConnection.test.js
+++ b/test/api/core/entrypoints/embedded/clientConnection.test.js
@@ -26,7 +26,7 @@ describe('core/clientConnection', () => {
     it('should be frozen', () => {
       connection.id = 'not-set';
       connection.protocol = 'not-set';
-      connection.headers.foo = 'not-set'
+      connection.headers.foo = 'not-set';
 
       should(() => connection.ips.push('not-pushed')).throw(TypeError);
       should(connection.headers.foo).not.be.eql('not-set');

--- a/test/api/core/entrypoints/embedded/clientConnection.test.js
+++ b/test/api/core/entrypoints/embedded/clientConnection.test.js
@@ -4,18 +4,34 @@ const
 
 describe('core/clientConnection', () => {
   describe('#constructor', () => {
+    let
+      headers,
+      connection;
+
+    beforeEach(() => {
+      headers = { foo: 'bar' };
+      connection =
+        new ClientConnection('protocol', ['ip1', 'ip2'], headers);
+    });
+
     it('should throw if ips is not an array', () => {
       return should(() => new ClientConnection('protocol', 'ips'))
         .throw(TypeError, {message: 'Expected ips to be an Array, got string'});
     });
 
     it('should set headers', () => {
-      const
-        headers = {foo: 'bar'},
-        connection = new ClientConnection('protocol', ['ip1', 'ip2'], headers);
-
-      should(connection.headers)
-        .be.exactly(headers);
+      should(connection.headers).be.exactly(headers);
     });
+
+    it('should be frozen', () => {
+      connection.id = 'not-set';
+      connection.protocol = 'not-set';
+      connection.headers.foo = 'not-set'
+
+      should(() => connection.ips.push('not-pushed')).throw(TypeError);
+      should(connection.headers.foo).not.be.eql('not-set');
+      should(connection.id).not.be.eql('not-set');
+      should(connection.protocol).not.be.eql('not-set');
+    })
   });
 });

--- a/test/api/core/entrypoints/embedded/clientConnection.test.js
+++ b/test/api/core/entrypoints/embedded/clientConnection.test.js
@@ -32,6 +32,6 @@ describe('core/clientConnection', () => {
       should(connection.headers.foo).not.be.eql('not-set');
       should(connection.id).not.be.eql('not-set');
       should(connection.protocol).not.be.eql('not-set');
-    })
+    });
   });
 });

--- a/test/api/core/entrypoints/embedded/index.test.js
+++ b/test/api/core/entrypoints/embedded/index.test.js
@@ -642,11 +642,13 @@ describe('lib/core/api/core/entrypoints/embedded/index', () => {
     it('should dispatch connection:new event', () => {
       entrypoint.newConnection(connection);
 
-      should(kuzzle.emit).be.calledWithMatch('connection:new', {
-        id: 'connectionId',
-        protocol: 'protocol',
-        headers: 'headers'
-      });
+      should(kuzzle.emit).be.calledWithMatch(
+        'connection:new',
+        {
+          id: 'connectionId',
+          protocol: 'protocol',
+          headers: 'headers'
+        });
     });
   });
 


### PR DESCRIPTION
## What does this PR do ?

PR in `2.x`: https://github.com/kuzzleio/kuzzle/pull/1418

Add two events on new/removed connections:
  - `connection:add`
  - `connection:remove`

The payload is the following:

| Properties   | Type              | Description                    |
| ------------ | ----------------- | ------------------------------ |
| `id`      | <pre>string</pre> | Connection unique ID              |
| `protocol` | <pre>string</pre> | Protocol name (eg: `websocket`, `http`, etc.)      |
| `headers` | <pre>object</pre> | Protocol specific headers                |
| `ips`      | <pre>array</pre> | Array of ips addresses              |

