### PR TITLE
Hotfix/subscribe dead connection

### DIFF
--- a/.ci/scripts/install-plugins.sh
+++ b/.ci/scripts/install-plugins.sh
@@ -11,7 +11,7 @@ for target in ${plugins_dir}/* ${protocols_dir}/* ; do
   if [ -d "$target" ]; then
     echo 'Installing dependencies for ' $(basename "$target")
     cd "$target"
-    npm install --silent --unsafe-perm
+    npm ci --silent --unsafe-perm
     find -L node_modules/.bin -type f -exec chmod 776 {} \;
     find node_modules/ -type d -exec chmod 755 {} \;
     cd "$working_dir"

--- a/lib/api/controllers/realtimeController.js
+++ b/lib/api/controllers/realtimeController.js
@@ -57,6 +57,12 @@ class RealtimeController extends BaseController {
 
     return this.kuzzle.hotelClerk.addSubscription(request)
       .then(result => {
+        if (!result) {
+          // can occur if the connection is dead.
+          // If so, we don't really have to care about the response
+          return;
+        }
+
         this.kuzzle.tokenManager.link(
           request.context.token,
           request.context.connection.id,

--- a/test/api/controllers/realtimeController.test.js
+++ b/test/api/controllers/realtimeController.test.js
@@ -93,6 +93,16 @@ describe('Test: subscribe controller', () => {
           should(kuzzle.hotelClerk.join).be.calledWith(request);
         });
     });
+
+    it('should return nothing if the connection is dead', () => {
+      // the check is actually done in the hotelclerk and returns undefined if so
+      kuzzle.hotelClerk.addSubscription.resolves();
+
+      return realtimeController.subscribe(request)
+        .then(result => {
+          should(result).be.undefined();
+        });
+    });
   });
 
   describe('#unsubscribe', () => {


### PR DESCRIPTION
Fixes an edge-case in which Kuzzle would crash when trying to subscribe a just-dead connection:

```
{ InternalError: Cannot read property 'roomId' of undefined at kuzzle.hotelClerk.addSubscription.then.result (/var/app/lib/api/controllers/realtimeController.js:63:18...
```

### Other

* settle `socket.io` version to `2.2.0` to keep node 6.x compatibility
* small enhancements to tests script