### PR TITLE
Add encryptSecrets and decryptSecrets route in adminController

### DIFF
--- a/doc/2/api/controllers/admin/decrypt-secrets/index.md
+++ b/doc/2/api/controllers/admin/decrypt-secrets/index.md
@@ -8,7 +8,7 @@ title: decryptSecrets
 
 <SinceBadge version="1.10.0" />
 
-Decrypt an object using [Vault](/core/2/guides/essentials/secrets-vault/).
+Decrypts an object using [Vault](/core/2/guides/essentials/secrets-vault/).
 
 ---
 

--- a/doc/2/api/controllers/admin/decrypt-secrets/index.md
+++ b/doc/2/api/controllers/admin/decrypt-secrets/index.md
@@ -6,7 +6,7 @@ title: decryptSecrets
 
 # decryptSecrets
 
-<SinceBadge version="2.0.0" />
+<SinceBadge version="1.10.0" />
 
 Encrypt an object using Vault.
 

--- a/doc/2/api/controllers/admin/decrypt-secrets/index.md
+++ b/doc/2/api/controllers/admin/decrypt-secrets/index.md
@@ -1,0 +1,83 @@
+---
+code: true
+type: page
+title: decryptSecrets
+---
+
+# decryptSecrets
+
+<SinceBadge version="2.0.0" />
+
+Encrypt an object using Vault.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/admin/_decryptSecrets
+Method: POST
+Body:
+```
+
+```js
+{
+  "vaultKey": "your_vault_key",
+  "secrets": {
+    "aws": {
+      "key": "a32d94368111ca329958e921a4fe5d70.36d6b839bcfee696b76b62c4de655cd0"
+    }
+  }
+}
+```
+
+
+### Other protocols
+
+
+```js
+{
+  "controller": "admin",
+  "action": "decryptSecrets",
+  "body": {
+    "vaultKey": "your_vault_key",
+    "secrets": {
+      "aws": {
+        "key": "a32d94368111ca329958e921a4fe5d70.36d6b839bcfee696b76b62c4de655cd0"
+      }
+    }
+  }
+}
+```
+
+## Body properties
+
+- `vaultKey`: the vault key used to decrypt your secrets
+- `secrets`: Object which represents the secrets to decrypt
+
+---
+
+## Response
+
+Returns an object with decrypted values.
+
+```js
+{
+  "requestId": "d16d5e8c-464a-4589-938f-fd84f46080b9",
+  "status": 200,
+  "error": null,
+  "controller": "admin",
+  "action": "encryptSecrets",
+  "collection": null,
+  "index": null,
+  "result": { 
+    "secrets": {
+      "aws": {
+        "key": "silmaril"
+      }
+    } 
+  }
+}
+```

--- a/doc/2/api/controllers/admin/decrypt-secrets/index.md
+++ b/doc/2/api/controllers/admin/decrypt-secrets/index.md
@@ -8,7 +8,7 @@ title: decryptSecrets
 
 <SinceBadge version="1.10.0" />
 
-Encrypt an object using Vault.
+Encrypt an object using [Vault](/core/2/guides/essentials/secrets-vault/).
 
 ---
 

--- a/doc/2/api/controllers/admin/decrypt-secrets/index.md
+++ b/doc/2/api/controllers/admin/decrypt-secrets/index.md
@@ -8,7 +8,7 @@ title: decryptSecrets
 
 <SinceBadge version="1.10.0" />
 
-Encrypt an object using [Vault](/core/2/guides/essentials/secrets-vault/).
+Decrypt an object using [Vault](/core/2/guides/essentials/secrets-vault/).
 
 ---
 

--- a/doc/2/api/controllers/admin/encrypt-secrets/index.md
+++ b/doc/2/api/controllers/admin/encrypt-secrets/index.md
@@ -6,7 +6,7 @@ title: encryptSecrets
 
 # encryptSecrets
 
-<SinceBadge version="2.0.0" />
+<SinceBadge version="1.10.0" />
 
 Encrypt an object using Vault.
 

--- a/doc/2/api/controllers/admin/encrypt-secrets/index.md
+++ b/doc/2/api/controllers/admin/encrypt-secrets/index.md
@@ -8,7 +8,7 @@ title: encryptSecrets
 
 <SinceBadge version="1.10.0" />
 
-Encrypt an object using [Vault](/core/2/guides/essentials/secrets-vault/).
+Encrypts an object using [Vault](/core/2/guides/essentials/secrets-vault/).
 
 ---
 

--- a/doc/2/api/controllers/admin/encrypt-secrets/index.md
+++ b/doc/2/api/controllers/admin/encrypt-secrets/index.md
@@ -1,0 +1,83 @@
+---
+code: true
+type: page
+title: encryptSecrets
+---
+
+# encryptSecrets
+
+<SinceBadge version="2.0.0" />
+
+Encrypt an object using Vault.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/admin/_encryptSecrets
+Method: POST
+Body:
+```
+
+```js
+{
+  "vaultKey": "your_vault_key",
+  "secrets": {
+    "aws": {
+      "key": "myKey"
+    }
+  }
+}
+```
+
+
+### Other protocols
+
+
+```js
+{
+  "controller": "admin",
+  "action": "encryptSecrets",
+  "body": {
+    "vaultKey": "your_vault_key",
+    "secrets": {
+      "aws": {
+        "key": "myKey"
+      }
+    }
+  }
+}
+```
+
+## Body properties
+
+- `vaultKey`: the vault key used to encrypt your secrets
+- `secrets`: Object which represents the secrets to encrypt
+
+---
+
+## Response
+
+Returns an object with encrypted values.
+
+```js
+{
+  "requestId": "d16d5e8c-464a-4589-938f-fd84f46080b9",
+  "status": 200,
+  "error": null,
+  "controller": "admin",
+  "action": "encryptSecrets",
+  "collection": null,
+  "index": null,
+  "result": { 
+    "secrets": {
+      "aws": {
+        "key": "a32d94368111ca329958e921a4fe5d70.36d6b839bcfee696b76b62c4de655cd0"
+      }
+    } 
+  }
+}
+```

