### PR TITLE
Fix CLI start --enable-plugin command

### DIFF
--- a/bin/commands/start.js
+++ b/bin/commands/start.js
@@ -64,7 +64,10 @@ function commandStart (options = {}) {
   }
 
   if (options.enablePlugins) {
-    kuzzleParams.additionalPlugins = options.enablePlugins.split(',').map(x => x.trim());
+    kuzzleParams.additionalPlugins = options.enablePlugins
+      .trim()
+      .split(',')
+      .map(x => x.trim().replace(/(^")|("$)/g, ''));
   }
 
   return Promise.all(promises)

--- a/docker-compose/scripts/run.sh
+++ b/docker-compose/scripts/run.sh
@@ -31,4 +31,4 @@ if [ -n "$KUZZLE_PLUGINS" ] && [ "$1" = "start" ]; then
   enable_plugins="--enable-plugins $KUZZLE_PLUGINS"
 fi
 
-exec ./bin/kuzzle "$@" "$enable_plugins"
+exec ./bin/kuzzle "$@" $enable_plugins


### PR DESCRIPTION
What this PR do?
================

In the `run.sh` script the `exec` command does not interpolate double
quote environment variable globbing.
This behavior results to this error on Kuzzle startup:

```
error: unknown option '--enable-plugins "kuzzle-plugin-cluster"'
```
