### PR TITLE
Remove superfluous shard check when checking connection to the ES stack

### DIFF
--- a/.ci/scripts/run-test-arm.sh
+++ b/.ci/scripts/run-test-arm.sh
@@ -31,6 +31,10 @@ echo "[$(date --rfc-3339 seconds)] - Elasticsearch is up. Waiting for shards to 
 E=$(curl -s "$elastic_host/_cluster/health?wait_for_status=yellow&timeout=60s")
 
 if ! (echo ${E} | grep -E '"status":"(yellow|green)"' > /dev/null); then
+    echo "============ Cluster health response"
+    echo $E
+    echo "============ Cluster allocation explanation"
+    curl -s http://$elastic_host/_cluster/allocation/explain?pretty
     echo "[$(date --rfc-3339 seconds)] - Could not connect to elasticsearch in time. Aborting..."
     exit 1
 fi

--- a/.ci/scripts/run-test-arm.sh
+++ b/.ci/scripts/run-test-arm.sh
@@ -26,11 +26,9 @@ do
     echo "[$(date --rfc-3339 seconds)] - Still trying to connect to $elastic_host"
     sleep 1
 done
-# create a tmp index just to force the shards to init
-curl -XPUT -s -o /dev/null "$elastic_host/%25___tmp"
+
 echo "[$(date --rfc-3339 seconds)] - Elasticsearch is up. Waiting for shards to be active (can take a while)"
-E=$(curl -s "$elastic_host/_cluster/health?wait_for_status=yellow&wait_for_active_shards=1&timeout=60s")
-curl -XDELETE -s -o /dev/null "$elastic_host/%25___tmp"
+E=$(curl -s "$elastic_host/_cluster/health?wait_for_status=yellow&timeout=60s")
 
 if ! (echo ${E} | grep -E '"status":"(yellow|green)"' > /dev/null); then
     echo "[$(date --rfc-3339 seconds)] - Could not connect to elasticsearch in time. Aborting..."

--- a/.ci/scripts/run-test.sh
+++ b/.ci/scripts/run-test.sh
@@ -34,7 +34,7 @@ timeout 30 bash -c "
   done"
 
 echo "[$(date --rfc-3339 seconds)] - Elasticsearch is up. Waiting for shards to be active (can take a while)"
-E=$(curl -s "$elastic_host/_cluster/health?wait_for_status=yellow=1&timeout=60s")
+E=$(curl -s "$elastic_host/_cluster/health?wait_for_status=yellow&timeout=60s")
 
 if ! (echo ${E} | grep -E '"status":"(yellow|green)"' > /dev/null); then
     echo "============ Cluster health response"

--- a/.ci/scripts/run-test.sh
+++ b/.ci/scripts/run-test.sh
@@ -32,11 +32,9 @@ timeout 30 bash -c "
     echo [$(date --rfc-3339 seconds)] - Still trying to connect to $elastic_host
     sleep 1
   done"
-# create a tmp index just to force the shards to init
-curl -XPUT -s -o /dev/null "$elastic_host/%25___tmp"
+
 echo "[$(date --rfc-3339 seconds)] - Elasticsearch is up. Waiting for shards to be active (can take a while)"
-E=$(curl -s "$elastic_host/_cluster/health?wait_for_status=yellow&wait_for_active_shards=1&timeout=60s")
-curl -XDELETE -s -o /dev/null "$elastic_host/%25___tmp"
+E=$(curl -s "$elastic_host/_cluster/health?wait_for_status=yellow=1&timeout=60s")
 
 if ! (echo ${E} | grep -E '"status":"(yellow|green)"' > /dev/null); then
     echo "[$(date --rfc-3339 seconds)] - Could not connect to elasticsearch in time. Aborting..."

--- a/.ci/scripts/run-test.sh
+++ b/.ci/scripts/run-test.sh
@@ -37,6 +37,10 @@ echo "[$(date --rfc-3339 seconds)] - Elasticsearch is up. Waiting for shards to 
 E=$(curl -s "$elastic_host/_cluster/health?wait_for_status=yellow=1&timeout=60s")
 
 if ! (echo ${E} | grep -E '"status":"(yellow|green)"' > /dev/null); then
+    echo "============ Cluster health response"
+    echo $E
+    echo "============ Cluster allocation explanation"
+    curl -s http://$elastic_host/_cluster/allocation/explain?pretty
     echo "[$(date --rfc-3339 seconds)] - Could not connect to elasticsearch in time. Aborting..."
     exit 1
 fi

--- a/.ci/scripts/run.sh
+++ b/.ci/scripts/run.sh
@@ -19,7 +19,11 @@ log "Elasticsearch is up. Waiting for shards..."
 E=$(curl -s "$elastic_host/_cluster/health?wait_for_status=yellow&timeout=60s")
 
 if ! (echo ${E} | grep -E '"status":"(yellow|green)"' > /dev/null); then
-    log "Could not connect to elasticsearch in time. Aborting..."
+    echo "============ Cluster health response"
+    echo $E
+    echo "============ Cluster allocation explanation"
+    curl -s http://$elastic_host/_cluster/allocation/explain?pretty
+    echo "[$(date --rfc-3339 seconds)] - Could not connect to elasticsearch in time. Aborting..."
     exit 1
 fi
 

--- a/.ci/scripts/run.sh
+++ b/.ci/scripts/run.sh
@@ -14,11 +14,9 @@ do
     log "Still trying to connect to $elastic_host"
     sleep 1
 done
-# create a tmp index just to force the shards to init
-curl -XPUT -s -o /dev/null "$elastic_host/%25___tmp"
+
 log "Elasticsearch is up. Waiting for shards..."
