### PR TITLE
Configured server limit were not applied to some m* and deleteByQuery routes

### DIFF
--- a/doc/2/api/controllers/collection/truncate/index.md
+++ b/doc/2/api/controllers/collection/truncate/index.md
@@ -6,9 +6,11 @@ title: truncate
 
 # truncate
 
-
-
 Empties a collection by removing all its documents, while keeping any associated mapping.
+
+::: info
+Documents removed that way do not trigger real-time notifications.
+:::
 
 ---
 

--- a/doc/2/api/controllers/document/delete-by-query/index.md
+++ b/doc/2/api/controllers/document/delete-by-query/index.md
@@ -6,9 +6,17 @@ title: deleteByQuery
 
 # deleteByQuery
 
+Deletes documents matching the provided search query. 
 
+Documents removed that way trigger real-time notifications.
 
-Deletes documents matching the provided search query.
+## Limitations
+
+The request fails if the number of documents returned by the search query exceeds the `documentsFetchCount` server configuration (see the [Configuring Kuzzle](/core/2/guides/essentials/configuration) guide).
+
+To remove a greater number of documents, either change the server configuration, or split the search query.
+
+To remove all documents from a collection, use [collection:truncate](/core/2/api/controllers/collection/truncate) instead.
 
 ---
 

--- a/doc/2/api/controllers/document/delete-by-query/index.md
+++ b/doc/2/api/controllers/document/delete-by-query/index.md
@@ -12,7 +12,7 @@ Documents removed that way trigger real-time notifications.
 
 ## Limitations
 
-The request fails if the number of documents returned by the search query exceeds the `documentsFetchCount` server configuration (see the [Configuring Kuzzle](/core/2/guides/essentials/configuration) guide).
+The request fails if the number of documents returned by the search query exceeds the `documentsWriteCount` server configuration (see the [Configuring Kuzzle](/core/2/guides/essentials/configuration) guide).
 
 To remove a greater number of documents, either change the server configuration, or split the search query.
 

--- a/doc/2/api/controllers/document/m-create-or-replace/index.md
+++ b/doc/2/api/controllers/document/m-create-or-replace/index.md
@@ -8,6 +8,10 @@ title: mCreateOrReplace
 
 Creates or replaces multiple documents.
 
+::: info
+The number of documents that can be created or replaced by a single request is limited by the `documentsWriteCount` server configuration (see the [Configuring Kuzzle](/core/2/guides/essentials/configuration) guide).
+:::
+
 ---
 
 ## Query Syntax

--- a/doc/2/api/controllers/document/m-create/index.md
+++ b/doc/2/api/controllers/document/m-create/index.md
@@ -10,6 +10,10 @@ Creates multiple documents.
 
 If a document identifier already exists, the creation fails for that document.
 
+::: info
+The number of documents that can be created by a single request is limited by the `documentsWriteCount` server configuration (see the [Configuring Kuzzle](/core/2/guides/essentials/configuration) guide).
+:::
+
 ---
 
 ## Query Syntax

--- a/doc/2/api/controllers/document/m-delete/index.md
+++ b/doc/2/api/controllers/document/m-delete/index.md
@@ -8,6 +8,10 @@ title: mDelete
 
 Deletes multiple documents.
 
+::: info
+The number of documents that can be deleted by a single request is limited by the `documentsWriteCount` server configuration (see the [Configuring Kuzzle](/core/2/guides/essentials/configuration) guide).
+:::
+
 ---
 
 ## Query Syntax

--- a/doc/2/api/controllers/document/m-get/index.md
+++ b/doc/2/api/controllers/document/m-get/index.md
@@ -8,6 +8,10 @@ title: mGet
 
 Gets multiple documents.
 
+::: info
+The number of documents that can be fetched by a single request is limited by the `documentsFetchCount` server configuration (see the [Configuring Kuzzle](/core/2/guides/essentials/configuration) guide).
+:::
+
 ---
 
 ## Query Syntax

--- a/doc/2/api/controllers/document/m-replace/index.md
+++ b/doc/2/api/controllers/document/m-replace/index.md
@@ -8,6 +8,10 @@ title: mReplace
 
 Replaces multiple documents.
 
+::: info
+The number of documents that can be replaced by a single request is limited by the `documentsWriteCount` server configuration (see the [Configuring Kuzzle](/core/2/guides/essentials/configuration) guide).
+:::
+
 ---
 
 ## Query Syntax

--- a/doc/2/api/controllers/document/m-update/index.md
+++ b/doc/2/api/controllers/document/m-update/index.md
@@ -6,9 +6,11 @@ title: mUpdate
 
 # mUpdate
 
-
-
 Updates multiple documents.
+
+::: info
+The number of documents that can be updated by a single request is limited by the `documentsWriteCount` server configuration (see the [Configuring Kuzzle](/core/2/guides/essentials/configuration) guide).
+:::
 
 ---
 

--- a/features/run.sh
+++ b/features/run.sh
@@ -7,10 +7,10 @@ set -e
 # profiles are defined in the cucumber.js file at the root of this project
 
 # http
-./node_modules/.bin/cucumber-js --format progress-bar --profile "http"
+./node_modules/.bin/cucumber-js --format progress-bar --profile "http" $1
 
 # websocket
-./node_modules/.bin/cucumber-js --format progress-bar --profile "websocket"
+./node_modules/.bin/cucumber-js --format progress-bar --profile "websocket" $1
 
 # mqtt
