### PR TITLE
fix init indices containing a dot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,8 @@ jobs:
       cache:
         directories:
           - $HOME/.gem/specs
+      env:
+        - REPOSITORIES=kuzzle-how-to,sdk-javascript-5,sdk-javascript-6,plugin-s3-1,sdk-php-3,plugin-cloudinary-1,sdk-cpp-1,sdk-csharp-1,sdk-go-1,sdk-go-2,sdk-java-1,sdk-java-2,sdk-java-3,kuzzle-1,sdk-android-3,plugin-multi-tenancy-1
       install:
         - gem install typhoeus
       before_script:

--- a/lib/util/esWrapper.js
+++ b/lib/util/esWrapper.js
@@ -252,7 +252,10 @@ class ESWrapper {
                   value = result[index].mappings[type];
                 }
 
-                _.set(picked, `${index}.mappings.${type}`, value);
+                if (!picked[index]) {
+                  picked[index] = {mappings: {}};
+                }
+                picked[index].mappings[type] = value;
               }
             }
           }

--- a/test/util/esWrapper.test.js
+++ b/test/util/esWrapper.test.js
@@ -224,5 +224,26 @@ describe('Test: ElasticSearch Wrapper', () => {
           });
         });
     });
+
+    it('should accept indices containing a dot', () => {
+      client.indices.getMapping.resolves({
+        '.foo.bar': {
+          mappings: {
+            foo: { properties: {} }
+          }
+        }
+      });
+
+      return esWrapper.getMapping()
+        .then(result => {
+          should(result).match({
+            '.foo.bar': {
+              mappings: {
+                foo: { properties: {} }
+              }
+            }
+          });
+        });
+    });
   });
 });


### PR DESCRIPTION
## What does this PR do ?

This PR fixes the case where Kuzzle would crash on start because of some existing elasticsearch indices containing a dot (.) in their name.

NB: does not apply to 2-dev