-E=$(curl -s "$elastic_host/_cluster/health?wait_for_status=yellow&wait_for_active_shards=1&timeout=60s")
-curl -XDELETE -s -o /dev/null "$elastic_host/%25___tmp"
+E=$(curl -s "$elastic_host/_cluster/health?wait_for_status=yellow&timeout=60s")
 
 if ! (echo ${E} | grep -E '"status":"(yellow|green)"' > /dev/null); then
     log "Could not connect to elasticsearch in time. Aborting..."

--- a/docker-compose/dev.yml
+++ b/docker-compose/dev.yml
@@ -16,7 +16,7 @@ services:
       - ./nginx:/etc/nginx/conf.d
 
   kuzzle:
-    image: kuzzleio/core-dev
+    image: kuzzleio/core-dev:1
     command: sh -c 'chmod 755 /run.sh && /run.sh'
     volumes:
       - "..:/var/app"
@@ -45,7 +45,6 @@ services:
       - kuzzle_server__protocols__mqtt__enabled=true
       - kuzzle_server__protocols__mqtt__developmentMode=false
       - NODE_ENV=${NODE_ENV:-development}
-    # - DEBUG=kuzzle:*
       - DEBUG=${DEBUG:-none}
       - DEBUG_DEPTH=${DEBUG_DEPTH:-0}
       - DEBUG_MAX_ARRAY_LENGTH=${DEBUG_MAX_ARRAY:-100}

--- a/docker-compose/scripts/run-dev.sh
+++ b/docker-compose/scripts/run-dev.sh
@@ -20,6 +20,10 @@ echo "[$(date --rfc-3339 seconds)] - Elasticsearch is up. Waiting for shards to 
 E=$(curl -s "$elastic_host/_cluster/health?wait_for_status=yellow&timeout=60s")
 
 if ! (echo ${E} | grep -E '"status":"(yellow|green)"' > /dev/null); then
+    echo "============ Cluster health response"
+    echo $E
+    echo "============ Cluster allocation explanation"
+    curl -s http://$elastic_host/_cluster/allocation/explain?pretty
     echo "[$(date --rfc-3339 seconds)] - Could not connect to elasticsearch in time. Aborting..."
     exit 1
 fi

--- a/docker-compose/scripts/run-dev.sh
+++ b/docker-compose/scripts/run-dev.sh
@@ -15,11 +15,9 @@ do
     echo "[$(date --rfc-3339 seconds)] - Still trying to connect to $elastic_host"
     sleep 1
 done
-# create a tmp index just to force the shards to init
-curl -XPUT -s -o /dev/null "$elastic_host/%25___tmp"
+
 echo "[$(date --rfc-3339 seconds)] - Elasticsearch is up. Waiting for shards to be active (can take a while)"
-E=$(curl -s "$elastic_host/_cluster/health?wait_for_status=yellow&wait_for_active_shards=1&timeout=60s")
-curl -XDELETE -s -o /dev/null "$elastic_host/%25___tmp"
+E=$(curl -s "$elastic_host/_cluster/health?wait_for_status=yellow&timeout=60s")
 
 if ! (echo ${E} | grep -E '"status":"(yellow|green)"' > /dev/null); then
     echo "[$(date --rfc-3339 seconds)] - Could not connect to elasticsearch in time. Aborting..."

--- a/docker-compose/scripts/run.sh
+++ b/docker-compose/scripts/run.sh
@@ -19,7 +19,11 @@ log "Elasticsearch is up. Waiting for shards..."
 E=$(curl -s "$elastic_host/_cluster/health?wait_for_status=yellow&timeout=60s")
 
 if ! (echo ${E} | grep -E '"status":"(yellow|green)"' > /dev/null); then
-    log "Could not connect to elasticsearch in time. Aborting..."
+    echo "============ Cluster health response"
+    echo $E
+    echo "============ Cluster allocation explanation"
+    curl -s http://$elastic_host/_cluster/allocation/explain?pretty
+    echo "[$(date --rfc-3339 seconds)] - Could not connect to elasticsearch in time. Aborting..."
     exit 1
 fi
 

--- a/docker-compose/scripts/run.sh
+++ b/docker-compose/scripts/run.sh
@@ -14,11 +14,9 @@ do
     log "Still trying to connect to $elastic_host"
     sleep 1
 done
-# create a tmp index just to force the shards to init
-curl -XPUT -s -o /dev/null "$elastic_host/%25___tmp"
+
 log "Elasticsearch is up. Waiting for shards..."
-E=$(curl -s "$elastic_host/_cluster/health?wait_for_status=yellow&wait_for_active_shards=1&timeout=60s")
-curl -XDELETE -s -o /dev/null "$elastic_host/%25___tmp"
+E=$(curl -s "$elastic_host/_cluster/health?wait_for_status=yellow&timeout=60s")
 
 if ! (echo ${E} | grep -E '"status":"(yellow|green)"' > /dev/null); then
     log "Could not connect to elasticsearch in time. Aborting..."


### PR DESCRIPTION
# Description

Start scripts used by docker images create an index named `%___tmp` in Elasticsearch to force shards to initialize. And then the script deletes that index.

This introduces a race condition in a cluster environment when multiple Kuzzle nodes start at roughly the same time: during its starting sequence, Kuzzle lists the existing indexes in ES and tries to apply its default mapping, but sometimes the fake index disappears during that moment, aborting the node's start sequence.

After discussing the issue with the team, it seems that this index creation was an old workaround made for dev environment: it is unnecessary for prod environments, and probably for dev ones too.

# Why merging on master?

This PR only updates docker scripts, and it's beneficial to re-generate our current images with that fix.