### PR TITLE
Adapt script to push major tag to Dockerhub

### DIFF
--- a/build-docker-images.sh
+++ b/build-docker-images.sh
@@ -115,11 +115,11 @@ elif [[ "$TRAVIS_BRANCH" == "master" ]] || [[ "$TRAVIS_BRANCH" == *"-stable" ]];
   # Also push the n-stable tag.
   # This tag is a pointer to the latest version of a major version
   #   image name example: kuzzleio/kuzzle:1-stable
-  docker_tag 'plugin-dev' "$RELEASE_TAG" "$MAJOR_VERSION-stable"
-  docker_tag 'kuzzle' "$RELEASE_TAG" "$MAJOR_VERSION-stable"
+  docker_tag 'plugin-dev' "$RELEASE_TAG" "$MAJOR_VERSION"
+  docker_tag 'kuzzle' "$RELEASE_TAG" "$MAJOR_VERSION"
 
-  docker_push 'plugin-dev' "$MAJOR_VERSION-stable"
-  docker_push 'kuzzle' "$MAJOR_VERSION-stable"
+  docker_push 'plugin-dev' "$MAJOR_VERSION"
+  docker_push 'kuzzle' "$MAJOR_VERSION"
 else
-  echo "Could not find RELEASE_TAG or TRAVIS_BRANCH variables. Exiting."
+  echo "Could not find TRAVIS_BRANCH variable. Exiting."
 fi

--- a/build-docker-images.sh
+++ b/build-docker-images.sh
@@ -112,9 +112,9 @@ elif [[ "$TRAVIS_BRANCH" == "master" ]] || [[ "$TRAVIS_BRANCH" == *"-stable" ]];
     docker_push 'kuzzle' 'latest'
   fi
 
-  # Also push the n-stable tag.
+  # Also push the major tag.
   # This tag is a pointer to the latest version of a major version
-  #   image name example: kuzzleio/kuzzle:1-stable
+  #   image name example: kuzzleio/kuzzle:1
   docker_tag 'plugin-dev' "$RELEASE_TAG" "$MAJOR_VERSION"
   docker_tag 'kuzzle' "$RELEASE_TAG" "$MAJOR_VERSION"
 


### PR DESCRIPTION

## What does this PR do ?

When we will release Kuzzle v2 officialy, we will have a problem because projects (and CI) using Kuzzle docker image will try to pull the latest image.. and this image will contain Kuzzle v2 instead of Kuzzle v1.

This PR modify the docker image building script to push a new tag which will point to the latest version of a major version.  

For example, is we release Kuzzle 1.10.3 and the current major is Kuzzle v2, the following images will be pushed:
```
kuzzleio/kuzzle:1.10.3
kuzzleio/kuzzle:1
```

Another example, if we release Kuzzle 2.0.1 and the current major is Kuzzle v2, the following images will be pushed:
```
kuzzleio/kuzzle:2.0.1
kuzzleio/kuzzle:latest
kuzzleio/kuzzle:2
```

Now we have to update all our CI (:expressionless:) to use the `kuzzleio/kuzzle:1` image instead of the latest version.  
I didn't change the `KUZZLE_LATEST_MAJOR` for now, we will do it when we will be ready.

### How should this be manually tested?

  - Step 1 : Run the script with `TRAVIS_BRANCH=1.10.3 bash build-docker-images.sh`
  - Step 2 : Check the printed docker commands (no actual commands will be run)

### Other changes

 - remove the `kuzzleio/kuzzle:develop` tag which is a tag on the latest development branch (eg: if the current major version is Kuzzle v2, this tag represent `2-dev`)
