### PR TITLE
Make the connection headers writable again

### DIFF
--- a/lib/api/core/entrypoints/clientConnection.js
+++ b/lib/api/core/entrypoints/clientConnection.js
@@ -46,8 +46,6 @@ class ClientConnection {
       this.headers = headers;
     }
 
-    Object.freeze(this.ips);
-    Object.freeze(this.headers);
     Object.freeze(this);
   }
 }

--- a/test/api/core/entrypoints/clientConnection.test.js
+++ b/test/api/core/entrypoints/clientConnection.test.js
@@ -22,11 +22,5 @@ describe('core/clientConnection', () => {
     it('should set headers', () => {
       should(connection.headers).be.exactly(headers);
     });
-
-    it('should be frozen', () => {
-      should(Object.isFrozen(connection)).be.true();
-      should(Object.isFrozen(connection.headers)).be.true();
-      should(Object.isFrozen(connection.ips)).be.true();
-    });
   });
 });

--- a/test/api/core/entrypoints/index.test.js
+++ b/test/api/core/entrypoints/index.test.js
@@ -613,11 +613,7 @@ describe('lib/core/api/core/entrypoints/index', () => {
     it('should dispatch connection:new event', () => {
       entrypoint.newConnection(connection);
 
-      should(kuzzle.emit).be.calledWithMatch('connection:new', {
-        id: 'connectionId',
-        protocol: 'protocol',
-        headers: 'headers'
-      });
+      should(kuzzle.emit).be.calledWithMatch('connection:new', connection);
     });
   });
 


### PR DESCRIPTION
:warning: This is the v2 version of #1469 

# Description

A regression has been introduced in Kuzzle 1.10, due to this PR's changes: https://github.com/kuzzleio/kuzzle/pull/1417#pullrequestreview-280634597
(sorry, this is partly my fault)

By freezing the ClientConnection object, Kuzzle prevents plugins from adding custom headers to a persisted connection. Which is a clear regression.

This PR prevents ClientConnection from freezing its maintained properties.

# Why unfreeze properties without counterpart?

The aim of freezing connection properties was to prevent hooks from modifying connection information. So, at first, I decided to duplicate the connection object before triggering the event.

And after thinking long and hard about it, I decided that this was dumb. Here is why: the only constraint hooks have over pipes, is that hooks aren't waited for.
Which is expected when connections are created: we don't want anything impedding the creation of new connections. But if pipes can modify things, hooks should be able too, even if that seems risky since there will be no guarantee that there won't be race conditions. But that's the problem of plugin devs, not Kuzzle's.
If plugin devs want ot modify connection information safely, they have pipes at their disposal (those are invoked later in a request processing).

So, this PR is really about removing a babysitting feature from Kuzzle.
