### PR TITLE
Allow to expose plugin routes and controller names without prefix

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -47,7 +47,7 @@
     // * requestsBufferWarningThreshold:
     //      Number of buffered requests after
     //      which Kuzzle will throw 'core:overload' events
-    //      (see https://docs.kuzzle.io/plugins/1/events/core-overload/)
+    //      (see https://docs.kuzzle.io/plugins/2/events/core-overload/)
     // * subscriptionConditionsCount
     //      Maximum number of conditions a subscription filter can contain
     //      NB: A condition is either a "simple" operator (anything but "and",
@@ -87,7 +87,7 @@
   },
 
   // The plugins section lets you define plugins behaviors
-  // (see https://docs.kuzzle.io/guide/1/essentials/plugins/)
+  // (see https://docs.kuzzle.io/guide/2/essentials/plugins/)
   "plugins": {
     // [Common]
     //   * bootstrapLockTimeout
@@ -102,11 +102,23 @@
     //   * initTimeout:
     //        Maximum execution time (in milliseconds)
     //        of a plugin initialization
+    //   * prefixRoutes:
+    //        Prefix plugin routes with "_plugin/<plugin-name>".
+    //        Can be either:
+    //          - a boolean value to activate/deactivate the prefix for all plugins
+    //          - an array of plugin names for whom the routes will be prefixed
+    //   * prefixControllers:
+    //        Prefix plugin controller names with "<plugin-name>/".
+    //        Can be either:
+    //          - a boolean value to activate/deactivate the prefix for all plugins
+    //          - an array of plugin names for whom the controller names will be prefixed
     "common": {
       "bootstrapLockTimeout": 5000,
       "pipeWarnTime": 40,
       "pipeTimeout": 250,
-      "initTimeout": 2000
+      "initTimeout": 2000,
+      "prefixRoutes": true,
+      "prefixControllers": true
     }
 
     // Custom plugin configurations must be described here.
@@ -589,7 +601,7 @@
   // [validation]
   // Defines the specifications used to validate data.
   // Please refer to the guide for more information.
-  // (https://docs.kuzzle.io/guide/1/datavalidation)
+  // (https://docs.kuzzle.io/guide/2/datavalidation)
   //
   // /!\ No syntax check will be performed here /!\
   "validation": {

--- a/default.config.js
+++ b/default.config.js
@@ -66,6 +66,8 @@ module.exports = {
       pipeWarnTime: 500,
       pipeTimeout: 5000,
       initTimeout: 10000,
+      prefixRoutes: true,
+      prefixControllers: true
     }
   },
 

--- a/lib/api/controllers/server.js
+++ b/lib/api/controllers/server.js
@@ -212,14 +212,13 @@ class ServerController extends NativeController {
         this.kuzzle.config.http.routes),
       pluginsApi = this._buildApiDefinition(
         this.kuzzle.pluginsManager.controllers,
-        this.kuzzle.pluginsManager.routes,
-        '_plugin/'),
+        this.kuzzle.pluginsManager.routes),
       apiDefinition = Object.assign({}, kuzzleApi, pluginsApi);
 
     return Bluebird.resolve(apiDefinition);
   }
 
