### PR TITLE
Add highlight to search results

### DIFF
--- a/doc/2/api/controllers/document/search/index.md
+++ b/doc/2/api/controllers/document/search/index.md
@@ -104,6 +104,7 @@ Returns a paginated search result set, with the following properties:
   - `_id`: document unique identifier
   - `_score`: [relevance score](https://www.elastic.co/guide/en/elasticsearch/guide/current/relevance-intro.html)
   - `_source`: new document content
+  - `highlight`: optional result from [highlight API](https://www.elastic.co/guide/en/elasticsearch/reference/7.3/search-request-body.html#request-body-search-highlighting)
 - `scrollId`: identifier to the next page of result. Present only if the `scroll` argument has been set
 - `total`: total number of found documents. Can be greater than the number of documents in a result page, meaning that other matches than the one retrieved are available
 

--- a/features-sdk/DocumentController.feature
+++ b/features-sdk/DocumentController.feature
@@ -1,5 +1,31 @@
 Feature: Document Controller
 
+  # document:search ============================================================
+
+  @mappings
+  Scenario: Search with highlight
+    Given an existing collection "nyc-open-data":"yellow-taxi"
+    And I "create" the following documents:
+    | _id          | body  |
+    | "document-1" | { "name": "document", "age": 42 } |
+    | -            | { "name": "document2", "age": 21 } |
+    When I search documents with the following query:
+    """
+    {
+      "match": { "name": "document" }
+    }
+    """
+    And with the following highlights:
+    """
+    {
+      "fields": { "name": {} }
+    }
+    """
+    And I execute the search query
+    Then I should receive a "hits" array of objects matching:
+    | _id | highlight |
+    | "document-1" | { "name": [ "<em>document</em>" ] } |
+
   # document:mCreate ===========================================================
 
   @mappings

--- a/features-sdk/step_definitions/documents-steps.js
+++ b/features-sdk/step_definitions/documents-steps.js
@@ -117,3 +117,22 @@ Then('I {string} the following document ids:', async function (action, dataTable
     ids,
     { refresh: 'wait_for' });
 });
+
+Then('I search documents with the following query:', function (queryRaw) {
+  const query = JSON.parse(queryRaw);
+
+  this.props.searchBody = { query };
+});
+
+Then('with the following highlights:', function (highlightsRaw) {
+  const highlights = JSON.parse(highlightsRaw);
+
+  this.props.searchBody.highlight = highlights;
+});
+
+Then('I execute the search query', async function () {
+  this.props.result = await this.sdk.document.search(
+    this.props.index,
+    this.props.collection,
+    this.props.searchBody);
+});

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -226,7 +226,8 @@ class ElasticSearch extends Service {
       hits.push({
         _id: hit._id,
         _score: hit._score,
-        _source: hit._source
+        _source: hit._source,
+        highlight: hit.highlight
       });
     }
 

--- a/lib/util/esWrapper.js
+++ b/lib/util/esWrapper.js
@@ -152,13 +152,9 @@ class ESWrapper {
       const matches = message.match(mapping.regex);
 
       if (matches) {
-        console.log(mapping.subcode)
-        console.log(mapping.getPlaceholders(matches))
-        const e = errorsManager.get(
+        return errorsManager.get(
           mapping.subcode,
           ...mapping.getPlaceholders(matches));
-          console.log(e)
-          return e
       }
     }
 

--- a/lib/util/esWrapper.js
+++ b/lib/util/esWrapper.js
@@ -62,8 +62,8 @@ const errorMessagesMapping = [
   {
     // [illegal_argument_exception] mapper [source.flags] of different type, current_type [string], merged_type [long]
     regex: /^mapper \[(.*?)] of different type, current_type \[(.*?)], merged_type \[(.*?)]$/,
-    subcode: 'invalid_type_change',
-    getPlaceholders: matches => [matches[1], matches[2], matches[3]]
+    subcode: 'cannot_change_mapping',
+    getPlaceholders: matches => [matches[1]]
   },
   {
     // [mapper_parsing_exception] Mapping definition for [flags] has unsupported parameters:  [index : not_analyzed]
@@ -152,9 +152,13 @@ class ESWrapper {
       const matches = message.match(mapping.regex);
 
       if (matches) {
-        return errorsManager.get(
+        console.log(mapping.subcode)
+        console.log(mapping.getPlaceholders(matches))
+        const e = errorsManager.get(
           mapping.subcode,
           ...mapping.getPlaceholders(matches));
+          console.log(e)
+          return e
       }
     }
 

--- a/test/services/elasticsearch.test.js
+++ b/test/services/elasticsearch.test.js
@@ -141,7 +141,7 @@ describe('Test: ElasticSearch service', () => {
       elasticsearch._client.search.resolves({
         body: {
           hits: {
-            hits: [ { _id: 'liia', _source: { city: 'Kathmandu' }, other: 'thing' } ],
+            hits: [ { _id: 'liia', _source: { city: 'Kathmandu' }, highlight: 'highlight', other: 'thing' } ],
             total: { value: 1 },
           },
           body: filter,
@@ -167,7 +167,7 @@ describe('Test: ElasticSearch service', () => {
 
           should(result).match({
             scrollId: 'i-am-scroll-id',
-            hits: [ { _id: 'liia', _source: { city: 'Kathmandu' } } ],
+            hits: [ { _id: 'liia', _source: { city: 'Kathmandu' }, highlight: 'highlight' } ],
             total: 1,
             aggregations: { some: 'aggregs' }
           });


### PR DESCRIPTION
## What does this PR do ?

Add highlight from [ES Highlight API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-highlighting) to search results

### Other changes

  - fix incorrect error returned when try to change a field mapping