### PR TITLE
Fix CLI start --enable-plugin command

### DIFF
--- a/bin/commands/start.js
+++ b/bin/commands/start.js
@@ -64,7 +64,10 @@ function commandStart (options = {}) {
   }
 
   if (options.enablePlugins) {
-    kuzzleParams.additionalPlugins = options.enablePlugins.split(',').map(x => x.trim());
+    kuzzleParams.additionalPlugins = options.enablePlugins
+      .trim()
+      .split(',')
+      .map(x => JSON.parse(x.trim()));
   }
 
   return Promise.all(promises)

--- a/bin/commands/start.js
+++ b/bin/commands/start.js
@@ -67,7 +67,7 @@ function commandStart (options = {}) {
     kuzzleParams.additionalPlugins = options.enablePlugins
       .trim()
       .split(',')
-      .map(x => JSON.parse(x.trim()));
+      .map(x => x.trim().replace (/(^")|("$)/g, ''));
   }
 
   return Promise.all(promises)

--- a/bin/commands/start.js
+++ b/bin/commands/start.js
@@ -67,7 +67,7 @@ function commandStart (options = {}) {
     kuzzleParams.additionalPlugins = options.enablePlugins
       .trim()
       .split(',')
-      .map(x => x.trim().replace (/(^")|("$)/g, ''));
+      .map(x => x.trim().replace(/(^")|("$)/g, ''));
   }
 
   return Promise.all(promises)

--- a/docker-compose/scripts/run.sh
+++ b/docker-compose/scripts/run.sh
@@ -31,4 +31,4 @@ if [ -n "$KUZZLE_PLUGINS" ] && [ "$1" = "start" ]; then
   enable_plugins="--enable-plugins $KUZZLE_PLUGINS"
 fi
 
-exec ./bin/kuzzle "$@" "$enable_plugins"
+exec ./bin/kuzzle "$@" $enable_plugins

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {


### PR DESCRIPTION
What this PR do?
================

In the `run.sh` script the `exec` command does not interpolate double
quote environment variable globbing.
This behavior results to this error on Kuzzle startup:

```
error: unknown option '--enable-plugins "kuzzle-plugin-cluster"'
```
