### PR TITLE
Fix socketio connections leak

### DIFF
--- a/lib/api/core/entrypoints/embedded/index.js
+++ b/lib/api/core/entrypoints/embedded/index.js
@@ -58,7 +58,7 @@ class EmbeddedEntryPoint extends EntryPoint {
 
     this.protocols = {};
 
-    this.clients = {};
+    this._clients = new Map();
 
     this.logger = null;
 
@@ -149,18 +149,16 @@ class EmbeddedEntryPoint extends EntryPoint {
       channel
     );
 
-    const client = this.clients[connectionId];
+    const client = this._clients.get(connectionId);
 
     if (!client || !client.protocol) {
       return;
     }
 
     try {
-      this.protocols[client.protocol].joinChannel(
-        channel,
-        connectionId
-      );
-    } catch (e) {
+      this.protocols[client.protocol].joinChannel(channel, connectionId);
+    }
+    catch (e) {
       this.kuzzle.log.error(`[join] protocol ${client && client.protocol} failed: ${e.message}`);
     }
   }
@@ -172,7 +170,7 @@ class EmbeddedEntryPoint extends EntryPoint {
       channel
     );
 
-    const client = this.clients[connectionId];
+    const client = this._clients.get(connectionId);
 
     if (!client || !client.protocol) {
       return;
@@ -317,15 +315,14 @@ class EmbeddedEntryPoint extends EntryPoint {
    * @param {object} extra
    */
   logAccess (request, extra = null) {
-    let connection = this.clients[request.context.connection.id];
+    let connection = this._clients.get(request.context.connection.id);
 
     // Make do with the RequestContext information
     if (!connection) {
       connection = new ClientConnection(
         request.context.connection.protocol || '-',
         request.context.connection.ips || [],
-        request.context.connection.misc.headers
-      );
+        request.context.connection.misc.headers);
     }
 
     if (this.config.logs.accessLogFormat === 'logstash') {
@@ -486,9 +483,10 @@ class EmbeddedEntryPoint extends EntryPoint {
    * @param {ClientConnection} connection
    */
   newConnection (connection) {
-    this.clients[connection.id] = connection;
+    this._clients.set(connection.id, connection);
 
     this.kuzzle.emit('connection:new', connection);
+    debug('New connection created: %s (protocol: %s)', connection.id, connection.protocol);
 
     this.kuzzle.router.newConnection(new RequestContext({ connection }));
   }
@@ -497,14 +495,14 @@ class EmbeddedEntryPoint extends EntryPoint {
    * @param {string} connectionId
    */
   removeConnection (connectionId) {
-    const connection = this.clients[connectionId];
+    const connection = this._clients.get(connectionId);
 
     if (connection) {
       this.kuzzle.emit('connection:remove', connection);
-
+      debug('Removing connection: %s (protocol: %s)', connection.id, connection.protocol);
       this.kuzzle.router.removeConnection(new RequestContext({ connection }));
 
-      delete this.clients[connectionId];
+      this._clients.delete(connectionId);
     }
   }
 
@@ -537,7 +535,7 @@ class EmbeddedEntryPoint extends EntryPoint {
   _notify (data) {
     debug('[server] sending notification to client with connection id "%s": %a', data.connectionId, data);
 
-    const client = this.clients[data.connectionId];
+    const client = this._clients.get(data.connectionId);
 
     if (!client || !client.protocol) {
       return;

--- a/lib/api/core/entrypoints/embedded/protocols/socketio.js
+++ b/lib/api/core/entrypoints/embedded/protocols/socketio.js
@@ -26,11 +26,13 @@ const
   debug = require('../../../../../kuzzleDebug')('kuzzle:entry-point:protocols:socketio'),
   ClientConnection = require('../clientConnection'),
   Protocol = require('./protocol'),
-  Request = require('kuzzle-common-objects').Request,
   {
-    KuzzleError,
-    InternalError: KuzzleInternalError
-  } = require('kuzzle-common-objects').errors;
+    Request,
+    errors: {
+      KuzzleError,
+      InternalError
+    }
+  } = require('kuzzle-common-objects');
 
 /**
  * @class SocketIoProtocol
@@ -56,9 +58,10 @@ class SocketIoProtocol extends Protocol {
         this.kuzzle = this.entryPoint.kuzzle;
 
         // Socket.io server listens by default to "/socket.io" path
-        // (see (http://socket.io/docs/server-api/#server#path(v:string):server))
+        // (see http://socket.io/docs/server-api/#server#path(v:string):server)
         this.io = require('socket.io')(entryPoint.httpServer, {
-          // maxHttpBufferSize is passed to the ws library as the maxPayload option
+          // maxHttpBufferSize is passed to the ws library as the maxPayload
+          // option
           // see https://github.com/socketio/socket.io/issues/2326#issuecomment-292146468
           maxHttpBufferSize: this.maxRequestSize
         });
@@ -86,7 +89,11 @@ class SocketIoProtocol extends Protocol {
         .concat(ips);
     }
 
-    const connection = new ClientConnection(_protocol, ips, socket.handshake.headers);
+    const connection = new ClientConnection(
+      _protocol,
+      ips,
+      socket.handshake.headers);
+
     debug('[%s] creating SocketIO connection on socket %s', connection.id, socket.id);
 
     try {
@@ -143,9 +150,8 @@ class SocketIoProtocol extends Protocol {
       });
     }
     catch (e) {
-      this.entryPoint.kuzzle.log.error(e instanceof KuzzleError ?
-        e :
-        new KuzzleInternalError(e.message));
+      const error = e instanceof KuzzleError ? e : new InternalError(e);
+      this.entryPoint.kuzzle.log.error(error);
 
       return this.io.to(socket.id).emit(data.requestId, {
         status: 400,
@@ -159,7 +165,10 @@ class SocketIoProtocol extends Protocol {
   broadcast(data) {
     debug('broadcast: %a', data);
 
-    for (const channel of data.channels) {
+    let i; // NOSONAR
+    for(i = 0; i < data.channels.length; i++) {
+      const channel = data.channels[i];
+
       this.io.to(channel).emit(channel, data.payload);
     }
   }
@@ -169,9 +178,11 @@ class SocketIoProtocol extends Protocol {
 
     if (socket) {
       debug('notify: %a', data);
-      data.channels.forEach(channel => {
-        socket.emit(channel, data.payload);
-      });
+
+      let i; // NOSONAR
+      for(i = 0; i < data.channels.length; i++) {
+        socket.emit(data.channels[i], data.payload);
+      }
     }
   }
 

--- a/lib/api/core/entrypoints/embedded/protocols/socketio.js
+++ b/lib/api/core/entrypoints/embedded/protocols/socketio.js
@@ -30,7 +30,7 @@ const
     Request,
     errors: {
       KuzzleError,
-      InternalError
+      InternalError: KuzzleInternalError
     }
   } = require('kuzzle-common-objects');
 
@@ -150,7 +150,7 @@ class SocketIoProtocol extends Protocol {
       });
     }
     catch (e) {
-      const error = e instanceof KuzzleError ? e : new InternalError(e);
+      const error = e instanceof KuzzleError ? e : new KuzzleInternalError(e);
       this.entryPoint.kuzzle.log.error(error);
 
       return this.io.to(socket.id).emit(data.requestId, {

--- a/lib/api/core/entrypoints/embedded/protocols/socketio.js
+++ b/lib/api/core/entrypoints/embedded/protocols/socketio.js
@@ -39,7 +39,7 @@ class SocketIoProtocol extends Protocol {
   constructor() {
     super();
 
-    this.sockets = {};
+    this.sockets = new Map();
     this.io = null;
     this.kuzzle = null;
   }
@@ -100,7 +100,7 @@ class SocketIoProtocol extends Protocol {
       return false;
     }
 
-    this.sockets[connection.id] = socket;
+    this.sockets.set(connection.id, socket);
 
     socket.on('disconnect', () => {
       debug('[%s] receiving a `disconnect` event', connection.id);
@@ -123,16 +123,15 @@ class SocketIoProtocol extends Protocol {
   onClientDisconnection(clientId) {
     debug('[%s] onClientDisconnection', clientId);
 
-    if (this.sockets[clientId]) {
-      delete this.sockets[clientId];
-      delete this.entryPoint.clients[clientId];
-
-      return this.entryPoint.removeConnection(clientId);
+    if (this.sockets.has(clientId)) {
+      this.sockets.delete(clientId);
+      this.entryPoint.removeConnection(clientId);
     }
+
   }
 
   onClientMessage(socket, connection, data) {
-    if (!data || !this.sockets[connection.id]) {
+    if (!data || !this.sockets.has(connection.id)) {
       return;
     }
 
@@ -166,36 +165,40 @@ class SocketIoProtocol extends Protocol {
   }
 
   notify(data) {
-    debug('notify: %a', data);
+    const socket = this.sockets.get(data.connectionId);
 
-    if (this.sockets[data.connectionId]) {
+    if (socket) {
+      debug('notify: %a', data);
       data.channels.forEach(channel => {
-        this.sockets[data.connectionId].emit(channel, data.payload);
+        socket.emit(channel, data.payload);
       });
     }
   }
 
   joinChannel(channel, connectionId) {
-    debug('joinChannel: %s %s', channel, connectionId);
+    const socket = this.sockets.get(connectionId);
 
-    if (this.sockets[connectionId]) {
-      this.sockets[connectionId].join(channel);
+    if (socket) {
+      debug('joinChannel: %s %s', channel, connectionId);
+      socket.join(channel);
     }
   }
 
   leaveChannel(channel, connectionId) {
-    debug('leaveChannel: %s %s', channel, connectionId);
+    const socket = this.sockets.get(connectionId);
 
-    if (this.sockets[connectionId]) {
-      this.sockets[connectionId].leave(channel);
+    if (socket) {
+      debug('leaveChannel: %s %s', channel, connectionId);
+      socket.leave(channel);
     }
   }
 
   disconnect(connectionId) {
-    debug('[%s] disconnect', connectionId);
+    const socket = this.sockets.get(connectionId);
 
-    if (this.sockets[connectionId]) {
-      this.sockets[connectionId].disconnect();
+    if (socket) {
+      debug('[%s] disconnect', connectionId);
+      socket.disconnect();
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {

--- a/test/api/core/entrypoints/embedded/index.test.js
+++ b/test/api/core/entrypoints/embedded/index.test.js
@@ -444,9 +444,7 @@ describe('lib/core/api/core/entrypoints/embedded/index', () => {
     });
 
     it('should call the connection protocol joinChannel method', () => {
-      entrypoint.clients.connectionId = {
-        protocol: 'protocol'
-      };
+      entrypoint._clients.set('connectionId', { protocol: 'protocol' });
       entrypoint.protocols.protocol = {
         joinChannel: sinon.spy()
       };
@@ -460,7 +458,7 @@ describe('lib/core/api/core/entrypoints/embedded/index', () => {
     it('should log errors and continue', () => {
       const error = new Error('test');
 
-      entrypoint.clients.connectionId = {protocol: 'protocol'};
+      entrypoint._clients.set('connectionId', { protocol: 'protocol' });
       entrypoint.protocols.protocol = {
         joinChannel: sinon.stub().throws(error)
       };
@@ -485,7 +483,7 @@ describe('lib/core/api/core/entrypoints/embedded/index', () => {
     });
 
     it('should call the connection protocol leaveChannel method', () => {
-      entrypoint.clients.connectionId = {protocol: 'protocol'};
+      entrypoint._clients.set('connectionId', { protocol: 'protocol' });
       entrypoint.protocols.protocol = {
         leaveChannel: sinon.spy()
       };
@@ -499,7 +497,7 @@ describe('lib/core/api/core/entrypoints/embedded/index', () => {
     it('should log errors and continue', () => {
       const error = new Error('test');
 
-      entrypoint.clients.connectionId = {protocol: 'protocol'};
+      entrypoint._clients.set('connectionId', { protocol: 'protocol' });
       entrypoint.protocols.protocol = {
         leaveChannel: sinon.stub().throws(error)
       };
@@ -631,8 +629,7 @@ describe('lib/core/api/core/entrypoints/embedded/index', () => {
     it('should add the connection to the store and call kuzzle router', () => {
       entrypoint.newConnection(connection);
 
-      should(entrypoint.clients.connectionId)
-        .eql(connection);
+      should(entrypoint._clients).have.value('connectionId', connection);
 
       should(kuzzle.router.newConnection)
         .be.calledOnce()
@@ -655,7 +652,7 @@ describe('lib/core/api/core/entrypoints/embedded/index', () => {
         headers: 'headers'
       };
 
-      entrypoint.clients[connection.id] = connection;
+      entrypoint._clients.set(connection.id, connection);
     });
 
     it('should remove the connection from the store and call kuzzle router', () => {
@@ -664,7 +661,7 @@ describe('lib/core/api/core/entrypoints/embedded/index', () => {
       should(kuzzle.router.removeConnection)
         .be.calledOnce()
         .be.calledWithMatch(new RequestContext({ connection }));
-      should(entrypoint.clients[connection.id]).be.undefined();
+      should(entrypoint._clients).not.have.keys(connection.id);
     });
 
     it('should dispatch connection:remove event', () => {
@@ -711,7 +708,7 @@ describe('lib/core/api/core/entrypoints/embedded/index', () => {
       error.status = 444;
       request.setError(error);
 
-      entrypoint.clients.connectionId = connection;
+      entrypoint._clients.set('connectionId', connection);
       entrypoint.config.logs.accessLogFormat = 'logstash';
 
       entrypoint.logAccess(request);
@@ -751,7 +748,7 @@ describe('lib/core/api/core/entrypoints/embedded/index', () => {
 
       request.status = 444;
 
-      entrypoint.clients.connectionId = connection;
+      entrypoint._clients.set('connectionId', connection);
       entrypoint.config.logs.accessLogFormat = 'combined';
       entrypoint.config.logs.accessLogIpOffset = 1;
 
@@ -784,7 +781,7 @@ describe('lib/core/api/core/entrypoints/embedded/index', () => {
       request.setResult({foo: 'bar'}, result);
 
       entrypoint.config.logs.accessLogFormat = 'combined';
-      entrypoint.clients.connectionId = connection;
+      entrypoint._clients.set('connectionId', connection);
 
       entrypoint.logAccess(request, extra);
 
@@ -836,7 +833,7 @@ describe('lib/core/api/core/entrypoints/embedded/index', () => {
       request.setResult({foo: 'bar'}, result);
 
       entrypoint.config.logs.accessLogFormat = 'combined';
-      entrypoint.clients.connectionId = connection;
+      entrypoint._clients.set('connectionId', connection);
 
       entrypoint.logAccess(request, extra);
 
@@ -873,7 +870,7 @@ describe('lib/core/api/core/entrypoints/embedded/index', () => {
       request.setResult({foo: 'bar'}, result);
 
       entrypoint.config.logs.accessLogFormat = 'combined';
-      entrypoint.clients.connectionId = connection;
+      entrypoint._clients.set('connectionId', connection);
 
       entrypoint.logAccess(request);
 
@@ -939,7 +936,7 @@ describe('lib/core/api/core/entrypoints/embedded/index', () => {
 
   describe('#_notify', () => {
     it('should call underlying protocols and log errors', () => {
-      entrypoint.clients.connectionId = {protocol: 'protocol'};
+      entrypoint._clients.set('connectionId', { protocol: 'protocol' });
       const error = new KuzzleInternalError('test');
 
       entrypoint.protocols = {

--- a/test/api/core/entrypoints/embedded/protocols/http.test.js
+++ b/test/api/core/entrypoints/embedded/protocols/http.test.js
@@ -61,8 +61,9 @@ describe('/lib/api/core/entrypoints/embedded/protocols/http', () => {
     kuzzle = new KuzzleMock();
 
     entrypoint = new EntryPoint(kuzzle);
-    entrypoint.execute = sinon.spy();
-    entrypoint.newConnection = sinon.spy();
+    sinon.stub(entrypoint, 'execute');
+    sinon.stub(entrypoint, 'newConnection');
+    sinon.stub(entrypoint, 'removeConnection');
     entrypoint.httpServer = {
       listen: sinon.spy(),
       on: sinon.spy()
@@ -70,7 +71,6 @@ describe('/lib/api/core/entrypoints/embedded/protocols/http', () => {
     entrypoint.logger = {
       info: sinon.stub()
     };
-
     protocol = new HttpProtocol();
   });
 
@@ -825,11 +825,9 @@ describe('/lib/api/core/entrypoints/embedded/protocols/http', () => {
       const error = new Error('test');
       error.status = 'status';
 
-      entrypoint.clients.connectionId = {};
-
       protocol._replyWithError({id: 'connectionId'}, {}, response, error);
 
-      should(entrypoint.clients).be.empty();
+      should(entrypoint.removeConnection).calledOnce().calledWith('connectionId');
     });
   });
 

--- a/test/api/core/entrypoints/embedded/protocols/socketio.test.js
+++ b/test/api/core/entrypoints/embedded/protocols/socketio.test.js
@@ -145,19 +145,17 @@ describe('/lib/api/core/entrypoints/embedded/protocols/socketio', () => {
 
   describe('#onClientDisconnection', () => {
     it('should delete the connection', () => {
-      entrypoint.clients.connectionId = {};
+      entrypoint._clients.set('connectionId', {});
+      sinon.stub(entrypoint, 'removeConnection');
 
       return protocol.init(entrypoint)
         .then(() => {
-          protocol.sockets = {
-            connectionId: {}
-          };
+          protocol.sockets.set('connectionId', {});
 
           protocol.onClientDisconnection('connectionId');
-          should(protocol.sockets)
-            .be.empty();
-          should(entrypoint.clients)
-            .be.empty();
+          should(protocol.sockets).be.empty();
+          should(entrypoint.removeConnection).calledOnce().calledWith('connectionId');
+          should(entrypoint._clients).have.keys('connectionId');
         });
     });
   });
@@ -179,9 +177,7 @@ describe('/lib/api/core/entrypoints/embedded/protocols/socketio', () => {
 
       return protocol.init(entrypoint)
         .then(() => {
-          protocol.sockets = {
-            connectionId: {}
-          };
+          protocol.sockets.set('connectionId', {});
         });
     });
 
@@ -253,11 +249,7 @@ describe('/lib/api/core/entrypoints/embedded/protocols/socketio', () => {
 
   describe('#notify', () => {
     it('should emit to the connection channel(s)', () => {
-      protocol.sockets = {
-        connectionId: {
-          emit: socketEmitStub
-        }
-      };
+      protocol.sockets.set('connectionId', { emit: socketEmitStub });
 
       protocol.notify({
         connectionId: 'connectionId',
@@ -274,44 +266,31 @@ describe('/lib/api/core/entrypoints/embedded/protocols/socketio', () => {
 
   describe('#joinChannel', () => {
     it('should call socket io join', () => {
-      protocol.sockets = {
-        connectionId: {
-          join: sinon.spy()
-        }
-      };
+      protocol.sockets.set('connectionId', { join: sinon.spy() });
 
       protocol.joinChannel('channel', 'connectionId');
-      should(protocol.sockets.connectionId.join)
+      should(protocol.sockets.get('connectionId').join)
         .be.calledWith('channel');
     });
   });
 
   describe('#leaveChannel', () => {
     it('should call socket io leave', () => {
-      protocol.sockets = {
-        connectionId: {
-          leave: sinon.spy()
-        }
-      };
+      protocol.sockets.set('connectionId', { leave: sinon.spy() });
 
       protocol.leaveChannel('channel', 'connectionId');
-      should(protocol.sockets.connectionId.leave)
+      should(protocol.sockets.get('connectionId').leave)
         .be.calledWith('channel');
     });
   });
 
   describe('#disconnect', () => {
     it('should call socket io disconnect', () => {
-      protocol.sockets = {
-        connectionId: {
-          disconnect: sinon.spy()
-        }
-      };
+      protocol.sockets.set('connectionId', { disconnect: sinon.spy() });
+
       protocol.disconnect('connectionId');
-      should(protocol.sockets.connectionId.disconnect)
+      should(protocol.sockets.get('connectionId').disconnect)
         .be.calledOnce();
     });
   });
-
-
 });

--- a/test/api/core/entrypoints/embedded/protocols/websocket.test.js
+++ b/test/api/core/entrypoints/embedded/protocols/websocket.test.js
@@ -22,6 +22,9 @@ describe('/lib/api/core/entrypoints/embedded/protocols/websocket', () => {
     kuzzle = new KuzzleMock();
     entrypoint = new EntryPoint(kuzzle);
 
+    sinon.stub(entrypoint, 'newConnection');
+    sinon.stub(entrypoint, 'removeConnection');
+
     WebSocketServer = sinon.spy(function () {
       this.on = sinon.spy();
     });
@@ -245,10 +248,8 @@ describe('/lib/api/core/entrypoints/embedded/protocols/websocket', () => {
     });
 
     it('should remove the client from its subscriptions', () => {
-      entrypoint.clients.connectionId = {};
       protocol.onClientDisconnection('connectionId');
-
-      should(entrypoint.clients).be.empty();
+      should(entrypoint.removeConnection).calledOnce().calledWith('connectionId');
 
       should(protocol.channels).deepEqual(new Map([
         ['c1', new Set(['foo', 'bar'])]


### PR DESCRIPTION
# Description

Sockets closed by socket.io are correctly caught by our socketio handler, which starts by removing the connection identifier from the entrypoint, and then calls `entrypoint.removeConnection`.

Since the connection has already been removed, the entrypoint believes that it's an unmanaged one, and skips it. 

This means that resources attached to a connection (usage statistics, real-time filters, router connection context, ...) aren't freed.

Also, the `connection:remove` event isn't triggered, making the prometheus plugin thinks that socketio connections are never closed.

# Other changes

* socket.io layer: make the `sockets` cache a Map instead of a raw object (more adapted to that kind of very volatile data)
* entrypoint:
  * make the clients cache a Map instead of a raw object
  * rename `clients` into `_clients` as a warning that this shouldn't be trifled with 
  * new debug entries added