### PR TITLE
Rejects new API requests during a shutdown sequence

### DIFF
--- a/doc/2/api/essentials/errors/codes/index.md
+++ b/doc/2/api/essentials/errors/codes/index.md
@@ -160,6 +160,7 @@ order: 500
 | api.process.controller_not_found<br/><pre>0x02020004</pre> | [NotFoundError](/core/2/api/essentials/errors/handling#notfounderror) <pre>(404)</pre> | API controller not found |
 | api.process.action_not_found<br/><pre>0x02020005</pre> | [NotFoundError](/core/2/api/essentials/errors/handling#notfounderror) <pre>(404)</pre> | API controller action not found |
 | api.process.incompatible_sdk_version<br/><pre>0x02020006</pre> | [BadRequestError](/core/2/api/essentials/errors/handling#badrequesterror) <pre>(400)</pre> | SDK is incompatible with the current Kuzzle version |
+| api.process.shutting_down<br/><pre>0x02020007</pre> | [ServiceUnavailableError](/core/2/api/essentials/errors/handling#serviceunavailableerror) <pre>(503)</pre> | This Kuzzle node is shutting down and refuses new requests |
 
 ---
 

--- a/doc/2/plugins/guides/events/core-shutdown/index.md
+++ b/doc/2/plugins/guides/events/core-shutdown/index.md
@@ -1,0 +1,14 @@
+---
+code: true
+type: page
+title: core:shutdown
+---
+
+# core:shutdown
+
+Triggered when the current node starts a graceful shutdown.  
+All new API requests are rejected, and the node halts once all pending requests have been played.
+
+:::info
+Pipes cannot listen to that event, only hooks can.
+:::

--- a/lib/api/controllers/funnelController.js
+++ b/lib/api/controllers/funnelController.js
@@ -70,6 +70,7 @@ class FunnelController {
     this.lastOverloadTime = 0;
     this.overloadWarned = false;
     this.lastWarningTime = 0;
+    this.shuttingDown = false;
 
     this.lastDumpedErrors = {};
     this.loadDocumentEventAliases();
@@ -78,6 +79,10 @@ class FunnelController {
   }
 
   init () {
+    this.kuzzle.on('core:shutdown', () => {
+      this.shuttingDown = true;
+    });
+
     this.controllers.set('auth', new AuthController(this.kuzzle));
     this.controllers.set('bulk', new BulkController(this.kuzzle));
     this.controllers.set('collection', new CollectionController(this.kuzzle));
@@ -133,6 +138,11 @@ class FunnelController {
    * @returns {boolean}
    */
   getRequestSlot (executor, request, executeCallback) {
+    if (this.shuttingDown) {
+      request.setError(processError.get('shutting_down'));
+      return false;
+    }
+
     if (this.overloaded) {
       const now = Date.now();
 

--- a/lib/api/core/janitor.js
+++ b/lib/api/core/janitor.js
@@ -23,12 +23,10 @@
 
 const
   Bluebird = require('bluebird'),
-  {
-    Request
-  } = require('kuzzle-common-objects'),
+  { Request } = require('kuzzle-common-objects'),
   errorsManager = require('../../util/errors'),
   { assertIsObject } = require('../../util/requestAssertions'),
-  pm2 = require('pm2'),
+  runShutdown = require('../../util/shutdown'),
   path = require('path'),
   fs = require('fs-extra'),
   os = require('os'),
@@ -159,22 +157,7 @@ class Janitor {
    * @returns {Promise}
    */
   shutdown () {
-    // pm2.delete sends a SIGINT signal
-    // we keep track of how many shutdowns are asked
-    // to detect when pm2 has finished deleting Kuzzle
-    // from its tasks list
-    this._shutdown++;
-
-    if (this._shutdown > 1) {
-      return Bluebird.resolve();
-    }
-
-    this.kuzzle.log.info('Initiating shutdown...');
-
-    return new Bluebird(resolve => {
-      this.kuzzle.entryPoints.dispatch('shutdown');
-      this._waitRemainingRequests(resolve);
-    });
+    return runShutdown(this.kuzzle);
   }
 
   /**
@@ -428,59 +411,6 @@ class Janitor {
         fs.unlinkSync(corefiles[0]);
       }
     }
-  }
-
-  _waitRemainingRequests (resolve) {
-    const remaining = this.kuzzle.funnel.remainingRequests;
-
-    if (remaining !== 0) {
-      this.kuzzle.log.info(`Waiting: ${remaining} remaining requests`);
-      return setTimeout(() => this._waitRemainingRequests(resolve), 1000);
-    }
-
-    resolve();
-
-    pm2.list((listerr, processes) => {
-      if (listerr) {
-        return this._halt();
-      }
-
-      const kuzzleProcess = processes
-        .filter(pm2Process => pm2Process.pid === process.pid);
-
-      // not started with PM2 or development mode => exit immediately
-      if (kuzzleProcess.length === 0 || kuzzleProcess[0].pm2_env.watch) {
-        if (kuzzleProcess.length !== 0) {
-          this.kuzzle.log.info('PM2 Watch activated: restarting Kuzzle');
-
-          return pm2.restart(kuzzleProcess[0].pm_id);
-        }
-
-        return this._halt();
-      }
-
-      // production mode: ask PM2 to stop & delete Kuzzle to prevent
-      // a restart
-      pm2.delete(kuzzleProcess[0].pm_id, delerr => {
-        this.kuzzle.log.info('PM2 failed to delete Kuzzle: ', delerr);
-        this.kuzzle.log.info('Exiting anyway.');
-      });
-
-      // pm2.delete does not notify when deletion is finished,
-      // so we use the shutdown counter to check how many
-      // SIGINT signals have been received
-      const interval = setInterval(() => {
-        if (this._shutdown > 1) {
-          clearInterval(interval);
-          this._halt();
-        }
-      }, 200);
-    });
-  }
-
-  _halt () {
-    this.kuzzle.log.info('Halted.');
-    process.exit(0);
   }
 
   _createSecurity (action, objects) {

--- a/lib/api/kuzzle.js
+++ b/lib/api/kuzzle.js
@@ -346,7 +346,7 @@ async function dumpAndExit(kuzzle, suffix) {
     }
   }
 
-  runShutdown(kuzzle);
+  await runShutdown(kuzzle);
 }
 
 function initVault (vaultKey, secretsFile) {

--- a/lib/config/error-codes/api.json
+++ b/lib/config/error-codes/api.json
@@ -110,6 +110,12 @@
           "code": 6,
           "message": "Incompatible SDK client. Your SDK version (%s) does not match Kuzzle requirement (%s).",
           "class": "BadRequestError"
+        },
+        "shutting_down": {
+          "description": "This Kuzzle node is shutting down and refuses new requests",
+          "code": 7,
+          "message": "Rejected: this node is shutting down.",
+          "class": "ServiceUnavailableError"
         }
       }
     }

--- a/lib/util/shutdown.js
+++ b/lib/util/shutdown.js
@@ -21,12 +21,7 @@
 
 'use strict';
 
-const
-  Bluebird = require('bluebird'),
-  pm2 = require('pm2');
-
-let
-  _shutdown = 0;
+const Bluebird = require('bluebird');
 
 /**
  * Gracefully exits after processing remaining requests
@@ -35,17 +30,8 @@ let
  * @returns {Promise}
  */
 function runShutdown (kuzzle) {
-  // pm2.delete sends a SIGINT signal
-  // we keep track of how many shutdowns are asked
-  // to detect when pm2 has finished deleting Kuzzle
-  // from its tasks list
-  _shutdown++;
-
-  if (_shutdown > 1) {
-    return Bluebird.resolve();
-  }
-
   kuzzle.log.info('Initiating shutdown...');
+  kuzzle.emit('core:shutdown');
 
   return new Bluebird(resolve => {
     kuzzle.entryPoints.dispatch('shutdown');
@@ -63,45 +49,6 @@ function waitRemainingRequests(kuzzle, resolve) {
 
   resolve();
 
-  pm2.list((listerr, processes) => {
-    if (listerr) {
-      return halt(kuzzle);
-    }
-
-    const kuzzleProcess = processes
-      .filter(pm2Process => pm2Process.pid === process.pid);
-
-    // not started with PM2 or development mode => exit immediately
-    if (kuzzleProcess.length === 0 || kuzzleProcess[0].pm2_env.watch) {
-      if (kuzzleProcess.length !== 0) {
-        kuzzle.log.info('PM2 Watch activated: restarting Kuzzle');
-
-        return pm2.restart(kuzzleProcess[0].pm_id);
-      }
-
-      return halt(kuzzle);
-    }
-
-    // production mode: ask PM2 to stop & delete Kuzzle to prevent
-    // a restart
-    pm2.delete(kuzzleProcess[0].pm_id, delerr => {
-      kuzzle.log.info('PM2 failed to delete Kuzzle: ', delerr);
-      kuzzle.log.info('Exiting anyway.');
-    });
-
-    // pm2.delete does not notify when deletion is finished,
-    // so we use the shutdown counter to check how many
-    // SIGINT signals have been received
-    const interval = setInterval(() => {
-      if (_shutdown > 1) {
-        clearInterval(interval);
-        halt(kuzzle);
-      }
-    }, 200);
-  });
-}
-
-function halt (kuzzle) {
   kuzzle.log.info('Halted.');
   process.exit(0);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -760,220 +760,6 @@
         "pump": "^3.0.0"
       }
     },
-    "@opencensus/core": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@opencensus/core/-/core-0.0.9.tgz",
-      "integrity": "sha512-31Q4VWtbzXpVUd2m9JS6HEaPjlKvNMOiF7lWKNmXF84yUcgfAFL5re7/hjDmdyQbOp32oGc+RFV78jXIldVz6Q==",
-      "requires": {
-        "continuation-local-storage": "^3.2.1",
-        "log-driver": "^1.2.7",
-        "semver": "^5.5.0",
-        "shimmer": "^1.2.0",
-        "uuid": "^3.2.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
-      }
-    },
-    "@opencensus/propagation-b3": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@opencensus/propagation-b3/-/propagation-b3-0.0.8.tgz",
-      "integrity": "sha512-PffXX2AL8Sh0VHQ52jJC4u3T0H6wDK6N/4bg7xh4ngMYOIi13aR1kzVvX1sVDBgfGwDOkMbl4c54Xm3tlPx/+A==",
-      "requires": {
-        "@opencensus/core": "^0.0.8",
-        "uuid": "^3.2.1"
-      },
-      "dependencies": {
-        "@opencensus/core": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/@opencensus/core/-/core-0.0.8.tgz",
-          "integrity": "sha512-yUFT59SFhGMYQgX0PhoTR0LBff2BEhPrD9io1jWfF/VDbakRfs6Pq60rjv0Z7iaTav5gQlttJCX2+VPxFWCuoQ==",
-          "requires": {
-            "continuation-local-storage": "^3.2.1",
-            "log-driver": "^1.2.7",
-            "semver": "^5.5.0",
-            "shimmer": "^1.2.0",
-            "uuid": "^3.2.1"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
-      }
-    },
-    "@pm2/agent": {
-      "version": "0.5.26",
-      "resolved": "https://registry.npmjs.org/@pm2/agent/-/agent-0.5.26.tgz",
-      "integrity": "sha512-pqiS87IiUprkSR7SG0RKMATuYXl4QjH1tSSUwM4wJcovRT4pD5dvnnu61w9y/4/Ur5V/+a7bqS8bZz51y3U2iA==",
-      "requires": {
-        "async": "^2.6.0",
-        "chalk": "^2.3.2",
-        "eventemitter2": "^5.0.1",
-        "fclone": "^1.0.11",
-        "moment": "^2.21.0",
-        "nssocket": "^0.6.0",
-        "pm2-axon": "^3.2.0",
-        "pm2-axon-rpc": "^0.5.0",
-        "proxy-agent": "^3.1.0",
-        "semver": "^5.5.0",
-        "ws": "^5.1.0"
-      },
-      "dependencies": {
-        "eventemitter2": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-5.0.1.tgz",
-          "integrity": "sha1-YZegldX7a1folC9v1+qtY6CclFI="
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        },
-        "ws": {
-          "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
-          "requires": {
-            "async-limiter": "~1.0.0"
-          }
-        }
-      }
-    },
-    "@pm2/agent-node": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@pm2/agent-node/-/agent-node-1.1.10.tgz",
-      "integrity": "sha512-xRcrk7OEwhS3d/227/kKGvxgmbIi6Yyp27FzGlFNermEKhgddmFaRnmd7GRLIsBM/KB28NrwflBZulzk/mma6g==",
-      "requires": {
-        "debug": "^3.1.0",
-        "eventemitter2": "^5.0.1",
-        "proxy-agent": "^3.0.3",
-        "ws": "^6.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "eventemitter2": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-5.0.1.tgz",
-          "integrity": "sha1-YZegldX7a1folC9v1+qtY6CclFI="
-        },
-        "ws": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
-          "requires": {
-            "async-limiter": "~1.0.0"
-          }
-        }
-      }
-    },
-    "@pm2/io": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@pm2/io/-/io-4.3.3.tgz",
-      "integrity": "sha512-ENGsdSVpnwbYMGdeB0/Xy2eZYo7oltzApoCsMD4ssqWNXDg9C4uQZy5J09iPsb0IHFwSDjU5oylXdwKDSoqODw==",
-      "requires": {
-        "@opencensus/core": "^0.0.9",
-        "@opencensus/propagation-b3": "^0.0.8",
-        "@pm2/agent-node": "^1.1.10",
-        "async": "~2.6.1",
-        "debug": "3.1.0",
-        "eventemitter2": "~5.0.1",
-        "require-in-the-middle": "^5.0.0",
-        "semver": "5.5.0",
-        "shimmer": "~1.2.0",
-        "signal-exit": "3.0.2",
-        "tslib": "1.9.3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "eventemitter2": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-5.0.1.tgz",
-          "integrity": "sha1-YZegldX7a1folC9v1+qtY6CclFI="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "semver": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-        },
-        "tslib": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
-        }
-      }
-    },
-    "@pm2/js-api": {
-      "version": "0.5.60",
-      "resolved": "https://registry.npmjs.org/@pm2/js-api/-/js-api-0.5.60.tgz",
-      "integrity": "sha512-CvAbpIB7ObOuwvqhDBB/E4Z4ANRx2dBk08zYpGPNg+1fDj14FJg2e7DWA8bblSGNC8QarIXPaqPDJBL1e8cRQw==",
-      "requires": {
-        "async": "^2.4.1",
-        "axios": "^0.19.0",
-        "debug": "^2.6.8",
-        "eventemitter2": "^4.1.0",
-        "ws": "^3.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "eventemitter2": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-4.1.2.tgz",
-          "integrity": "sha1-DhqEd6+CGm7zmVsxG/dMI6UkfxU="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "ultron": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-          "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
-        },
-        "ws": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-          "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
-          }
-        }
-      }
-    },
     "@sinonjs/commons": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
@@ -1223,6 +1009,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
       "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "dev": true,
       "requires": {
         "es6-promisify": "^5.0.0"
       }
@@ -1255,19 +1042,6 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
       "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ=="
-    },
-    "amp": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/amp/-/amp-0.3.1.tgz",
-      "integrity": "sha1-at+NWKdPNh6CwfqNOJwHnhOfxH0="
-    },
-    "amp-message": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/amp-message/-/amp-message-0.1.2.tgz",
-      "integrity": "sha1-p48cmJlQh602GSpBKY5NtJ49/EU=",
-      "requires": {
-        "amp": "0.3.1"
-      }
     },
     "amqp": {
       "version": "0.2.7",
@@ -1319,7 +1093,8 @@
     "ansi": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-      "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
+      "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
+      "optional": true
     },
     "ansi-colors": {
       "version": "3.2.3",
@@ -1440,6 +1215,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
       "integrity": "sha1-7FanSe4QPk4Ix5C5w1PfFgVbl/k=",
+      "optional": true,
       "requires": {
         "debug": "^2.2.0",
         "es6-symbol": "^3.0.2"
@@ -1457,7 +1233,8 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "optional": true
         }
       }
     },
