### PR TITLE
mapping - enable dynamic templates

### DIFF
--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -35,7 +35,7 @@ const
 
 const scrollCachePrefix = '_docscroll_';
 
-const rootMappingProperties = ['properties', '_meta', 'dynamic'];
+const rootMappingProperties = ['properties', '_meta', 'dynamic', 'dynamic_templates'];
 const childMappingProperties = ['type'];
 
 /**

--- a/test/services/implementations/elasticsearch.test.js
+++ b/test/services/implementations/elasticsearch.test.js
@@ -2885,6 +2885,7 @@ describe('Test: ElasticSearch service', () => {
           name: { type: 'keyword' },
           car: {
             dynamic: 'false',
+            dynamic_templates: {},
             type: 'nested',
             properties: {
               brand: { type: 'keyword' }


### PR DESCRIPTION
Allow [`dynamic templates`](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/dynamic-templates.html) in `updateMapping`.