### PR TITLE
Allow uppercased plugins

### DIFF
--- a/doc/1/api/essentials/errors/subcodes/index.md
+++ b/doc/1/api/essentials/errors/subcodes/index.md
@@ -585,7 +585,7 @@ order: 500
 
 | Code | Message          | Class              | Error              | FullName           |
 ------ | -----------------| ------------------ | ------------------ | ------------------ |
-`0x04010001`  | `[<placeholder>] Invalid plugin name. The name must be comprised only of lowercased letters, numbers, hyphens and underscores.` | [PluginImplementationError](https://docs.kuzzle.io/core/1/api/essentials/errors/#pluginimplementationerror) | invalid_plugin_name | plugins.validation.invalid_plugin_name
+`0x04010001`  | `[<placeholder>] Invalid plugin name. The name must be comprised only of letters, numbers, hyphens and underscores.` | [PluginImplementationError](https://docs.kuzzle.io/core/1/api/essentials/errors/#pluginimplementationerror) | invalid_plugin_name | plugins.validation.invalid_plugin_name
 `0x04010002`  | `[<placeholder>] Invalid "privileged" property: expected a boolean, got a <placeholder>.` | [PluginImplementationError](https://docs.kuzzle.io/core/1/api/essentials/errors/#pluginimplementationerror) | invalid_privileged_property | plugins.validation.invalid_privileged_property
 `0x04010003`  | `[<placeholder>] No package.json file found.` | [PluginImplementationError](https://docs.kuzzle.io/core/1/api/essentials/errors/#pluginimplementationerror) | missing_package_json | plugins.validation.missing_package_json
 `0x04010004`  | `You must provide a valid User object when adding context with as().` | [PluginImplementationError](https://docs.kuzzle.io/core/1/api/essentials/errors/#pluginimplementationerror) | invalid_user_object | plugins.validation.invalid_user_object

--- a/doc/1/api/essentials/errors/subcodes/index.md
+++ b/doc/1/api/essentials/errors/subcodes/index.md
@@ -572,7 +572,7 @@ order: 500
 
 | Code | Message          | Class              | Error              | FullName           |
 ------ | -----------------| ------------------ | ------------------ | ------------------ |
-`67174401`  | `[<placeholder>] Invalid plugin name. The name must be comprised only of lowercased letters, numbers, hyphens and underscores.` | [PluginImplementationError](https://docs.kuzzle.io/core/1/api/essentials/errors/#pluginimplementationerror) | invalid_plugin_name | plugins.validation.invalid_plugin_name
+`67174401`  | `[<placeholder>] Invalid plugin name. The name must be comprised only of letters, numbers, hyphens and underscores.` | [PluginImplementationError](https://docs.kuzzle.io/core/1/api/essentials/errors/#pluginimplementationerror) | invalid_plugin_name | plugins.validation.invalid_plugin_name
 `67174402`  | `[<placeholder>] Invalid "privileged" property: expected a boolean, got a <placeholder>.` | [PluginImplementationError](https://docs.kuzzle.io/core/1/api/essentials/errors/#pluginimplementationerror) | invalid_privileged_property | plugins.validation.invalid_privileged_property
 `67174403`  | `[<placeholder>] No package.json file found.` | [PluginImplementationError](https://docs.kuzzle.io/core/1/api/essentials/errors/#pluginimplementationerror) | missing_package_json | plugins.validation.missing_package_json
 `67174404`  | `You must provide a valid User object when adding context with as().` | [PluginImplementationError](https://docs.kuzzle.io/core/1/api/essentials/errors/#pluginimplementationerror) | invalid_user_object | plugins.validation.invalid_user_object

--- a/doc/1/plugins/guides/manual-setup/prerequisites/index.md
+++ b/doc/1/plugins/guides/manual-setup/prerequisites/index.md
@@ -32,7 +32,7 @@ Kuzzle needs a few information to make your plugin work properly. These informat
 
 The following properties can be defined in this `manifest.json` file:
 
-- `name` (**required**): plugin unique identifier. Names can only contain lowercase letters, numbers, hyphens and underscores.
+- `name` (**required**): plugin unique identifier. Names can only contain letters, numbers, hyphens and underscores.
 - `kuzzleVersion`: a non-empty string describing a [semver range](https://www.npmjs.com/package/semver#ranges), limiting the range of Kuzzle versions supported by this plugin. If not set, a warning is displayed on the console, and Kuzzle assumes that the plugin is only compatible with Kuzzle v1.x
 
 <DeprecatedBadge version="1.5.0" /> Kuzzle still allows plugins to be loaded without a <code>manifest.json</code> file, for backward compatibility reasons, falling back to the <a href=https://docs.npmjs.com/files/package.json#name>package.json</a> file to retrieve the plugin's name. This will change in next major releases of Kuzzle.

--- a/lib/api/core/plugins/manifest.js
+++ b/lib/api/core/plugins/manifest.js
@@ -53,11 +53,7 @@ class Manifest extends AbstractManifest {
       super.load();
     }
 
-    // Plugin names are used to create a database index, and those cannot
-    // contain upercased caracters. We should also limit the
-    // characters set to the standard \w regexp, minus uppercased
-    // characters, and with the widely used '-' char
-    if (!/^[a-z0-9_-]+$/.test(this.name)) {
+    if (!/^[\w-]+$/.test(this.name)) {
       errorsManager.throw(
         'plugins',
         'validation',

--- a/lib/api/core/plugins/manifest.js
+++ b/lib/api/core/plugins/manifest.js
@@ -53,6 +53,7 @@ class Manifest extends AbstractManifest {
       super.load();
     }
 
+    // Ensure ES will accept the lower-cased name as index
     if (!/^[\w-]+$/.test(this.name)) {
       errorsManager.throw(
         'plugins',

--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -1106,15 +1106,17 @@ class PluginsManager {
           plugin.manifest.name);
       }
 
-      if (loadedPlugins[plugin.manifest.name]) {
+      const key = plugin.manifest.name.toLowerCase();
+
+      if (loadedPlugins[key]) {
         errorsManager.throw(
           'plugins',
           'runtime',
           'plugin_name_already_exists',
-          plugin.manifest.name);
+          key);
       }
 
-      loadedPlugins[plugin.manifest.name] = plugin;
+      loadedPlugins[key] = plugin;
     }
 
     return loadedPlugins;

--- a/lib/config/error-codes/plugins.json
+++ b/lib/config/error-codes/plugins.json
@@ -6,7 +6,7 @@
       "errors" : {
         "invalid_plugin_name": {
           "code": 1,
-          "message": "[%s] Invalid plugin name. The name must be comprised only of lowercased letters, numbers, hyphens and underscores.",
+          "message": "[%s] Invalid plugin name. The name must be comprised only of letters, numbers, hyphens and underscores.",
           "class": "PluginImplementationError"
         },
         "invalid_privileged_property": {

--- a/test/api/core/pluginsManager/init.test.js
+++ b/test/api/core/pluginsManager/init.test.js
@@ -94,11 +94,10 @@ describe('PluginsManager', () => {
       should(pluginsManager.plugins).be.empty();
     });
 
-    it('should throw if a plugin with the same name already exists', () => {
-      const instanceName = 'kuzzle-plugin-test';
+    it('should throw if a plugin with the same lower-cased name already exists', () => {
       pluginsManager = new PluginsManager(kuzzle);
 
-      fsStub.readdirSync.returns([instanceName, 'another-plugin']);
+      fsStub.readdirSync.returns(['kuzzle-plugin-test', 'another-plugin']);
       fsStub.statSync.returns({
         isDirectory: () => true
       });
@@ -106,16 +105,16 @@ describe('PluginsManager', () => {
       mockrequire('/kuzzle/plugins/enabled/another-plugin', pluginStub);
       mockrequire(
         '/kuzzle/plugins/enabled/kuzzle-plugin-test/manifest.json',
-        { name: instanceName, kuzzleVersion: '^1.x'});
+        { name: 'foobar', kuzzleVersion: '^1.x'});
       mockrequire(
         '/kuzzle/plugins/enabled/another-plugin/manifest.json',
-        { name: instanceName, kuzzleVersion: '^1.x'});
+        { name: 'fooBAR', kuzzleVersion: '^1.x'});
 
       PluginsManager = mockrequire.reRequire('../../../../lib/api/core/plugins/pluginsManager');
 
       should(() => pluginsManager.init()).throw(
         PluginImplementationError,
-        {message: /A plugin named kuzzle-plugin-test already exists/});
+        {message: /A plugin named foobar already exists/});
     });
 
     it('should throw if a plugin does not expose a "init" method', () => {

--- a/test/api/core/pluginsManager/manifest.test.js
+++ b/test/api/core/pluginsManager/manifest.test.js
@@ -115,13 +115,14 @@ describe('Plugins manifest class', () => {
 
   it('should throw if the provided name contains invalid characters', () => {
     const
-      message = new RegExp(`\\[${pluginPath}\\] Invalid plugin name. The name must be comprised only of lowercased letters, numbers, hyphens and underscores`),
+      message = new RegExp(`^\\[${pluginPath}\\] Invalid plugin name. The name must be comprised only of letters, numbers, hyphens and underscores`),
       manifest = new Manifest(kuzzle, pluginPath);
 
-    ['fooBar', 'foobâr', 'foobar!'].forEach(name => {
+    for (const name of ['foo$Bar', 'foobâr', 'foobar!']) {
       manifest.name = name;
-      should(() => manifest.load()).throw(PluginImplementationError, {message});
-    });
+      should(() => manifest.load())
+        .throw(PluginImplementationError, {message});
+    }
   });
 
 


### PR DESCRIPTION
## What does this PR do ?

This PR allows plugins to use uppercase letters in their names. 
Actually, all checks related to elasticsearch index creation were already in place (handled in the plugin context). The PR only implements dedupe checks on plugin init.