@@ -1654,11 +1431,6 @@
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
-    "ast-types": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.2.tgz",
-      "integrity": "sha512-uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA=="
-    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -1706,22 +1478,6 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
-    "async-listener": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
-      "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
-      "requires": {
-        "semver": "^5.3.0",
-        "shimmer": "^1.1.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
-      }
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1746,22 +1502,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
-    },
-    "axios": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
-      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
-      "requires": {
-        "follow-redirects": "1.5.10",
-        "is-buffer": "^2.0.2"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
-        }
-      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -1955,15 +1695,11 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "blessed": {
-      "version": "0.1.81",
-      "resolved": "https://registry.npmjs.org/blessed/-/blessed-0.1.81.tgz",
-      "integrity": "sha1-+WLWh+wsNpVwrnGvhDJW5tDKESk="
-    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "optional": true,
       "requires": {
         "inherits": "~2.0.0"
       }
@@ -1977,11 +1713,6 @@
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-    },
-    "bodec": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/bodec/-/bodec-0.1.0.tgz",
-      "integrity": "sha1-vIUVVUMPI8n3ZQp172TGqUw0GMw="
     },
     "boost-geospatial-index": {
       "version": "1.0.5",
@@ -2176,7 +1907,8 @@
     "buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+      "optional": true
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -2186,7 +1918,8 @@
     "buffer-more-ints": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-0.0.2.tgz",
-      "integrity": "sha1-JrOIXRD6E9t/wBquOquHAZngEkw="
+      "integrity": "sha1-JrOIXRD6E9t/wBquOquHAZngEkw=",
+      "optional": true
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -2371,11 +2104,6 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
-    "charm": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
-      "integrity": "sha1-BsIe7RobBq62dVPNxT4jJ0usIpY="
-    },
     "chokidar": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