-./node_modules/.bin/cucumber-js --format progress-bar --profile "mqtt"
+./node_modules/.bin/cucumber-js --format progress-bar --profile "mqtt" $1

--- a/lib/api/controllers/base.js
+++ b/lib/api/controllers/base.js
@@ -671,7 +671,7 @@ class NativeController extends BaseController {
   /**
    * Throws if number of documents exceeed Kuzzle limits
    *
-   * @param {String} index
+   * @param {Number} asked
    * @param {String} collection
    */
   assertNotExceedMaxWrite (asked) {
@@ -684,4 +684,3 @@ class NativeController extends BaseController {
 }
 
 module.exports = { BaseController, NativeController };
-

--- a/lib/api/controllers/base.js
+++ b/lib/api/controllers/base.js
@@ -672,7 +672,7 @@ class NativeController extends BaseController {
    * Throws if number of documents exceeed Kuzzle limits
    *
    * @param {Number} asked
-   * @param {String} collection
+   * @throws
    */
   assertNotExceedMaxWrite (asked) {
     const limit = this._kuzzle.config.limits.documentsWriteCount;

--- a/lib/api/controllers/base.js
+++ b/lib/api/controllers/base.js
@@ -60,7 +60,7 @@ class NativeController extends BaseController {
     this._kuzzle = kuzzle;
     this.__actions = new Set(actions);
   }
-  
+
   get publicStorage () {
     return this._kuzzle.storageEngine.public;
   }
@@ -665,6 +665,20 @@ class NativeController extends BaseController {
 
     if (asked > limit) {
       errorsManager.throw('services', 'storage', 'get_limit_exceeded');
+    }
+  }
+
+  /**
+   * Throws if number of documents exceeed Kuzzle limits
+   *
+   * @param {String} index
+   * @param {String} collection
+   */
+  assertNotExceedMaxWrite (asked) {
+    const limit = this._kuzzle.config.limits.documentsWriteCount;
+
+    if (asked > limit) {
+      errorsManager.throw('services', 'storage', 'write_limit_exceeded');
     }
   }
 }

--- a/lib/api/controllers/document.js
+++ b/lib/api/controllers/document.js
@@ -442,29 +442,21 @@ class DocumentController extends NativeController {
    * @param {Request} request
    * @returns {Promise<Object>}
    */
-  deleteByQuery (request) {
+  async deleteByQuery (request) {
     const
-      deletedIds = [],
       query = this.getBodyObject(request, 'query'),
       refresh = this.getString(request, 'refresh', 'false'),
       { index, collection } = this.getIndexAndCollection(request);
 
-    return this.publicStorage.deleteByQuery(
+    const { documents } = await this.publicStorage.deleteByQuery(
       index,
       collection,
       query,
-      { refresh }
-    )
-      .then(({ documents }) => {
-        for (let i = 0; i < documents.length; i++) {
-          deletedIds.push(documents[i]._id);
-        }
+      { refresh });
 
-        return this.kuzzle.notifier.notifyDocumentMDelete(request, documents);
-      })
-      .then(() => ({
-        ids: deletedIds
-      }));
+    await this.kuzzle.notifier.notifyDocumentMDelete(request, documents);
+
+    return { ids: documents.map(d => d._id) };
   }
 
   /**

--- a/lib/api/controllers/document.js
+++ b/lib/api/controllers/document.js
@@ -410,30 +410,24 @@ class DocumentController extends NativeController {
    * @param {Request} request
    * @returns {Promise<Object>}
    */
-  mDelete (request) {
-    let _errors;
-
+  async mDelete (request) {
     const
-      deletedIds = [],
       ids = this.getBodyArray(request, 'ids'),
       refresh = this.getString(request, 'refresh', 'false'),
       { index, collection } = this.getIndexAndCollection(request);
 
-    return this.publicStorage.mDelete(index, collection, ids, { refresh })
-      .then(({ documents, errors }) => {
-        _errors = errors;
+    const { documents, errors } = await this.publicStorage.mDelete(
+      index,
+      collection,
+      ids,
+      { refresh });
 
-        for (let i = 0; i < documents.length; i++) {
-          deletedIds.push(documents[i]._id);
-        }
+    await this.kuzzle.notifier.notifyDocumentMDelete(request, documents);
 
-        // @todo should be done in clientAdapter ?
-        return this.kuzzle.notifier.notifyDocumentMDelete(request, documents);
-      })
-      .then(() => ({
-        successes: deletedIds,
-        errors: _errors
-      }));
+    return {
+      successes: documents.map(d => d._id),
+      errors
+    };
   }
 
   /**
@@ -482,33 +476,30 @@ class DocumentController extends NativeController {
    * @param  {boolean} cached Action requires the notifier to pull ids from cache
    * @return {Promise.<Object>} { successes, errors }
    */
-  _mChanges (request, methodName, cached) {
+  async _mChanges (request, methodName, cached) {
     const
       refresh = this.getString(request, 'refresh', 'false'),
       userId = this.getUserId(request),
       documents = this.getBodyArray(request, 'documents'),
       { index, collection } = this.getIndexAndCollection(request);
 
-    let response;
+    this.assertNotExceedMaxWrite(documents.length);
 
-    return this.publicStorage[methodName](
+    const response = await this.publicStorage[methodName](
       index,
       collection,
       documents,
-      { refresh, userId }
-    )
-      .then(_response => {
-        response = _response;
+      { refresh, userId });
 
-        return this.kuzzle.notifier.notifyDocumentMChanges(
-          request,
-          response.items,
-          cached);
-      })
-      .then(() => ({
-        successes: response.items,
-        errors: response.errors
-      }));
+    await this.kuzzle.notifier.notifyDocumentMChanges(
+      request,
+      response.items,
+      cached);
+
+    return {
+      successes: response.items,
+      errors: response.errors
+    };
   }
 }
 

--- a/lib/api/controllers/security.js
+++ b/lib/api/controllers/security.js
@@ -1377,11 +1377,7 @@ function mDelete (kuzzle, type, request) {
   assertBodyAttributeType(request, 'ids', 'array');
 
   if (request.input.body.ids.length > kuzzle.config.limits.documentsWriteCount) {
-    errorsManager.throw(
-      'services',
-      'storage',
-      'write_limit_exceeded',
-      kuzzle.config.limits.documentsWriteCount);
+    errorsManager.throw('services', 'storage', 'write_limit_exceeded');
   }
 
   const promises = request.input.body.ids.map(id => {
@@ -1432,11 +1428,7 @@ function checkSearchPageLimit(request, limit) {
     const size = request.input.args.size - (request.input.args.from || 0);
 
     if (size > limit) {
-      errorsManager.throw(
-        'services',
-        'storage',
-        'get_limit_exceeded',
-        limit);
+      errorsManager.throw('services', 'storage', 'get_limit_exceeded');
     }
   }
 }

--- a/lib/config/error-codes/services.json
+++ b/lib/config/error-codes/services.json
@@ -19,13 +19,13 @@
         "get_limit_exceeded": {
           "description": "The number of documents returned by this request exceeds the configured server limit",
           "code": 3,
-          "message": "The number of documents returned by this request exceeds the configured server limit ( %s ).",
+          "message": "The number of documents returned by this request exceeds the configured server limit.",
           "class": "SizeLimitError"
         },
         "write_limit_exceeded": {
           "description": "The number of documents edited by this request exceeds the configured server limit",
           "code": 4,
-          "message": "The number of documents edited by this request exceeds the configured server limit ( %s ).",
+          "message": "The number of documents edited by this request exceeds the configured server limit.",
           "class": "SizeLimitError"
         },
         "import_failed": {

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -301,8 +301,8 @@ class ElasticSearch extends Service {
 
   /**
    * Returns the list of documents matching the ids given in the body param
-   * NB: Due to internal Kuzzle mechanism, can only be called on a single index/collection,
-   * using the body { ids: [.. } syntax.
+   * NB: Due to internal Kuzzle mechanism, can only be called on a single
+   * index/collection, using the body { ids: [.. } syntax.
    *
    * @param {String} index - Index name
    * @param {String} collection - Collection name
@@ -310,51 +310,50 @@ class ElasticSearch extends Service {
    *
    * @returns {Promise.<Object>} { items: [ _id, _source, _version ], errors }
    */
-  mGet (index, collection, ids) {
+  async mGet (index, collection, ids) {
     if (ids.length === 0) {
-      return Bluebird.resolve({ item: [], errors: [] });
+      return { item: [], errors: [] };
+    }
+
+    if (ids.length > this._kuzzle.config.limits.documentsFetchCount) {
+      errorsManager.throw('get_limit_exceeded');
     }
 
     const
       esIndex = this._getESIndex(index, collection),
       esRequest = {
-        body: { docs: [] }
+        body: {
+          docs: ids.map(_id => ({ _index: esIndex, _id }))
+        }
       };
-
-    for (const _id of ids) {
-      esRequest.body.docs.push({
-        _index: esIndex,
-        _id
-      });
-    }
 
     debug('Multi-get documents: %o', esRequest);
 
-    return this._client.mget(esRequest)
-      .then(({ body }) => {
-        const
-          errors = [],
-          items = [];
+    let body;
 
-        for (const doc of body.docs) {
-          if (doc.found) {
-            items.push({
-              _id: doc._id,
-              _source: doc._source,
-              _version: doc._version
-            });
-          }
-          else {
-            errors.push(doc._id);
-          }
-        }
+    try {
+      ({ body } = await this._client.mget(esRequest)); // NOSONAR
+    }
+    catch (e) {
+      throw this._esWrapper.formatESError(e);
+    }
 
-        return {
-          items,
-          errors
-        };
-      })
-      .catch(error => this._esWrapper.reject(error));
+    const
+      errors = [],
+      items = [];
+
+    for (let i = 0; i < body.docs.length; i++) {
+      const { found, _id, _source, _version } = body.docs[i];
+
+      if (found) {
+        items.push({ _id, _source, _version });
+      }
+      else {
+        errors.push(_id);
+      }
+    }
+
+    return { items, errors };
   }
 
   /**
@@ -623,37 +622,35 @@ class ElasticSearch extends Service {
    *
    * @returns {Promise.<Object>} { documents, total, deleted, failures: [ _shardId, reason ] }
    */
-  deleteByQuery (
+  async deleteByQuery (
     index,
     collection,
     query,
-    { refresh, from, size } = {})
+    { refresh, from, size = 1000 } = {})
   {
     const esRequest = {
       index: this._getESIndex(index, collection),
       body: this._avoidEmptyClause({ query }),
       scroll: '5s',
+      refresh: refresh === 'wait_for' ? true : refresh,
       from,
       size
     };
 
     if (!isPlainObject(query)) {
-      return errorsManager.reject('missing_argument', 'body.query');
+      errorsManager.throw('missing_argument', 'body.query');
     }
 
-    let documents;
+    await this.refreshCollection(index, collection);
 
-    esRequest.refresh = refresh === 'wait_for' ? true : refresh;
+    try {
+      const documents = await this._getAllDocumentsFromQuery(esRequest);
 
-    return this.refreshCollection(index, collection)
-      .then(() => this._getAllDocumentsFromQuery(esRequest))
-      .then(_documents => {
-        documents = _documents;
+      debug('Delete by query: %o', esRequest);
 
-        debug('Delete by query: %o', esRequest);
-        return this._client.deleteByQuery(esRequest);
-      })
-      .then(({ body }) => ({
+      const { body } = await this._client.deleteByQuery(esRequest);
+
+      return {
         documents,
         total: body.total,
         deleted: body.deleted,
@@ -662,8 +659,11 @@ class ElasticSearch extends Service {
             shardId,
             reason
           }))
-      }))
-      .catch(error => this._esWrapper.reject(error));
+      };
+    }
+    catch (error) {
+      throw this._esWrapper.formatESError(error);
+    }
   }
 
   /**
@@ -1297,12 +1297,16 @@ class ElasticSearch extends Service {
    *
    * @return {Promise.<Object>} { items, errors }
    */
-  mCreate (
+  async mCreate (
     index,
     collection,
     documents,
     { refresh, timeout, userId=null } = {})
   {
+    if (documents.length > this._kuzzle.config.limits.documentsWriteCount) {
+      errorsManager.throw('write_limit_exceeded');
+    }
+
     const
       esIndex = this._getESIndex(index, collection),
       kuzzleMeta = {
@@ -1320,80 +1324,66 @@ class ElasticSearch extends Service {
       } = this._extractMDocuments(documents, kuzzleMeta, { prepareMGet: true });
 
     // prepare the mget request, but only for document having a specified id
-    let mGetRequest;
+    const {body} = documentsToGet.length > 0
+      ? await this._client.mget({index: esIndex, body: {docs: documentsToGet}})
+      : {body: {docs: []}};
 
-    if (documentsToGet.length > 0) {
-      mGetRequest =
-        this._client.mget({ index: esIndex, body: { docs: documentsToGet }});
-    } else {
-      mGetRequest = Bluebird.resolve({ body: { docs: [] } });
-    }
+    const
+      existingDocuments = body.docs,
+      esRequest = {
+        index: esIndex,
+        body: [],
+        refresh,
+        timeout
+      },
+      toImport = [];
 
-    return mGetRequest
-      .then(({ body }) => {
-        const
-          existingDocuments = body.docs,
-          esRequest = {
-            index: esIndex,
-            body: [],
-            refresh,
-            timeout
-          },
-          toImport = [];
+    /**
+     * @warning Critical code section
+     *
+     * request can contain more than 10K elements
+     */
+    for (let i = 0, idx = 0; i < extractedDocuments.length; i++) {
+      const document = extractedDocuments[i];
 
-        let idx = 0;
+      // Documents are retrieved in the same order than we got them from user
+      if (typeof document._id === 'string' && existingDocuments[idx]) {
+        if (existingDocuments[idx].found) {
+          delete document._source._kuzzle_info;
 
-        /**
-         * @warning Critical code section
-         *
-         * request can contain more than 10K elements
-         */
-        for (let i = 0; i < extractedDocuments.length; i++) {
-          const document = extractedDocuments[i];
+          rejected.push({
+            document: {
+              _id: document._id,
+              body: document._source
+            },
+            reason: 'document already exists',
+            status: 400
+          });
 
-          // Documents are retrieved in the same order than we got them from user
-          if ( typeof document._id === 'string'
-            && existingDocuments[idx]
-            && existingDocuments[idx].found
-          ) {
-            delete document._source._kuzzle_info;
-
-            rejected.push({
-              document: {
-                _id: document._id,
-                body: document._source
-              },
-              reason: 'document already exists',
-              status: 400
-            });
-
-            idx++;
-          }
-          else if (typeof document._id === 'string'
-            && existingDocuments[idx]
-            && ! existingDocuments[idx].found
-          ) {
-            esRequest.body.push({
-              index: {
-                _index: esIndex,
-                _id: document._id
-              }
-            });
-            esRequest.body.push(document._source);
-
-            toImport.push(document);
-          }
-          else {
-            esRequest.body.push({ index: { _index: esIndex } });
-            esRequest.body.push(document._source);
-
-            toImport.push(document);
-          }
+          idx++;
         }
-        /* end critical code section */
+        else {
+          esRequest.body.push({
+            index: {
+              _index: esIndex,
+              _id: document._id
+            }
+          });
+          esRequest.body.push(document._source);
 
-        return this._mExecute(esRequest, toImport, rejected);
-      });
+          toImport.push(document);
+        }
+      }
+      else {
+        esRequest.body.push({ index: { _index: esIndex } });
+        esRequest.body.push(document._source);
+
+        toImport.push(document);
+      }
+    }
+    /* end critical code section */
+
+    return this._mExecute(esRequest, toImport, rejected);
   }
 
   /**
@@ -1406,12 +1396,16 @@ class ElasticSearch extends Service {
    *
    * @return {Promise.<Object>} { items, errors }
    */
-  mCreateOrReplace(
+  async mCreateOrReplace(
     index,
     collection,
     documents,
     { refresh, timeout, userId=null, injectKuzzleMeta=true } = {})
   {
+    if (documents.length > this._kuzzle.config.limits.documentsWriteCount) {
+      errorsManager.throw('write_limit_exceeded');
+    }
+
     let kuzzleMeta = {};
 
     if (injectKuzzleMeta) {
@@ -1471,12 +1465,16 @@ class ElasticSearch extends Service {
    *
    * @return {Promise.<Object>} { items, errors }
    */
-  mUpdate (
+  async mUpdate (
     index,
     collection,
     documents,
     { refresh, timeout, userId=null } = {})
   {
+    if (documents.length > this._kuzzle.config.limits.documentsWriteCount) {
+      errorsManager.throw('write_limit_exceeded');
+    }
+
     const
       esIndex = this._getESIndex(index, collection),
       toImport = [],
@@ -1536,35 +1534,33 @@ class ElasticSearch extends Service {
     }
     /* end critical code section */
 
-    return this._mExecute(esRequest, toImport, rejected)
-      .then(response => {
-        const docs = [];
+    const response = await this._mExecute(esRequest, toImport, rejected);
+    const docs = [];
 
-        /**
-         * @warning Critical code section
-         *
-         * request can contain more than 10K elements
-         */
-        // with _source: true, ES returns the updated document in
-        // response.result.get._source
-        // => we replace response.result._source with it so that the notifier
-        // module can seamlessly process all kind of m* response*
-        for (let i = 0; i < response.items.length; i++) {
-          const item = response.items[i];
+    /**
+     * @warning Critical code section
+     *
+     * request can contain more than 10K elements
+     */
+    // with _source: true, ES returns the updated document in
+    // response.result.get._source
+    // => we replace response.result._source with it so that the notifier
+    // module can seamlessly process all kind of m* response*
+    for (let i = 0; i < response.items.length; i++) {
+      const item = response.items[i];
 
-          docs.push({
-            _id: item._id,
-            _source: item.get._source,
-            status: item.status,
-            result: item.result
-          });
-        }
-        /* end critical code section */
-
-        response.items = docs;
-
-        return response;
+      docs.push({
+        _id: item._id,
+        _source: item.get._source,
+        status: item.status,
+        result: item.result
       });
+    }
+    /* end critical code section */
+
+    response.items = docs;
+
+    return response;
   }
 
   /**
@@ -1579,12 +1575,16 @@ class ElasticSearch extends Service {
    *
    * @return {Promise.<Object>} { items, errors }
    */
-  mReplace (
+  async mReplace (
     index,
     collection,
     documents,
     { refresh, timeout, userId=null } = {})
   {
+    if (documents.length > this._kuzzle.config.limits.documentsWriteCount) {
+      errorsManager.throw('write_limit_exceeded');
+    }
+
     const
       esIndex = this._getESIndex(index, collection),
       kuzzleMeta = {
@@ -1605,57 +1605,59 @@ class ElasticSearch extends Service {
         { prepareMGet: true, requireId: true });
 
     if (documentsToGet.length < 1) {
-      return Bluebird.resolve({ items: [], errors: rejected });
+      return { items: [], errors: rejected };
     }
 
-    return this._client.mget({ index: esIndex, body: { docs: documentsToGet }})
-      .then(({ body }) => {
-        const
-          existingDocuments = body.docs,
-          esRequest = {
-            body: [],
-            refresh,
-            timeout
+    const {body} = await this._client.mget({
+      index: esIndex,
+      body: { docs: documentsToGet }
+    });
+
+    const
+      existingDocuments = body.docs,
+      esRequest = {
+        body: [],
+        refresh,
+        timeout
+      },
+      toImport = [];
+
+    /**
+     * @warning Critical code section
+     *
+     * request can contain more than 10K elements
+     */
+    for (let i = 0; i < extractedDocuments.length; i++) {
+      const document = extractedDocuments[i];
+
+      // Documents are retrieved in the same order than we got them from user
+      if (existingDocuments[i] && existingDocuments[i].found) {
+        esRequest.body.push({
+          index: {
+            _index: esIndex,
+            _id: document._id
+          }
+        });
+        esRequest.body.push(document._source);
+
+        toImport.push(document);
+      }
+      else {
+        delete document._source._kuzzle_info;
+
+        rejected.push({
+          document: {
+            _id: document._id,
+            body: document._source
           },
-          toImport = [];
+          reason: 'document not found',
+          status: 404
+        });
+      }
+    }
+    /* end critical code section */
 
-        /**
-         * @warning Critical code section
-         *
-         * request can contain more than 10K elements
-         */
-        for (let i = 0; i < extractedDocuments.length; i++) {
-          const document = extractedDocuments[i];
-
-          // Documents are retrieved in the same order than we got them from user
-          if (existingDocuments[i] && existingDocuments[i].found) {
-            esRequest.body.push({
-              index: {
-                _index: esIndex,
-                _id: document._id
-              }
-            });
-            esRequest.body.push(document._source);
-
-            toImport.push(document);
-          }
-          else {
-            delete document._source._kuzzle_info;
-
-            rejected.push({
-              document: {
-                _id: document._id,
-                body: document._source
-              },
-              reason: 'document not found',
-              status: 404
-            });
-          }
-        }
-        /* end critical code section */
-
-        return this._mExecute(esRequest, toImport, rejected);
-      });
+    return this._mExecute(esRequest, toImport, rejected);
   }
 
   /**
@@ -1668,7 +1670,7 @@ class ElasticSearch extends Service {
    *
    * @return {Promise.<Object>} { documents, errors }
    */
-  mDelete (
+  async mDelete (
     index,
     collection,
     ids,
@@ -1679,7 +1681,6 @@ class ElasticSearch extends Service {
       validIds = [],
       partialErrors = [];
 
-    // @todo should be done in clientAdapter
     if (ids.length > this._kuzzle.config.limits.documentsWriteCount) {
       return errorsManager.reject('write_limit_exceeded');
     }
@@ -1705,43 +1706,43 @@ class ElasticSearch extends Service {
     }
     /* end critical code section */
 
-    return this.mGet(index, collection, validIds)
-      .then(({ items }) => {
-        let idx = 0;
+    const {items} = await this.mGet(index, collection, validIds);
 
-        /**
-         * @warning Critical code section
-         *
-         * request can contain more than 10K elements
-         */
-        for (let i = 0; i < validIds.length; i++) {
-          const
-            validId = validIds[i],
-            item = items[idx];
+    let idx = 0;
 
-          if (item && item._id === validId) {
-            query.ids.values.push(validId);
-            idx++;
-          }
-          else {
-            partialErrors.push({
-              _id: validId,
-              reason: 'document not found',
-              status: 404
-            });
-          }
-        }
-        /* end critical code section */
+    /**
+     * @warning Critical code section
+     *
+     * request can contain more than 10K elements
+     */
+    for (let i = 0; i < validIds.length; i++) {
+      const
+        validId = validIds[i],
+        item = items[idx];
 
-        // @todo duplicated query to get documents body, mGet here and search in
-        // deleteByQuery
-        return this.deleteByQuery(index, collection, query, { refresh, timeout });
-      })
-      .then(({ documents }) => ({
-        documents,
-        errors: partialErrors
-      }))
-      .catch(error => this._esWrapper.reject(error));
+      if (item && item._id === validId) {
+        query.ids.values.push(validId);
+        idx++;
+      }
+      else {
+        partialErrors.push({
+          _id: validId,
+          reason: 'document not found',
+          status: 404
+        });
+      }
+    }
+    /* end critical code section */
+
+    // @todo duplicated query to get documents body, mGet here and search in
+    // deleteByQuery
+    const {documents} = await this.deleteByQuery(
+      index,
+      collection,
+      query,
+      { refresh, timeout });
+
+    return {documents, errors: partialErrors};
   }
 
   /**
@@ -2034,37 +2035,28 @@ class ElasticSearch extends Service {
    *
    * @returns {Promise.<Array>} resolve to an array of documents
    */
-  _getAllDocumentsFromQuery ({ index, body, scroll, from, size }) {
-    const
-      client = this._client,
-      documents = [];
+  async _getAllDocumentsFromQuery (esRequest) {
+    let { body: { hits, _scroll_id } } = await this._client.search(esRequest);
 
-    return new Bluebird((resolve, reject) => {
-      client.search(
-        { index, body, scroll, from, size },
-        function getMoreUntilDone(error, { body: { hits, _scroll_id } }) {
-          if (error) {
-            return reject(error);
-          }
+    if (hits.total.value > this._kuzzle.config.limits.documentsFetchCount) {
+      errorsManager.throw('get_limit_exceeded');
+    }
 
-          for (const hit of hits.hits) {
-            documents.push({
-              _id: hit._id,
-              _source: hit._source
-            });
-          }
+    const documents = hits.hits.map(h => ({ _id: h._id, _source: h._source }));
 
-          if (hits.total.value !== documents.length) {
-            client.scroll({
-              scrollId: _scroll_id,
-              scroll
-            }, getMoreUntilDone);
-          }
-          else {
-            resolve(documents);
-          }
-        });
-    });
+    while (hits.total.value !== documents.length) {
+      ({ body: { hits, _scroll_id } } = await this._client.scroll({
+        scrollId: _scroll_id,
+        scroll: esRequest.scroll
+      }));
+
+      hits.hits.forEach(h => documents.push({
+        _id: h._id,
+        _source: h._source
+      }));
+    }
+
+    return documents;
   }
 
   /**

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -632,7 +632,6 @@ class ElasticSearch extends Service {
       index: this._getESIndex(index, collection),
       body: this._avoidEmptyClause({ query }),
       scroll: '5s',
-      refresh: refresh === 'wait_for' ? true : refresh,
       from,
       size
     };
@@ -647,6 +646,8 @@ class ElasticSearch extends Service {
       const documents = await this._getAllDocumentsFromQuery(esRequest);
 
       debug('Delete by query: %o', esRequest);
+
+      esRequest.refresh = refresh === 'wait_for' ? true : refresh;
 
       const { body } = await this._client.deleteByQuery(esRequest);
 

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -315,10 +315,6 @@ class ElasticSearch extends Service {
       return { item: [], errors: [] };
     }
 
-    if (ids.length > this._kuzzle.config.limits.documentsFetchCount) {
-      errorsManager.throw('get_limit_exceeded');
-    }
-
     const
       esIndex = this._getESIndex(index, collection),
       esRequest = {
@@ -1304,10 +1300,6 @@ class ElasticSearch extends Service {
     documents,
     { refresh, timeout, userId=null } = {})
   {
-    if (documents.length > this._kuzzle.config.limits.documentsWriteCount) {
-      errorsManager.throw('write_limit_exceeded');
-    }
-
     const
       esIndex = this._getESIndex(index, collection),
       kuzzleMeta = {
@@ -1403,10 +1395,6 @@ class ElasticSearch extends Service {
     documents,
     { refresh, timeout, userId=null, injectKuzzleMeta=true } = {})
   {
-    if (documents.length > this._kuzzle.config.limits.documentsWriteCount) {
-      errorsManager.throw('write_limit_exceeded');
-    }
-
     let kuzzleMeta = {};
 
     if (injectKuzzleMeta) {
@@ -1472,10 +1460,6 @@ class ElasticSearch extends Service {
     documents,
     { refresh, timeout, userId=null } = {})
   {
-    if (documents.length > this._kuzzle.config.limits.documentsWriteCount) {
-      errorsManager.throw('write_limit_exceeded');
-    }
-
     const
       esIndex = this._getESIndex(index, collection),
       toImport = [],
@@ -1582,10 +1566,6 @@ class ElasticSearch extends Service {
     documents,
     { refresh, timeout, userId=null } = {})
   {
-    if (documents.length > this._kuzzle.config.limits.documentsWriteCount) {
-      errorsManager.throw('write_limit_exceeded');
-    }
-
     const
       esIndex = this._getESIndex(index, collection),
       kuzzleMeta = {
@@ -1681,10 +1661,6 @@ class ElasticSearch extends Service {
       query = { ids: { values: [] } },
       validIds = [],
       partialErrors = [];
-
-    if (ids.length > this._kuzzle.config.limits.documentsWriteCount) {
-      return errorsManager.reject('write_limit_exceeded');
-    }
 
     /**
      * @warning Critical code section

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -2030,6 +2030,8 @@ class ElasticSearch extends Service {
 
   /**
    * Scroll index in elasticsearch and return all document that match the filter
+   * /!\ throws a write_limit_exceed error: this method is intended to be used
+   * by deleteByQuery
    *
    * @param {Object} esRequest - Search request body
    *
@@ -2038,8 +2040,8 @@ class ElasticSearch extends Service {
   async _getAllDocumentsFromQuery (esRequest) {
     let { body: { hits, _scroll_id } } = await this._client.search(esRequest);
 
-    if (hits.total.value > this._kuzzle.config.limits.documentsFetchCount) {
-      errorsManager.throw('get_limit_exceeded');
+    if (hits.total.value > this._kuzzle.config.limits.documentsWriteCount) {
+      errorsManager.throw('write_limit_exceeded');
     }
 
     const documents = hits.hits.map(h => ({ _id: h._id, _source: h._source }));

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -339,13 +339,17 @@ class ElasticSearch extends Service {
       items = [];
 
     for (let i = 0; i < body.docs.length; i++) {
-      const { found, _id, _source, _version } = body.docs[i];
+      const doc = body.docs[i];
 
-      if (found) {
-        items.push({ _id, _source, _version });
+      if (doc.found) {
+        items.push({
+          _id: doc._id,
+          _source: doc._source,
+          _version: doc._version
+        });
       }
       else {
-        errors.push(_id);
+        errors.push(doc._id);
       }
     }
 
@@ -1389,7 +1393,7 @@ class ElasticSearch extends Service {
    *
    * @return {Promise.<Object>} { items, errors }
    */
-  async mCreateOrReplace(
+  mCreateOrReplace(
     index,
     collection,
     documents,
@@ -1520,30 +1524,17 @@ class ElasticSearch extends Service {
     /* end critical code section */
 
     const response = await this._mExecute(esRequest, toImport, rejected);
-    const docs = [];
 
-    /**
-     * @warning Critical code section
-     *
-     * request can contain more than 10K elements
-     */
     // with _source: true, ES returns the updated document in
     // response.result.get._source
     // => we replace response.result._source with it so that the notifier
     // module can seamlessly process all kind of m* response*
-    for (let i = 0; i < response.items.length; i++) {
-      const item = response.items[i];
-
-      docs.push({
-        _id: item._id,
-        _source: item.get._source,
-        status: item.status,
-        result: item.result
-      });
-    }
-    /* end critical code section */
-
-    response.items = docs;
+    response.items = response.items.map(item => ({
+      _id: item._id,
+      _source: item.get._source,
+      status: item.status,
+      result: item.result
+    }));
 
     return response;
   }
@@ -2021,7 +2012,7 @@ class ElasticSearch extends Service {
       errorsManager.throw('write_limit_exceeded');
     }
 
-    const documents = hits.hits.map(h => ({ _id: h._id, _source: h._source }));
+    let documents = hits.hits.map(h => ({ _id: h._id, _source: h._source }));
 
     while (hits.total.value !== documents.length) {
       ({ body: { hits, _scroll_id } } = await this._client.scroll({ //NOSONAR
@@ -2029,10 +2020,10 @@ class ElasticSearch extends Service {
         scroll: esRequest.scroll
       }));
 
-      hits.hits.forEach(h => documents.push({
+      documents = documents.concat(hits.hits.map(h => ({
         _id: h._id,
         _source: h._source
-      }));
+      })));
     }
 
     return documents;

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -2045,7 +2045,7 @@ class ElasticSearch extends Service {
     const documents = hits.hits.map(h => ({ _id: h._id, _source: h._source }));
 
     while (hits.total.value !== documents.length) {
-      ({ body: { hits, _scroll_id } } = await this._client.scroll({
+      ({ body: { hits, _scroll_id } } = await this._client.scroll({ //NOSONAR
         scrollId: _scroll_id,
         scroll: esRequest.scroll
       }));

--- a/test/api/controllers/document.test.js
+++ b/test/api/controllers/document.test.js
@@ -398,6 +398,15 @@ describe('DocumentController', () => {
         ]
       });
     });
+
+    it('should reject if the number of documents to edit exceeds server configuration', () => {
+      kuzzle.config.limits.documentsWriteCount = 1;
+
+      return should(documentController._mChanges(request, 'foobar'))
+        .rejectedWith(
+          SizeLimitError,
+          { id: 'services.storage.write_limit_exceeded' });
+    });
   });
 
   describe('#createOrReplace', () => {

--- a/test/services/elasticsearch.test.js
+++ b/test/services/elasticsearch.test.js
@@ -2923,16 +2923,6 @@ describe('Test: ElasticSearch service', () => {
           });
         });
     });
-
-    it('should abort if the number of documents exceeds the configured limit', () => {
-      kuzzle.config.limits.documentsWriteCount = 1;
-
-      const promise = elasticsearch.mDelete(index, collection, documentIds);
-
-      return should(promise).be.rejectedWith({
-        id: 'services.storage.write_limit_exceeded'
-      });
-    });
   });
 
   describe('_mExecute', () => {

--- a/test/services/elasticsearch.test.js
+++ b/test/services/elasticsearch.test.js
@@ -327,15 +327,6 @@ describe('Test: ElasticSearch service', () => {
             .be.calledWith(esClientError);
         });
     });
-
-    it('should reject if the number of ids exceeds the server configured limit', () => {
-      kuzzle.config.limits.documentsFetchCount = 1;
-
-      return should(elasticsearch.mGet(index, collection, ['foo', 'bar']))
-        .rejectedWith(
-          SizeLimitError,
-          { id: 'services.storage.get_limit_exceeded'});
-    });
   });
 
   describe('#count', () => {
@@ -930,7 +921,7 @@ describe('Test: ElasticSearch service', () => {
       return should(elasticsearch.deleteByQuery(index, collection, {}))
         .rejectedWith(
           SizeLimitError,
-          { id: 'services.storage.get_limit_exceeded' });
+          { id: 'services.storage.write_limit_exceeded' });
     });
   });
 
@@ -2317,15 +2308,6 @@ describe('Test: ElasticSearch service', () => {
           should(result).match(mExecuteResult);
         });
     });
-
-    it('should reject if the number of ids exceeds the server configured limit', () => {
-      kuzzle.config.limits.documentsWriteCount = 1;
-
-      return should(elasticsearch.mCreate(index, collection, documentsWithIds))
-        .rejectedWith(
-          SizeLimitError,
-          { id: 'services.storage.write_limit_exceeded'});
-    });
   });
 
   describe('#mCreateOrReplace', () => {
@@ -2449,15 +2431,6 @@ describe('Test: ElasticSearch service', () => {
 
           should(result).match(mExecuteResult);
         });
-    });
-
-    it('should reject if the number of ids exceeds the server configured limit', () => {
-      kuzzle.config.limits.documentsWriteCount = 1;
-
-      return should(elasticsearch.mCreateOrReplace(index, collection, documents))
-        .rejectedWith(
-          SizeLimitError,
-          { id: 'services.storage.write_limit_exceeded'});
     });
   });
 
@@ -2609,15 +2582,6 @@ describe('Test: ElasticSearch service', () => {
             toImport,
             rejected);
         });
-    });
-
-    it('should reject if the number of ids exceeds the server configured limit', () => {
-      kuzzle.config.limits.documentsWriteCount = 1;
-
-      return should(elasticsearch.mUpdate(index, collection, documents))
-        .rejectedWith(
-          SizeLimitError,
-          { id: 'services.storage.write_limit_exceeded'});
     });
   });
 
@@ -2821,15 +2785,6 @@ describe('Test: ElasticSearch service', () => {
           should(result).match(mExecuteResult);
         });
     });
-
-    it('should reject if the number of ids exceeds the server configured limit', () => {
-      kuzzle.config.limits.documentsWriteCount = 1;
-
-      return should(elasticsearch.mReplace(index, collection, documents))
-        .rejectedWith(
-          SizeLimitError,
-          { id: 'services.storage.write_limit_exceeded'});
-    });
   });
 
   describe('#mDelete', () => {
@@ -2977,15 +2932,6 @@ describe('Test: ElasticSearch service', () => {
       return should(promise).be.rejectedWith({
         id: 'services.storage.write_limit_exceeded'
       });
-    });
-
-    it('should reject if the number of ids exceeds the server configured limit', () => {
-      kuzzle.config.limits.documentsWriteCount = 1;
-
-      return should(elasticsearch.mDelete(index, collection, documentIds))
-        .rejectedWith(
-          SizeLimitError,
-          { id: 'services.storage.write_limit_exceeded'});
     });
   });
 


### PR DESCRIPTION
# Description

Kuzzle configuration file contains the following configurable parameters in the `limits` section: documentsFetchCount, documentsWriteCount

These parameters control how many documents can be retrieved or edited by a single multi-documents requests, but they weren't always applied:

* mDeleteByQuery ignored these limits
* mCreate/mCreateOrReplace/mUpdate/mReplace applied the limits only after all the preliminary work was done, including fetching a possibly huge quantity of documents in RAM from ES to perform a few checks
* mDelete checked for these limits in the ES service code instead of doing it in the document API controller

Those limits are there primarily to keep the necessary quantity of resources for these operations under control (RAM: most of m* routes load documents in memory first, and CPU: all these routes trigger real-time notifications).

# Other changes

* Document how these limits are applied in the m*/deleteByQuery API documentation
* Document that collection:truncate does not trigger real-time notifications
* Remove the configured server limit from error messages, as this information is not needed by clients, and I'm not sure that leaking server configuration to the outside is a good thing (very minor issue though)

# Boyscout

* asyncify modified functions