### PR TITLE
More precise server:healthCheck route

### DIFF
--- a/doc/2/api/controllers/server/health-check/index.md
+++ b/doc/2/api/controllers/server/health-check/index.md
@@ -8,7 +8,7 @@ title: healthCheck
 
 
 
-Returns status of the different services.
+Returns the status of the different services.
 
 ---
 

--- a/doc/2/api/controllers/server/health-check/index.md
+++ b/doc/2/api/controllers/server/health-check/index.md
@@ -1,0 +1,69 @@
+---
+code: true
+type: page
+title: healthCheck
+---
+
+# healthCheck
+
+
+
+Returns status of the different services.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_healthCheck[?services]
+Method: GET
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "server",
+  "action": "healthCheck",
+  // optional
+  "services" : "<services>"
+}
+```
+
+---
+
+### Optional:
+
+- `services` : You can specify which services you want the status of.(`eg: "storageEngine,memoryStorage"`)
+
+
+## Response
+
+Returns the status of each services.
+- `internalCache` : used by Kuzzle to cache internal data, such as authentication tokens, documents followed by real-time subscriptions, active paginated search queries, API usage statistics or cluster state
+- `memoryStorage` : memory cache managed by Kuzzle's [memoryStorage](/core/2/api/controllers/memory-storage) API
+- `storageEngine`: Underlying storage layer
+
+The status can either be `green`, `yellow` or `red`.
+
+```js
+{
+  "status": 200,
+  "error": null,
+  "action": "healthCheck",
+  "controller": "server",
+  "collection": null,
+  "index": null,
+  "volatile": null
+  "requestId": "<unique request identifier>",
+  "result": {
+    "status": "<status>",
+      "services": {
+        "internalCache" : "<status>",
+        "memoryStorage" : "<status>",
+        "storageEngine" : "<status>"
+      }
+}
+```

--- a/doc/2/api/controllers/server/health-check/index.md
+++ b/doc/2/api/controllers/server/health-check/index.md
@@ -8,7 +8,7 @@ title: healthCheck
 
 
 
-Returns the status of the different services.
+Returns the status of Kuzzle and it's internal services.
 
 ---
 

--- a/features-sdk/ServerController.feature
+++ b/features-sdk/ServerController.feature
@@ -45,3 +45,16 @@ Feature: Server Controller
     | internalCache | "green" |
     | memoryStorage | "green" |
     | storageEngine | "green" |
+    When I successfully call the route "server":"healthCheck" with args:
+    | services | "storageEngine" |
+    Then I should receive a result matching:
+    | status | "green" |
+    Then The property "services" of the result should match:
+    | storageEngine | "green" |
+    When I successfully call the route "server":"healthCheck" with args:
+    | services | "storageEngine,memoryStorage" |
+    Then I should receive a result matching:
+    | status | "green" |
+    Then The property "services" of the result should match:
+    | memoryStorage | "green" |
+    | storageEngine | "green" |

--- a/features-sdk/step_definitions/documents-steps.js
+++ b/features-sdk/step_definitions/documents-steps.js
@@ -136,7 +136,6 @@ Then(/The document "(.*?)" should( not)? exist/, async function (id, not) {
 Then(/I "(.*?)" the following document ids( with verb "(.*?)")?:/, async function (action, verb, dataTable) {
   action = `m${action[0].toUpperCase() + action.slice(1)}`;
   const options = verb ? { verb, refresh: 'wait_for' } : { refresh: 'wait_for' };
-  console.log(options);
   const ids = _.flatten(dataTable.rawTable).map(JSON.parse);
 
   this.props.result = await this.sdk.document[action](

--- a/lib/api/controllers/server.js
+++ b/lib/api/controllers/server.js
@@ -123,7 +123,7 @@ class ServerController extends NativeController {
       result = { status: 'green', services: {} };
 
     let services;
-    if (request.input.args && request.input.args.services) {
+    if (typeof request.input.args.services === 'string') {
       services = request.input.args.services.split(',');
     }
     if (!services || services.includes('internalCache')) {

--- a/lib/api/controllers/server.js
+++ b/lib/api/controllers/server.js
@@ -122,41 +122,48 @@ class ServerController extends NativeController {
         err => errorsManager.get('core', 'fatal', 'service_unavailable', err),
       result = { status: 'green', services: {} };
 
-    try {
-      await this.kuzzle.cacheEngine.internal.info();
-      result.services.internalCache = 'green';
+    let services;
+    if (request.input.args && request.input.args.services) {
+      services = request.input.args.services.split(',');
     }
-    catch (error) {
-      request.setError(getServiceUnavailableError(error));
-      result.services.internalCache = 'red';
-      result.status = 'red';
-    }
-
-    try {
-      await this.kuzzle.cacheEngine.public.info();
-      result.services.memoryStorage = 'green';
-    }
-    catch (error) {
-      request.setError(getServiceUnavailableError(error));
-      result.services.memoryStorage = 'red';
-      result.status = 'red';
-    }
-
-    try {
-      const response = await this.kuzzle.storageEngine.public.info();
-
-      if (response.status !== 'yellow' && response.status !== 'green') {
-        throw new Error(`ElasticSearch is down: ${JSON.stringify(response)}`);
+    if (!services || services.includes('internalCache')) {
+      try {
+        await this.kuzzle.cacheEngine.internal.info();
+        result.services.internalCache = 'green';
       }
-
-      result.services.storageEngine = 'green';
+      catch (error) {
+        request.setError(getServiceUnavailableError(error));
+        result.services.internalCache = 'red';
+        result.status = 'red';
+      }
     }
-    catch (error) {
-      request.setError(getServiceUnavailableError(error));
-      result.services.storageEngine = 'red';
-      result.status = 'red';
+    if (!services || services.includes('memoryStorage')) {
+      try {
+        await this.kuzzle.cacheEngine.public.info();
+        result.services.memoryStorage = 'green';
+      }
+      catch (error) {
+        request.setError(getServiceUnavailableError(error));
+        result.services.memoryStorage = 'red';
+        result.status = 'red';
+      }
     }
+    if (!services || services.includes('storageEngine')) {
+      try {
+        const response = await this.kuzzle.storageEngine.public.info();
 
+        if (response.status !== 'yellow' && response.status !== 'green') {
+          throw new Error(`ElasticSearch is down: ${JSON.stringify(response)}`);
+        }
+
+        result.services.storageEngine = 'green';
+      }
+      catch (error) {
+        request.setError(getServiceUnavailableError(error));
+        result.services.storageEngine = 'red';
+        result.status = 'red';
+      }
+    }
     return result;
   }
 

--- a/test/api/controllers/server.test.js
+++ b/test/api/controllers/server.test.js
@@ -140,6 +140,45 @@ describe('ServerController', () => {
         });
     });
 
+    it('should return 200 response with status "green" if storageEngine status is "green"', () => {
+      request.input.args.services = 'storageEngine';
+      
+      return serverController.healthCheck(request)
+        .then(response => {
+          should(request.response.error).be.null();
+          should(response.status).be.exactly('green');
+          should(response.services.storageEngine).be.exactly('green');
+          should(response.services.internalCache).be.exactly(undefined);
+          should(response.services.memoryStorage).be.exactly(undefined);
+        });
+    });
+
+    it('should return 200 response with status "green" if storageEngine and memoryStorage status are "green"', () => {
+      request.input.args.services = 'storageEngine,memoryStorage';
+
+      return serverController.healthCheck(request)
+        .then(response => {
+          should(request.response.error).be.null();
+          should(response.status).be.exactly('green');
+          should(response.services.storageEngine).be.exactly('green');
+          should(response.services.internalCache).be.exactly(undefined);
+          should(response.services.memoryStorage).be.exactly('green');
+        });
+    });
+
+    it('should return 200 response with status "green" if storageEngine, memoryStorage and internalCache status are "green"', () => {
+      request.input.args.services = 'storageEngine,memoryStorage,internalCache';
+
+      return serverController.healthCheck(request)
+        .then(response => {
+          should(request.response.error).be.null();
+          should(response.status).be.exactly('green');
+          should(response.services.storageEngine).be.exactly('green');
+          should(response.services.internalCache).be.exactly('green');
+          should(response.services.memoryStorage).be.exactly('green');
+        });
+    });
+
     it('should return a 503 response with status "red" if storageEngine status is "red"', () => {
       kuzzle.storageEngine.public.info.resolves({status: 'red'});
 


### PR DESCRIPTION
## What does this PR do ?

Before this PR:
Hitting `server:healthCheck` returned you the status of each services.

Now:
You can specify which service you want the status of.

[Jira Ticket](https://jira.kaliop.net/browse/KZL-1316)

### How should this be manually tested?

`http://localhost:7512/_healthCheck`

`http://localhost:7512/_healthCheck?services=storageEngine`

`http://localhost:7512/_healthCheck?services=storageEngine,memoryStorage`

`http://localhost:7512/_healthCheck?services=storageEngine,memoryStorage,internalCache`



### Other changes

Document the route

<!--
  Please describe here all changes not directly linked to the main issue, but made because of it.
  For instance: issues spotted during this PR and fixed on-the-fly, dependencies update, and so on
-->

### Boyscout

<!--
  Describe here minor improvements in the code base and not directly linked to the main changes:
  typos fixes, better/new comments, small code simplification, new debug messages, and so on.
-->