@@ -2470,46 +2198,6 @@
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.2.0.tgz",
       "integrity": "sha512-tgU3fKwzYjiLEQgPMD9Jt+JjHVL9kW93FiIMX/l7rivvOD4/LL0Mf7gda3+4U2KJBloybwgj5KEoQgGRioMiKQ=="
     },
-    "cli-table-redemption": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cli-table-redemption/-/cli-table-redemption-1.0.1.tgz",
-      "integrity": "sha512-SjVCciRyx01I4azo2K2rcc0NP/wOceXGzG1ZpYkEulbbIxDA/5YWv0oxG2HtQ4v8zPC6bgbRI7SbNaTZCxMNkg==",
-      "requires": {
-        "chalk": "^1.1.3"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
-      }
-    },
     "cli-table3": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
@@ -2549,29 +2237,9 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-regex": "^3.0.0"
           }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
-      }
-    },
-    "cli-table3": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
-      "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
-      "dev": true,
-      "requires": {
-        "colors": "^1.1.2",
-        "object-assign": "^4.1.0",
-        "string-width": "^2.1.1"
       }
     },
     "cli-width": {
@@ -2624,7 +2292,8 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -2766,15 +2435,6 @@
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
     },
-    "continuation-local-storage": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
-      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
-      "requires": {
-        "async-listener": "^0.6.0",
-        "emitter-listener": "^1.1.1"
-      }
-    },
     "convert-source-map": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -2874,14 +2534,6 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
