### PR TITLE
Add a warning on createUser method for anonymous user

### DIFF
--- a/doc/2/api/controllers/security/create-user/index.md
+++ b/doc/2/api/controllers/security/create-user/index.md
@@ -10,6 +10,12 @@ Creates a new user.
 
 The body contains the user data and must have the following properties:
 
+::: warning
+This method is not intended to be exposed to the anonymous user because it allows the user to assign the profile of their choice.
+
+Expose the [security:createRestrictedUser](/core/2/api/controllers/security/create-restricted-user) method instead.
+:::
+
 ---
 
 ## Query Syntax


### PR DESCRIPTION

## What does this PR do ?

Add a warning to advise user to use `createRestrictedUser` when they want to allow anonymous user to sign in

### How should this be manually tested?

<!--
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration
-->
  - Step 1 :
  - Step 2 :
  - Step 3 :  
  ...

### Other changes

<!--
  Please describe here all changes not directly linked to the main issue, but made because of it.
  For instance: issues spotted during this PR and fixed on-the-fly, dependencies update, and so on
-->

### Boyscout

<!--
  Describe here minor improvements in the code base and not directly linked to the main changes:
  typos fixes, better/new comments, small code simplification, new debug messages, and so on.
-->
