### PR TITLE
Remove usage of array.shift

### DIFF
--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -934,7 +934,7 @@ class ElasticSearch extends Service {
           errors: []
         };
 
-        let idx = 0
+        let idx = 0;
 
         for (let i = 0; i < body.items.length; i++) {
           const

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -934,13 +934,11 @@ class ElasticSearch extends Service {
           errors: []
         };
 
-        let
-          i = 0,
-          row;
+        let idx = 0
 
-
-        while ((row = body.items.shift()) !== undefined) {
+        for (let i = 0; i < body.items.length; i++) {
           const
+            row = body.items[i],
             action = Object.keys(row)[0],
             item = row[action];
 
@@ -953,11 +951,11 @@ class ElasticSearch extends Service {
             // update action contain body in "doc" field
             // the delete action is not followed by an action payload
             if (action === 'update') {
-              error._source = documents[i + 1].doc;
+              error._source = documents[idx + 1].doc;
               delete error._source._kuzzle_info;
             }
             else if (action !== 'delete') {
-              error._source = documents[i + 1];
+              error._source = documents[idx + 1];
               delete error._source._kuzzle_info;
             }
 
@@ -982,9 +980,9 @@ class ElasticSearch extends Service {
           }
 
           // the delete action is not followed by an action payload
-          i = action === 'delete'
-            ? i + 1
-            : i + 2;
+          idx = action === 'delete'
+            ? idx + 1
+            : idx + 2;
         }
 
         return result;
@@ -1244,11 +1242,11 @@ class ElasticSearch extends Service {
           },
           toImport = [];
 
-        let
-          document,
-          idx = 0;
+        let idx = 0;
 
-        while ((document = extractedDocuments.shift()) !== undefined) {
+        for (let i = 0; i < extractedDocuments.length; i++) {
+          const document = extractedDocuments[i];
+
           // Documents are retrieved in the same order than we got them from user
           if ( typeof document._id === 'string'
             && existingDocuments[idx]
@@ -1388,9 +1386,9 @@ class ElasticSearch extends Service {
         extractedDocuments
       } = this._extractMDocuments(documents, kuzzleMeta);
 
-    let extractedDocument;
+    for (let i = 0; i < extractedDocuments.length; i++) {
+      const extractedDocument = extractedDocuments[i];
 
-    while ((extractedDocument = extractedDocuments.shift()) !== undefined) {
       if (typeof extractedDocument._id === 'string') {
         esRequest.body.push({
           update: {
@@ -1406,7 +1404,8 @@ class ElasticSearch extends Service {
           _source: true
         });
         toImport.push(extractedDocument);
-      } else {
+      }
+      else {
         delete extractedDocument._source._kuzzle_info;
 
         rejected.push({
@@ -1428,8 +1427,9 @@ class ElasticSearch extends Service {
         // response.result.get._source
         // => we replace response.result._source with it so that the notifier
         // module can seamlessly process all kind of m* response*
-        let item;
-        while ((item = response.items.shift()) !== undefined) {
+        for (let i = 0; i < response.items.length; i++) {
+          const item = response.items[i];
+
           docs.push({
             _id: item._id,
             _source: item.get._source,
@@ -1496,11 +1496,9 @@ class ElasticSearch extends Service {
           },
           toImport = [];
 
-        let
-          i = 0,
-          document;
+        for (let i = 0; i < extractedDocuments.length; i++) {
+          const document = extractedDocuments[i];
 
-        while ((document = extractedDocuments.shift()) !== undefined) {
           // Documents are retrieved in the same order than we got them from user
           if (existingDocuments[i] && existingDocuments[i].found) {
             esRequest.body.push({
@@ -1525,7 +1523,6 @@ class ElasticSearch extends Service {
               status: 404
             });
           }
-          i++;
         }
 
         return this._mExecute(esRequest, toImport, rejected);
@@ -1558,8 +1555,9 @@ class ElasticSearch extends Service {
       return errorsManager.reject('write_limit_exceeded');
     }
 
-    let _id;
-    while ((_id = ids.shift()) !== undefined) {
+    for (let i = 0; i < ids.length; i++) {
+      const _id = ids[i];
+
       if (typeof _id === 'string') {
         validIds.push(_id);
       }
@@ -1631,12 +1629,10 @@ class ElasticSearch extends Service {
       .then(({ body }) => {
         const successes = [];
 
-        let
-          item,
-          i = 0;
-
-        while ((item = body.items.shift()) !== undefined) {
-          const result = item[Object.keys(item)[0]];
+        for (let i = 0; i < body.items.length; i++) {
+          const
+            item = body.items[i],
+            result = item[Object.keys(item)[0]];
 
           if (result.status >= 400) {
             if (result.status === 404) {
@@ -1667,8 +1663,6 @@ class ElasticSearch extends Service {
               get: result.get // used by mUpdate to get the full document body
             });
           }
-
-          i++;
         }
 
         return {


### PR DESCRIPTION
## What does this PR do ?

Don't use `Array.shift` anymore. Benchmark performances were faulty.
