### PR TITLE
Prevent overloads caused by pre-funnel pipes

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -102,11 +102,25 @@
     //   * initTimeout:
     //        Maximum execution time (in milliseconds)
     //        of a plugin initialization
+    //   * maxConcurrentPipes:
+    //        Maximum number of pipes that can be executed in parallel
+    //        New pipes submitted while the maximum number of pipes is met are
+    //        delayed for later execution.
+    //        This parameter controls is used to limit the stress put on the
+    //        event loop, allowing for Kuzzle to process pipes faster, and to
+    //        protect it from performances degradation if an abnormal number of
+    //        pipes are submitted.
+    //        (timers do not start while a pipe is hold back)
+    //   * pipesBufferSize:
+    //        Maximum number of pipes that can be delayed. If full, new pipes
+    //        are rejected.
     "common": {
       "bootstrapLockTimeout": 5000,
       "pipeWarnTime": 40,
       "pipeTimeout": 250,
-      "initTimeout": 2000
+      "initTimeout": 2000,
+      "maxConcurrentPipes": 50,
+      "pipesBufferSize": 50000
     }
 
     // Custom plugin configurations must be described here.

--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -103,7 +103,7 @@
     //        Maximum execution time (in milliseconds)
     //        of a plugin initialization
     //   * maxConcurrentPipes:
-    //        Maximum number of pipes that can be executed in parallel
+    //        Maximum number of pipes that can be executed in parallel.
     //        New pipes submitted while the maximum number of pipes is met are
     //        delayed for later execution.
     //        This parameter controls is used to limit the stress put on the

--- a/default.config.js
+++ b/default.config.js
@@ -66,6 +66,8 @@ module.exports = {
       pipeWarnTime: 500,
       pipeTimeout: 5000,
       initTimeout: 10000,
+      maxConcurrentPipes: 50,
+      pipesBufferSize: 50000
     }
   },
 