-      }
-    },
-    "cron": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/cron/-/cron-1.7.2.tgz",
-      "integrity": "sha512-+SaJ2OfeRvfQqwXQ2kgr0Y5pzBR/lijf5OpnnaruwWnmI799JfWr2jN2ItOV9s3A/+TFOt6mxvKzQq5F0Jp6VQ==",
-      "requires": {
-        "moment-timezone": "^0.5.x"
       }
     },
     "cross-spawn": {
@@ -2984,11 +2636,6 @@
       "integrity": "sha1-f1x7cACbwrZmWRv+ZIVFeL7e6Fo=",
       "dev": true
     },
-    "culvert": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/culvert/-/culvert-0.1.2.tgz",
-      "integrity": "sha1-lQL18BVKLVoioCPnn3HMk2+m728="
-    },
     "cycle": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
@@ -3015,16 +2662,6 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
-    },
-    "data-uri-to-buffer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
-      "integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ=="
-    },
-    "date-fns": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
     },
     "debug": {
       "version": "4.1.1",
@@ -3137,23 +2774,6 @@
         }
       }
     },
-    "degenerator": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
-      "integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
-      "requires": {
-        "ast-types": "0.x.x",
-        "escodegen": "1.x.x",
-        "esprima": "3.x.x"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-        }
-      }
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -3168,11 +2788,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
       "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
-    },
-    "depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "des.js": {
       "version": "1.0.1",
@@ -3362,14 +2977,6 @@
         "minimalistic-crypto-utils": "^1.0.0"
       }
     },
-    "emitter-listener": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
-      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
-      "requires": {
-        "shimmer": "^1.2.0"
-      }
-    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -3543,6 +3150,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
       "requires": {
         "es6-promise": "^4.0.3"
       },
@@ -3550,7 +3158,8 @@
         "es6-promise": {
           "version": "4.2.8",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-          "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+          "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+          "dev": true
         }
       }
     },
@@ -3598,11 +3207,6 @@
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.1"
       }
-    },
-    "escape-regexp": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/escape-regexp/-/escape-regexp-0.0.1.tgz",
-      "integrity": "sha1-9EvaEtRbvfnLf4Yu5+SCez3TIlQ="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -4112,11 +3716,6 @@
         "xtend": "^4.0.0"
       }
     },
-    "fclone": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fclone/-/fclone-1.0.11.tgz",
-      "integrity": "sha1-EOhdo4v+p/xZk0HClu4ddyZu5kA="
-    },
     "fd": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/fd/-/fd-0.0.3.tgz",
@@ -4252,29 +3851,6 @@
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
-      }
-    },
-    "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "requires": {
-        "debug": "=3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
       }
     },
     "for-in": {
@@ -4423,7 +3999,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4441,11 +4018,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4458,15 +4037,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4569,7 +4151,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4579,6 +4162,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4591,17 +4175,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4618,6 +4205,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4690,7 +4278,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4700,6 +4289,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4775,7 +4365,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4805,6 +4396,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4822,6 +4414,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4860,11 +4453,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -4878,38 +4473,6 @@
         "inherits": "~2.0.0",
         "mkdirp": ">=0.5 0",
         "rimraf": "2"
-      }
-    },
-    "ftp": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
-      "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
-      "requires": {
-        "readable-stream": "1.1.x",
-        "xregexp": "2.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
       }
     },
     "function-bind": {
@@ -4970,34 +4533,6 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
-    "get-uri": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.4.tgz",
-      "integrity": "sha512-v7LT/s8kVjs+Tx0ykk1I+H/rbpzkHvuIq87LmeXptcf5sNWm9uQiwjNAt94SJPA1zOlCntmnOlJvVWKmzsxG8Q==",
-      "requires": {
-        "data-uri-to-buffer": "1",
-        "debug": "2",
-        "extend": "~3.0.2",
-        "file-uri-to-path": "1",
-        "ftp": "~0.3.10",
-        "readable-stream": "2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
-    },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -5049,16 +4584,6 @@
         "jsonist": "~2.1.0",
         "xtend": "~4.0.1"
       }
-    },
-    "git-node-fs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/git-node-fs/-/git-node-fs-1.0.0.tgz",
-      "integrity": "sha1-SbIV4kLr5Dqkx1Ybu6SZUhdSCA8="
-    },
-    "git-sha1": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/git-sha1/-/git-sha1-0.1.2.tgz",
-      "integrity": "sha1-WZrBkrcYdYJeE6RF86bgURjC90U="
     },
     "github-from-package": {
       "version": "0.0.0",
@@ -5301,42 +4826,6 @@
       "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
       "dev": true
     },
-    "http-errors": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
-      "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
-      "requires": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.1.1",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.0"
-      }
-    },
-    "http-proxy-agent": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-      "requires": {
-        "agent-base": "4",
-        "debug": "3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
-    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -5351,25 +4840,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
-    },
-    "https-proxy-agent": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
-      "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
-      "requires": {
-        "agent-base": "^4.3.0",
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
     },
     "humanize-ms": {
       "version": "1.2.1",
@@ -5400,6 +4870,7 @@
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
           "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+          "optional": true,
           "requires": {
             "readable-stream": "~1.1.9"
           }
@@ -5407,12 +4878,14 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "optional": true
         },
         "readable-stream": {
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.1",
@@ -5423,12 +4896,14 @@
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "optional": true
         },
         "through2": {
           "version": "0.6.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "optional": true,
           "requires": {
             "readable-stream": ">=1.0.33-1 <1.1.0-0",
             "xtend": ">=4.0.0 <4.1.0-0"
@@ -5438,6 +4913,7 @@
               "version": "1.0.34",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+              "optional": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.1",
@@ -5550,11 +5026,6 @@
       "integrity": "sha1-J3siiofZWtd30HwTgyAiQGpHNCM=",
       "optional": true
     },
-    "interpret": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
-    },
     "into-stream": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-5.1.1.tgz",
@@ -5587,11 +5058,6 @@
         "redis-parser": "^3.0.0",
         "standard-as-callback": "^2.0.1"
       }
-    },
-    "ip": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "is-absolute": {
       "version": "1.0.0",
@@ -5916,24 +5382,6 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/js-combinatorics/-/js-combinatorics-0.5.4.tgz",
       "integrity": "sha512-PCqUIKGqv/Kjao1G4GE/Yni6QkCP2nWW3KnxL+8IGWPlP18vQpT8ufGMf4XUAAY8JHEryUCJbf51zG8329ntMg=="
-    },
-    "js-git": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/js-git/-/js-git-0.7.8.tgz",
-      "integrity": "sha1-UvplWrYYd9bxB578ZTS1VPMeVEQ=",
-      "requires": {
-        "bodec": "^0.1.0",
-        "culvert": "^0.1.2",
-        "git-sha1": "^0.1.2",
-        "pako": "^0.2.5"
-      },
-      "dependencies": {
-        "pako": {
-          "version": "0.2.9",
-          "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-          "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
-        }
-      }
     },
     "js-levenshtein": {
       "version": "1.1.6",
@@ -6625,19 +6073,6 @@
         "lodash": "^4.17.15"
       }
     },
