### PR TITLE
Fix URL parsing w/ trailing slash & querystring

### DIFF
--- a/lib/core/httpRouter/index.js
+++ b/lib/core/httpRouter/index.js
@@ -28,9 +28,7 @@ const
   RoutePart = require('./routePart'),
   { Request, errors: { KuzzleError } } = require('kuzzle-common-objects');
 
-const
-  LeadingSlashRegex = /\/+$/,
-  CharsetRegex = /charset=([\w-]+)/i;
+const CharsetRegex = /charset=([\w-]+)/i;
 
 /**
  * Attach handler to routes and dispatch a HTTP
@@ -148,8 +146,6 @@ class Router {
       return this.routeUnhandledHttpMethod(message, cb);
     }
 
-    message.url = message.url.replace(LeadingSlashRegex, '');
-
     let routeHandler;
 
     try {
@@ -245,10 +241,10 @@ class Router {
  * @param {RoutePart} target
  */
 function attach(url, handler, target) {
-  const cleanedUrl = url.replace(LeadingSlashRegex, '');
+  const sanitized = url[url.length - 1] === '/' ? url.slice(0, -1) : url;
 
-  if (!attachParts(cleanedUrl.split('/'), handler, target)) {
-    errorsManager.throw('duplicate_url', cleanedUrl);
+  if (!attachParts(sanitized.split('/'), handler, target)) {
+    errorsManager.throw('duplicate_url', sanitized);
   }
 }
 

--- a/lib/core/httpRouter/routePart.js
+++ b/lib/core/httpRouter/routePart.js
@@ -24,7 +24,6 @@
 const
   querystring = require('querystring'),
   RouteHandler = require('./routeHandler'),
-  URL = require('url'),
   { has } = require('../../util/safeObject');
 
 /**
@@ -73,10 +72,25 @@ class RoutePart {
    * @return {RouteHandler} registered function handler
    */
   getHandler(message) {
-    const
-      parsed = URL.parse(message.url, true),
-      pathname = parsed.pathname || '', // pathname is set to null if empty
-      routeHandler = new RouteHandler(pathname, parsed.query, message);
+    // we need a fake URL base because the WHATWG API currently doesn't handle
+    // relative URLs, and the http.IncomingMessage class doesn't provide an
+    // easy way (and an inexpensive one) of getting an absolute URL
+    // See: https://github.com/nodejs/node/issues/12682
+    const parsed = new URL(
+      message.url,
+      message.url[0] === '/' ? 'http://fake' : null);
+
+    // limit calls to "parsed.pathname", it's a getter joining an array
+    let pathname = parsed.pathname;
+
+    if (pathname[pathname.length - 1] === '/') {
+      pathname = pathname.slice(0, -1);
+    }
+
+    const qs = {};
+    parsed.searchParams.forEach((v, k) => (qs[k] = v));
+
+    const routeHandler = new RouteHandler(pathname, qs, message);
 
     return getHandlerPart(this, pathname.split('/'), routeHandler);
   }

--- a/lib/core/httpRouter/routePart.js
+++ b/lib/core/httpRouter/routePart.js
@@ -88,7 +88,7 @@ class RoutePart {
     }
 
     const qs = {};
-    parsed.searchParams.forEach((v, k) => (qs[k] = v));
+    parsed.searchParams.forEach((v, k) => (qs[k] = v)); // NOSONAR (false positive -_-)
 
     const routeHandler = new RouteHandler(pathname, qs, message);
 

--- a/lib/core/httpRouter/routePart.js
+++ b/lib/core/httpRouter/routePart.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const
+  URL = require('url'),
   querystring = require('querystring'),
   RouteHandler = require('./routeHandler'),
   { has } = require('../../util/safeObject');
@@ -72,25 +73,18 @@ class RoutePart {
    * @return {RouteHandler} registered function handler
    */
   getHandler(message) {
-    // we need a fake URL base because the WHATWG API currently doesn't handle
-    // relative URLs, and the http.IncomingMessage class doesn't provide an
-    // easy way (and an inexpensive one) of getting an absolute URL
-    // See: https://github.com/nodejs/node/issues/12682
-    const parsed = new URL(
-      message.url,
-      message.url[0] === '/' ? 'http://fake' : null);
-
-    // limit calls to "parsed.pathname", it's a getter joining an array
-    let pathname = parsed.pathname;
+    // Do not use WHATWG API yet, stick with the legacy (and deprecated) URL
+    // There are two issues:
+    //   - Heavy performance impact: https://github.com/nodejs/node/issues/30334
+    //   - Double slash bug: https://github.com/nodejs/node/issues/30776
+    const parsed = URL.parse(message.url, true);
+    let pathname = parsed.pathname || ''; // pathname is set to null if empty
 
     if (pathname[pathname.length - 1] === '/') {
       pathname = pathname.slice(0, -1);
     }
 
-    const qs = {};
-    parsed.searchParams.forEach((v, k) => (qs[k] = v)); // NOSONAR (false positive -_-)
-
-    const routeHandler = new RouteHandler(pathname, qs, message);
+    const routeHandler = new RouteHandler(pathname, parsed.query, message);
 
     return getHandlerPart(this, pathname.split('/'), routeHandler);
   }

--- a/test/core/httpRouter/httpRouter.test.js
+++ b/test/core/httpRouter/httpRouter.test.js
@@ -65,7 +65,10 @@ describe('core/httpRouter', () => {
 
     it('should raise an internal error when trying to add a duplicate', () => {
       router.post('/foo/bar', handler);
+
       should(function () { router.post('/foo/bar', handler); })
+        .throw(InternalError, { id: 'network.http.duplicate_url' });
+      should(function () { router.post('/foo/bar/', handler); })
         .throw(InternalError, { id: 'network.http.duplicate_url' });
     });
   });
@@ -157,6 +160,50 @@ describe('core/httpRouter', () => {
             modifiedBy: 'John Doe',
             reason: 'foobar'
           });
+
+          done();
+        }
+        catch (e) {
+          done(e);
+        }
+      });
+    });
+
+    it('should properly handle querystrings (w/o url trailing slash)', done => {
+      router.post('/foo/bar', handler);
+
+      rq.url = '/foo/bar?foo=bar';
+      rq.method = 'POST';
+
+      router.route(rq, () => {
+        try {
+          should(handler).be.calledOnce();
+
+          const payload = handler.firstCall.args[0];
+          should(payload).be.instanceOf(Request);
+          should(payload.input.args.foo).eql('bar');
+
+          done();
+        }
+        catch (e) {
+          done(e);
+        }
+      });
+    });
+
+    it('should properly handle querystrings (w/ url trailing slash)', done => {
+      router.post('/foo/bar', handler);
+
+      rq.url = '/foo/bar/?foo=bar';
+      rq.method = 'POST';
+
+      router.route(rq, () => {
+        try {
+          should(handler).be.calledOnce();
+
+          const payload = handler.firstCall.args[0];
+          should(payload).be.instanceOf(Request);
+          should(payload.input.args.foo).eql('bar');
 
           done();
         }


### PR DESCRIPTION
# Description

Fix a bug where an URL containing both a trailing slash and a querystring would be incorrectly parsed.

# How to reproduce

The following HTTP GET request works fine:

`http://localhost:7512/_now?pretty`

But not this one without this PR:

`http://localhost:7512/_now/?pretty`

Both requests are equivalent and should be regarded as identical.

# Other changes

~Use the WHATWG URL parsing API instead of the legacy (and deprecated) Node.js URL parser.
Unfortunately, the latter was much more adapted to URL parsing server-side than the former. :expressionless:~

Reverted to the legacy URL API because of:
* https://github.com/nodejs/node/issues/30334 (huge performance hit with WHATWG)
* https://github.com/nodejs/node/issues/30776 (bug with relative URLs starting with double-slashes)