--- a/doc/2/api/essentials/errors/codes/index.md
+++ b/doc/2/api/essentials/errors/codes/index.md
@@ -250,6 +250,7 @@ order: 500
 | plugin.runtime.failed_init<br/><pre>0x04020001</pre> | [PluginImplementationError](/core/2/api/essentials/errors/handling#pluginimplementationerror) <pre>(500)</pre> | An exception was thrown by a plugin's init function |
 | plugin.runtime.unexpected_error<br/><pre>0x04020002</pre> | [PluginImplementationError](/core/2/api/essentials/errors/handling#pluginimplementationerror) <pre>(500)</pre> | Embeds an unexpected plugin error into a standardized KuzzleError object |
 | plugin.runtime.pipe_timeout<br/><pre>0x04020003</pre> | [GatewayTimeoutError](/core/2/api/essentials/errors/handling#gatewaytimeouterror) <pre>(504)</pre> | A pipe function execution took more than the configured server limit |
+| plugin.runtime.too_many_pipes<br/><pre>0x04020004</pre> | [ServiceUnavailableError](/core/2/api/essentials/errors/handling#serviceunavailableerror) <pre>(503)</pre> | The number of running pipes exceeds the configured capacity (see configuration files). This may be caused by pipes being too slow, or by an insufficient number of Kuzzle nodes. |
 
 ---
 

--- a/lib/config/error-codes/plugin.json
+++ b/lib/config/error-codes/plugin.json
@@ -80,6 +80,12 @@
           "code": 3,
           "message": "Plugin \"%s\": timeout error. A pipe on the event \"%s\" exceeded the timeout delay (%sms). Aborting.",
           "class": "GatewayTimeoutError"
+        },
+        "too_many_pipes": {
+          "description": "The number of running pipes exceeds the configured capacity (see configuration files). This may be caused by pipes being too slow, or by an insufficient number of Kuzzle nodes.",
+          "code": 4,
+          "message": "Request discarded: maximum number of executing pipe functions reached.",
+          "class": "ServiceUnavailableError"
         }
       }
     },

--- a/lib/core/httpRouter/index.js
+++ b/lib/core/httpRouter/index.js
@@ -202,12 +202,13 @@ class Router {
       request.input.headers = message.headers;
       request.setResult({}, 200);
 
-      this.kuzzle.pipe('http:options', request)
-        .then(result => {
-          cb(result);
-          return null;
-        })
-        .catch(error => replyWithError(cb, request, error));
+      this.kuzzle.pipe('http:options', request, (error, result) => {
+        if (error) {
+          return replyWithError(cb, request, error);
+        }
+
+        cb(result);
+      });
 
       return;
     }

--- a/lib/core/httpRouter/index.js
+++ b/lib/core/httpRouter/index.js
@@ -166,7 +166,8 @@ class Router {
       }
 
       routeHandler.invokeHandler(cb);
-    } catch (err) {
+    }
+    catch (err) {
       let request;
       if (!routeHandler || !routeHandler._request) {
         request = new Request({requestId: message.requestId}, {});

--- a/lib/core/plugins/manager.js
+++ b/lib/core/plugins/manager.js
@@ -27,7 +27,6 @@ const
   debug = require('../../util/debug')('kuzzle:plugins'),
   PluginContext = require('./context'),
   PrivilegedPluginContext = require('./privilegedContext'),
-  async = require('async'),
   path = require('path'),
   Bluebird = require('bluebird'),
   _ = require('lodash'),
@@ -36,7 +35,8 @@ const
   Manifest = require('./manifest'),
   { loadPluginsErrors } = require('../../config/error-codes'),
   { has, get, isPlainObject } = require('../../util/safeObject'),
-  { BaseController } = require('../../api/controllers/base');
+  { BaseController } = require('../../api/controllers/base'),
+  PipeRunner = require('./pipeRunner');
 
 const
   assertionError = errorsManager.wrap('plugin', 'assert'),
@@ -51,6 +51,7 @@ const
 class PluginsManager {
   constructor(kuzzle) {
     this.kuzzle = kuzzle;
+    this.pipeRunner = new PipeRunner();
     this.plugins = {};
     this.pipes = {};
 
@@ -227,13 +228,13 @@ class PluginsManager {
    *  - pipes can be triggered thousand of time per second
    *
    * @param  {Array.<string>} events
-   * @param  {*} data
-   * @return {Promise.<*>}
+   * @param  {Array.<*>} data
+   * @param  {Function} callback
    */
-  pipe (events, data, ...info) {
+  pipe (events, data, callback) {
     debug('trigger "%s" event', events);
 
-    const preparedPipes = [cb => cb(null, data, ...info)];
+    const preparedPipes = [cb => cb(null, ...data)];
 
     for (let i = 0; i < events.length; i++) {
       const event = events[i];
@@ -246,25 +247,10 @@ class PluginsManager {
     }
 
     if (preparedPipes.length === 1) {
-      return Bluebird.resolve(data);
+      return callback(null, data[0]);
     }
 
-    return new Bluebird((resolve, reject) => {
-      async.waterfall(preparedPipes, (error, result) => {
-        if (error) {
-          if (error instanceof KuzzleError) {
-            return reject(error);
-          }
-
-          return reject(runtimeError.getFrom(
-            error,
-            'unexpected_error',
-            error.message));
-        }
-
-        resolve(result);
-      });
-    });
+    this.pipeRunner.run(preparedPipes, callback);
   }
 
   /**
@@ -414,9 +400,15 @@ class PluginsManager {
       this.pipes[event] = [];
     }
 
-    this.pipes[event].push((data, ...info) => {
-      const callback = info.pop();
-      const name = plugin.manifest.name;
+    this.pipes[event].push((...data) => {
+      const
+        callback = data.pop(),
+        name = plugin.manifest.name;
+
+      if (data.length === 0) {
+        data.push(null);
+      }
+
       let
         pipeWarnTimer,
         pipeTimeoutTimer,
@@ -443,39 +435,34 @@ class PluginsManager {
         }, timeoutDelay);
       }
 
-      const cb = (err, pipeResponse, ...info2) => {
-        if (pipeWarnTimer !== undefined) {
-          clearTimeout(pipeWarnTimer);
-        }
-        if (pipeTimeoutTimer !== undefined) {
-          clearTimeout(pipeTimeoutTimer);
-        }
+      const cb = (...args) => {
+        clearTimeout(pipeWarnTimer);
+        clearTimeout(pipeTimeoutTimer);
 
         if (!timedOut) {
-          callback(err, pipeResponse, ...info2);
+          callback(...args);
         }
       };
 
       try {
         const pipeResponse = (typeof fn === 'function')
-          ? fn(data, ...info, cb)
-          : plugin.object[fn](data, ...info, cb);
+          ? fn(...data, cb)
+          : plugin.object[fn](...data, cb);
 
-        if (typeof pipeResponse === 'object'
+        if ( typeof pipeResponse === 'object'
           && pipeResponse !== null
           && typeof pipeResponse.then === 'function'
           && typeof pipeResponse.catch === 'function'
         ) {
           pipeResponse
-            .then(request => cb(null, request))
+            .then(result => cb(null, result))
             .catch(error => cb(error));
         }
-      } catch (error) {
-        if (error instanceof KuzzleError) {
-          return cb(error);
-        }
-
-        cb(runtimeError.getFrom(error, 'unexpected_error', error.message));
+      }
+      catch (error) {
+        cb(error instanceof KuzzleError
+          ? error
+          : runtimeError.getFrom(error, 'unexpected_error', error.message));
       }
     });
   }

--- a/lib/core/plugins/manager.js
+++ b/lib/core/plugins/manager.js
@@ -51,7 +51,9 @@ const
 class PluginsManager {
   constructor(kuzzle) {
     this.kuzzle = kuzzle;
-    this.pipeRunner = new PipeRunner();
+    this.pipeRunner = new PipeRunner(
+      kuzzle.config.plugins.common.maxConcurrentPipes,
+      kuzzle.config.plugins.common.pipesBufferSize);
     this.plugins = {};
     this.pipes = {};
 

--- a/lib/core/plugins/manager.js
+++ b/lib/core/plugins/manager.js
@@ -249,7 +249,7 @@ class PluginsManager {
     }
 
     if (preparedPipes.length === 1) {
-      return callback(null, data[0]);
+      return callback(null, ...data);
     }
 
     this.pipeRunner.run(preparedPipes, callback);
@@ -437,12 +437,13 @@ class PluginsManager {
         }, timeoutDelay);
       }
 
-      const cb = (...args) => {
+      const cb = (error, result) => {
         clearTimeout(pipeWarnTimer);
         clearTimeout(pipeTimeoutTimer);
 
         if (!timedOut) {
-          callback(...args);
+          data[0] = result;
+          callback(error, ...data);
         }
       };
 

--- a/lib/core/plugins/pipeRunner.js
+++ b/lib/core/plugins/pipeRunner.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const
+  assert = require('assert'),
   Denque = require('denque'),
   async = require('async'),
   {errors: {KuzzleError}} = require('kuzzle-common-objects'),
@@ -49,6 +50,8 @@ class PipeChain {
  */
 class PipeRunner {
   constructor (concurrent, bufferSize) {
+    assert(typeof concurrent === 'number' && concurrent > 0, 'Cannot instantiate pipes executor: invalid maxConcurrentPipes parameter value');
+    assert(typeof bufferSize === 'number' && bufferSize > 0, 'Cannot instantiate pipes executor: invalid pipesBufferSize parameter value');
     this.maxConcurrent = concurrent;
     this.running = 0;
     this.maxBufferSize = bufferSize;

--- a/lib/core/plugins/pipeRunner.js
+++ b/lib/core/plugins/pipeRunner.js
@@ -1,0 +1,98 @@
+/*
+ * Kuzzle, a backend software, self-hostable and ready to use
+ * to power modern apps
+ *
+ * Copyright 2015-2018 Kuzzle
+ * mailto: support AT kuzzle.io
+ * website: http://kuzzle.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const
+  Denque = require('denque'),
+  async = require('async'),
+  {errors: {KuzzleError}} = require('kuzzle-common-objects'),
+  errorsManager = require('../../util/errors').wrap('plugin', 'runtime');
+
+/**
+ * @private
+ * @class PipeChain
+ */
+class PipeChain {
+  constructor (chain, callback) {
+    this.chain = chain;
+    this.callback = callback;
+  }
+}
+
+/**
+ * @class PipeRunner
+ * Runs pipe chins if the number of already running concurrent pipes allows it.
+ * Otherwise, delays the pipe chain until a slot is freed. If the storage
+ * buffer is full, rejects the provided callback and discard the pipe chain.
+ *
+ * @param {Number} concurrent - max number of concurrent pipes
+ * @param {Number} bufferSize - max number of delayed pipe chains
+ */
+class PipeRunner {
+  constructor (concurrent, bufferSize) {
+    this.maxConcurrent = concurrent;
+    this.running = 0;
+    this.maxBufferSize = bufferSize;
+    this.buffer = new Denque();
+  }
+
+  run (chain, callback) {
+    if (this.running >= this.maxConcurrent) {
+      if (this.buffer.length >= this.maxBufferSize) {
+        return callback(errorsManager.get('too_many_pipes'));
+      }
+
+      this.buffer.push(new PipeChain(chain, callback));
+      return;
+    }
+
+    this.running++;
+
+    async.waterfall(chain, (error, result) => {
+      this.running--;
+
+      if (!this.buffer.isEmpty()) {
+        setImmediate(this._runNext.bind(this));
+      }
+
+      if (error) {
+        return callback(error instanceof KuzzleError
+          ? error
+          : errorsManager.getFrom(error, 'unexpected_error', error.message));
+      }
+
+      callback(null, result);
+    });
+  }
+
+  _runNext () {
+    if (this.buffer.isEmpty() || this.running >= this.maxConcurrent) {
+      return;
+    }
+
+    const pipe = this.buffer.shift();
+
+    this.run(pipe.chain, pipe.callback);
+  }
+}
+
+module.exports = PipeRunner;

--- a/lib/core/plugins/pipeRunner.js
+++ b/lib/core/plugins/pipeRunner.js
@@ -41,7 +41,7 @@ class PipeChain {
 
 /**
  * @class PipeRunner
- * Runs pipe chins if the number of already running concurrent pipes allows it.
+ * Runs pipe chains if the number of already running concurrent pipes allows it.
  * Otherwise, delays the pipe chain until a slot is freed. If the storage
  * buffer is full, rejects the provided callback and discard the pipe chain.
  *

--- a/lib/core/router.js
+++ b/lib/core/router.js
@@ -142,8 +142,8 @@ class Router {
   }
 
   /**
-   * Transmit HTTP requests to the funnel controller and forward its response back to
-   * the client
+   * Transmit HTTP requests to the funnel controller and forward its response
+   * back to the client
    *
    * @param {object} route contains the request action, controller and verb
    * @param {Request} request - includes URL and POST query data
@@ -153,21 +153,16 @@ class Router {
     request.input.controller = route.controller;
     request.input.action = route.action;
 
-    this.kuzzle.pipe(`http:${route.verb}`, request)
-      .then(mutatedRequest => {
-        this.kuzzle.funnel.execute(mutatedRequest, (err, result) => {
-          cb(result);
-        });
-
-        // otherwise bluebird complains about the promise not
-        // returning anything
-        return null;
-      })
-      .catch(error => {
+    this.kuzzle.pipe(`http:${route.verb}`, request, (error, mutatedRequest) => {
+      if (error) {
         request.setError(error);
+        return cb(request);
+      }
 
-        cb(request);
+      this.kuzzle.funnel.execute(mutatedRequest, (err, result) => {
+        cb(result);
       });
+    });
   }
 }
 

--- a/lib/kuzzle.js
+++ b/lib/kuzzle.js
@@ -229,23 +229,50 @@ class Kuzzle extends EventEmitter {
    * Chains all registered pipes on an event, and then emits it the regular
    * way.
    *
+   * Accepts a callback argument (to be used by pipes invoked before the funnel
+   * overload-protection mechanism). If a callback is provided, this method
+   * doesn't return a promise.
+   *
    * @warning Critical code section
    *
    * @param  {string} event
    * @param  {*} data
-   * @return {Promise.<*>}
+   * @return {Promise.<*>|null}
    */
   pipe (event, ...data) {
     const events = getWildcardEvents(event);
+    let
+      callback = null,
+      deferred,
+      resolve,
+      reject;
 
-    return this.pluginsManager.pipe(events, ...data)
-      .then(updated => {
-        for (let i = 0; i < events.length; i++) {
-          super.emit(events[i], updated);
-        }
-
-        return updated;
+    // safe: a pipe's payload can never contain functions
+    if (typeof data[data.length-1] === 'function') {
+      callback = data.pop();
+    }
+    else {
+      deferred = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
       });
+    }
+
+    this.pluginsManager.pipe(events, data, (error, updated) => {
+      if (error) {
+        return callback ? callback(error) : reject(error);
+      }
+
+      for (let i = 0; i < events.length; i++) {
+        super.emit(events[i], updated);
+      }
+
+      return callback ? callback(null, updated) : resolve(updated);
+    });
+
+    if (!callback) {
+      return deferred;
+    }
   }
 
   adminExists () {

--- a/lib/kuzzle.js
+++ b/lib/kuzzle.js
@@ -243,7 +243,7 @@ class Kuzzle extends EventEmitter {
     const events = getWildcardEvents(event);
     let
       callback = null,
-      deferred,
+      deferred = null,
       resolve,
       reject;
 
@@ -270,9 +270,7 @@ class Kuzzle extends EventEmitter {
       return callback ? callback(null, updated) : resolve(updated);
     });
 
-    if (!callback) {
-      return deferred;
-    }
+    return deferred;
   }
 
   adminExists () {

--- a/test/core/plugins/manager/pipe.test.js
+++ b/test/core/plugins/manager/pipe.test.js
@@ -193,8 +193,8 @@ describe('pluginsManager.pipe', () => {
 
   it('should pass the correct number of arguments along the whole pipes chain', async () => {
     const
-      fn = sinon.stub().resolves('foo2'),
-      fn2 = sinon.stub().resolves('foo3');
+      fn = sinon.stub().callsArgWith(3, null, 'foo2'),
+      fn2 = sinon.stub().callsArgWith(3, null, 'foo3');
 
     pluginsManager.plugins = [{
       object: {

--- a/test/core/plugins/manager/pipe.test.js
+++ b/test/core/plugins/manager/pipe.test.js
@@ -8,7 +8,7 @@ const
     errors: {
       PluginImplementationError
     },
-    Request: KuzzleRequest
+    Request
   } = require('kuzzle-common-objects');
 
 describe('pluginsManager.pipe', () => {
@@ -102,7 +102,7 @@ describe('pluginsManager.pipe', () => {
         pipes: {
           'foo:*': 'myFunc'
         },
-        myFunc: sinon.stub().callsArgWith(1, null, new KuzzleRequest({}))
+        myFunc: sinon.stub().callsArgWith(1, null, new Request({}))
       },
       config: {},
       activated: true,
@@ -125,7 +125,7 @@ describe('pluginsManager.pipe', () => {
         pipes: {
           'foo:before*': 'myFunc'
         },
-        myFunc: sinon.stub().callsArgWith(1, null, new KuzzleRequest({}))
+        myFunc: sinon.stub().callsArgWith(1, null, new Request({}))
       },
       config: {},
       activated: true,
@@ -148,7 +148,7 @@ describe('pluginsManager.pipe', () => {
         pipes: {
           'foo:after*': 'myFunc'
         },
-        myFunc: sinon.stub().callsArgWith(1, null, new KuzzleRequest({}))
+        myFunc: sinon.stub().callsArgWith(1, null, new Request({}))
       },
       config: {},
       activated: true,

--- a/test/core/plugins/manager/pipeRunner.test.js
+++ b/test/core/plugins/manager/pipeRunner.test.js
@@ -36,7 +36,7 @@ class RemoteControlledPipe {
   }
 }
 
-describe.only('#pipeRunner', () => {
+describe('#pipeRunner', () => {
   let
     clock,
     pipeRunner,

--- a/test/core/plugins/manager/pipeRunner.test.js
+++ b/test/core/plugins/manager/pipeRunner.test.js
@@ -1,0 +1,226 @@
+const
+  assert = require('assert'),
+  should = require('should'),
+  sinon = require('sinon'),
+  PipeRunner = require('../../../../lib/core/plugins/pipeRunner'),
+  {
+    errors: {
+      BadRequestError,
+      PluginImplementationError,
+      ServiceUnavailableError}
+  } = require('kuzzle-common-objects');
+
+class RemoteControlledPipe {
+  constructor () {
+    this._callback = null;
+    this.fn = (...args) => {
+      this._callback = args.pop();
+    };
+  }
+
+  get callback () {
+    assert(typeof this._callback === 'function', new Error('Invalid callback'));
+    return this._callback;
+  }
+
+  get chain () {
+    return [this.fn];
+  }
+
+  resolve (...data) {
+    this.callback(null, ...data);
+  }
+
+  reject (error) {
+    this.callback(error);
+  }
+}
+
+describe.only('#pipeRunner', () => {
+  let
+    clock,
+    pipeRunner,
+    maxConcurrentPipes,
+    bufferSize,
+    remoteControlledPipe;
+
+  beforeEach(() => {
+    maxConcurrentPipes = 50;
+    bufferSize = 50000;
+    pipeRunner = new PipeRunner(maxConcurrentPipes, bufferSize);
+    remoteControlledPipe = new RemoteControlledPipe();
+
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(() => {
+    clock.restore();
+  });
+
+  describe('#constructor', () => {
+    it('should throw if an invalid number of max concurrent request is provided', () => {
+      for (const invalid of [-1, [], {}, 0, null, undefined, 'URGH']) {
+        should(() => new PipeRunner(invalid, 123))
+          .throw('Cannot instantiate pipes executor: invalid maxConcurrentPipes parameter value');
+      }
+    });
+
+    it('should throw if an invalid buffer size is provided', () => {
+      for (const invalid of [-1, [], {}, 0, null, undefined, 'URGH']) {
+        should(() => new PipeRunner(123, invalid))
+          .throw('Cannot instantiate pipes executor: invalid pipesBufferSize parameter value');
+      }
+    });
+  });
+
+  describe('#run', () => {
+    it('should run a pipe immediately if there is space', () => {
+      should(pipeRunner.running).eql(0);
+
+      pipeRunner.run(remoteControlledPipe.chain, (err, res) => {
+        should(err).be.null();
+        should(res).eql('foo');
+      });
+
+      should(pipeRunner.running).eql(1);
+      should(pipeRunner.buffer.length).eql(0);
+
+      remoteControlledPipe.resolve('foo');
+
+      clock.runAll();
+
+      should(pipeRunner.running).eql(0);
+    });
+
+    it('should forward a KuzzleError unchanged', () => {
+      const error = new BadRequestError('oh noes');
+
+      should(pipeRunner.running).eql(0);
+
+      pipeRunner.run(remoteControlledPipe.chain, err => {
+        should(err).eql(error);
+      });
+
+      should(pipeRunner.running).eql(1);
+      should(pipeRunner.buffer.length).eql(0);
+
+      remoteControlledPipe.reject(error);
+
+      clock.runAll();
+
+      should(pipeRunner.running).eql(0);
+    });
+
+    it('should return an unexpected error if a non-kuzzle error is returned', () => {
+      const error = new Error('oh noes');
+
+      should(pipeRunner.running).eql(0);
+
+      pipeRunner.run(remoteControlledPipe.chain, err => {
+        should(err).instanceof(PluginImplementationError);
+        should(err.message).containEql(error.message);
+        should(err.id).eql('plugin.runtime.unexpected_error');
+      });
+
+      should(pipeRunner.running).eql(1);
+      should(pipeRunner.buffer.length).eql(0);
+
+      remoteControlledPipe.reject(error);
+
+      clock.runAll();
+
+      should(pipeRunner.running).eql(0);
+    });
+
+    it('should bufferize and replay pipes if there are no more slots available', () => {
+      const runCB = (err, res) => {
+        should(err).be.null();
+        should(res).eql('foo');
+      };
+
+      pipeRunner.running = maxConcurrentPipes - 1;
+      should(pipeRunner.buffer.length).eql(0);
+
+      pipeRunner.run(remoteControlledPipe.chain, runCB);
+
+      should(pipeRunner.running).eql(maxConcurrentPipes);
+      should(pipeRunner.buffer.length).eql(0);
+
+      const remoteControlledPipe2 = new RemoteControlledPipe();
+
+      pipeRunner.run(remoteControlledPipe2.chain, runCB);
+
+      should(pipeRunner.running).eql(maxConcurrentPipes);
+      should(pipeRunner.buffer.length).eql(1);
+
+      clock.runAll();
+
+      remoteControlledPipe.resolve('foo');
+
+      clock.runAll();
+
+      should(pipeRunner.running).eql(maxConcurrentPipes);
+      should(pipeRunner.buffer.length).eql(0);
+
+      remoteControlledPipe2.resolve('foo');
+
+      clock.runAll();
+
+      should(pipeRunner.running).eql(maxConcurrentPipes - 1);
+      should(pipeRunner.buffer.length).eql(0);
+    });
+
+    it('should reject the callback immediately if there is no room left in the buffer', () => {
+      pipeRunner.running = maxConcurrentPipes;
+      pipeRunner.buffer = { length: bufferSize };
+
+      pipeRunner.run(remoteControlledPipe.chain, err => {
+        should(err).instanceof(ServiceUnavailableError);
+        should(err.id).eql('plugin.runtime.too_many_pipes');
+        should(remoteControlledPipe._callback).be.null();
+      });
+
+      clock.runAll();
+    });
+  });
+
+  describe('#_runNext', () => {
+    beforeEach(() => {
+      sinon.stub(pipeRunner, 'run');
+    });
+
+    it('should resubmit the first item of the buffer', () => {
+      const chain = {chain: 'foo', callback: sinon.stub()};
+      pipeRunner.buffer.push(chain);
+      pipeRunner.buffer.push({chain: 'bar', callback: sinon.stub()});
+      pipeRunner.buffer.push({chain: 'baz', callback: sinon.stub()});
+
+      pipeRunner._runNext();
+
+      should(pipeRunner.buffer.length).eql(2);
+      should(pipeRunner.run)
+        .calledOnce()
+        .calledWith(chain.chain, chain.callback);
+    });
+
+    it('should skip if the buffer is empty', () => {
+      pipeRunner._runNext();
+
+      should(pipeRunner.buffer.length).eql(0);
+      should(pipeRunner.run).not.called();
+    });
+
+    it('should skip if there are already too many pipes running', () => {
+      pipeRunner.buffer.push({chain: 'foo', callback: sinon.stub()});
+      pipeRunner.buffer.push({chain: 'bar', callback: sinon.stub()});
+      pipeRunner.buffer.push({chain: 'baz', callback: sinon.stub()});
+
+      pipeRunner.running = maxConcurrentPipes;
+
+      pipeRunner._runNext();
+
+      should(pipeRunner.buffer.length).eql(3);
+      should(pipeRunner.run).not.called();
+    });
+  });
+});

--- a/test/core/router/httpRequest.test.js
+++ b/test/core/router/httpRequest.test.js
@@ -3,11 +3,11 @@
 const
   should = require('should'),
   { Request } = require('kuzzle-common-objects'),
-  RouterController = require('../../../lib/core/router'),
+  Router = require('../../../lib/core/router'),
   { HttpMessage } = require('../../../lib/core/entrypoints/protocols/http'),
   KuzzleMock = require('../../mocks/kuzzle.mock');
 
-describe('Test: routerController.httpRequest', () => {
+describe('Test: router.httpRequest', () => {
   let
     kuzzle,
     httpRequest,
@@ -27,7 +27,7 @@ describe('Test: routerController.httpRequest', () => {
 
     kuzzle.config.http.accessControlAllowOrigin = 'foobar';
 
-    routeController = new RouterController(kuzzle);
+    routeController = new Router(kuzzle);
     routeController.init();
 
     httpRequest = new HttpMessage(

--- a/test/core/router/router.test.js
+++ b/test/core/router/router.test.js
@@ -2,19 +2,19 @@ const
   should = require('should'),
   sinon = require('sinon'),
   KuzzleMock = require('../../mocks/kuzzle.mock'),
-  RouterController = require('../../../lib/core/router'),
+  Router = require('../../../lib/core/router'),
   {
     models: { RequestContext },
     errors: { PluginImplementationError }
   } = require('kuzzle-common-objects');
 
-describe('Test: routerController', () => {
+describe('Test: router', () => {
   const
     protocol = 'foo',
     connectionId = 'bar';
   let
     kuzzle,
-    routerController,
+    router,
     requestContext;
 
   beforeEach(() => {
@@ -25,14 +25,14 @@ describe('Test: routerController', () => {
       }
     });
     kuzzle = new KuzzleMock();
-    routerController = new RouterController(kuzzle);
+    router = new Router(kuzzle);
   });
 
   describe('#newConnection', () => {
     it('should have registered the connection', () => {
-      routerController.newConnection(requestContext);
+      router.newConnection(requestContext);
 
-      const context = routerController.connections.get(connectionId);
+      const context = router.connections.get(connectionId);
       should(context).be.instanceOf(RequestContext);
       should(context.connectionId).be.eql(connectionId);
       should(context.protocol).be.eql(protocol);
@@ -44,7 +44,7 @@ describe('Test: routerController', () => {
 
     it('should return an error if no connectionId is provided', () => {
       const context = new RequestContext({connection: {protocol}});
-      routerController.newConnection(context);
+      router.newConnection(context);
 
       should(kuzzle.log.error)
         .calledOnce()
@@ -53,7 +53,7 @@ describe('Test: routerController', () => {
 
     it('should return an error if no protocol is provided', () => {
       const context = new RequestContext({connection: {id: connectionId}});
-      routerController.newConnection(context);
+      router.newConnection(context);
 
       should(kuzzle.log.error)
         .calledOnce()
@@ -63,8 +63,8 @@ describe('Test: routerController', () => {
 
   describe('#removeConnection', () => {
     it('should remove the context from the context pool', () => {
-      routerController.connections.set(connectionId, requestContext);
-      routerController.removeConnection(requestContext);
+      router.connections.set(connectionId, requestContext);
+      router.removeConnection(requestContext);
 
       should(kuzzle.hotelClerk.removeCustomerFromAllRooms)
         .calledOnce()
@@ -72,11 +72,11 @@ describe('Test: routerController', () => {
       should(kuzzle.statistics.dropConnection)
         .calledOnce()
         .calledWith(requestContext);
-      should(routerController.connections.has(connectionId)).be.false();
+      should(router.connections.has(connectionId)).be.false();
     });
 
     it('should remove the context from the context pool', () => {
-      routerController.removeConnection(requestContext);
+      router.removeConnection(requestContext);
 
       should(kuzzle.hotelClerk.removeCustomerFromAllRooms).not.be.called();
       should(kuzzle.statistics.dropConnection).not.be.called();
@@ -87,8 +87,8 @@ describe('Test: routerController', () => {
 
     it('should return an error if no connectionId is provided', () => {
       const context = new RequestContext({connection: {protocol}});
-      routerController.connections.set(connectionId, context);
-      routerController.removeConnection(context);
+      router.connections.set(connectionId, context);
+      router.removeConnection(context);
 
       should(kuzzle.log.error)
         .calledOnce()
@@ -97,8 +97,8 @@ describe('Test: routerController', () => {
 
     it('should return an error if no protocol is provided', () => {
       const context = new RequestContext({connection: {id: connectionId}});
-      routerController.connections.set(connectionId, context);
-      routerController.removeConnection(context);
+      router.connections.set(connectionId, context);
+      router.removeConnection(context);
 
       should(kuzzle.log.error)
         .calledOnce()
@@ -108,14 +108,14 @@ describe('Test: routerController', () => {
 
   describe('#isConnectionActive', () => {
     it('should resolve to false if the connection is unknown', () => {
-      should(routerController.isConnectionAlive(requestContext)).be.false();
+      should(router.isConnectionAlive(requestContext)).be.false();
     });
 
     it('should interact correctly with newConnection/removeConnection', () => {
-      routerController.newConnection(requestContext);
-      should(routerController.isConnectionAlive(requestContext)).be.true();
-      routerController.removeConnection(requestContext);
-      should(routerController.isConnectionAlive(requestContext)).be.false();
+      router.newConnection(requestContext);
+      should(router.isConnectionAlive(requestContext)).be.true();
+      router.removeConnection(requestContext);
+      should(router.isConnectionAlive(requestContext)).be.false();
     });
 
     it('should always return true for connections without an id', () => {
@@ -125,7 +125,7 @@ describe('Test: routerController', () => {
           protocol: 'foobar'
         }
       });
-      should(routerController.isConnectionAlive(context)).be.true();
+      should(router.isConnectionAlive(context)).be.true();
     });
   });
 });

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -22,8 +22,14 @@ class KuzzleMock extends Kuzzle {
     this.config = _.merge({}, config);
 
     // emit + pipe mocks
-    sinon.stub(this, 'pipe').callsFake(
-      (...args) => Bluebird.resolve(args[1]));
+    sinon.stub(this, 'pipe').callsFake((...args) => {
+      if (typeof args[args.length - 1] !== 'function') {
+        return Bluebird.resolve(...args.slice(1));
+      }
+
+      const cb = args.pop();
+      cb(null, ...args.slice(1));
+    });
 
     sinon.spy(this, 'emit');
 


### PR DESCRIPTION
# Description

When plugin developers design pipe functions, they can either accept a callback, or return a promise.
The latter was added to make the plugin development experience better, but this can make Kuzzle brittle against flooding if a pipe is added to a pre-funnel event, meaning promises are created on the event loop without any sort of control (e.g. `http:*` events).

This PR solves the problem by making the following changes:

* the plugin's manager `pipe` method now only work with callbacks
* an overload-protection mechanism has been added to pipe executions, similar to the existing one in the funnel. It can be controlled by two new properties in Kuzzle's configuration file (`plugins.common.maxConcurrentPipes` and `plugins.common.pipesBufferSize`)
* the main entry point for triggering pipe events (`kuzzle.pipe(event, ...data)`) now accepts a callback argument, and creates+returns a promise only if NO callback has been provided
* `kuzzle.pipe` is now invoked with a callback by events triggered before the funnel's overload-protection mechanism

# Other changes

* Pipe events accepting multiple arguments now correctly pass all arguments from a pipe function to another