### PR TITLE
Fix default secret file loading

### DIFF
--- a/doc/2/guides/essentials/secrets-vault/index.md
+++ b/doc/2/guides/essentials/secrets-vault/index.md
@@ -89,6 +89,7 @@ The decryption key must be provided in one of the following ways, in order of pr
 Kuzzle start sequence ends in failure if:
   - a decryption key is provided and Kuzzle cannot find a file
   - Kuzzle finds a file and no decryption key is provided
+  - a file is provided but Kuzzle cannot read it
 :::
 
 ## Accessing secrets in plugin

--- a/lib/kuzzle.js
+++ b/lib/kuzzle.js
@@ -383,19 +383,28 @@ function initVault (vaultKey, secretsFile) {
       secretsFile || process.env.KUZZLE_SECRETS_FILE || defaultEncryptedSecretsFile;
 
   let key = vaultKey;
-  if ((!_.isString(vaultKey) || vaultKey.length <= 0)
-     && _.isString(process.env.KUZZLE_VAULT_KEY)
-     && process.env.KUZZLE_VAULT_KEY.length > 0
-  ) {
+  if (_.isEmpty(vaultKey) && !_.isEmpty(process.env.KUZZLE_VAULT_KEY)) {
     key = process.env.KUZZLE_VAULT_KEY;
   }
+  const
+    fileExists = fs.existsSync(encryptedSecretsFile),
+    vault = new Vault(key, null, encryptedSecretsFile);
 
-  const vault = new Vault(key, null, encryptedSecretsFile);
+  if (!_.isEmpty(secretsFile) || !_.isEmpty(process.env.KUZZLE_SECRETS_FILE)) {
+    console.log({ fileExists, encryptedSecretsFile})
+    assert(
+      fileExists,
+      `A secret file has been provided but Kuzzle cannot find it at '${encryptedSecretsFile}'.`);
+
+    assert(
+      !_.isEmpty(key),
+      'A secret file has been provided but Kuzzle cannot find the Vault key. Aborting.');
+  }
 
   if (key) {
     assert(
       fs.existsSync(encryptedSecretsFile),
-      `A Vault key is present but Kuzzle cannot find the secret file at '${encryptedSecretsFile}'. Aborting`);
+      `A Vault key is present but Kuzzle cannot find the secret file at '${encryptedSecretsFile}'. Aborting.`);
 
     vault.decrypt();
   }

--- a/lib/kuzzle.js
+++ b/lib/kuzzle.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const
+  assert = require('assert'),
   EventEmitter = require('eventemitter3'),
   Bluebird = require('bluebird'),
   config = require('./config'),
@@ -377,7 +378,7 @@ async function dumpAndExit(kuzzle, suffix) {
 function initVault (vaultKey, secretsFile) {
   const
     defaultEncryptedSecretsFile =
-      path.resolve(`${__dirname}/../../config/secrets.enc.json`),
+      path.resolve(`${__dirname}/../config/secrets.enc.json`),
     encryptedSecretsFile =
       secretsFile || process.env.KUZZLE_SECRETS_FILE || defaultEncryptedSecretsFile;
 
@@ -391,7 +392,11 @@ function initVault (vaultKey, secretsFile) {
 
   const vault = new Vault(key, null, encryptedSecretsFile);
 
-  if (key && fs.existsSync(encryptedSecretsFile)) {
+  if (key) {
+    assert(
+      fs.existsSync(encryptedSecretsFile),
+      `A Vault key is present but Kuzzle cannot find the secret file at '${encryptedSecretsFile}'. Aborting`);
+
     vault.decrypt();
   }
 

--- a/lib/kuzzle.js
+++ b/lib/kuzzle.js
@@ -386,12 +386,12 @@ function initVault (vaultKey, secretsFile) {
   if (_.isEmpty(vaultKey) && !_.isEmpty(process.env.KUZZLE_VAULT_KEY)) {
     key = process.env.KUZZLE_VAULT_KEY;
   }
+
   const
     fileExists = fs.existsSync(encryptedSecretsFile),
     vault = new Vault(key, null, encryptedSecretsFile);
 
   if (!_.isEmpty(secretsFile) || !_.isEmpty(process.env.KUZZLE_SECRETS_FILE)) {
-    console.log({ fileExists, encryptedSecretsFile})
     assert(
       fileExists,
       `A secret file has been provided but Kuzzle cannot find it at '${encryptedSecretsFile}'.`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {


### PR DESCRIPTION

## What does this PR do ?

By default, the Vault try to load the file present at `{root}/config/secrets.enc.json`, since we move the files and repertories this behaviour is broken. 

Also fix raising an error and stop Kuzzle loading if a secret key is provided and no secret file can be found.

### Other change

 - Raise an error and stop Kuzzle loading if the provided secret file cannot be found on filesystem