### PR TITLE
Access to the plugin repository using the lowercased manifest name

### DIFF
--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -75,7 +75,7 @@ class PluginsManager {
 
   /**
    * Load plugin located in "plugins/enabled" folder and from CLI arguments
-   * 
+   *
    * @param  {Array.<string>} plugins - Plugins passed as CLI arguments
    * @throws PluginImplementationError - Throws when an error occurs when loading a plugin
    */
@@ -331,7 +331,7 @@ class PluginsManager {
         strategy.methods);
     }
 
-    const pluginObject = this.plugins[pluginName].object;
+    const pluginObject = this.plugins[pluginName.toLowerCase()].object;
 
     // required methods check
     ['exists', 'create', 'update', 'delete', 'validate', 'verify'].forEach(methodName => {
@@ -560,12 +560,13 @@ class PluginsManager {
   }
 
   /**
-   * Register an authentication strategy.
+   * Registers an authentication strategy.
    *
    * @param {string} pluginName - plugin name
    * @param {string} strategyName - strategy name
    * @param {object} strategy - strategy properties
-   * @throws {PluginImplementationError} If the strategy is invalid or if registration fails
+   * @throws {PluginImplementationError} If the strategy is invalid or if
+   *                                     registration fails
    */
   registerStrategy(pluginName, strategyName, strategy) {
     const errorPrefix = `[${pluginName}] Strategy ${strategyName}:`;
@@ -576,7 +577,7 @@ class PluginsManager {
     }
 
     const
-      plugin = this.plugins[pluginName],
+      plugin = this.plugins[pluginName.toLowerCase()],
       methods = {};
 
     // wrap plugin methods to force their context and to
@@ -1001,7 +1002,7 @@ class PluginsManager {
    * @returns {object} list of loaded plugin
    */
   load(additionalPlugins = []) {
-    const 
+    const
       loadedPlugins = {},
       getPluginDir = plugin => {
         return additionalPlugins.includes(plugin)
@@ -1053,7 +1054,7 @@ class PluginsManager {
         pluginPath = path.resolve(pluginDir, relativePluginPath),
         manifest = new Manifest(this.kuzzle, pluginPath);
 
-      
+
       manifest.load();
 
       const


### PR DESCRIPTION
# Description

Since #1430 it is now possible to set plugin names using uppercases, and the plugin key is still lowercased to better detect duplicates. 
There were a couple places in plugin strategies where the plugins repository was still accessed using the raw manifest name, instead of lowercasing it beforehand. 

This leads to TypeError exceptions + crash when that happens.