### PR TITLE
Support unicode payload in notifications

### DIFF
--- a/lib/api/core/entrypoints/protocols/websocket.js
+++ b/lib/api/core/entrypoints/protocols/websocket.js
@@ -274,12 +274,13 @@ class WebSocketProtocol extends Protocol {
   broadcast(data) {
     const
       stringified = JSON.stringify(data.payload),
+      payloadByteSize = Buffer.from(stringified).byteLength,
       // 255 bytes should be enough to hold the following:
       //     ,"room":"<channel identifier>"
       // (with current channel encoding, this is less than 100 bytes)
-      payload = Buffer.allocUnsafe(stringified.length + 255);
+      payload = Buffer.allocUnsafe(payloadByteSize + 255);
 
-    let offset = stringified.length - 1;
+    let offset = payloadByteSize - 1;
 
     payload.write(stringified, 0);
     payload.write(jsonRoomProp, offset);
@@ -307,9 +308,9 @@ class WebSocketProtocol extends Protocol {
         for (const connectionId of connectionIds) {
           const connection = this.connectionPool.get(connectionId);
 
-          if (connection &&
-            connection.alive &&
-            connection.socket.readyState === connection.socket.OPEN
+          if ( connection
+            && connection.alive
+            && connection.socket.readyState === connection.socket.OPEN
           ) {
             connection.socket._sender.sendFrame(frame);
           }

--- a/test/api/core/entrypoints/protocols/websocket.test.js
+++ b/test/api/core/entrypoints/protocols/websocket.test.js
@@ -401,6 +401,23 @@ describe('/lib/api/core/entrypoints/protocols/websocket', () => {
           .calledWith(frame);
       }
     });
+
+    it('should handle unicode payload', () => {
+      const data = {
+        channels: ['c1'],
+        payload: { text: 'žluťoučký kůň' }
+      };
+
+      protocol.broadcast(data);
+
+      data.payload.room = 'c1';
+      frame = Buffer.from(JSON.stringify(data.payload));
+
+      for (const connId of ['cx1', 'cx2', 'cx3']) {
+        should(protocol.connectionPool.get(connId).socket._sender.sendFrame)
+          .calledWith(frame);
+      }
+    });
   });
 
   describe('#notify', () => {

--- a/test/api/core/entrypoints/protocols/websocket.test.js
+++ b/test/api/core/entrypoints/protocols/websocket.test.js
@@ -411,7 +411,7 @@ describe('/lib/api/core/entrypoints/protocols/websocket', () => {
       protocol.broadcast(data);
 
       data.payload.room = 'c1';
-      frame = Buffer.from(JSON.stringify(data.payload));
+      const frame = Buffer.from(JSON.stringify(data.payload));
 
       for (const connId of ['cx1', 'cx2', 'cx3']) {
         should(protocol.connectionPool.get(connId).socket._sender.sendFrame)


### PR DESCRIPTION
## What does this PR do ?

Fix #1465 

Data was written to the payload assuming 1 char = 1 byte, but with non-utf8 char we need to use the `byteLength` property from the buffer and not just the string length.

`Kuzzle 1.x`: https://github.com/kuzzleio/kuzzle/pull/1466

### How should this be manually tested?

  - Step 1 : Subscribe to some notifications
  - Step 2 : Create a document containing the string `žluťoučký kůň`
