### PR TITLE
Fix socketio connections leak & deactivate this protocol by default

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -345,7 +345,7 @@
         }
       },
       "socketio": {
-        "enabled": true,
+        "enabled": false,
         // value of Access-Control-Allow-Origin header to answer the upgrade
         // request
         "origins": "*:*"

--- a/default.config.js
+++ b/default.config.js
@@ -189,7 +189,7 @@ module.exports = {
         }
       },
       socketio: {
-        enabled: true,
+        enabled: false,
         origins: '*:*'
       },
       websocket: {

--- a/lib/api/core/entrypoints/index.js
+++ b/lib/api/core/entrypoints/index.js
@@ -54,7 +54,7 @@ class EntryPoint {
 
     this.protocols = {};
 
-    this.clients = {};
+    this._clients = new Map();
 
     this.logger = null;
 
@@ -130,7 +130,7 @@ class EntryPoint {
   joinChannel (channel, connectionId) {
     debug('[server] client "%s" joining channel "%s"', connectionId, channel);
 
-    const client = this.clients[connectionId];
+    const client = this._clients.get(connectionId);
 
     if (!client || !client.protocol) {
       return;
@@ -150,7 +150,7 @@ class EntryPoint {
       connectionId,
       channel);
 
-    const client = this.clients[connectionId];
+    const client = this._clients.get(connectionId);
 
     if (!client || !client.protocol) {
       return;
@@ -305,7 +305,7 @@ class EntryPoint {
    * @param {object} extra
    */
   logAccess (request, extra = null) {
-    let connection = this.clients[request.context.connection.id];
+    let connection = this._clients.get(request.context.connection.id);
 
     // Make do with the RequestContext information
     if (!connection) {
@@ -483,25 +483,33 @@ class EntryPoint {
    * @param {ClientConnection} connection
    */
   newConnection (connection) {
-    this.clients[connection.id] = connection;
+    this._clients.set(connection.id, connection);
 
     this.kuzzle.emit('connection:new', connection);
-
     this.kuzzle.router.newConnection(new RequestContext({ connection }));
+    debug(
+      'New connection created: %s (protocol: %s)',
+      connection.id,
+      connection.protocol);
   }
 
   /**
    * @param {string} connectionId
    */
   removeConnection (connectionId) {
-    const connection = this.clients[connectionId];
+    const connection = this._clients.get(connectionId);
 
     if (connection) {
       this.kuzzle.emit('connection:remove', connection);
 
       this.kuzzle.router.removeConnection(new RequestContext({ connection }));
 
-      delete this.clients[connectionId];
+      this._clients.delete(connectionId);
+
+      debug(
+        'Removed connection: %s (protocol: %s)',
+        connection.id,
+        connection.protocol);
     }
   }
 
@@ -535,7 +543,7 @@ class EntryPoint {
       data.connectionId,
       data);
 
-    const client = this.clients[data.connectionId];
+    const client = this._clients.get(data.connectionId);
 
     if (!client || !client.protocol) {
       return;

--- a/lib/api/core/entrypoints/protocols/socketio.js
+++ b/lib/api/core/entrypoints/protocols/socketio.js
@@ -41,7 +41,7 @@ class SocketIoProtocol extends Protocol {
   constructor() {
     super();
 
-    this.sockets = {};
+    this.sockets = new Map();
     this.io = null;
     this.kuzzle = null;
   }
@@ -58,9 +58,10 @@ class SocketIoProtocol extends Protocol {
         this.kuzzle = this.entryPoint.kuzzle;
 
         // Socket.io server listens by default to "/socket.io" path
-        // (see (http://socket.io/docs/server-api/#server#path(v:string):server))
+        // (see http://socket.io/docs/server-api/#server#path(v:string):server)
         this.io = require('socket.io')(entryPoint.httpServer, {
-          // maxHttpBufferSize is passed to the ws library as the maxPayload option
+          // maxHttpBufferSize is passed to the ws library as the maxPayload
+          // option
           // see https://github.com/socketio/socket.io/issues/2326#issuecomment-292146468
           maxHttpBufferSize: this.maxRequestSize
         });
@@ -88,7 +89,11 @@ class SocketIoProtocol extends Protocol {
         .concat(ips);
     }
 
-    const connection = new ClientConnection(_protocol, ips, socket.handshake.headers);
+    const connection = new ClientConnection(
+      _protocol,
+      ips,
+      socket.handshake.headers);
+
     debug('[%s] creating SocketIO connection on socket %s', connection.id, socket.id);
 
     try {
@@ -102,7 +107,7 @@ class SocketIoProtocol extends Protocol {
       return false;
     }
 
-    this.sockets[connection.id] = socket;
+    this.sockets.set(connection.id, socket);
 
     socket.on('disconnect', () => {
       debug('[%s] receiving a `disconnect` event', connection.id);
@@ -125,16 +130,15 @@ class SocketIoProtocol extends Protocol {
   onClientDisconnection(clientId) {
     debug('[%s] onClientDisconnection', clientId);
 
-    if (this.sockets[clientId]) {
-      delete this.sockets[clientId];
-      delete this.entryPoint.clients[clientId];
-
-      return this.entryPoint.removeConnection(clientId);
+    if (this.sockets.has(clientId)) {
+      this.sockets.delete(clientId);
+      this.entryPoint.removeConnection(clientId);
     }
+
   }
 
   onClientMessage(socket, connection, data) {
-    if (!data || !this.sockets[connection.id]) {
+    if (!data || !this.sockets.has(connection.id)) {
       return;
     }
 
@@ -146,9 +150,8 @@ class SocketIoProtocol extends Protocol {
       });
     }
     catch (e) {
-      this.entryPoint.kuzzle.log.error(e instanceof KuzzleError ?
-        e :
-        new KuzzleInternalError(e.message));
+      const error = e instanceof KuzzleError ? e : new KuzzleInternalError(e);
+      this.entryPoint.kuzzle.log.error(error);
 
       return this.io.to(socket.id).emit(data.requestId, {
         status: 400,
@@ -162,42 +165,51 @@ class SocketIoProtocol extends Protocol {
   broadcast(data) {
     debug('broadcast: %a', data);
 
-    for (const channel of data.channels) {
+    let i; // NOSONAR
+    for(i = 0; i < data.channels.length; i++) {
+      const channel = data.channels[i];
+
       this.io.to(channel).emit(channel, data.payload);
     }
   }
 
   notify(data) {
-    debug('notify: %a', data);
+    const socket = this.sockets.get(data.connectionId);
 
-    if (this.sockets[data.connectionId]) {
-      data.channels.forEach(channel => {
-        this.sockets[data.connectionId].emit(channel, data.payload);
-      });
+    if (socket) {
+      debug('notify: %a', data);
+
+      let i; // NOSONAR
+      for(i = 0; i < data.channels.length; i++) {
+        socket.emit(data.channels[i], data.payload);
+      }
     }
   }
 
   joinChannel(channel, connectionId) {
-    debug('joinChannel: %s %s', channel, connectionId);
+    const socket = this.sockets.get(connectionId);
 
-    if (this.sockets[connectionId]) {
-      this.sockets[connectionId].join(channel);
+    if (socket) {
+      debug('joinChannel: %s %s', channel, connectionId);
+      socket.join(channel);
     }
   }
 
   leaveChannel(channel, connectionId) {
-    debug('leaveChannel: %s %s', channel, connectionId);
+    const socket = this.sockets.get(connectionId);
 
-    if (this.sockets[connectionId]) {
-      this.sockets[connectionId].leave(channel);
+    if (socket) {
+      debug('leaveChannel: %s %s', channel, connectionId);
+      socket.leave(channel);
     }
   }
 
   disconnect(connectionId) {
-    debug('[%s] disconnect', connectionId);
+    const socket = this.sockets.get(connectionId);
 
-    if (this.sockets[connectionId]) {
-      this.sockets[connectionId].disconnect();
+    if (socket) {
+      debug('[%s] disconnect', connectionId);
+      socket.disconnect();
     }
   }
 }

--- a/test/api/core/entrypoints/index.test.js
+++ b/test/api/core/entrypoints/index.test.js
@@ -444,9 +444,7 @@ describe('lib/core/api/core/entrypoints/index', () => {
     });
 
     it('should call the connection protocol joinChannel method', () => {
-      entrypoint.clients.connectionId = {
-        protocol: 'protocol'
-      };
+      entrypoint._clients.set('connectionId', { protocol: 'protocol' });
       entrypoint.protocols.protocol = {
         joinChannel: sinon.spy()
       };
@@ -460,7 +458,7 @@ describe('lib/core/api/core/entrypoints/index', () => {
     it('should log errors and continue', () => {
       const error = new Error('test');
 
-      entrypoint.clients.connectionId = {protocol: 'protocol'};
+      entrypoint._clients.set('connectionId', { protocol: 'protocol' });
       entrypoint.protocols.protocol = {
         joinChannel: sinon.stub().throws(error)
       };
@@ -485,7 +483,7 @@ describe('lib/core/api/core/entrypoints/index', () => {
     });
 
     it('should call the connection protocol leaveChannel method', () => {
-      entrypoint.clients.connectionId = {protocol: 'protocol'};
+      entrypoint._clients.set('connectionId', { protocol: 'protocol' });
       entrypoint.protocols.protocol = {
         leaveChannel: sinon.spy()
       };
@@ -499,7 +497,7 @@ describe('lib/core/api/core/entrypoints/index', () => {
     it('should log errors and continue', () => {
       const error = new Error('test');
 
-      entrypoint.clients.connectionId = {protocol: 'protocol'};
+      entrypoint._clients.set('connectionId', { protocol: 'protocol' });
       entrypoint.protocols.protocol = {
         leaveChannel: sinon.stub().throws(error)
       };
@@ -603,8 +601,7 @@ describe('lib/core/api/core/entrypoints/index', () => {
     it('should add the connection to the store and call kuzzle router', () => {
       entrypoint.newConnection(connection);
 
-      should(entrypoint.clients.connectionId)
-        .eql(connection);
+      should(entrypoint._clients).have.value('connectionId', connection);
 
       should(kuzzle.router.newConnection)
         .be.calledOnce()
@@ -628,7 +625,7 @@ describe('lib/core/api/core/entrypoints/index', () => {
         headers: 'headers'
       };
 
-      entrypoint.clients[connection.id] = connection;
+      entrypoint._clients.set(connection.id, connection);
     });
 
     it('should remove the connection from the store and call kuzzle router', () => {
@@ -637,7 +634,7 @@ describe('lib/core/api/core/entrypoints/index', () => {
       should(kuzzle.router.removeConnection)
         .be.calledOnce()
         .be.calledWithMatch(new RequestContext({ connection }));
-      should(entrypoint.clients[connection.id]).be.undefined();
+      should(entrypoint._clients).not.have.keys(connection.id);
     });
 
     it('should dispatch connection:remove event', () => {
@@ -686,7 +683,7 @@ describe('lib/core/api/core/entrypoints/index', () => {
       error.status = 444;
       request.setError(error);
 
-      entrypoint.clients.connectionId = connection;
+      entrypoint._clients.set('connectionId', connection);
       entrypoint.config.logs.accessLogFormat = 'logstash';
 
       entrypoint.logAccess(request);
@@ -726,7 +723,7 @@ describe('lib/core/api/core/entrypoints/index', () => {
 
       request.status = 444;
 
-      entrypoint.clients.connectionId = connection;
+      entrypoint._clients.set('connectionId', connection);
       entrypoint.config.logs.accessLogFormat = 'combined';
       entrypoint.config.logs.accessLogIpOffset = 1;
 
@@ -759,7 +756,7 @@ describe('lib/core/api/core/entrypoints/index', () => {
       request.setResult({foo: 'bar'}, result);
 
       entrypoint.config.logs.accessLogFormat = 'combined';
-      entrypoint.clients.connectionId = connection;
+      entrypoint._clients.set('connectionId', connection);
 
       entrypoint.logAccess(request, extra);
 
@@ -811,7 +808,7 @@ describe('lib/core/api/core/entrypoints/index', () => {
       request.setResult({foo: 'bar'}, result);
 
       entrypoint.config.logs.accessLogFormat = 'combined';
-      entrypoint.clients.connectionId = connection;
+      entrypoint._clients.set('connectionId', connection);
 
       entrypoint.logAccess(request, extra);
 
@@ -848,7 +845,7 @@ describe('lib/core/api/core/entrypoints/index', () => {
       request.setResult({foo: 'bar'}, result);
 
       entrypoint.config.logs.accessLogFormat = 'combined';
-      entrypoint.clients.connectionId = connection;
+      entrypoint._clients.set('connectionId', connection);
 
       entrypoint.logAccess(request);
 
@@ -914,7 +911,7 @@ describe('lib/core/api/core/entrypoints/index', () => {
 
   describe('#_notify', () => {
     it('should call underlying protocols and log errors', () => {
-      entrypoint.clients.connectionId = {protocol: 'protocol'};
+      entrypoint._clients.set('connectionId', { protocol: 'protocol' });
       const error = new KuzzleInternalError('test');
 
       entrypoint.protocols = {

--- a/test/api/core/entrypoints/protocols/http.test.js
+++ b/test/api/core/entrypoints/protocols/http.test.js
@@ -64,8 +64,9 @@ describe('/lib/api/core/entrypoints/protocols/http', () => {
     kuzzle = new KuzzleMock();
 
     entrypoint = new EntryPoint(kuzzle);
-    entrypoint.execute = sinon.spy();
-    entrypoint.newConnection = sinon.spy();
+    sinon.stub(entrypoint, 'execute');
+    sinon.stub(entrypoint, 'newConnection');
+    sinon.stub(entrypoint, 'removeConnection');
     entrypoint.httpServer = {
       listen: sinon.spy(),
       on: sinon.spy()
@@ -73,7 +74,6 @@ describe('/lib/api/core/entrypoints/protocols/http', () => {
     entrypoint.logger = {
       info: sinon.stub()
     };
-
     protocol = new HttpProtocol();
   });
 
@@ -837,14 +837,12 @@ describe('/lib/api/core/entrypoints/protocols/http', () => {
       const error = new Error('test');
       error.status = 'status';
 
-      entrypoint.clients.connectionId = {};
-
       protocol._replyWithError(
         new HttpMessage({id: 'connectionId'}, {}),
         response,
         error);
 
-      should(entrypoint.clients).be.empty();
+      should(entrypoint.removeConnection).calledOnce().calledWith('connectionId');
     });
   });
 

--- a/test/api/core/entrypoints/protocols/socketio.test.js
+++ b/test/api/core/entrypoints/protocols/socketio.test.js
@@ -29,6 +29,8 @@ describe('/lib/api/core/entrypoints/protocols/socketio', () => {
     SocketIoProtocol = mockrequire.reRequire('../../../../../lib/api/core/entrypoints/protocols/socketio');
 
     protocol = new SocketIoProtocol();
+
+    entrypoint.config.protocols.socketio.enabled = true;
   });
 
   describe('#init', () => {
@@ -48,7 +50,6 @@ describe('/lib/api/core/entrypoints/protocols/socketio', () => {
 
       return protocol.init(entrypoint)
         .then(() => {
-
           should(protocol.io.set).be.calledOnce();
           should(protocol.io.on).be.calledTwice();
           {
@@ -145,19 +146,17 @@ describe('/lib/api/core/entrypoints/protocols/socketio', () => {
 
   describe('#onClientDisconnection', () => {
     it('should delete the connection', () => {
-      entrypoint.clients.connectionId = {};
+      entrypoint._clients.set('connectionId', {});
+      sinon.stub(entrypoint, 'removeConnection');
 
       return protocol.init(entrypoint)
         .then(() => {
-          protocol.sockets = {
-            connectionId: {}
-          };
+          protocol.sockets.set('connectionId', {});
 
           protocol.onClientDisconnection('connectionId');
-          should(protocol.sockets)
-            .be.empty();
-          should(entrypoint.clients)
-            .be.empty();
+          should(protocol.sockets).be.empty();
+          should(entrypoint.removeConnection).calledOnce().calledWith('connectionId');
+          should(entrypoint._clients).have.keys('connectionId');
         });
     });
   });
@@ -179,9 +178,7 @@ describe('/lib/api/core/entrypoints/protocols/socketio', () => {
 
       return protocol.init(entrypoint)
         .then(() => {
-          protocol.sockets = {
-            connectionId: {}
-          };
+          protocol.sockets.set('connectionId', {});
         });
     });
 
@@ -253,11 +250,7 @@ describe('/lib/api/core/entrypoints/protocols/socketio', () => {
 
   describe('#notify', () => {
     it('should emit to the connection channel(s)', () => {
-      protocol.sockets = {
-        connectionId: {
-          emit: socketEmitStub
-        }
-      };
+      protocol.sockets.set('connectionId', { emit: socketEmitStub });
 
       protocol.notify({
         connectionId: 'connectionId',
@@ -274,44 +267,31 @@ describe('/lib/api/core/entrypoints/protocols/socketio', () => {
 
   describe('#joinChannel', () => {
     it('should call socket io join', () => {
-      protocol.sockets = {
-        connectionId: {
-          join: sinon.spy()
-        }
-      };
+      protocol.sockets.set('connectionId', { join: sinon.spy() });
 
       protocol.joinChannel('channel', 'connectionId');
-      should(protocol.sockets.connectionId.join)
+      should(protocol.sockets.get('connectionId').join)
         .be.calledWith('channel');
     });
   });
 
   describe('#leaveChannel', () => {
     it('should call socket io leave', () => {
-      protocol.sockets = {
-        connectionId: {
-          leave: sinon.spy()
-        }
-      };
+      protocol.sockets.set('connectionId', { leave: sinon.spy() });
 
       protocol.leaveChannel('channel', 'connectionId');
-      should(protocol.sockets.connectionId.leave)
+      should(protocol.sockets.get('connectionId').leave)
         .be.calledWith('channel');
     });
   });
 
   describe('#disconnect', () => {
     it('should call socket io disconnect', () => {
-      protocol.sockets = {
-        connectionId: {
-          disconnect: sinon.spy()
-        }
-      };
+      protocol.sockets.set('connectionId', { disconnect: sinon.spy() });
+
       protocol.disconnect('connectionId');
-      should(protocol.sockets.connectionId.disconnect)
+      should(protocol.sockets.get('connectionId').disconnect)
         .be.calledOnce();
     });
   });
-
-
 });

--- a/test/api/core/entrypoints/protocols/websocket.test.js
+++ b/test/api/core/entrypoints/protocols/websocket.test.js
@@ -22,6 +22,9 @@ describe('/lib/api/core/entrypoints/protocols/websocket', () => {
     kuzzle = new KuzzleMock();
     entrypoint = new EntryPoint(kuzzle);
 
+    sinon.stub(entrypoint, 'newConnection');
+    sinon.stub(entrypoint, 'removeConnection');
+
     WebSocketServer = sinon.spy(function () {
       this.on = sinon.spy();
     });
@@ -244,10 +247,8 @@ describe('/lib/api/core/entrypoints/protocols/websocket', () => {
     });
 
     it('should remove the client from its subscriptions', () => {
-      entrypoint.clients.connectionId = {};
       protocol.onClientDisconnection('connectionId');
-
-      should(entrypoint.clients).be.empty();
+      should(entrypoint.removeConnection).calledOnce().calledWith('connectionId');
 
       should(protocol.channels).deepEqual(new Map([
         ['c1', new Set(['foo', 'bar'])]


### PR DESCRIPTION
# Description

Same as #1482 , with the following additional change: the socketio protocol is now deactivated by default (files `default.config.js` and `.kuzzlerc.sample`)
