### PR TITLE
Restore compatibility with Node.js 6 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ coverage
 
 # Plugin config folder
 config/plugins/
-dump
+/dump
 
 # IDE
 .idea

--- a/doc/1/api/controllers/admin/dump/index.md
+++ b/doc/1/api/controllers/admin/dump/index.md
@@ -1,0 +1,60 @@
+---
+code: true
+type: page
+title: dump
+---
+
+# dump
+
+<SinceBadge version="1.4.0" />
+
+Asynchronously creates a snapshot of Kuzzle's state.  
+Depending on the configuration of Kuzzle, this may include the following:
+
+* a coredump of Kuzzle running process
+* the current Kuzzle configuration
+* server logs
+* Node.js binary & properties
+* a list of OS properties
+* plugins configurations
+* usage statistics of the dumped instance
+
+The generated directory can be used to feed a complete report to the support team.  
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/admin/_dump
+Method: POST
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "admin",
+  "action": "dump"
+}
+```
+
+---
+
+## Response
+
+Returns an acknowledgement.
+
+```javascript
+{
+  "status": 200,
+  "error": null,
+  "controller": "admin",
+  "action": "dump",
+  "result": { 
+    "acknowledge": true 
+  }
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -3370,11 +3370,6 @@
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
     },
-    "dayjs": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.16.tgz",
-      "integrity": "sha512-XPmqzWz/EJiaRHjBqSJ2s6hE/BUoCIHKgdS2QPtTQtKcS9E4/Qn0WomoH1lXanWCzri+g7zPcuNV4aTZ8PMORQ=="
-    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -3997,54 +3992,53 @@
       }
     },
     "eslint": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.3.0.tgz",
-      "integrity": "sha512-ZvZTKaqDue+N8Y9g0kp6UPZtS4FSY3qARxBs7p4f0H0iof381XHduqVerFWtK8DPtKmemqbqCFENWSQgPR/Gow==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
+      "integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "ajv": "^6.10.0",
+        "ajv": "^6.9.1",
         "chalk": "^2.1.0",
         "cross-spawn": "^6.0.5",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
-        "eslint-scope": "^5.0.0",
-        "eslint-utils": "^1.4.2",
-        "eslint-visitor-keys": "^1.1.0",
-        "espree": "^6.1.1",
+        "eslint-scope": "^4.0.3",
+        "eslint-utils": "^1.3.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^5.0.1",
         "esquery": "^1.0.1",
         "esutils": "^2.0.2",
         "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^5.0.0",
+        "glob": "^7.1.2",
         "globals": "^11.7.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^6.4.1",
-        "is-glob": "^4.0.0",
-        "js-yaml": "^3.13.1",
+        "inquirer": "^6.2.2",
+        "js-yaml": "^3.13.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
-        "lodash": "^4.17.14",
+        "lodash": "^4.17.11",
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
         "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
         "progress": "^2.0.0",
         "regexpp": "^2.0.1",
-        "semver": "^6.1.2",
-        "strip-ansi": "^5.2.0",
-        "strip-json-comments": "^3.0.1",
+        "semver": "^5.5.1",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "^2.0.1",
         "table": "^5.2.3",
-        "text-table": "^0.2.0",
-        "v8-compile-cache": "^2.0.3"
+        "text-table": "^0.2.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "ansi-styles": {
@@ -4067,48 +4061,26 @@
             "supports-color": "^5.3.0"
           }
         },
-        "eslint-scope": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-          "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        },
-        "eslint-utils": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-          "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^1.0.0"
-          }
-        },
-        "eslint-visitor-keys": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-          "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
-        "glob-parent": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
-          "integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "is-glob": "^4.0.1"
+            "ansi-regex": "^3.0.0"
           }
         },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
@@ -4131,8 +4103,9 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.0",
-      "resolved": "",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
       "requires": {
         "eslint-visitor-keys": "^1.0.0"
       }
@@ -4143,32 +4116,20 @@
       "integrity": "sha1-PzGA+y4pEBdxastMnW1bXDSmqB0="
     },
     "espree": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
