### PR TITLE
Fix an unhandled promise rejection

### DIFF
--- a/lib/api/controllers/adminController.js
+++ b/lib/api/controllers/adminController.js
@@ -184,6 +184,9 @@ class AdminController extends BaseController {
     const refresh = request.input.args.refresh === 'wait_for';
 
     if (! refresh) {
+      // Attaching an error handler to the provided promise to prevent
+      // uncaught rejections
+      promise.catch(err => this.kuzzle.log.error(err));
       return Bluebird.resolve(result);
     }
 

--- a/test/api/controllers/adminController.test.js
+++ b/test/api/controllers/adminController.test.js
@@ -207,6 +207,15 @@ describe('AdminController', () => {
             .be.calledWith({ city: { seventeen: [] } });
         });
     });
+
+    it('should handle rejections if the janitor rejects when not waiting for a refresh', () => {
+      const err = new Error('err');
+      kuzzle.janitor.loadFixtures.rejects(err);
+      request.input.args.refresh = null;
+
+      return adminController.loadFixtures(request)
+        .then(() => should(kuzzle.log.error).calledWith(err));
+    });
   });
 
   describe('#loadSecurities', () => {


### PR DESCRIPTION
# Description

Most API routes in the admin controller can respond immediately if the `refresh` flag is not set. But in this case, the underlying promises created are unhandled if they are rejected, which makes Kuzzle crash in development environments.
