### PR TITLE
Update kuzzle-plugin-auth-passport-local to versiokn 6.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {


### PR DESCRIPTION
# Description

Make Kuzzle use kuzzle-plugin-auth-passport-local@6.1.1, applying a hotfix about the new `requirePassword` parameter (see https://github.com/kuzzleio/kuzzle-plugin-auth-passport-local/releases/tag/6.1.1)