### PR TITLE
Add more example to security:getCredentialsById documentation

### DIFF
--- a/doc/2/api/controllers/security/get-credentials-by-id/index.md
+++ b/doc/2/api/controllers/security/get-credentials-by-id/index.md
@@ -6,13 +6,14 @@ title: getCredentialsById
 
 # getCredentialsById
 
-
-
 Gets credential information for the user identified by the strategy's unique user identifier `userId`.
 
-The returned `result` object will vary depending on the strategy (see the [getById plugin function](/core/2/plugins/guides/strategies#optional-getbyid)), and it can be empty.
+The returned `result` object will vary depending on the strategy (see the [getById() plugin function](/core/2/plugins/guides/strategies#optional-getbyid)), and it can be empty.
 
-**Note:** the user identifier to use depends on the specified strategy. If you wish to get credential information using a [kuid](/core/2/guides/essentials/user-authentication#kuzzle-user-identifier-kuid) identifier, use the [getCredentials](/core/2/api/controllers/security/get-credentials) API route instead.
+::: info
+The user identifier to use depends on the specified strategy. 
+If you wish to get credential information using a [kuid](/core/2/guides/essentials/user-authentication#kuzzle-user-identifier-kuid) identifier, use the [getCredentials](/core/2/api/controllers/security/get-credentials) API route instead.
+:::
 
 ---
 
@@ -43,6 +44,11 @@ Method: GET
 - `_id`: user credential identifier (this is NOT the kuid)
 - `strategy`: authentication strategy
 
+::: warning
+The provided `_id` is NOT the `kuid` but the credentials identifier.
+For example, with the `local` strategy, the credential identifier is the `username` field.
+:::
+
 ---
 
 ## Response
@@ -51,6 +57,17 @@ Returns credentials information (depend on the authentication strategy).
 
 ### Example with the "local" authentication strategy:
 
+**Request:**
+```js
+{
+  "controller": "security",
+  "action": "getCredentialsById",
+  "strategy": "local",
+  "_id": "johndoe@kuzzle.io"
+}
+```
+
+**Response:**
 ```js
 {
   "status": 200,
@@ -58,7 +75,7 @@ Returns credentials information (depend on the authentication strategy).
   "action": "getCredentialsById",
   "controller": "security",
   "result": {
-    "username": "<userId>",
+    "username": "johndoe@kuzzle.io",
     "kuid": "<kuid>"
   }
 }


### PR DESCRIPTION
## What does this PR do ?

Users get often confused with this function that take the strategy id and not the kuid.  
This PR add more example on how to use this method.

https://deploy-preview-1441--doc-kuzzle.netlify.com/api/controllers/security/get-credentials-by-id/