-    "kuzzle-vault": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/kuzzle-vault/-/kuzzle-vault-1.0.1.tgz",
-      "integrity": "sha512-1ijACvf5nOzIcZ9xtMmomkqOudpMcI2iFc/NeT3BTtC/T3hPM1QM2E2iJO49187q/EXt/OCvgYKXaBlgp7jH5A==",
-      "requires": {
-        "lodash": "^4.17.15"
-      }
-    },
-    "lazy": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/lazy/-/lazy-1.0.11.tgz",
-      "integrity": "sha1-2qBoIGKCVCwIgojpdcKXwa53tpA="
-    },
     "level-codec": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
@@ -6921,11 +6356,6 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
     },
-    "lodash.findindex": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.findindex/-/lodash.findindex-4.6.0.tgz",
-      "integrity": "sha1-oyRd7mH7m24GJLU1ElYku2nBEQY="
-    },
     "lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
@@ -6936,16 +6366,6 @@
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
-    },
-    "lodash.foreach": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
-      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
-    },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -6977,11 +6397,6 @@
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
-    "lodash.last": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.last/-/lodash.last-3.0.0.tgz",
-      "integrity": "sha1-JC9mMRLdTG5jcoxgo8kJ0b2tvUw="
-    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -6990,23 +6405,20 @@
     "lodash.pad": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
-      "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA="
+      "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA=",
+      "optional": true
     },
     "lodash.padend": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4="
+      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
+      "optional": true
     },
     "lodash.padstart": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
       "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
       "optional": true
-    },
-    "log-driver": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
     },
     "log-symbols": {
       "version": "2.2.0",
@@ -7505,23 +6917,10 @@
         }
       }
     },
-    "module-details-from-path": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
-      "integrity": "sha1-EUyUlnPiqKNenTV4hSeqN7Z52is="
-    },
     "moment": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
-    },
-    "moment-timezone": {
-      "version": "0.5.27",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.27.tgz",
-      "integrity": "sha512-EIKQs7h5sAsjhPCqN6ggx6cEbs94GK050254TIJySD1bzoM5JTYDwAU1IoVOeTOL6Gm27kYJ51/uuvq1kIlrbw==",
-      "requires": {
-        "moment": ">= 2.9.0"
-      }
     },
     "mongodb": {
       "version": "2.1.21",
@@ -8025,11 +7424,6 @@
         "inherits": "~2.0.1"
       }
     },
-    "netmask": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
-      "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
-    },
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
@@ -8446,22 +7840,6 @@
         "set-blocking": "~2.0.0"
       }
     },
-    "nssocket": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/nssocket/-/nssocket-0.6.0.tgz",
-      "integrity": "sha1-Wflvb/MhVm8zxw99vu7N/cBxVPo=",
-      "requires": {
-        "eventemitter2": "~0.4.14",
-        "lazy": "~1.0.11"
-      },
-      "dependencies": {
-        "eventemitter2": {
-          "version": "0.4.14",
-          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
-          "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas="
-        }
-      }
-    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -8824,33 +8202,6 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
-    "pac-proxy-agent": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-3.0.1.tgz",
-      "integrity": "sha512-44DUg21G/liUZ48dJpUSjZnFfZro/0K5JTyFYLBcmh9+T6Ooi4/i4efwUiEy0+4oQusCBqWdhv16XohIj1GqnQ==",
-      "requires": {
-        "agent-base": "^4.2.0",
-        "debug": "^4.1.1",
-        "get-uri": "^2.0.0",
-        "http-proxy-agent": "^2.1.0",
-        "https-proxy-agent": "^3.0.0",
-        "pac-resolver": "^3.0.0",
-        "raw-body": "^2.2.0",
-        "socks-proxy-agent": "^4.0.1"
-      }
-    },
-    "pac-resolver": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-3.0.0.tgz",
-      "integrity": "sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==",
-      "requires": {
-        "co": "^4.6.0",
-        "degenerator": "^1.0.4",
-        "ip": "^1.1.5",
-        "netmask": "^1.0.6",
-        "thunkify": "^2.1.2"
-      }
-    },
     "package-hash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-3.0.0.tgz",
@@ -8941,6 +8292,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
       "integrity": "sha1-fi8PNfB6IBUSK4aLfqwOssT+wnE=",
+      "optional": true,
       "requires": {
         "array-index": "^1.0.0"
       }