--- a/doc/2/api/controllers/admin/encrypt-secrets/index.md
+++ b/doc/2/api/controllers/admin/encrypt-secrets/index.md
@@ -8,7 +8,7 @@ title: encryptSecrets
 
 <SinceBadge version="1.10.0" />
 
-Encrypt an object using Vault.
+Encrypt an object using [Vault](/core/2/guides/essentials/secrets-vault/).
 
 ---
 

--- a/features/kuzzle.feature
+++ b/features/kuzzle.feature
@@ -37,7 +37,6 @@ Feature: Kuzzle functional tests
     When I send request to "decrypt" the following secrets '{ "aws": { "key": "a32d94368111ca329958e921a4fe5d70.36d6b839bcfee696b76b62c4de655cd0" }, "secret": "4ffdc98e54f4febaa90b9b6de93732be.bcae7ae4a036b6abbdd6fa9376b7b447" }' with a vaultKey of value "my42Vault42Key"
     Then I should receive '{ "aws": { "key": "silmaril" }, "secret": "ring" }'
 
-
   Scenario: Bulk mWrite
     When I create a collection "kuzzle-test-index":"kuzzle-collection-test"
     When I use bulk:mWrite action with

--- a/features/kuzzle.feature
+++ b/features/kuzzle.feature
@@ -31,6 +31,13 @@ Feature: Kuzzle functional tests
     When I use the CLI command 'decryptSecrets config/testsecrets.enc.json --noint --vault-key azerty --outputFile config/testsecrets.json'
     Then A file "config/testsecrets.json" exists and contain '{ "aws": { "key": "silmaril" }, "secret": "ring" }'
 