-      "integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+      "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
       "dev": true,
       "requires": {
-        "acorn": "^7.0.0",
-        "acorn-jsx": "^5.0.2",
-        "eslint-visitor-keys": "^1.1.0"
+        "acorn": "^6.0.7",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
-          "integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==",
-          "dev": true
-        },
-        "acorn-jsx": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
-          "integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
-          "dev": true
-        },
-        "eslint-visitor-keys": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-          "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
           "dev": true
         }
       }
@@ -4442,6 +4403,11 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+    },
     "falafel": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz",
@@ -4603,23 +4569,6 @@
       "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
       "requires": {
         "locate-path": "^3.0.0"
-      }
-    },
-    "fix": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/fix/-/fix-0.0.6.tgz",
-      "integrity": "sha1-B+WTonQU3cSG7lLVD5yOCYhaAwU=",
-      "requires": {
-        "pipe": "0.0.2",
-        "underscore": "1.1.6",
-        "underscore.string": "1.1.4"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.6.tgz",
-          "integrity": "sha1-aGjaG91y11KFvgtOUPIo5w0AGiw="
-        }
       }
     },
     "flat": {
@@ -6897,29 +6846,18 @@
       }
     },
     "kuzzle-sdk": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/kuzzle-sdk/-/kuzzle-sdk-6.2.2.tgz",
-      "integrity": "sha512-dc+fe6w7am3FyqdA6h8RPG8y+7/9VyOJtCLwhcz2PdcKV79qsp/dvMdf3PWqZ2QBIgxR23d8NV5pBos/U2uJLQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/kuzzle-sdk/-/kuzzle-sdk-6.2.4.tgz",
+      "integrity": "sha512-s9g97X2Hyf5+M8NsVH0CJM2ddW8stSq+bTcSkMpqMUjPkntzr6vzhoZHJc9Qc/occjmN5be1dNQYf1Z+J3z8nQ==",
       "requires": {
         "@babel/core": "^7.6.0",
         "@babel/preset-env": "^7.6.0",
         "audit": "0.0.6",
         "babel-loader": "^8.0.6",
-        "fix": "0.0.6",
         "min-req-promise": "^1.0.1",
         "ora": "^3.4.0",
         "webpack": "^4.39.3",
-        "ws": "^7.1.2"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.1.2.tgz",
-          "integrity": "sha512-gftXq3XI81cJCgkUiAVixA0raD9IVmXqsylCrjRygw4+UOOGzPoxnQ6r/CnVL9i+mDncJo94tSkyrtuuQVBmrg==",
-          "requires": {
-            "async-limiter": "^1.0.0"
-          }
-        }
+        "ws": "^6.2.1"
       }
     },
     "lazy": {
@@ -7255,6 +7193,11 @@
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
     },
+    "lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
+    },
     "lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
@@ -7280,11 +7223,6 @@
       "resolved": "https://registry.npmjs.org/lodash.last/-/lodash.last-3.0.0.tgz",
       "integrity": "sha1-JC9mMRLdTG5jcoxgo8kJ0b2tvUw="
     },
-    "lodash.omit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
-    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -7307,6 +7245,11 @@
       "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
       "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
       "optional": true
+    },
+    "lodash.trimend": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/lodash.trimend/-/lodash.trimend-4.5.1.tgz",
+      "integrity": "sha1-EoBENyhrmMrYmWt5QU4RMAEUCC8="
     },
     "log-driver": {
       "version": "1.2.7",
@@ -9376,11 +9319,6 @@
         "quick-format-unescaped": "^1.0.0",
         "split2": "^2.0.1"
       }
-    },
-    "pipe": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/pipe/-/pipe-0.0.2.tgz",
-      "integrity": "sha1-oW/m/AGddb2YfEkopn4eUOT1tE8="
     },
     "pkg-dir": {
       "version": "3.0.0",
@@ -12302,21 +12240,6 @@
       "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
       "optional": true
     },
