### PR TITLE
Add cluster plugin to default plugins

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "plugins/available/kuzzle-plugin-auth-passport-local"]
 	path = plugins/available/kuzzle-plugin-auth-passport-local
 	url = https://github.com/kuzzleio/kuzzle-plugin-auth-passport-local.git
+[submodule "plugins/available/kuzzle-plugin-cluster"]
+	path = plugins/available/kuzzle-plugin-cluster
+	url = https://github.com/kuzzleio/kuzzle-plugin-cluster

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,8 @@ WORKDIR /var/app
 
 RUN  npm install --unsafe-perm \
   && npm rebuild all --unsafe-perm \
-  && for plugin in plugins/enabled/*; do cd "$plugin"; npm install --unsafe-perm; cd /var/app; done
+  && for plugin in plugins/enabled/*; do cd "$plugin"; npm install --unsafe-perm; cd /var/app
+  && for plugin in plugins/available/*; do cd "$plugin"; npm install --unsafe-perm; cd /var/app; done
 
 ################################################################################
 # Production image

--- a/doc/1/guides/essentials/plugins/index.md
+++ b/doc/1/guides/essentials/plugins/index.md
@@ -55,6 +55,13 @@ To install a plugin, you need to make it accessible in the `plugins/enabled` fol
 
 A common practice is to first copy the plugin to a `plugins/available` folder, and then creating a symbolic link from that folder to the `plugins/enabled` folder. This way, you can easily enable and disable a plugin just by creating or deleting a symbolic link, respectively.
 
+:::info
+<SinceBadge version="1.9.3" />
+
+If you are running Kuzzle in a Docker container, you can use `$KUZZLE_PLUGINS` environment variable to enable plugins located in `plugins/available` folder.
+The variable will be used as argument for the `--enable-plugins` options from the [Kuzzle CLI start command](/core/1/guides/essentials/cli).
+:::
+
 Prior to loading the plugin into Kuzzle, you will need to load all of the plugin dependencies by running `npm install` from within the plugin folder.
 
 To demonstrate, we are going to install the [**Plugin Boilerplate**](https://github.com/kuzzleio/kuzzle-core-plugin-boilerplate), a plugin example that uses all features available to a plugin.

--- a/doc/1/guides/essentials/plugins/index.md
+++ b/doc/1/guides/essentials/plugins/index.md
@@ -56,7 +56,7 @@ To install a plugin, you need to make it accessible in the `plugins/enabled` fol
 A common practice is to first copy the plugin to a `plugins/available` folder, and then creating a symbolic link from that folder to the `plugins/enabled` folder. This way, you can easily enable and disable a plugin just by creating or deleting a symbolic link, respectively.
 
 :::info
-<SinceBadge version="1.9.3" />
+<SinceBadge version="1.10.0" />
 
 If you are running Kuzzle in a Docker container, you can use `$KUZZLE_PLUGINS` environment variable to enable plugins located in `plugins/available` folder.
 The variable will be used as argument for the `--enable-plugins` options from the [Kuzzle CLI start command](/core/1/guides/essentials/cli).

--- a/doc/1/guides/essentials/plugins/index.md
+++ b/doc/1/guides/essentials/plugins/index.md
@@ -58,7 +58,7 @@ A common practice is to first copy the plugin to a `plugins/available` folder, a
 :::info
 <SinceBadge version="1.10.0" />
 
-If you are running Kuzzle in a Docker container, you can use `$KUZZLE_PLUGINS` environment variable to enable plugins located in `plugins/available` folder.
+If you are running Kuzzle in a Docker container, you can use the `$KUZZLE_PLUGINS` environment variable to enable plugins located in `plugins/available` folder.
 The variable will be used as argument for the `--enable-plugins` options from the [Kuzzle CLI start command](/core/1/guides/essentials/cli).
 :::
 

--- a/doc/1/guides/kuzzle-depth/scalability/index.md
+++ b/doc/1/guides/kuzzle-depth/scalability/index.md
@@ -62,7 +62,7 @@ You should now have a Kuzzle cluster stack running with 3 Kuzzle nodes.
 <SinceBadge version="1.9.3" />
 
 Kuzzle Docker images are shipped with the cluster plugin.
-It is disable by default, but can be enable setting up the [`$KUZZLE_PLUGINS` variable environment](/core/1/guides/essentials/plugins#installing-a-plugin).
+The cluster is disabled by default but you can use [`$KUZZLE_PLUGINS`](/core/1/guides/essentials/plugins#installing-a-plugin) environment variable to enabled it.
 :::
 
 ### ENOSPC error

--- a/doc/1/guides/kuzzle-depth/scalability/index.md
+++ b/doc/1/guides/kuzzle-depth/scalability/index.md
@@ -58,6 +58,13 @@ docker-compose -p cluster up --scale kuzzle=3
 
 You should now have a Kuzzle cluster stack running with 3 Kuzzle nodes.
 
+::: info
+<SinceBadge version="1.9.3" />
+
+Kuzzle images are shipped with the cluster plugin.
+It is disable by default, but can be enable setting up the [`$KUZZLE_PLUGINS` variable environment](/core/1/guides/essentials/plugins#installing-a-plugin).
+:::
+
 ### ENOSPC error
 
 On some Linux environments, you may get `ENOSPC` errors from the filesystem watcher, because of limits set too low.

--- a/doc/1/guides/kuzzle-depth/scalability/index.md
+++ b/doc/1/guides/kuzzle-depth/scalability/index.md
@@ -59,7 +59,7 @@ docker-compose -p cluster up --scale kuzzle=3
 You should now have a Kuzzle cluster stack running with 3 Kuzzle nodes.
 
 ::: info
-<SinceBadge version="1.9.3" />
+<SinceBadge version="1.10.0" />
 
 Kuzzle Docker images are shipped with the cluster plugin.
 The cluster is disabled by default but you can use [`$KUZZLE_PLUGINS`](/core/1/guides/essentials/plugins#installing-a-plugin) environment variable to enabled it.

--- a/doc/1/guides/kuzzle-depth/scalability/index.md
+++ b/doc/1/guides/kuzzle-depth/scalability/index.md
@@ -61,7 +61,7 @@ You should now have a Kuzzle cluster stack running with 3 Kuzzle nodes.
 ::: info
 <SinceBadge version="1.9.3" />
 
-Kuzzle images are shipped with the cluster plugin.
+Kuzzle Docker images are shipped with the cluster plugin.
 It is disable by default, but can be enable setting up the [`$KUZZLE_PLUGINS` variable environment](/core/1/guides/essentials/plugins#installing-a-plugin).
 :::
 

--- a/doc/1/guides/kuzzle-depth/scalability/index.md
+++ b/doc/1/guides/kuzzle-depth/scalability/index.md
@@ -62,7 +62,7 @@ You should now have a Kuzzle cluster stack running with 3 Kuzzle nodes.
 <SinceBadge version="1.10.0" />
 
 Kuzzle Docker images are shipped with the cluster plugin.
-The cluster is disabled by default but you can use [`$KUZZLE_PLUGINS`](/core/1/guides/essentials/plugins#installing-a-plugin) environment variable to enabled it.
+The cluster is disabled by default but you can use the [`$KUZZLE_PLUGINS`](/core/1/guides/essentials/plugins#installing-a-plugin) environment variable to enable it.
 :::
 
 ### ENOSPC error

--- a/docker-compose/scripts/run.sh
+++ b/docker-compose/scripts/run.sh
@@ -27,7 +27,7 @@ fi
 
 log "Starting Kuzzle..."
 
-if [ -n "$KUZZLE_PLUGINS" ]; then
+if [ -n "$KUZZLE_PLUGINS" ] && [ "$1" = "start" ]; then
   enable_plugins="--enable-plugins $KUZZLE_PLUGINS"
 fi
 

--- a/docker-compose/scripts/run.sh
+++ b/docker-compose/scripts/run.sh
@@ -27,4 +27,8 @@ fi
 
 log "Starting Kuzzle..."
 
-exec ./bin/kuzzle "$@"
+if [ -n "$KUZZLE_PLUGINS" ]; then
+  enable_plugins="--enable-plugins $KUZZLE_PLUGINS"
+fi
+
+exec ./bin/kuzzle "$@" "$enable_plugins"


### PR DESCRIPTION
What does this PR do?
=====================

Add cluster plugin to default plugins but disable it by default

* Add cluster submodule to plugins/available folder.
* Update Docker scripts to also install dependencies for 'available
plugins'.
* Update documentation

Other changes
=============

Add a new environment variable `$KUZZLE_PLUGINS` to enable plugins "on
the fly" when running Kuzzle using Docker & Docker Compose
