### PR TITLE
Allow to dynamically add strategy in the pugin init method

### DIFF
--- a/lib/api/core/plugins/pluginsManager.js
+++ b/lib/api/core/plugins/pluginsManager.js
@@ -166,22 +166,12 @@ class PluginsManager {
         plugin.manifest.name,
         plugin.config.privileged ? 'privileged' : 'standard');
 
-      return Bluebird
-        .resolve(plugin.object.init(
-          plugin.config,
-          plugin.config.privileged
-            ? new PrivilegedPluginContext(this.kuzzle, plugin.manifest.name)
-            : new PluginContext(this.kuzzle, plugin.manifest.name)))
-        .timeout(initTimeout)
-        .then(initStatus => {
-          if (initStatus === false) {
-            errorsManager.throw(
-              'plugins',
-              'validation',
-              'plugin_initialization_failed',
-              plugin.manifest.name);
-          }
+      const pluginContext = plugin.config.privileged
+        ? new PrivilegedPluginContext(this.kuzzle, plugin.manifest.name)
+        : new PluginContext(this.kuzzle, plugin.manifest.name);
 
+      return Bluebird.resolve()
+        .then(() => {
           if (plugin.object.controllers) {
             this._initControllers(plugin);
           }
@@ -200,6 +190,17 @@ class PluginsManager {
 
           if (plugin.object.pipes) {
             this._initPipes(plugin, pipeWarnTime, pipeTimeout);
+          }
+        })
+        .then(() => plugin.object.init(plugin.config, pluginContext))
+        .timeout(initTimeout)
+        .then(initStatus => {
+          if (initStatus === false) {
+            errorsManager.throw(
+              'plugins',
+              'validation',
+              'plugin_initialization_failed',
+              plugin.manifest.name);
           }
 
           debug('[%s] plugin started', plugin.manifest.name);


### PR DESCRIPTION
## What does this PR do ?

When dynamically adding strategies with the `accessors.strategies.add` method in the plugin `init` method, the authenticators have not been initialized yet.  

This PR initialize statically declared resources (controllers, authenticators, pipes, etc.) before calling the plugin `init` method.

### How should this be manually tested?

Test plugin:
```
class TestPlugin {
  constructor () {
    this.authenticators = {
      'ExampleStrategy': require('passport-custom').Strategy
    };
  }

  init (config, context) {
    return context.accessors.strategies.add('test',  {
      config: {
        authenticator: 'ExampleStrategy'
      },
      methods: {
        create: 'create',
        delete: 'delete',
        exists: 'exists',
        getById: 'getById',
        getInfo: 'getInfo',
        update: 'update',
        validate: 'validate',
        verify: 'verify'
      }
    })
  }

  create () {}
  exists () {}
  delete () {}
  getById () {}
  getInfo () {}
  update () {}
  validate () {}
  verify () {}
}

module.exports = TestPlugin
```