### PR TITLE
API documentation: fix index:create response example

### DIFF
--- a/doc/2/api/controllers/index/create/index.md
+++ b/doc/2/api/controllers/index/create/index.md
@@ -49,8 +49,7 @@ Returns a confirmation that the index is being created:
   "index": "<index>",
   "action": "create",
   "controller": "index",
-  "requestId": "<unique request identifier>",
-  "result": {}
+  "requestId": "<unique request identifier>"
 }
 ```
 


### PR DESCRIPTION
# Description

The `index:create` API route does not return any result value.