@@ -9044,14 +8396,6 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
-    "pidusage": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/pidusage/-/pidusage-2.0.17.tgz",
-      "integrity": "sha512-N8X5v18rBmlBoArfS83vrnD0gIFyZkXEo7a5pAS2aT0i2OLVymFb2AzVg+v8l/QcXnE1JwZcaXR8daJcoJqtjw==",
-      "requires": {
-        "safe-buffer": "^5.1.2"
-      }
-    },
     "pify": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -9117,138 +8461,6 @@
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
-    },
-    "pm2": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/pm2/-/pm2-3.5.1.tgz",
-      "integrity": "sha512-pDPBetbI48JDynxmtSPNSKRDk/LRbhsHrJ/WSCKVD1TUNnb6XNMe6GzO7DCNijJBvdaQ+u1WxNudxqExlXdhEw==",
-      "requires": {
-        "@pm2/agent": "^0.5.22",
-        "@pm2/io": "^4.1.2",
-        "@pm2/js-api": "^0.5.43",
-        "async": "^2.6.1",
-        "blessed": "^0.1.81",
-        "chalk": "^2.4.1",
-        "chokidar": "^2.0.4",
-        "cli-table-redemption": "^1.0.0",
-        "commander": "2.15.1",
-        "cron": "^1.3",
-        "date-fns": "^1.29.0",
-        "debug": "^3.1",
-        "eventemitter2": "5.0.1",
-        "fclone": "1.0.11",
-        "mkdirp": "0.5.1",
-        "moment": "^2.22.2",
-        "needle": "^2.2.1",
-        "pidusage": "^2.0.14",
-        "pm2-axon": "3.3.0",
-        "pm2-axon-rpc": "^0.5.1",
-        "pm2-deploy": "^0.4.0",
-        "pm2-multimeter": "^0.1.2",
-        "promptly": "^2",
-        "semver": "^5.5",
-        "shelljs": "~0.8.2",
-        "source-map-support": "^0.5.6",
-        "sprintf-js": "1.1.1",
-        "v8-compile-cache": "^2.0.0",
-        "vizion": "~2.0.2",
-        "yamljs": "^0.3.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
-        },
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "eventemitter2": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-5.0.1.tgz",
-          "integrity": "sha1-YZegldX7a1folC9v1+qtY6CclFI="
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        },
-        "sprintf-js": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
-          "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
-        },
-        "yamljs": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
-          "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
-          "requires": {
-            "argparse": "^1.0.7",
-            "glob": "^7.0.5"
-          }
-        }
-      }
-    },
-    "pm2-axon": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/pm2-axon/-/pm2-axon-3.3.0.tgz",
-      "integrity": "sha512-dAFlFYRuFbFjX7oAk41zT+dx86EuaFX/TgOp5QpUKRKwxb946IM6ydnoH5sSTkdI2pHSVZ+3Am8n/l0ocr7jdQ==",
-      "requires": {
-        "amp": "~0.3.1",
-        "amp-message": "~0.1.1",
-        "debug": "^3.0",
-        "escape-regexp": "0.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
-    },
-    "pm2-axon-rpc": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/pm2-axon-rpc/-/pm2-axon-rpc-0.5.1.tgz",
-      "integrity": "sha512-hT8gN3/j05895QLXpwg+Ws8PjO4AVID6Uf9StWpud9HB2homjc1KKCcI0vg9BNOt56FmrqKDT1NQgheIz35+sA==",
-      "requires": {
-        "debug": "^3.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
-    },
-    "pm2-deploy": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/pm2-deploy/-/pm2-deploy-0.4.0.tgz",
-      "integrity": "sha512-3BdCghcGwMKwl3ffHZhc+j5JY5dldH9nq8m/I9W5wehJuSRZIyO96VOgKTMv3hYp7Yk5E+2lRGm8WFNlp65vOA==",
-      "requires": {
-        "async": "^2.6",
-        "tv4": "^1.3"
-      }
-    },
-    "pm2-multimeter": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/pm2-multimeter/-/pm2-multimeter-0.1.2.tgz",
-      "integrity": "sha1-Gh5VFT1BoFU0zqI8/oYKuqDrSs4=",
-      "requires": {
-        "charm": "~0.1.1"
-      }
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -9360,34 +8572,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
-    },
-    "promptly": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/promptly/-/promptly-2.2.0.tgz",
-      "integrity": "sha1-KhP6BjaIoqWYOxYf/wEIoH0m/HQ=",
-      "requires": {
-        "read": "^1.0.4"
-      }
-    },
-    "proxy-agent": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-3.1.1.tgz",
-      "integrity": "sha512-WudaR0eTsDx33O3EJE16PjBRZWcX8GqCEeERw1W3hZJgH/F2a46g7jty6UGty6NeJ4CKQy8ds2CJPMiyeqaTvw==",
-      "requires": {
-        "agent-base": "^4.2.0",
-        "debug": "4",
-        "http-proxy-agent": "^2.1.0",
-        "https-proxy-agent": "^3.0.0",
-        "lru-cache": "^5.1.1",
-        "pac-proxy-agent": "^3.0.1",
-        "proxy-from-env": "^1.0.0",
-        "socks-proxy-agent": "^4.0.1"
-      }
-    },
-    "proxy-from-env": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
-      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
     },
     "prr": {
       "version": "1.0.1",
@@ -9584,17 +8768,6 @@
         "safe-buffer": "^5.1.0"
       }
     },
-    "raw-body": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
-      "integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
-      "requires": {
-        "bytes": "3.1.0",
-        "http-errors": "1.7.3",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      }
-    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -9619,14 +8792,6 @@
       "integrity": "sha512-SDmTeowmNBnJFA0X4vVEuMIOg0lSDwkHnwxIDBL69j1jpGhsxuZvYEjZyod4d4AlKWdT/gHWRjteQFlYCDgtzQ==",
       "requires": {
         "nan": "^2.14.0"
-      }
-    },
-    "read": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
-      "requires": {
-        "mute-stream": "~0.0.4"
       }
     },
     "read-pkg": {
@@ -9678,14 +8843,6 @@
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
       "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw=="
-    },
-    "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "requires": {
-        "resolve": "^1.1.6"
-      }
     },
     "redis-commands": {
       "version": "1.5.0",
@@ -9915,16 +9072,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-    },
-    "require-in-the-middle": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.0.0.tgz",
-      "integrity": "sha512-92TmKFoE6qS0AbZvHPekkgon45OY5bbHl4+cCHm0qBx8+ktV9gEAQoYtuB1ArJnTbqb0020bn5Co9QzjsGkyJg==",
-      "requires": {
-        "debug": "^4.1.1",
-        "module-details-from-path": "^1.0.3",
-        "resolve": "^1.12.0"
-      }
     },
     "require-main-filename": {
       "version": "2.0.0",
@@ -10269,6 +9416,12 @@
             "through": "^2.3.6"
           }
         },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
         "json-schema-traverse": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
@@ -10343,7 +9496,7 @@
           "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "is-fullwidth-code-point": "^2.0.0"
           }
         },
         "string-width": {
@@ -10352,7 +9505,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -10552,11 +9706,6 @@
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
-    "setprototypeof": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
-    },
     "sha.js": {
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
@@ -10588,21 +9737,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-    },
-    "shelljs": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
-      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
-      "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      }
-    },
-    "shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "should": {
       "version": "13.2.3",
@@ -10725,11 +9859,6 @@
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         }
       }
-    },
-    "smart-buffer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
-      "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -10863,34 +9992,6 @@
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz",
           "integrity": "sha1-gioNwmYpDOTNOhIoLKPn42Rmigg=",
           "optional": true
-        }
-      }
-    },
-    "socks": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
-      "integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
-      "requires": {
-        "ip": "1.1.5",
-        "smart-buffer": "^4.1.0"
-      }
-    },
-    "socks-proxy-agent": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
-      "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
-      "requires": {
-        "agent-base": "~4.2.1",
-        "socks": "~2.3.2"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-          "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
-          "requires": {
-            "es6-promisify": "^5.0.0"
-          }
         }
       }
     },
@@ -11176,11 +10277,6 @@
         }
       }
     },
-    "statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
-    },
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
@@ -11377,6 +10473,11 @@
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
           "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "string-width": {
           "version": "3.1.0",
