### PR TITLE
Add the http verb to the requestContext object

### DIFF
--- a/lib/core/httpRouter/routeHandler.js
+++ b/lib/core/httpRouter/routeHandler.js
@@ -56,7 +56,8 @@ class RouteHandler {
         protocol: 'http',
         url: message.url,
         headers: message.headers,
-        ips: message.ips
+        ips: message.ips,
+        verb: message.method
       }
     };
 

--- a/test/core/httpRouter/httpRouter.test.js
+++ b/test/core/httpRouter/httpRouter.test.js
@@ -133,7 +133,7 @@ describe('core/httpRouter', () => {
       });
     });
 
-    it('should init request.context with the good values', done => {
+    it('should init request.context with the right values', done => {
       router.post('/foo/bar', handler);
 
       rq.url = '/foo/bar';
@@ -149,12 +149,13 @@ describe('core/httpRouter', () => {
           const apiRequest = handler.firstCall.args[0];
 
           should(apiRequest).be.instanceOf(Request);
-          should(apiRequest.context.protocol).be.exactly('http');
-          should(apiRequest.context.connectionId).be.exactly('requestId');
-          should(apiRequest.input.headers).be.eql({
+          should(apiRequest.context.connection.protocol).be.exactly('http');
+          should(apiRequest.context.connection.id).be.exactly('requestId');
+          should(apiRequest.context.connection.misc.headers).be.eql({
             foo: 'bar',
             Authorization: 'Bearer jwtFoobar',
             'X-Kuzzle-Volatile': '{"modifiedBy": "John Doe", "reason": "foobar"}'});
+          should(apiRequest.context.connection.misc.verb).eql('POST');
           should(apiRequest.input.jwt).be.exactly('jwtFoobar');
           should(apiRequest.input.volatile).be.eql({
             modifiedBy: 'John Doe',


### PR DESCRIPTION
# Description

Add the HTTP verb used to invoke an API route to the Request object, in the `request.context.connection.misc` object.

There are use cases from clients where they expose a single route that can be invoked with multiple verbs to simplify their API, and they need to be able to differenciate with what verb that route is called.

