### PR TITLE
fix-default-mapping-for-discovered-collection

### DIFF
--- a/lib/api/core/indexCache.js
+++ b/lib/api/core/indexCache.js
@@ -214,7 +214,11 @@ class IndexCache {
           return false;
         }
 
-        return this.kuzzle.internalEngine.applyDefaultMapping(index, collection)
+        if (!this.defaultMappings[index]) {
+          this.defaultMappings[index] = _.cloneDeep(this.commonMapping);
+        }
+
+        return this.kuzzle.internalEngine.applyDefaultMapping(index, collection, this.defaultMappings[index])
           .then(() => this.add(index, collection, true));
       });
   }

--- a/lib/services/internalEngine/index.js
+++ b/lib/services/internalEngine/index.js
@@ -576,7 +576,7 @@ class InternalEngine {
    * @param {object} mapping
    * @returns {Promise.<object>} returns the updated default mapping
    */
-  applyDefaultMapping (index, collection, mapping) {
+  applyDefaultMapping (index, collection, mapping = this.kuzzle.config.services.db.commonMapping) {
     const defaultMapping = _.cloneDeep(mapping);
 
     return this.getMapping({ index, type: collection }, true)

--- a/test/api/core/indexCache.test.js
+++ b/test/api/core/indexCache.test.js
@@ -5,7 +5,7 @@ const
   IndexCache = require('../../../lib/api/core/indexCache');
 
 describe('Test: core/indexCache', () => {
-  var
+  let
     listAliasesStub,
     listIndexesStub,
     listCollectionsStub,
@@ -180,18 +180,18 @@ describe('Test: core/indexCache', () => {
         .catch(error => done(error));
     });
 
-    it('should resolve with true and update the cache and apply mapping if the collection exists in ES but not in Kuzzle', done => {
+    it('should resolve with true and update the cache and apply mapping if the collection exists in ES but not in Kuzzle', () => {
       kuzzle.services.list.storageEngine.collectionExists.resolves(true);
       indexCache.add('index1');
 
-      indexCache.exists('index1', 'collection1')
+      return indexCache.exists('index1', 'collection1')
         .then(result => {
           should(result).be.true();
           should(indexCache.indexes.index1).be.eql(['collection1']);
-          should(kuzzle.internalEngine.applyDefaultMapping).be.calledOnce();
-          done();
-        })
-        .catch(error => done(error));
+          should(kuzzle.internalEngine.applyDefaultMapping)
+            .be.calledOnce()
+            .be.calledWith('index1', 'collection1', kuzzle.config.services.db.commonMapping);
+        });
     });
 
     it('should resolve with false if the index does not exists in ES', done => {

--- a/test/services/internalEngine/index.test.js
+++ b/test/services/internalEngine/index.test.js
@@ -943,6 +943,13 @@ describe('InternalEngine', () => {
       kuzzle.internalEngine.getMapping = sinon.stub().resolves(getMappingResponse);
     });
 
+    it('should apply default mapping if none provided', () => {
+      return kuzzle.internalEngine.applyDefaultMapping(index, collection)
+        .then(mapping => {
+          should(mapping).match(kuzzle.config.services.db.commonMapping);
+        });
+    });
+
     it('should update collection mapping with default mapping', () => {
       return kuzzle.internalEngine.applyDefaultMapping(index, collection, commonMapping)
         .then(defaultMapping => {


### PR DESCRIPTION
Fix a situation where Kuzzle would crash when trying to apply the default mapping to a newly discovered collection.