@@ -11583,11 +10684,6 @@
         "xtend": "~4.0.0"
       }
     },
-    "thunkify": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
-      "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0="
-    },
     "timers-browserify": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
@@ -11613,14 +10709,6 @@
       "requires": {
         "no-case": "^2.2.0",
         "upper-case": "^1.0.3"
-      }
-    },
-    "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "requires": {
-        "rimraf": "^2.6.3"
       }
     },
     "to-absolute-glob": {
@@ -11686,11 +10774,6 @@
         "repeat-string": "^1.6.1"
       }
     },
-    "toidentifier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
-    },
     "tough-cookie": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
@@ -11735,11 +10818,6 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
-    },
-    "tv4": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.3.0.tgz",
-      "integrity": "sha1-0CDIRvrdUMhVq7JeuuzGj8EPeWM="
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -11904,11 +10982,6 @@
         "nan": "^2.10.0"
       }
     },
-    "unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-    },
     "unset-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
@@ -12056,7 +11129,8 @@
     "v8-compile-cache": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
-      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g=="
+      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -12081,31 +11155,6 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
-      }
-    },
-    "vizion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/vizion/-/vizion-2.0.2.tgz",
-      "integrity": "sha512-UGDB/UdC1iyPkwyQaI9AFMwKcluQyD4FleEXObrlu254MEf16MV8l+AZdpFErY/iVKZVWlQ+OgJlVVJIdeMUYg==",
-      "requires": {
-        "async": "2.6.1",
-        "git-node-fs": "^1.0.0",
-        "ini": "^1.3.4",
-        "js-git": "^0.7.8",
-        "lodash.findindex": "^4.6.0",
-        "lodash.foreach": "^4.5.0",
-        "lodash.get": "^4.4.2",
-        "lodash.last": "^3.0.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-          "requires": {
-            "lodash": "^4.17.10"
-          }
-        }
       }
     },
     "vlq": {
@@ -12413,11 +11462,6 @@
       "requires": {
         "async-limiter": "^1.0.0"
       }
-    },
-    "xregexp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
-      "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "npm run --silent lint && npm run unit-testing && npm run functional-testing && npm run functional-testing2",
-    "unit-testing": "nyc --reporter=text-summary --reporter=lcov mocha",
+    "unit-testing": "DEBUG= nyc --reporter=text-summary --reporter=lcov mocha",
     "functional-testing": "bash features/run.sh",
     "functional-testing2": "bash features-sdk/run.sh",
     "cucumber": "cucumber.js --fail-fast",
@@ -58,7 +58,6 @@
     "murmurhash-native": "^3.4.1",
     "ndjson": "^1.5.0",
     "passport": "^0.4.0",
-    "pm2": "^3.5.1",
     "rc": "1.2.8",
     "readline-sync": "^1.4.10",
     "semver": "^6.2.0",

