### PR TITLE
Fix document:mGet to return a partial error with missing docs

### DIFF
--- a/doc/1/api/controllers/document/m-get/index.md
+++ b/doc/1/api/controllers/document/m-get/index.md
@@ -71,8 +71,13 @@ Each document is an object with the following properties:
 - `_id`: document unique identifier
 - `_source`: document content
 - `_version`: version number of the document
+- `found`: false if the document was missing
 
-If one or more document retrievals fail, the response status is set to `206`, and the `error` object contain a [partial error](/core/1/api/essentials/errors#partialerror) error.
+If one or more document retrievals fail, the response status is set to `206`, and the `error` object contain a [partial error](/core/1/api/essentials/errors#partialerror) error.  
+
+::: info
+You can use the `found` attribute on hits to identify missing documents.
+:::
 
 ```js
 {
@@ -90,14 +95,20 @@ If one or more document retrievals fail, the response status is set to `206`, an
         "_source": {
           // document content
         },
-        "_version": 4
+        "_version": 4,
+        "found": true
       },
       {
         "_id": "<anotherDocumentId>",
         "_source": {
           // document content
         },
-        "_version": 2
+        "_version": 2,
+        "found": true
+      },
+      {
+        "_id": "<anotherDocumentId>",
+        "found": false
       }
     ]
     "total": 2

--- a/doc/1/api/essentials/errors/subcodes/index.md
+++ b/doc/1/api/essentials/errors/subcodes/index.md
@@ -312,6 +312,7 @@ order: 500
 `0x02030005`  | `Number of gets to perform exceeds the server configured value ( <placeholder> ).` | [SizeLimitError](https://docs.kuzzle.io/core/1/api/essentials/errors/#sizelimiterror) | get_limit_reached | api.document.get_limit_reached
 `0x02030006`  | `Some document creations failed : <placeholder>.` | [PartialError](https://docs.kuzzle.io/core/1/api/essentials/errors/#partialerror) | creation_failed | api.document.creation_failed
 `0x02030007`  | `Some document deletions failed : <placeholder>.` | [PartialError](https://docs.kuzzle.io/core/1/api/essentials/errors/#partialerror) | deletion_failed | api.document.deletion_failed
+`0x02030008`  | `Some document are missing.` | [PartialError](https://docs.kuzzle.io/core/1/api/essentials/errors/#partialerror) | some_document_missing | api.document.some_document_missing
 
 ---
 

--- a/lib/api/controllers/documentController.js
+++ b/lib/api/controllers/documentController.js
@@ -83,7 +83,7 @@ class DocumentController extends BaseController {
     }
 
     if (request.input.args.size) {
-      const documentsCount = 
+      const documentsCount =
         request.input.args.size - (request.input.args.from || 0);
 
       if (documentsCount > this.kuzzle.config.limits.documentsFetchCount) {
@@ -117,7 +117,7 @@ class DocumentController extends BaseController {
 
     return this.engine.get(request)
       .then(() => Bluebird.resolve(true))
-      .catch(error => 
+      .catch(error =>
         error.status === 404
           ? Bluebird.resolve(false)
           : Bluebird.reject(error)
@@ -156,6 +156,11 @@ class DocumentController extends BaseController {
     return this.engine.mget(request)
       .then(documents => {
         documents.total = documents.hits.length;
+
+        if (documents.hits.some(doc => ! doc.found)) {
+          request.setError(errorsManager.get('some_document_missing'));
+        }
+
         return documents;
       });
   }

--- a/lib/config/error-codes/api.json
+++ b/lib/config/error-codes/api.json
@@ -63,6 +63,11 @@
           "code": 7,
           "message": "Some document deletions failed : %s.",
           "class": "PartialError"
+        },
+        "some_document_missing": {
+          "code": 8,
+          "message": "Some document are missing.",
+          "class": "PartialError"
         }
       }
     },

--- a/test/api/controllers/documentController.test.js
+++ b/test/api/controllers/documentController.test.js
@@ -208,7 +208,7 @@ describe('Test: document controller', () => {
       return documentController.mGet(request)
         .then(() => {
           should(request.error).be.instanceOf(PartialError);
-        })
+        });
     });
   });
 

--- a/test/api/controllers/documentController.test.js
+++ b/test/api/controllers/documentController.test.js
@@ -195,6 +195,21 @@ describe('Test: document controller', () => {
         SizeLimitError,
         { message: 'Number of gets to perform exceeds the server configured value ( 1 ).' });
     });
+
+    it('should set a partial error if some documents are missing', () => {
+      request.input.body = {ids: ['foo', 'bar']};
+      kuzzle.services.list.storageEngine.mget.resolves({
+        hits: [
+          { _id: 'foo', found: true },
+          { _id: 'bar', found: false },
+        ]
+      });
+
+      return documentController.mGet(request)
+        .then(() => {
+          should(request.error).be.instanceOf(PartialError);
+        })
+    });
   });
 
   describe('#count', () => {
@@ -557,7 +572,7 @@ describe('Test: document controller', () => {
       });
 
       request.input.body = {ids: ['documentId', 'anotherDocumentId']};
-   
+
       return documentController.mDelete(request)
         .then(result => {
           should(result).match(['documentId']);


### PR DESCRIPTION
## What does this PR do ?

Returns a `PartialError` when some documents are not found with `document:mGet`

This fix has been ported on Kuzzle 2.x on this PR: https://github.com/kuzzleio/kuzzle/pull/1446
See commit in tree: https://github.com/kuzzleio/kuzzle/pull/1446/commits/0352527ed1fcdf4b368f8583cd46ebbfdfa0d67a