### PR TITLE
Add kuzzle version to the dumped informations

### DIFF
--- a/lib/api/core/janitor.js
+++ b/lib/api/core/janitor.js
@@ -228,11 +228,18 @@ class Janitor {
         return reject(new Error(message));
       }
 
-      // dumping kuzzle configuration
+      // dumping kuzzle information
       this.kuzzle.log.info('> dumping kuzzle configuration');
       fs.writeFileSync(
-        path.join(dumpPath, 'config.json'),
-        JSON.stringify(this.kuzzle.config, null, ' ').concat('\n'));
+        path.join(dumpPath, 'kuzzle.json'),
+        JSON.stringify(
+          {
+            version: require('../../../package.json').version,
+            config: this.kuzzle.config
+          },
+          null,
+          ' ')
+          .concat('\n'));
 
       // dumping plugins configuration
       this.kuzzle.log.info('> dumping plugins configuration');

--- a/test/api/core/janitor.test.js
+++ b/test/api/core/janitor.test.js
@@ -302,8 +302,13 @@ describe('Test: core/janitor', () => {
             should(fsStub.mkdirsSync).be.calledOnce();
             should(fsStub.mkdirsSync.getCall(0).args[0]).be.exactly(baseDumpPath);
 
-            should(fsStub.writeFileSync.getCall(0).args[0]).be.exactly(baseDumpPath.concat('/config.json'));
-            should(fsStub.writeFileSync.getCall(0).args[1]).be.exactly(JSON.stringify(kuzzle.config, null, ' ').concat('\n'));
+            should(fsStub.writeFileSync.getCall(0).args[0])
+              .be.exactly(baseDumpPath.concat('/kuzzle.json'));
+            should(fsStub.writeFileSync.getCall(0).args[1])
+              .be.exactly(JSON.stringify({
+                version: require('../../../package.json').version,
+                config: kuzzle.config
+              }, null, ' ').concat('\n'));
 
             should(fsStub.writeFileSync.getCall(1).args[0]).be.exactly(baseDumpPath.concat('/plugins.json'));
             should(fsStub.writeFileSync.getCall(1).args[1]).be.exactly(JSON.stringify(kuzzle.pluginsManager.plugins, null, ' ').concat('\n'));


### PR DESCRIPTION
# Description

This is really awkward, but... the current Kuzzle version is not dumped along with the vast quantities of information dumped by our dump command.

This PR fixes that.

V2 PR: https://github.com/kuzzleio/kuzzle/pull/1488