--- a/test/api/core/janitor.test.js
+++ b/test/api/core/janitor.test.js
@@ -23,24 +23,25 @@ describe('Test: core/janitor', () => {
   let
     Janitor,
     janitor,
-    kuzzle;
+    kuzzle,
+    runShutdown;
 
   beforeEach(() => {
     kuzzle = new KuzzleMock();
+
+    runShutdown = sinon.stub().resolves();
+    mockrequire('../../../lib/util/shutdown', runShutdown);
+    Janitor = mockrequire.reRequire('../../../lib/api/core/janitor');
     Janitor = rewire('../../../lib/api/core/janitor');
     janitor = new Janitor(kuzzle);
   });
 
+  afterEach(() => {
+    mockrequire.stopAll();
+  });
+
   describe('#loadSecurities', () => {
     const securities = require('../../mocks/securities.json');
-
-    beforeEach(() => {
-      Janitor = mockrequire.reRequire('../../../lib/api/core/janitor');
-    });
-
-    afterEach(() => {
-      mockrequire.stopAll();
-    });
 
     it('should create or replace roles', () => {
       kuzzle.funnel.processRequest.resolves(true);
@@ -132,10 +133,6 @@ describe('Test: core/janitor', () => {
   describe('#loadFixtures', () => {
     const fixtures = require('../../mocks/fixtures.json');
 
-    beforeEach(() => {
-      janitor = new Janitor(kuzzle);
-    });
-
     it('create index and collection that does not exists', () => {
       const storageEngine = kuzzle.storageEngine.public;
       storageEngine.import.onCall(0).resolves({ errors: []});
@@ -162,10 +159,6 @@ describe('Test: core/janitor', () => {
 
   describe('#loadMappings', () => {
     const mappings = require('../../mocks/mappings.json');
-
-    beforeEach(() => {
-      janitor = new Janitor(kuzzle);
-    });
 
     it('create index and collection that does not exists', () => {
       const storageEngine = kuzzle.storageEngine.public;
@@ -201,11 +194,6 @@ describe('Test: core/janitor', () => {
       getAllStatsStub,
       suffix,
       globStub;
-
-    afterEach(() => {
-      mockrequire.stopAll();
-      janitor._dump = false;
-    });
 
     beforeEach(() => {
       fsStub = {
@@ -455,166 +443,9 @@ describe('Test: core/janitor', () => {
   });
 
   describe('#shutdown', () => {
-    let pm2Mock;
-
-    beforeEach(() => {
-      kuzzle.funnel.remainingRequests = 0;
-
-      pm2Mock = {
-        list: sinon.stub(),
-        restart: sinon.stub(),
-        delete: sinon.stub()
-      };
-
-      mockrequire('pm2', pm2Mock);
-      mockrequire.reRequire('../../../lib/api/core/janitor');
-      Janitor = rewire('../../../lib/api/core/janitor');
-
-      Janitor.__set__({
-        // prevent waiting seconds for unit tests
-        setTimeout: sinon.spy(function (...args) { setImmediate(args[0]); })
-      });
-
-      janitor = new Janitor(kuzzle);
-
-      sinon.stub(janitor, '_halt');
-    });
-
-    afterEach(() => {
-      mockrequire.stopAll();
-    });
-
-    it('should exit immediately if unable to retrieve the PM2 process list', done => {
-      pm2Mock.list.yields(new Error('foo'));
-
-      janitor.shutdown(kuzzle, sinon.stub())
-        .then(() => {
-          setTimeout(() => {
-            should(kuzzle.entryPoints.dispatch)
-              .calledOnce()
-              .calledWith('shutdown');
-
-            should(janitor._halt).calledOnce();
-            should(pm2Mock.delete).not.be.called();
-            should(pm2Mock.restart).not.be.called();
-            done();
-          }, 50);
-        });
-    });
-
-    it('should exit immediately if kuzzle was not started with PM2', done => {
-      pm2Mock.list.yields(null, []);
-
-      janitor.shutdown(kuzzle, sinon.stub())
-        .then(() => {
-          setTimeout(() => {
-            should(kuzzle.entryPoints.dispatch)
-              .calledOnce()
-              .calledWith('shutdown');
-
-            should(janitor._halt).calledOnce();
-            should(pm2Mock.delete).not.be.called();
-            should(pm2Mock.restart).not.be.called();
-            done();
-          }, 50);
-        });
-    });
-
-    it('should restart Kuzzle instead of stopping it if the PM2 watcher is active', done => {
-      pm2Mock.list.yields(null, [{
-        pid: process.pid,
-        pm_id: 'foobar',
-        pm2_env: {
-          watch: true
-        }
-      }]);
-
-      janitor.shutdown(kuzzle, sinon.stub())
-        .then(() => {
-          setTimeout(() => {
-            should(kuzzle.entryPoints.dispatch)
-              .calledOnce()
-              .calledWith('shutdown');
-
-            should(janitor._halt).not.called();
-            should(pm2Mock.delete).not.be.called();
-            should(pm2Mock.restart).be.calledOnce().calledWith('foobar');
-            done();
-          }, 50);
-        });
-    });
-
-    it('should delete entries from PM2 if PM2 watcher is inactive and halt Kuzzle', done => {
-      pm2Mock.list.yields(null, [{
-        pid: process.pid,
-        pm_id: 'foobar',
-        pm2_env: {}
-      }]);
-
-      janitor.shutdown(kuzzle, sinon.stub())
-        .then(() => {
-          // should wait until called a second time by PM2
-          setTimeout(() => {
-            should(kuzzle.entryPoints.dispatch)
-              .calledOnce()
-              .calledWith('shutdown');
-
-            should(janitor._halt).not.be.called();
-            should(pm2Mock.delete).be.calledOnce().calledWith('foobar');
-            should(pm2Mock.restart).not.be.called();
-
-            janitor.shutdown(kuzzle, sinon.stub());
-
-            setTimeout(() => {
-              should(kuzzle.entryPoints.dispatch)
-                .calledOnce()
-                .calledWith('shutdown');
-
-              should(janitor._halt).be.calledOnce();
-              should(pm2Mock.delete).be.calledOnce().calledWith('foobar');
-              should(pm2Mock.restart).not.be.called();
-              done();
-            }, 200);
-          }, 50);
-        });
-    });
-
-    it('should wait for the funnel to finish remaining requests before shutting down', done => {
-      // security against a wrong "success" test
-      let remainingChanged = false;
-
-      kuzzle.funnel.remainingRequests = 123;
-
-      pm2Mock.list.yields(new Error('foo'));
-
-      janitor.shutdown(kuzzle, sinon.stub())
-        .then(() => {
-          setTimeout(() => {
-            should(remainingChanged).be.true();
-            should(kuzzle.entryPoints.dispatch)
-              .calledOnce()
-              .calledWith('shutdown');
-
-            should(janitor._halt).calledOnce();
-            should(pm2Mock.delete).not.be.called();
-            should(pm2Mock.restart).not.be.called();
-            done();
-          }, 50);
-        });
-
-      setTimeout(() => {
-        should(kuzzle.entryPoints.dispatch)
-          .calledOnce()
-          .calledWith('shutdown');
-
-        should(pm2Mock.delete).not.be.called();
-        should(pm2Mock.restart).not.be.called();
-        should(janitor._halt).not.be.called();
-
-        kuzzle.funnel.remainingRequests = 0;
-        remainingChanged = true;
-      }, 100);
+    it('should exit immediately if unable to retrieve the PM2 process list', async () => {
+      await janitor.shutdown(kuzzle);
+      should(runShutdown).calledOnce().calledWith(kuzzle);
     });
   });
-
 });

--- a/test/services/elasticsearch.test.js
+++ b/test/services/elasticsearch.test.js
@@ -1086,9 +1086,17 @@ describe('Test: ElasticSearch service', () => {
     });
 
     it('should not reject when a race condition occur between exists and create methods', () => {
-      elasticsearch._client.indices.create.rejects({
-        meta: { body: { error: { type: 'resource_already_exists_exception' } } }
-      });
+      const esReject = new Error('foo');
+
+      esReject.meta = {
+        body: {
+          error: {
+            type: 'resource_already_exists_exception'
+          }
+        }
+      };
+
+      elasticsearch._client.indices.create.rejects(esReject);
 
       const promise = elasticsearch.createCollection(
         index,

--- a/test/util/shutdown.test.js
+++ b/test/util/shutdown.test.js
@@ -1,0 +1,46 @@
+const
+  rewire = require('rewire'),
+  sinon = require('sinon'),
+  should = require('should'),
+  KuzzleMock = require('../mocks/kuzzle.mock');
+
+// require runShutdown only after fake timers are installed
+function requireRunShutdown() {
+  return rewire('../../lib/util/shutdown');
+}
+
+describe('#util/shutdown', () => {
+  let kuzzle;
+  const saveExit = process.exit;
+
+  beforeEach(() => {
+    kuzzle = new KuzzleMock();
+    Object.assign(process, {exit: sinon.stub()});
+  });
+
+  afterEach(() => {
+    process.exit = saveExit;
+  });
+
+  it('should exit only when there is no request left in the funnel', () => {
+    const clock = sinon.useFakeTimers();
+
+    const runShutdown = requireRunShutdown();
+    kuzzle.funnel.remainingRequests = 1;
+
+    try {
+      runShutdown(kuzzle);
+      clock.next();
+      should(process.exit).not.be.called();
+
+      kuzzle.funnel.remainingRequests = 0;
+      clock.next();
+      should(process.exit).calledOnce().calledWith(0);
+      clock.restore();
+    }
+    catch (e) {
+      clock.restore();
+      throw e;
+    }
+  });
+});


### PR DESCRIPTION
# Description

- DRYify the shutdown code
- PM2 code was there only to prevent PM2 to restart Kuzzle in production when the shutdown command was issued. This is a bad design choice and we don't use PM2 anymore in production anyway
- Rejects all new API requests once a graceful shutdown has been initiated, to allow it to finish even if the node is still under fire
- Add a new `core:shutdown` event

# Other changes

* Unset the DEBUG variable for unit tests, to make it easier to spot warning such as "unhandled promise rejection"
* Fix a `promise rejected a non-error object` warning in unit tests