+  Scenario: adminController: encrypt and decrypt secrets
+    When I send request to "encrypt" the following secrets '{ "aws": { "key": "silmaril" }, "secret": "ring" }' with a vaultKey of value "my42Vault42Key"
+    Then It should be encrypted
+    When I send request to "decrypt" the following secrets '{ "aws": { "key": "a32d94368111ca329958e921a4fe5d70.36d6b839bcfee696b76b62c4de655cd0" }, "secret": "4ffdc98e54f4febaa90b9b6de93732be.bcae7ae4a036b6abbdd6fa9376b7b447" }' with a vaultKey of value "my42Vault42Key"
+    Then I should receive '{ "aws": { "key": "silmaril" }, "secret": "ring" }'
+
+
   Scenario: Bulk mWrite
     When I create a collection "kuzzle-test-index":"kuzzle-collection-test"
     When I use bulk:mWrite action with

--- a/features/step_definitions/adminController.js
+++ b/features/step_definitions/adminController.js
@@ -1,4 +1,5 @@
-const { Given, When } = require('cucumber');
+const { Given, When, Then } = require('cucumber'),
+  should = require('should');
 
 Given('I load the mappings {string}', function (mappings) {
   return this.api.loadMappings(JSON.parse(mappings));
@@ -11,4 +12,38 @@ When('I load the fixtures', function (fixtures) {
 When('I load the securities', function (securities) {
   const parsed = JSON.parse(securities.replace(/#prefix#/g, this.idPrefix));
   return this.api.loadSecurities(parsed);
+});
+
+When('I send request to {string} the following secrets {string} with a vaultKey of value {string}', function (action, secrets, vaultKey, callback) {
+  if (action === 'encrypt') {
+    this.api.encryptSecrets(vaultKey, JSON.parse(secrets))
+      .then(response => {
+        if (response.error) {
+          callback(new Error(response.error.message));
+          return false;
+        }
+        this.result = response.result;
+        callback();
+      })
+      .catch(error => callback(error));
+    return;
+  }
+  this.api.decryptSecrets(vaultKey, JSON.parse(secrets))
+    .then(response => {
+      if (response.error) {
+        callback(new Error(response.error.message));
+        return false;
+      }
+      this.result = response.result;
+      callback();
+    })
+    .catch(error => callback(error));
+});
+
+Then('It should be encrypted', function () {
+  should(this.result.aws.key.length).be.eql(65);
+});
+
+Then('I should receive {string}', function (result) {
+  should(this.result).be.eql(JSON.parse(result));
 });

--- a/features/support/api/apiBase.js
+++ b/features/support/api/apiBase.js
@@ -1324,6 +1324,28 @@ class ApiBase {
     });
   }
 
+  decryptSecrets (vaultKey, secrets) {
+    return this.send({
+      controller: 'admin',
+      action: 'decryptSecrets',
+      body: {
+        vaultKey,
+        secrets
+      }
+    });
+  }
+
+  encryptSecrets (vaultKey, secrets) {
+    return this.send({
+      controller: 'admin',
+      action: 'encryptSecrets',
+      body: {
+        vaultKey,
+        secrets
+      }
+    });
+  }
+
   resetCache (database) {
     return this.send({
       controller: 'admin',

--- a/features/support/api/http.js
+++ b/features/support/api/http.js
@@ -1290,6 +1290,32 @@ class HttpApi {
     return this.callApi(options);
   }
 
+  decryptSecrets (vaultKey, secrets) {
+    const options = {
+      url: this.apiPath('admin/decryptSecrets'),
+      method: 'POST',
+      body: {
+        vaultKey,
+        secrets
+      }
+    };
+
+    return this.callApi(options);
+  }
+
+  encryptSecrets (vaultKey, secrets) {
+    const options = {
+      url: this.apiPath('admin/encryptSecrets'),
+      method: 'POST',
+      body: {
+        vaultKey,
+        secrets
+      }
+    };
+
+    return this.callApi(options);
+  }
+
   resetCache (database) {
     const options = {
       url: this.apiPath(`admin/_resetCache/${database}`),

--- a/features/support/api/http.js
+++ b/features/support/api/http.js
@@ -1292,7 +1292,7 @@ class HttpApi {
 
   decryptSecrets (vaultKey, secrets) {
     const options = {
-      url: this.apiPath('admin/decryptSecrets'),
+      url: this.apiPath('admin/_decryptSecrets'),
       method: 'POST',
       body: {
         vaultKey,
@@ -1305,7 +1305,7 @@ class HttpApi {
 
   encryptSecrets (vaultKey, secrets) {
     const options = {
-      url: this.apiPath('admin/encryptSecrets'),
+      url: this.apiPath('admin/_encryptSecrets'),
       method: 'POST',
       body: {
         vaultKey,

--- a/lib/api/controllers/adminController.js
+++ b/lib/api/controllers/adminController.js
@@ -59,6 +59,7 @@ class AdminController extends BaseController {
   decryptSecrets (request) {
     assertHasBody(request);
     assertBodyHasAttribute(request, 'secrets');
+    assertBodyHasAttribute(request, 'vaultKey');
 
     const voltKey = request.input.body.vaultKey,
       secrets = request.input.body.secrets,
@@ -74,6 +75,7 @@ class AdminController extends BaseController {
   encryptSecrets (request) {
     assertHasBody(request);
     assertBodyHasAttribute(request, 'secrets');
+    assertBodyHasAttribute(request, 'vaultKey');
 
     const voltKey = request.input.body.vaultKey,
       secrets = request.input.body.secrets,

--- a/lib/api/controllers/adminController.js
+++ b/lib/api/controllers/adminController.js
@@ -61,11 +61,11 @@ class AdminController extends BaseController {
     assertBodyHasAttribute(request, 'secrets');
     assertBodyHasAttribute(request, 'vaultKey');
 
-    const voltKey = request.input.body.vaultKey,
+    const vaultKey = request.input.body.vaultKey,
       secrets = request.input.body.secrets,
       vault = new Vault();
 
-    vault.prepareCrypto(voltKey);
+    vault.prepareCrypto(vaultKey);
 
     const decryptedSecrets = vault.decryptObject(secrets);
 
@@ -77,11 +77,11 @@ class AdminController extends BaseController {
     assertBodyHasAttribute(request, 'secrets');
     assertBodyHasAttribute(request, 'vaultKey');
 
-    const voltKey = request.input.body.vaultKey,
+    const vaultKey = request.input.body.vaultKey,
       secrets = request.input.body.secrets,
       vault = new Vault();
 
-    vault.prepareCrypto(voltKey);
+    vault.prepareCrypto(vaultKey);
 
     const encryptSecrets = vault.encryptObject(secrets);
 

--- a/lib/api/controllers/adminController.js
+++ b/lib/api/controllers/adminController.js
@@ -83,9 +83,9 @@ class AdminController extends BaseController {
 
     vault.prepareCrypto(vaultKey);
 
-    const encryptSecrets = vault.encryptObject(secrets);
+    const encryptedSecrets = vault.encryptObject(secrets);
 
-    return Promise.resolve(encryptSecrets);
+    return Promise.resolve(encryptedSecrets);
   }
 
   /**

--- a/lib/api/controllers/adminController.js
+++ b/lib/api/controllers/adminController.js
@@ -42,6 +42,8 @@ const _locks = {};
 class AdminController extends BaseController {
   constructor(kuzzle) {
     super(kuzzle, [
+      'encryptSecrets',
+      'decryptSecrets',
       'dump',
       'loadFixtures',
       'loadMappings',

--- a/lib/api/controllers/adminController.js
+++ b/lib/api/controllers/adminController.js
@@ -60,8 +60,7 @@ class AdminController extends BaseController {
     assertBodyHasAttribute(request, 'secrets');
     assertBodyHasAttribute(request, 'vaultKey');
 
-    const vaultKey = request.input.body.vaultKey,
-      secrets = request.input.body.secrets;
+    const { vaultKey, secrets } = request.input.body;
 
     this.kuzzle.vault.prepareCrypto(vaultKey);
 
@@ -75,8 +74,7 @@ class AdminController extends BaseController {
     assertBodyHasAttribute(request, 'secrets');
     assertBodyHasAttribute(request, 'vaultKey');
 
-    const vaultKey = request.input.body.vaultKey,
-      secrets = request.input.body.secrets;
+    const { vaultKey, secrets } = request.input.body;
 
     this.kuzzle.vault.prepareCrypto(vaultKey);
 

--- a/lib/api/controllers/adminController.js
+++ b/lib/api/controllers/adminController.js
@@ -28,8 +28,10 @@ const
   { Request } = require('kuzzle-common-objects'),
   {
     assertHasBody,
-    assertArgsHasAttribute
-  } = require('../../util/requestAssertions');
+    assertArgsHasAttribute,
+    assertBodyHasAttribute
+  } = require('../../util/requestAssertions'),
+  Vault = require('../core/vault');
 
 const _locks = {};
 
@@ -52,6 +54,35 @@ class AdminController extends BaseController {
     ]);
   }
 
+  decryptSecrets (request) {
+    assertHasBody(request);
+    assertBodyHasAttribute(request, 'secrets');
+
+    const voltKey = request.input.body.vaultKey,
+      secrets = request.input.body.secrets,
+      vault = new Vault();
+
+    vault.prepareCrypto(voltKey);
+
+    const decryptedSecrets = vault.decryptObject(secrets);
+
+    return Promise.resolve(decryptedSecrets);
+  }
+
+  encryptSecrets (request) {
+    assertHasBody(request);
+    assertBodyHasAttribute(request, 'secrets');
+
+    const voltKey = request.input.body.vaultKey,
+      secrets = request.input.body.secrets,
+      vault = new Vault();
+
+    vault.prepareCrypto(voltKey);
+
+    const encryptSecrets = vault.encryptObject(secrets);
+
+    return Promise.resolve(encryptSecrets);
+  }
 
   /**
    * Reset the internal storage components (internalEngine index, cache and memory storage)

--- a/lib/api/controllers/adminController.js
+++ b/lib/api/controllers/adminController.js
@@ -30,8 +30,7 @@ const
     assertHasBody,
     assertArgsHasAttribute,
     assertBodyHasAttribute
-  } = require('../../util/requestAssertions'),
-  Vault = require('../core/vault');
+  } = require('../../util/requestAssertions');
 
 const _locks = {};
 
@@ -62,12 +61,11 @@ class AdminController extends BaseController {
     assertBodyHasAttribute(request, 'vaultKey');
 
     const vaultKey = request.input.body.vaultKey,
-      secrets = request.input.body.secrets,
-      vault = new Vault();
+      secrets = request.input.body.secrets;
 
-    vault.prepareCrypto(vaultKey);
+    this.kuzzle.vault.prepareCrypto(vaultKey);
 
-    const decryptedSecrets = vault.decryptObject(secrets);
+    const decryptedSecrets = this.kuzzle.vault.decryptObject(secrets);
 
     return Promise.resolve(decryptedSecrets);
   }
@@ -78,12 +76,11 @@ class AdminController extends BaseController {
     assertBodyHasAttribute(request, 'vaultKey');
 
     const vaultKey = request.input.body.vaultKey,
-      secrets = request.input.body.secrets,
-      vault = new Vault();
+      secrets = request.input.body.secrets;
 
-    vault.prepareCrypto(vaultKey);
+    this.kuzzle.vault.prepareCrypto(vaultKey);
 
-    const encryptedSecrets = vault.encryptObject(secrets);
+    const encryptedSecrets = this.kuzzle.vault.encryptObject(secrets);
 
     return Promise.resolve(encryptedSecrets);
   }

--- a/lib/api/core/vault.js
+++ b/lib/api/core/vault.js
@@ -118,7 +118,7 @@ class Vault {
       if (_.isPlainObject(value)) {
         secrets[key] = this.decryptObject(value);
       } else if (_.isString(value)) {
-        secrets[key] = this._decryptData(value);        
+        secrets[key] = this._decryptData(value);
       }
     }
 

--- a/lib/api/core/vault.js
+++ b/lib/api/core/vault.js
@@ -27,7 +27,7 @@ const
   _ = require('lodash'),
   path = require('path'),
   fs = require('fs'),
-  errorsManager = require('../../config/error-codes/throw');
+  errorsManager = require('../../config/error-codes/throw').wrap('internal', 'vault');
 
 class Vault {
   constructor () {
@@ -96,9 +96,6 @@ class Vault {
         this.secrets = secrets;
 
         return null;
-      })
-      .catch(error => {
-        errorsManager.throw('decrypt_secrets', error.message);
       });
   }
 
@@ -121,7 +118,7 @@ class Vault {
       if (_.isPlainObject(value)) {
         secrets[key] = this.decryptObject(value);
       } else if (_.isString(value)) {
-        secrets[key] = this._decryptData(value);
+        secrets[key] = this._decryptData(value);        
       }
     }
 
@@ -137,6 +134,9 @@ class Vault {
   encryptObject (secrets) {
     if (!this.vaultKey) {
       errorsManager.throw('vault_key_not_found');
+    }
+    if (!_.isPlainObject(secrets)) {
+      errorsManager.throw('secrets_must_be_object');
     }
 
     const encryptedSecrets = {};
@@ -180,7 +180,11 @@ class Vault {
       iv = ivHex.length === 16 ? ivHex : Buffer.from(ivHex, 'hex'),
       decipher = crypto.createDecipheriv('aes-256-cbc', this.vaultKeyHash, iv);
 
-    return decipher.update(encryptedData, 'hex', 'utf8') + decipher.final('utf8');
+    try {
+      return decipher.update(encryptedData, 'hex', 'utf8') + decipher.final('utf8');
+    } catch (error) {
+      errorsManager.throw('decrypt_secrets', error.message);
+    }
   }
 
   _readJsonFile (file) {

--- a/lib/config/error-codes/internal.json
+++ b/lib/config/error-codes/internal.json
@@ -118,6 +118,11 @@
           "code": 2,
           "message": "Cannot find vault key. Aborting.",
           "class": "NotFoundError"
+        },
+        "secrets_must_be_object": {
+          "code": 3,
+          "message": "Secrets must be an object.",
+          "class": "PreconditionError"
         }
       }
     },

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -36,6 +36,8 @@ module.exports = [
   {verb: 'get', url: '/validations/_scroll/:scrollId', controller: 'collection', action: 'scrollSpecifications'},
   {verb: 'get', url: '/:index/_list', controller: 'collection', action: 'list'},
 
+  {verb: 'post', url: '/admin/_decryptSecrets', controller: 'admin', action: 'decryptSecrets'},
+  {verb: 'post', url: '/admin/_encryptSecrets', controller: 'admin', action: 'encryptSecrets'},
   {verb: 'post', url: '/admin/_resetCache', controller: 'admin', action: 'resetCache'},
   {verb: 'post', url: '/admin/_resetSecurity/', controller: 'admin', action: 'resetSecurity'},
   {verb: 'post', url: '/admin/_resetDatabase/', controller: 'admin', action: 'resetDatabase'},

--- a/test/api/controllers/adminController.test.js
+++ b/test/api/controllers/adminController.test.js
@@ -30,6 +30,34 @@ describe('Test: admin controller', () => {
     });
   });
 
+  describe('#encryptSecrets', () => {
+    beforeEach(() => {
+      request.input.action = 'encryptSecrets';
+      request.input.body = { vaultKey: 'my42Vault42Key', secrets: {aws: 'silmaril'} };
+    });
+
+    it('should encrypt an object with vault', () => {
+      return adminController.encryptSecrets(request)
+        .then((res) => {
+          should(res.aws.length).be.eql(65);
+        });
+    });
+  });
+
+  describe('#decryptSecrets', () => {
+    beforeEach(() => {
+      request.input.action = 'decryptSecrets';
+      request.input.body = { vaultKey: 'my42Vault42Key', secrets: {aws: 'a32d94368111ca329958e921a4fe5d70.36d6b839bcfee696b76b62c4de655cd0'} };
+    });
+
+    it('should encrypt an object with vault', () => {
+      return adminController.decryptSecrets(request)
+        .then((res) => {
+          should(res.aws).be.eql('silmaril');
+        });
+    });
+  });
+
   describe('#resetCache', () => {
     let flushdbStub = sinon.stub();
 

--- a/test/api/controllers/adminController.test.js
+++ b/test/api/controllers/adminController.test.js
@@ -38,8 +38,8 @@ describe('Test: admin controller', () => {
 
     it('should encrypt an object with vault', () => {
       return adminController.encryptSecrets(request)
-        .then((res) => {
-          should(res.aws.length).be.eql(65);
+        .then(() => {
+          should(kuzzle.vault.encryptObject).be.calledOnce();
         });
     });
   });
@@ -52,8 +52,8 @@ describe('Test: admin controller', () => {
 
     it('should encrypt an object with vault', () => {
       return adminController.decryptSecrets(request)
-        .then((res) => {
-          should(res.aws).be.eql('silmaril');
+        .then(() => {
+          should(kuzzle.vault.decryptObject).be.calledOnce();          
         });
     });
   });

--- a/test/api/core/vault.test.js
+++ b/test/api/core/vault.test.js
@@ -116,6 +116,11 @@ describe('Test: vault core component', () => {
         .be.calledWith(false, 'A vault key is present and no secrets file can be found. Aborting.');
     });
 
+    it('rejects if secrets is not an object', () => {
+      should(() => {
+        vault.encryptObject('not an object');
+      }).throw();    });
+
     it('reads the secret file and store decrypted secrets', () => {
       vault.prepareCrypto();
 

--- a/test/api/core/vault.test.js
+++ b/test/api/core/vault.test.js
@@ -119,7 +119,8 @@ describe('Test: vault core component', () => {
     it('rejects if secrets is not an object', () => {
       should(() => {
         vault.encryptObject('not an object');
-      }).throw();    });
+      }).throw();
+    });
 
     it('reads the secret file and store decrypted secrets', () => {
       vault.prepareCrypto();

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -365,6 +365,8 @@ class KuzzleMock extends Kuzzle {
     this.vault = {
       init: this.sandbox.stub(),
       prepareCrypto: this.sandbox.stub(),
+      encryptObject: this.sandbox.stub(),
+      decryptObject: this.sandbox.stub(),
       secrets: {
         aws: {
           secretKeyId: 'the cake is a lie'


### PR DESCRIPTION
## What does this PR do ?

Add encryptSecrets and decryptSecrets route in adminController.

Same PR for 1.x https://github.com/kuzzleio/kuzzle/pull/1434

### How should this be manually tested?

```http
URL: http://kuzzle:7512/admin/_encryptSecrets
Method: POST
Body:
```

```js
{
  "vaultKey": "your_vault_key",
  "secrets": {
    "aws": {
      "key": "myKey"
    }
  }
}
```

```http
URL: http://kuzzle:7512/admin/_decryptSecrets
Method: POST
Body:
```

```js
{
  "vaultKey": "your_vault_key",
  "secrets": {
    "aws": {
      "key": "a32d94368111ca329958e921a4fe5d70.36d6b839bcfee696b76b62c4de655cd0"
    }
  }
}
```

### Other changes

Make vault throw an exception if `secrets` is not an object.