### PR TITLE
Keep kuzzle_info after truncating a collection

### DIFF
--- a/doc/2/api/controllers/collection/get-mapping/index.md
+++ b/doc/2/api/controllers/collection/get-mapping/index.md
@@ -19,7 +19,7 @@ Also returns the collection [dynamic mapping policy](/core/2/guides/essentials/d
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/<index>/<collection>/_mapping
+URL: http://kuzzle:7512/<index>/<collection>/_mapping[?includeKuzzleMeta]
 Method: GET
 ```
 
@@ -30,7 +30,8 @@ Method: GET
   "index": "<index>",
   "collection": "<collection>",
   "controller": "collection",
-  "action": "getMapping"
+  "action": "getMapping",
+  "includeKuzzleMeta": false
 }
 ```
 
@@ -40,6 +41,7 @@ Method: GET
 
 - `collection`: collection name
 - `index`: index name
+- `includeKuzzleMeta`: include [Kuzzle metadata](/core/2/guides/essentials/database-mappings#collection-metadata) mappings in the response
 
 ---
 

--- a/features-sdk/CollectionController.feature
+++ b/features-sdk/CollectionController.feature
@@ -1,5 +1,37 @@
 Feature: Collection Controller
 
+  # collection:truncate ========================================================
+
+  Scenario: Truncate a collection
+    Given an index "nyc-open-data"
+    And I successfully call the route "collection":"create" with args:
+    | index | "nyc-open-data" |
+    | collection | "green-taxi" |
+    | body | { "dynamic": "strict", "properties": { "name": { "type": "keyword" } } } |
+    And an existing collection "nyc-open-data":"green-taxi"
+    And I "create" the following documents:
+    | _id          | body  |
+    | "document-1" | { "name": "document1" } |
+    | "document-2" | { "name": "document2" } |
+    When I successfully call the route "collection":"truncate" with args:
+    | index | "nyc-open-data" |
+    | collection | "green-taxi" |
+    And The document "document-1" should not exist
+    And The document "document-2" should not exist
+    And I successfully call the route "collection":"getMapping" with args:
+    | index | "nyc-open-data" |
+    | collection | "green-taxi" |
+    | includeKuzzleMeta | true |
+    And I should receive a result matching:
+    | dynamic | "strict" |
+    And The property "properties" of the result should match:
+    | name | { "type": "keyword" } |
+    And The property "properties._kuzzle_info.properties" of the result should match:
+    | author | { "type": "keyword" } |
+    | updater | { "type": "keyword" } |
+    | createdAt | { "type": "date" } |
+    | updatedAt | { "type": "date" } |
+
   # collection:delete ==========================================================
 
   Scenario: Delete a collection

--- a/features-sdk/DocumentController.feature
+++ b/features-sdk/DocumentController.feature
@@ -26,6 +26,7 @@ Feature: Document Controller
     Then I should receive a "hits" array of objects matching:
     | _id | highlight |
     | "document-1" | { "name": [ "<em>document</em>" ] } |
+
   # document:exists ============================================================
 
   @mappings

--- a/features-sdk/support/assertions.js
+++ b/features-sdk/support/assertions.js
@@ -28,7 +28,7 @@ should.Assertion.add(
       else {
         should(objectValue).match(
           expectedValue,
-          `${keyPath} does not match. Expected "${expectedValue}" have "${objectValue}"`);
+          `${keyPath} does not match. Expected "${JSON.stringify(expectedValue)}" have "${JSON.stringify(objectValue)}"`);
       }
     }
   },

--- a/features/kuzzle.feature
+++ b/features/kuzzle.feature
@@ -148,12 +148,6 @@ Feature: Kuzzle functional tests
   Scenario: Can't do a bulk import on internal index
     When I can't do a bulk import from index "%kuzzle"
 
-  Scenario: Truncate collection
-    When I write the document
-    Then I refresh the collection
-    Then I truncate the collection
-    Then I'm not able to get the document
-
   Scenario: Search with scroll documents
     When I write the document "documentGrace"
     When I write the document "documentGrace"

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -928,7 +928,7 @@ class ElasticSearch extends Service {
       index: this._getESIndex(index, collection)
     };
 
-    return this.getMapping(index, collection)
+    return this.getMapping(index, collection, { includeKuzzleMeta: true })
       .then(collectionMappings => {
         mappings = collectionMappings;
 


### PR DESCRIPTION
## What does this PR do ?

After truncating a collection, Kuzzle metadata were lost. It happen because we delete then recreate the subsequent Elasticsearch index when truncating a collection.  

The ES index is now recreated with Kuzzle metadata.