-    "underscore.string": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-1.1.4.tgz",
-      "integrity": "sha1-m+BrI7jj2ZbqICD5mEICBp497hI=",
-      "requires": {
-        "underscore": "1.1.6"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.6.tgz",
-          "integrity": "sha1-aGjaG91y11KFvgtOUPIo5w0AGiw="
-        }
-      }
-    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
@@ -12769,25 +12692,74 @@
       }
     },
     "winston-elasticsearch": {
-      "version": "0.7.13",
-      "resolved": "https://registry.npmjs.org/winston-elasticsearch/-/winston-elasticsearch-0.7.13.tgz",
-      "integrity": "sha512-iOyRIIE7LIxW13I/pGz31uSD0Rf9v3xuD4jcia/o61dMIiH79kW2WziVqruk7Hg7rNsuMyaT11mwmAEYeG3vsA==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/winston-elasticsearch/-/winston-elasticsearch-0.5.9.tgz",
+      "integrity": "sha512-5vbqQviMIXjx7tj9SZ7z143lURzmL+VzsMJwT+zLUjW2LXFKwpV8v/+tCYe/GZ3763mQWOAW7N6AuoGRSkF9gg==",
       "requires": {
-        "dayjs": "^1.8.16",
-        "debug": "4.1.1",
-        "elasticsearch": "^16.3.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.omit": "^4.5.0",
-        "promise": "^8.0.3",
+        "debug": "^3.1.0",
+        "elasticsearch": "^14.2.2",
+        "lodash": "^4.17.5",
+        "moment": "^2.22.1",
+        "promise": "^8.0.1",
         "retry": "^0.12.0",
-        "winston": "^3.2.1",
-        "winston-transport": "4.3.0"
+        "winston": "^2.4.1"
       },
       "dependencies": {
+        "async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+        },
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "elasticsearch": {
+          "version": "14.2.2",
+          "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-14.2.2.tgz",
+          "integrity": "sha1-a7tjsZsX+pchGyLurLD5EZf01rY=",
+          "requires": {
+            "agentkeepalive": "^3.4.1",
+            "chalk": "^1.0.0",
+            "lodash": "2.4.2",
+            "lodash.get": "^4.4.2",
+            "lodash.isempty": "^4.4.0",
+            "lodash.trimend": "^4.5.1"
+          },
+          "dependencies": {
+            "lodash": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+            }
+          }
+        },
         "retry": {
           "version": "0.12.0",
           "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
           "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
+        },
+        "winston": {
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
+          "integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
+          "requires": {
+            "async": "~1.0.0",
+            "colors": "1.0.x",
+            "cycle": "1.0.x",
+            "eyes": "0.1.x",
+            "isstream": "0.1.x",
+            "stack-trace": "0.0.x"
+          }
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "jsonwebtoken": "^8.5.1",
     "koncorde": "^1.2.2",
     "kuzzle-common-objects": "^3.0.16",
-    "kuzzle-sdk": "^6.2.2",
+    "kuzzle-sdk": "^6.2.4",
     "lodash": "4.17.15",
     "moment": "^2.24.0",
     "mosca": "^2.8.3",
@@ -76,7 +76,7 @@
     "uuid": "^3.3.3",
     "validator": "^11.1.0",
     "winston": "^3.2.1",
-    "winston-elasticsearch": "0.7.13",
+    "winston-elasticsearch": "^0.5.9",
     "winston-syslog": "^2.2.0",
     "winston-transport": "^4.3.0",
     "ws": "^6.2.1"
@@ -88,7 +88,7 @@
   "devDependencies": {
     "codecov": "^3.5.0",
     "cucumber": "^5.1.0",
-    "eslint": "^6.3.0",
+    "eslint": "^5.16.0",
     "minimist": "1.2.0",
     "mocha": "^6.2.0",
     "mock-require": "^3.0.3",


### PR DESCRIPTION
# Description

An update to dependencies and in our Javascript SDK broke Kuzzle's compatibility with Node.js 6. This PR makes Kuzzle compatible again with node6.

# Other changes

Restore the `admin:dump` API documentation page, which wasn't imported from the old documentation repository due to a .gitignore exclusion being too hungry.