### PR TITLE
mapping - enable dynamic templates

### DIFF
--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -36,7 +36,7 @@ const
 
 const scrollCachePrefix = '_docscroll_';
 
-const rootMappingProperties = ['properties', '_meta', 'dynamic'];
+const rootMappingProperties = ['properties', '_meta', 'dynamic', 'dynamic_templates'];
 const childMappingProperties = ['type'];
 
 // Used for collection emulation

--- a/test/services/elasticsearch.test.js
+++ b/test/services/elasticsearch.test.js
@@ -3003,6 +3003,7 @@ describe('Test: ElasticSearch service', () => {
           name: { type: 'keyword' },
           car: {
             dynamic: 'false',
+            dynamic_templates: {},
             type: 'nested',
             properties: {
               brand: { type: 'keyword' }


### PR DESCRIPTION
Allow [`dynamic templates`](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/dynamic-templates.html) in `updateMapping`.