-  _buildApiDefinition (controllers, httpRoutes, urlPrefix = '') {
+  _buildApiDefinition (controllers, httpRoutes) {
     const routes = {};
 
     for (const [ name, controller ] of controllers.entries()) {
@@ -242,7 +241,7 @@ class ServerController extends NativeController {
           }
 
           actionList[action].http.push({
-            url: (urlPrefix + routeDescription.url).replace(/\/\//g, '/'),
+            url: routeDescription.url.replace(/\/\//g, '/'),
             verb: routeDescription.verb.toUpperCase()
           });
         }

--- a/lib/api/controllers/server.js
+++ b/lib/api/controllers/server.js
@@ -184,8 +184,7 @@ class ServerController extends NativeController {
         this.kuzzle.config.http.routes),
       pluginsApi = this._buildApiDefinition(
         this.kuzzle.pluginsManager.controllers,
-        this.kuzzle.pluginsManager.routes,
-        '_plugin/'),
+        this.kuzzle.pluginsManager.routes),
       apiDefinition = Object.assign({}, kuzzleApi, pluginsApi);
 
     response.kuzzle.api.routes = apiDefinition;

--- a/lib/core/plugins/manager.js
+++ b/lib/core/plugins/manager.js
@@ -1068,7 +1068,7 @@ class PluginsManager {
         plugin.manifest.name);
     }
     else {
-      assert(false, 'Wrong value type for plugins.common.prefixControllers. Expect "Array" or "boolean".')
+      assert(false, 'Wrong value type for plugins.common.prefixControllers. Expect "Array" or "boolean".');
     }
 
     return prefixController
@@ -1095,7 +1095,7 @@ class PluginsManager {
         plugin.manifest.name);
     }
     else {
-      assert(false, 'Wrong value type for plugins.common.prefixRoutes. Expect "Array" or "boolean".')
+      assert(false, 'Wrong value type for plugins.common.prefixRoutes. Expect "Array" or "boolean".');
     }
 
     return prefixRoute

--- a/lib/core/plugins/manager.js
+++ b/lib/core/plugins/manager.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const
+  assert = require('assert'),
   errorsManager = require('../../util/errors'),
   didYouMean = require('../../util/didYouMean'),
   debug = require('../../util/debug')('kuzzle:plugins'),
@@ -89,7 +90,7 @@ class PluginsManager {
    * @param  {Array.<string>} plugins - Plugins passed as CLI arguments
    * @throws PluginImplementationError - Throws when an error occurs when loading a plugin
    */
-  init(additionalPlugins = []) {
+  init (additionalPlugins = []) {
     this.plugins = this.load(additionalPlugins);
   }
 
@@ -98,7 +99,7 @@ class PluginsManager {
    *
    * @returns {object}
    */
-  getPluginsDescription() {
+  getPluginsDescription () {
     const pluginsDescription = {};
 
     Object.keys(this.plugins).forEach(plugin => {
@@ -126,7 +127,7 @@ class PluginsManager {
         if (has(pluginInfo.object, 'controllers')) {
           description.controllers = _
             .uniq(Object.keys(pluginInfo.object.controllers))
-            .map(item => `${pluginInfo.manifest.name}/${item}`);
+            .map(controller => this._getControllerName(pluginInfo, controller));
         }
 
         if (has(pluginInfo.object, 'routes')) {
@@ -136,7 +137,8 @@ class PluginsManager {
         if (has(pluginInfo.object, 'strategies')) {
           description.strategies = Object.keys(pluginInfo.object.strategies);
         }
-      } else {
+      }
+      else {
         this.kuzzle.log.warn(`[Plugin manager]: Unable to load features from plugin "${plugin}"`);
       }
 
@@ -745,7 +747,7 @@ class PluginsManager {
 
       const
         methodsList = getMethods(plugin.object),
-        controllerName = `${plugin.manifest.name}/${controller}`,
+        controllerName = this._getControllerName(plugin, controller),
         description = plugin.object.controllers[controller],
         errorControllerPrefix = `Unable to inject controller "${controller}" from plugin "${plugin.manifest.name}":`;
 
@@ -799,12 +801,14 @@ class PluginsManager {
     const
       httpVerbs = ['get', 'head', 'post', 'put', 'delete', 'patch'],
       routeProperties = ['verb', 'url', 'controller', 'action'],
-      controllerNames = Object.keys(plugin.object.controllers);
+      controllerNames = Object
+        .keys(plugin.object.controllers)
+        .map(controller => this._getControllerName(plugin, controller));
 
     if (plugin.object.routes) {
       plugin.object.routes.forEach(route => {
         const
-          controllerName = `${plugin.manifest.name}/${route.controller}`,
+          controllerName = this._getControllerName(plugin, route.controller),
           errorRoutePrefix = `Unable to inject API route "${JSON.stringify(route)}" from plugin "${plugin.manifest.name}":`;
 
         Object.keys(route).forEach(key => {
@@ -856,7 +860,7 @@ class PluginsManager {
           route.url,
           route.controller);
 
-        route.url = `/${plugin.manifest.name}${route.url}`;
+        route.url = this._getRouteUrl(plugin, route.url);
         route.controller = controllerName;
 
         this.routes.push(route);
@@ -934,7 +938,8 @@ class PluginsManager {
 
     try {
       plugins = fs.readdirSync(this.pluginsDir);
-    } catch (e) {
+    }
+    catch (e) {
       assertionError.throw('invalid_plugins_dir', this.pluginsDir, e.message);
     }
 
@@ -951,7 +956,8 @@ class PluginsManager {
 
       try {
         fs.statSync(pluginPath).isDirectory();
-      } catch (e) {
+      }
+      catch (e) {
         assertionError.throw('cannot_load', pluginPath, e.message);
       }
     }
@@ -984,7 +990,8 @@ class PluginsManager {
             : 0x00;
           loadPluginsErrors(plugin.manifest.raw, pluginCode);
           this.kuzzle.log.info(`[${plugin.manifest.name}] Custom errors successfully loaded.`);
-        } catch (err) {
+        }
+        catch (err) {
           if ( err.message.match(/Error configuration file/i)
             || err instanceof SyntaxError
           ) {
@@ -1005,7 +1012,8 @@ class PluginsManager {
       try {
         const PluginClass = require(pluginPath);
         plugin.object = new PluginClass();
-      } catch (e) {
+      }
+      catch (e) {
         if (e.message.match(/not a constructor/i)) {
           assertionError.throw('not_a_constructor', plugin.manifest.name);
         }
@@ -1024,7 +1032,8 @@ class PluginsManager {
         if (!plugin.manifest.privileged) {
           assertionError.throw('privileged_not_supported', plugin.manifest.name);
         }
-      } else if (plugin.manifest.privileged) {
+      }
+      else if (plugin.manifest.privileged) {
         assertionError.throw('privileged_not_set', plugin.manifest.name);
       }
 
@@ -1039,6 +1048,60 @@ class PluginsManager {
 
     return loadedPlugins;
   }
+
+  /**
+   * Get controller name and prefix it according to the configuration.
+   *
+   * @param {Object} plugin - Plugin Object
+   * @param {String} controller - Controller name
+   *
+   * @returns {String} - Controller name
+   */
+  _getControllerName (plugin, controller) {
+    let prefixController;
+
+    if (typeof this.config.common.prefixControllers === 'boolean') {
+      prefixController = this.config.common.prefixControllers;
+    }
+    else if (_.isArray(this.config.common.prefixControllers)) {
+      prefixController = this.config.common.prefixControllers.includes(
+        plugin.manifest.name);
+    }
+    else {
+      assert(false, 'Wrong value type for plugins.common.prefixControllers. Expect "Array" or "boolean".')
+    }
+
+    return prefixController
+      ? `${plugin.manifest.name}/${controller}`
+      : controller;
+  }
+
+  /**
+   * Get route url and prefix it according to the configuration.
+   *
+   * @param {Object} plugin - Plugin object
+   * @param {String} url - Url
+   *
+   * @returns {String} - Route url
+   */
+  _getRouteUrl (plugin, url) {
+    let prefixRoute;
+
+    if (typeof this.config.common.prefixRoutes === 'boolean') {
+      prefixRoute = this.config.common.prefixRoutes;
+    }
+    else if (_.isArray(this.config.common.prefixRoutes)) {
+      prefixRoute = this.config.common.prefixRoutes.includes(
+        plugin.manifest.name);
+    }
+    else {
+      assert(false, 'Wrong value type for plugins.common.prefixRoutes. Expect "Array" or "boolean".')
+    }
+
+    return prefixRoute
+      ? `/_plugin/${plugin.manifest.name}${url}`
+      : url;
+  }
 }
 
 /**
@@ -1050,7 +1113,8 @@ class PluginsManager {
 function isConstructor (arg) {
   try {
     Reflect.construct(Object, [], arg);
-  } catch (e) {
+  }
+  catch (e) {
     return false;
   }
 

--- a/lib/core/router.js
+++ b/lib/core/router.js
@@ -102,15 +102,6 @@ class Router {
    * Initializes the HTTP routes for the Kuzzle HTTP API.
    */
   init() {
-    // create and mount a new router for plugins
-    this.kuzzle.pluginsManager.routes.forEach(route => {
-      const verb = route.verb.toLowerCase();
-
-      this.http[verb]('/_plugin/' + route.url, (data, cb) => {
-        this._executeFromHttp(route, data, cb);
-      });
-    });
-
     this.http.get('/swagger.json', (request, cb) => {
       request.setResult(generateSwagger(this.kuzzle), {
         status: 200,
@@ -133,6 +124,15 @@ class Router {
 
     // Register API routes
     this.kuzzle.config.http.routes.forEach(route => {
+      const verb = route.verb.toLowerCase();
+
+      this.http[verb](route.url, (data, cb) => {
+        this._executeFromHttp(route, data, cb);
+      });
+    });
+
+    // Register plugins routes
+    this.kuzzle.pluginsManager.routes.forEach(route => {
       const verb = route.verb.toLowerCase();
 
       this.http[verb](route.url, (data, cb) => {


### PR DESCRIPTION
## What does this PR do ?

Introduce two new options that allows to bypass the plugin controller names and routes prefixing.  

These options could be either a boolean to activate the prefix on all plugins or an array of plugin name for which whom the prefix must be added:
 - `config.plugins.common.prefixControllers`
 - `config.plugins.common.prefixRoutes`

Example:
```js
  plugins: {
    common: {
      prefixRoutes: true, // prefix all plugin routes
      prefixControllers: ['s3'] // prefix only the s3 plugin controller names
    }
  }
```


### Other changes

<!--
  Please describe here all changes not directly linked to the main issue, but made because of it.
  For instance: issues spotted during this PR and fixed on-the-fly, dependencies update, and so on
-->

### Boyscout

<!--
  Describe here minor improvements in the code base and not directly linked to the main changes:
  typos fixes, better/new comments, small code simplification, new debug messages, and so on.
-->
