### PR TITLE
Make the connection headers writable again

### DIFF
--- a/lib/api/core/entrypoints/embedded/clientConnection.js
+++ b/lib/api/core/entrypoints/embedded/clientConnection.js
@@ -45,8 +45,6 @@ class ClientConnection {
       this.headers = headers;
     }
 
-    Object.freeze(this.headers);
-    Object.freeze(this.ips);
     Object.freeze(this);
   }
 }

--- a/lib/api/core/entrypoints/embedded/index.js
+++ b/lib/api/core/entrypoints/embedded/index.js
@@ -488,7 +488,9 @@ class EmbeddedEntryPoint extends EntryPoint {
   newConnection (connection) {
     this.clients[connection.id] = connection;
 
-    this.kuzzle.emit('connection:new', connection);
+    if (this.kuzzle.listenerCount('connection:new') > 0) {
+      this.kuzzle.emit('connection:new', JSON.parse(JSON.stringify(connection)));
+    }
 
     this.kuzzle.router.newConnection(new RequestContext({ connection }));
   }

--- a/lib/api/core/entrypoints/embedded/index.js
+++ b/lib/api/core/entrypoints/embedded/index.js
@@ -488,9 +488,7 @@ class EmbeddedEntryPoint extends EntryPoint {
   newConnection (connection) {
     this.clients[connection.id] = connection;
 
-    if (this.kuzzle.listenerCount('connection:new') > 0) {
-      this.kuzzle.emit('connection:new', JSON.parse(JSON.stringify(connection)));
-    }
+    this.kuzzle.emit('connection:new', connection);
 
     this.kuzzle.router.newConnection(new RequestContext({ connection }));
   }

--- a/test/api/core/entrypoints/embedded/clientConnection.test.js
+++ b/test/api/core/entrypoints/embedded/clientConnection.test.js
@@ -22,16 +22,5 @@ describe('core/clientConnection', () => {
     it('should set headers', () => {
       should(connection.headers).be.exactly(headers);
     });
-
-    it('should be frozen', () => {
-      connection.id = 'not-set';
-      connection.protocol = 'not-set';
-      connection.headers.foo = 'not-set';
-
-      should(() => connection.ips.push('not-pushed')).throw(TypeError);
-      should(connection.headers.foo).not.be.eql('not-set');
-      should(connection.id).not.be.eql('not-set');
-      should(connection.protocol).not.be.eql('not-set');
-    });
   });
 });

--- a/test/api/core/entrypoints/embedded/index.test.js
+++ b/test/api/core/entrypoints/embedded/index.test.js
@@ -639,16 +639,33 @@ describe('lib/core/api/core/entrypoints/embedded/index', () => {
         .be.calledWithMatch(new RequestContext({connection}));
     });
 
-    it('should dispatch connection:new event', () => {
+    it('should dispatch connection:new event if there are listeners on it', () => {
       entrypoint.newConnection(connection);
 
-      should(kuzzle.emit).be.calledWithMatch(
+      should(kuzzle.emit).not.be.called();
+
+      kuzzle.on('connection:new', sinon.stub());
+      entrypoint.newConnection(connection);
+
+      should(kuzzle.emit).calledOnce().calledWithMatch(
         'connection:new',
         {
           id: 'connectionId',
           protocol: 'protocol',
           headers: 'headers'
         });
+    });
+
+    it('should provide a copy of the underlying connection object', () => {
+      kuzzle.on('connection:new', sinon.stub());
+
+      entrypoint.newConnection(connection);
+
+      should(kuzzle.emit).calledOnce();
+
+      const payload = kuzzle.emit.firstCall.args[1];
+
+      should(payload).match(connection).and.not.exactly(connection);
     });
   });
 

--- a/test/api/core/entrypoints/embedded/index.test.js
+++ b/test/api/core/entrypoints/embedded/index.test.js
@@ -641,31 +641,7 @@ describe('lib/core/api/core/entrypoints/embedded/index', () => {
 
     it('should dispatch connection:new event if there are listeners on it', () => {
       entrypoint.newConnection(connection);
-
-      should(kuzzle.emit).not.be.called();
-
-      kuzzle.on('connection:new', sinon.stub());
-      entrypoint.newConnection(connection);
-
-      should(kuzzle.emit).calledOnce().calledWithMatch(
-        'connection:new',
-        {
-          id: 'connectionId',
-          protocol: 'protocol',
-          headers: 'headers'
-        });
-    });
-
-    it('should provide a copy of the underlying connection object', () => {
-      kuzzle.on('connection:new', sinon.stub());
-
-      entrypoint.newConnection(connection);
-
-      should(kuzzle.emit).calledOnce();
-
-      const payload = kuzzle.emit.firstCall.args[1];
-
-      should(payload).match(connection).and.not.exactly(connection);
+      should(kuzzle.emit).calledOnce().calledWith('connection:new', connection);
     });
   });
 

--- a/test/api/core/entrypoints/embedded/index.test.js
+++ b/test/api/core/entrypoints/embedded/index.test.js
@@ -639,7 +639,7 @@ describe('lib/core/api/core/entrypoints/embedded/index', () => {
         .be.calledWithMatch(new RequestContext({connection}));
     });
 
-    it('should dispatch connection:new event if there are listeners on it', () => {
+    it('should dispatch connection:new event', () => {
       entrypoint.newConnection(connection);
       should(kuzzle.emit).calledOnce().calledWith('connection:new', connection);
     });


### PR DESCRIPTION
# Description

A regression has been introduced in Kuzzle 1.10, due to this PR's changes: https://github.com/kuzzleio/kuzzle/pull/1417#pullrequestreview-280634597
(sorry, this is partly my fault)

By freezing the ClientConnection object, Kuzzle prevents plugins from adding custom headers to a persisted connection. Which is a clear regression.

This PR prevents ClientConnection from freezing its maintained properties.

:warning: there is no version bump in this hotfix because it'll be included in the next 1.10.2 patch initiated by https://github.com/kuzzleio/kuzzle/pull/1468

# Why unfreeze properties without counterpart?

The aim of freezing connection properties was to prevent hooks from modifying connection information. So, at first, I decided to duplicate the connection object before triggering the event.

And after thinking long and hard about it, I decided that this was dumb. Here is why: the only constraint hooks have over pipes, is that hooks aren't waited for. 
Which is expected when connections are created: we don't want anything impedding the creation of new connections. But if pipes can modify things, hooks should be able too, even if that seems risky since there will be no guarantee that there won't be race conditions. But that's the problem of plugin devs, not Kuzzle's.
If plugin devs want ot modify connection information safely, they have pipes at their disposal (those are invoked later in a request processing).

So, this PR is really about removing a babysitting feature from Kuzzle. 
