### PR TITLE
Fix a bug that prevents Kuzzle to shutdown

### DIFF
--- a/lib/api/kuzzle.js
+++ b/lib/api/kuzzle.js
@@ -274,6 +274,9 @@ function registerSignalHandlers(kuzzle) {
     // as it helps spotting code errors. And according to the warning messages,
     // this is what Node.js will do automatically in future versions anyway.
     if (process.env.NODE_ENV === 'development') {
+      kuzzle.log.error('Kuzzle caught an unhandled rejected promise and will shutdown.');
+      kuzzle.log.error('This behavior is only triggered if NODE_ENV is set to "development"');
+
       throw reason;
     }
   });

--- a/lib/util/shutdown.js
+++ b/lib/util/shutdown.js
@@ -68,7 +68,7 @@ function waitRemainingRequests(kuzzle, resolve) {
 
   pm2.list((listerr, processes) => {
     if (listerr) {
-      return halt();
+      return halt(kuzzle);
     }
 
     const kuzzleProcess = processes
@@ -82,7 +82,7 @@ function waitRemainingRequests(kuzzle, resolve) {
         return pm2.restart(kuzzleProcess[0].pm_id);
       }
 
-      return halt();
+      return halt(kuzzle);
     }
 
     // production mode: ask PM2 to stop & delete Kuzzle to prevent


### PR DESCRIPTION
## What does this PR do ?

When Kuzzle is running without PM2, it could never be stopped gracefully because of an uncaught exception in the `halt()` function caused by calling this function without the Kuzzle object.  
After the exception, Kuzzle will discard new request but it will not shutdown.
