### PR TITLE
Fix URL parsing w/ trailing slash & querystring

### DIFF
--- a/lib/api/core/httpRouter/index.js
+++ b/lib/api/core/httpRouter/index.js
@@ -233,7 +233,7 @@ class Router {
  * @param {RoutePart} target
  */
 function attach(url, handler, target) {
-  let sanitized = url[url.length - 1] === '/' ? url.slice(0, -1) : url;
+  const sanitized = url[url.length - 1] === '/' ? url.slice(0, -1) : url;
 
   if (!attachParts(sanitized.split('/'), handler, target)) {
     errorsManager.throw('duplicate_url', sanitized);

--- a/lib/api/core/httpRouter/index.js
+++ b/lib/api/core/httpRouter/index.js
@@ -28,9 +28,7 @@ const
   RoutePart = require('./routePart'),
   { Request, errors: { KuzzleError } } = require('kuzzle-common-objects');
 
-const
-  LeadingSlashRegex = /\/+$/,
-  CharsetRegex = /charset=([\w-]+)/i;
+const CharsetRegex = /charset=([\w-]+)/i;
 
 /**
  * Attach handler to routes and dispatch a HTTP
@@ -178,8 +176,6 @@ class Router {
       return;
     }
 
-    httpRequest.url = httpRequest.url.replace(LeadingSlashRegex, '');
-
     try {
       const routeHandler = this.routes[httpRequest.method].getHandler(
         httpRequest);
@@ -237,10 +233,10 @@ class Router {
  * @param {RoutePart} target
  */
 function attach(url, handler, target) {
-  const cleanedUrl = url.replace(LeadingSlashRegex, '');
+  let sanitized = url[url.length - 1] === '/' ? url.slice(0, -1) : url;
 
-  if (!attachParts(cleanedUrl.split('/'), handler, target)) {
-    errorsManager.throw('duplicate_url', cleanedUrl);
+  if (!attachParts(sanitized.split('/'), handler, target)) {
+    errorsManager.throw('duplicate_url', sanitized);
   }
 }
 

--- a/lib/api/core/httpRouter/routePart.js
+++ b/lib/api/core/httpRouter/routePart.js
@@ -73,10 +73,14 @@ class RoutePart {
    * @return {RouteHandler} registered function handler
    */
   getHandler(request) {
-    const
-      parsed = URL.parse(request.url, true),
-      pathname = parsed.pathname || '', // pathname is set to null if empty
-      routeHandler = new RouteHandler(pathname, parsed.query, request);
+    const parsed = URL.parse(request.url, true);
+    let pathname = parsed.pathname || ''; // pathname is set to null if empty
+
+    if (pathname[pathname.length - 1] === '/') {
+      pathname = pathname.slice(0, -1);
+    }
+
+    const routeHandler = new RouteHandler(pathname, parsed.query, request);
 
     return getHandlerPart(this, pathname.split('/'), routeHandler);
   }


### PR DESCRIPTION
# Description

Fix a bug where an URL containing both a trailing slash and a querystring would be incorrectly parsed.

# How to reproduce

The following HTTP GET request works fine:

`http://localhost:7512/_now?pretty`

But not this one without this PR:

`http://localhost:7512/_now/?pretty`

Both requests are equivalent and should be regarded as identical.