### PR TITLE
Optimization : get rid of the "delete" keyword on objects

### DIFF
--- a/lib/api/controllers/server.js
+++ b/lib/api/controllers/server.js
@@ -82,14 +82,14 @@ class ServerController extends NativeController {
     const config = Object.assign({}, this.kuzzle.config);
 
     // Already and more appropriately returned by server:info
-    delete config.http;
+    config.http = undefined;
 
     // Not a good idea to export Kuzzle's salt, hash algorithm
     // and default rights
-    delete config.security;
+    config.security = undefined;
 
     if (config.VAULT_KEY) {
-      delete config.VAULT_KEY;
+      config.VAULT_KEY = undefined;
     }
 
     return config;

--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -67,7 +67,7 @@ class Funnel {
     this.concurrentRequests = 0;
     this.controllers = new Map();
     this.requestsCacheQueue = new Deque();
-    this.requestsCacheById = {};
+    this.requestsCacheById = new Map();
     this.lastOverloadTime = 0;
     this.overloadWarned = false;
     this.lastWarningTime = 0;
@@ -166,8 +166,8 @@ class Funnel {
 
     // resolves the callback immediately if a slot is available
     if (this.concurrentRequests < this.kuzzle.config.limits.concurrentRequests) {
-      if (this.requestsCacheById[request.internalId]) {
-        delete this.requestsCacheById[request.internalId];
+      if (this.requestsCacheById.has(request.internalId)) {
+        this.requestsCacheById.delete(request.internalId);
       }
       return true;
     }
@@ -191,9 +191,10 @@ class Funnel {
       return false;
     }
 
-    if (!this.requestsCacheById[request.internalId]) {
-      this.requestsCacheById[request.internalId] =
-        new CacheItem(executor, request, executeCallback);
+    if (!this.requestsCacheById.has(request.internalId)) {
+      this.requestsCacheById.set(
+        request.internalId,
+        new CacheItem(executor, request, executeCallback));
       this.requestsCacheQueue.push(request.internalId);
 
       if (!this.overloaded) {
@@ -696,12 +697,13 @@ class Funnel {
     if (quantityToInject > 0) {
       for (let i = 0; i < quantityToInject; i++) {
         const cachedItem =
-          this.requestsCacheById[this.requestsCacheQueue.peekFront()];
+          this.requestsCacheById.get(this.requestsCacheQueue.peekFront());
 
         if (this[cachedItem.executor](cachedItem.request, cachedItem.callback) === -1) {
           // no slot found again. We stop here and try next time
           break;
-        } else {
+        }
+        else {
           this.requestsCacheQueue.shift();
         }
       }
@@ -709,7 +711,8 @@ class Funnel {
 
     if (this.requestsCacheQueue.length > 0) {
       setTimeout(() => this._playCachedRequests(), 0);
-    } else {
+    }
+    else {
       const now = Date.now();
       // No request remaining in cache => stop the background task and return to normal behavior
       this.overloaded = false;

--- a/lib/core/entrypoints/protocols/mqtt.js
+++ b/lib/core/entrypoints/protocols/mqtt.js
@@ -44,7 +44,7 @@ class MqttProtocol extends Protocol {
     this.kuzzle = null;
 
     this.connections = new Map();
-    this.connectionsById = {};
+    this.connectionsById = new Map();
   }
 
   init (entryPoint) {
@@ -123,11 +123,11 @@ class MqttProtocol extends Protocol {
   disconnect (connectionId, message = 'Connection closed by remote host') {
     debug('[mqtt] disconnect: connection id: %s, message %s', connectionId, message);
 
-    if (!this.connectionsById[connectionId]) {
+    if (!this.connectionsById.has(connectionId)) {
       return;
     }
 
-    this.connectionsById[connectionId].close(undefined, message);
+    (this.connectionsById.get(connectionId)).close(undefined, message);
   }
 
   joinChannel () {
@@ -141,12 +141,12 @@ class MqttProtocol extends Protocol {
   notify (data) {
     debug('[mqtt] notify %a', data);
 
-    if (!this.connectionsById[data.connectionId]) {
+    if (!this.connectionsById.has(data.connectionId)) {
       return;
     }
 
     const
-      client = this.connectionsById[data.connectionId],
+      client = this.connectionsById.get(data.connectionId),
       payload = JSON.stringify(data.payload);
 
     for (const channel of data.channels) {
@@ -168,7 +168,7 @@ class MqttProtocol extends Protocol {
       this.entryPoint.newConnection(connection);
 
       this.connections.set(client, connection);
-      this.connectionsById[connection.id] = client;
+      this.connectionsById.set(connection.id, client);
     }
     catch (e) {
       this.kuzzle.log.error(`[plugin-mqtt] Unable to register new connection\n${e.stack}`);
@@ -187,7 +187,7 @@ class MqttProtocol extends Protocol {
         const connection = this.connections.get(client);
 
         this.connections.delete(client);
-        delete this.connectionsById[connection.id];
+        this.connectionsById.delete(connection.id);
         this.entryPoint.removeConnection(connection.id);
       }, this.config.disconnectDelay);
     }

--- a/lib/core/statistics.js
+++ b/lib/core/statistics.js
@@ -42,10 +42,10 @@ class StatisticsController {
     this.timer = null;
 
     this.currentStats = {
-      completedRequests: {},
-      connections: {},
-      failedRequests: {},
-      ongoingRequests: {}
+      completedRequests: new Map(),
+      connections: new Map(),
+      failedRequests: new Map(),
+      ongoingRequests: new Map()
     };
   }
 
@@ -61,11 +61,13 @@ class StatisticsController {
       return;
     }
 
-    if (!this.currentStats.ongoingRequests[protocol]) {
-      this.currentStats.ongoingRequests[protocol] = 1;
+    if (!this.currentStats.ongoingRequests.has(protocol)) {
+      this.currentStats.ongoingRequests.set(protocol, 1);
     }
     else {
-      this.currentStats.ongoingRequests[protocol]++;
+      this.currentStats.ongoingRequests.set(
+        protocol,
+        this.currentStats.ongoingRequests.get(protocol) + 1);
     }
   }
 
@@ -81,13 +83,17 @@ class StatisticsController {
       return;
     }
 
-    this.currentStats.ongoingRequests[protocol]--;
+    this.currentStats.ongoingRequests.set(
+      protocol,
+      this.currentStats.ongoingRequests.get(protocol) - 1);
 
-    if (!this.currentStats.completedRequests[protocol]) {
-      this.currentStats.completedRequests[protocol] = 1;
+    if (!this.currentStats.completedRequests.has(protocol)) {
+      this.currentStats.completedRequests.set(protocol, 1);
     }
     else {
-      this.currentStats.completedRequests[protocol]++;
+      this.currentStats.completedRequests.set(
+        protocol,
+        this.currentStats.completedRequests.get(protocol) + 1);
     }
   }
 
@@ -103,13 +109,17 @@ class StatisticsController {
       return;
     }
 
-    this.currentStats.ongoingRequests[protocol]--;
+    this.currentStats.ongoingRequests.set(
+      protocol,
+      this.currentStats.ongoingRequests.get(protocol) - 1);
 
-    if (!this.currentStats.failedRequests[protocol]) {
-      this.currentStats.failedRequests[protocol] = 1;
+    if (!this.currentStats.failedRequests.has(protocol)) {
+      this.currentStats.failedRequests.set(protocol, 1);
     }
     else {
-      this.currentStats.failedRequests[protocol]++;
+      this.currentStats.failedRequests.set(
+        protocol,
+        this.currentStats.failedRequests.get(protocol) + 1);
     }
   }
 
@@ -123,11 +133,13 @@ class StatisticsController {
       return;
     }
 
-    if (!this.currentStats.connections[requestContext.connection.protocol]) {
-      this.currentStats.connections[requestContext.connection.protocol] = 1;
+    if (!this.currentStats.connections.has(requestContext.connection.protocol)) {
+      this.currentStats.connections.set(requestContext.connection.protocol, 1);
     }
     else {
-      this.currentStats.connections[requestContext.connection.protocol]++;
+      this.currentStats.connections.set(
+        requestContext.connection.protocol,
+        this.currentStats.connections.get(requestContext.connection.protocol) + 1);
     }
   }
 
@@ -141,11 +153,13 @@ class StatisticsController {
       return;
     }
 
-    if (this.currentStats.connections[requestContext.connection.protocol] === 1) {
-      delete this.currentStats.connections[requestContext.connection.protocol];
+    if (this.currentStats.connections.get(requestContext.connection.protocol) === 1) {
+      this.currentStats.connections.delete(requestContext.connection.protocol);
     }
     else {
-      this.currentStats.connections[requestContext.connection.protocol]--;
+      this.currentStats.connections.set(
+        requestContext.connection.protocol,
+        this.currentStats.connections.get(requestContext.connection.protocol) - 1);
     }
   }
 
@@ -212,12 +226,19 @@ class StatisticsController {
       return response;
     }
 
+    const stats = {
+      completedRequests: Object.fromEntries(this.currentStats.completedRequests),
+      connections: Object.fromEntries(this.currentStats.connections),
+      failedRequests: Object.fromEntries(this.currentStats.failedRequests),
+      ongoingRequests: Object.fromEntries(this.currentStats.ongoingRequests),
+    };
+
     if (!this.lastFrame) {
       if (!stopTime || stopTime >= currentDate) {
         response.hits.push(
           Object.assign(
             {timestamp: (new Date(currentDate)).getTime()},
-            this.currentStats));
+            stats));
       }
 
       response.total = response.hits.length;
@@ -285,8 +306,8 @@ function writeStats () {
     this.ttl,
     JSON.stringify(this.currentStats));
 
-  this.currentStats.completedRequests = {};
-  this.currentStats.failedRequests = {};
+  this.currentStats.completedRequests = new Map();
+  this.currentStats.failedRequests = new Map();
 
   this.timer = setTimeout(() => writeStats.call(this), this.interval);
 }

--- a/lib/core/swagger.js
+++ b/lib/core/swagger.js
@@ -114,7 +114,7 @@ module.exports = function generateSwagger (kuzzle) {
       }
 
       if (route.infos.parameters.length === 0) {
-        delete route.infos.parameters;
+        route.infos.parameters = undefined;
       }
 
       if (route.infos.responses === undefined) {

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -1107,7 +1107,7 @@ class ElasticSearch extends Service {
         item[action]._index = esIndex;
 
         if (item[action]._type) {
-          delete item[action]._type;
+          item[action]._type = undefined;
         }
       }
       else if (lastAction === 'index' || lastAction === 'create') {
@@ -1158,11 +1158,11 @@ class ElasticSearch extends Service {
             // the delete action is not followed by an action payload
             if (action === 'update') {
               error._source = documents[idx + 1].doc;
-              delete error._source._kuzzle_info;
+              error._source._kuzzle_info = undefined;
             }
             else if (action !== 'delete') {
               error._source = documents[idx + 1];
-              delete error._source._kuzzle_info;
+              error._source._kuzzle_info = undefined;
             }
 
             // ES response does not systematicaly includes an error object
@@ -1453,7 +1453,7 @@ class ElasticSearch extends Service {
       // Documents are retrieved in the same order than we got them from user
       if (typeof document._id === 'string' && existingDocuments[idx]) {
         if (existingDocuments[idx].found) {
-          delete document._source._kuzzle_info;
+          document._source._kuzzle_info = undefined;
 
           rejected.push({
             document: {
@@ -1616,7 +1616,7 @@ class ElasticSearch extends Service {
         toImport.push(extractedDocument);
       }
       else {
-        delete extractedDocument._source._kuzzle_info;
+        extractedDocument._source._kuzzle_info = undefined;
 
         rejected.push({
           document: {
@@ -1722,7 +1722,7 @@ class ElasticSearch extends Service {
         toImport.push(document);
       }
       else {
-        delete document._source._kuzzle_info;
+        document._source._kuzzle_info = undefined;
 
         rejected.push({
           document: {

--- a/test/api/funnel/execute.test.js
+++ b/test/api/funnel/execute.test.js
@@ -197,7 +197,7 @@ describe('funnelController.execute', () => {
       should(funnel.processRequest).not.be.called();
       should(funnel.requestsCacheQueue.length).be.eql(1);
       should(funnel.requestsCacheQueue.shift()).eql(request.internalId);
-      should(funnel.requestsCacheById[request.internalId]).eql(new (FunnelController.__get__('CacheItem'))('execute', request, callback));
+      should(funnel.requestsCacheById.get(request.internalId)).eql(new (FunnelController.__get__('CacheItem'))('execute', request, callback));
       should(funnel._playCachedRequests).be.calledOnce();
     });
 
@@ -227,7 +227,7 @@ describe('funnelController.execute', () => {
       should(funnel.processRequest).not.be.called();
       should(funnel.requestsCacheQueue.length).be.eql(1);
       should(funnel.requestsCacheQueue.shift()).be.eql(request.internalId);
-      should(funnel.requestsCacheById[request.internalId]).match({request, callback});
+      should(funnel.requestsCacheById.get(request.internalId)).match({request, callback});
       should(funnel._playCachedRequests).have.callCount(0);
     });
 

--- a/test/core/entrypoints/protocols/mqtt.test.js
+++ b/test/core/entrypoints/protocols/mqtt.test.js
@@ -225,7 +225,7 @@ describe('/lib/core/entrypoints/protocols/mqtt', () => {
         close: sinon.spy()
       };
 
-      protocol.connectionsById.id = connection;
+      protocol.connectionsById.set('id', connection);
 
       protocol.disconnect('id');
 
@@ -236,15 +236,9 @@ describe('/lib/core/entrypoints/protocols/mqtt', () => {
 
   describe('#notify', () => {
     it('should forward the payload to the matching clients', () => {
-      protocol.connectionsById = {
-        id: {
-          forward: sinon.spy()
-        },
-        foo: {
-          forward: sinon.spy()
-        }
-      };
 
+      protocol.connectionsById.set('id', {forward: sinon.spy()});
+      protocol.connectionsById.set('foo', {forward: sinon.spy()});
       protocol.notify({
         connectionId: 'id',
         payload: 'payload',
@@ -254,11 +248,11 @@ describe('/lib/core/entrypoints/protocols/mqtt', () => {
         ]
       });
 
-      should(protocol.connectionsById.id.forward)
+      should(protocol.connectionsById.get('id').forward)
         .be.calledTwice()
         .be.calledWith('ch1', '"payload"', {}, 'ch1', 0);
 
-      should(protocol.connectionsById.foo.forward)
+      should(protocol.connectionsById.get('foo').forward)
         .have.callCount(0);
     });
   });
@@ -280,9 +274,9 @@ describe('/lib/core/entrypoints/protocols/mqtt', () => {
       protocol.onConnection(client);
 
       should(protocol.connections.size).eql(1);
-      should(Object.keys(protocol.connectionsById)).length(1);
+      should(protocol.connectionsById.size).eql(1);
 
-      const connectionId = Object.keys(protocol.connectionsById)[0];
+      const connectionId = protocol.connectionsById.entries().next().value[0];
       should(protocol.connections.get(client).id)
         .be.exactly(connectionId);
 
@@ -309,9 +303,7 @@ describe('/lib/core/entrypoints/protocols/mqtt', () => {
         client = {};
 
       protocol.connections.set(client, {id: 'id'});
-      protocol.connectionsById = {
-        id: client
-      };
+      protocol.connectionsById.set('id', client);
 
       protocol.onDisconnection(client);
       clock.tick(protocol.config.disconnectDelay + 1);

--- a/test/services/elasticsearch.test.js
+++ b/test/services/elasticsearch.test.js
@@ -2701,7 +2701,7 @@ describe('Test: ElasticSearch service', () => {
           ];
           const rejected = [
             {
-              document: { _id: undefined, body: { _kuzzle_info:undefined, city: 'Ho Chi Minh City' } },
+              document: { _id: undefined, body: { _kuzzle_info: undefined, city: 'Ho Chi Minh City' } },
               reason: 'document _id must be a string',
               status: 400
             }

--- a/test/services/elasticsearch.test.js
+++ b/test/services/elasticsearch.test.js
@@ -1650,7 +1650,7 @@ describe('Test: ElasticSearch service', () => {
             }
           },
 
-          { index: { _id: 2, _index: esIndexName } },
+          { index: { _id: 2, _index: esIndexName, _type: undefined } },
           {
             firstName: 'bar',
             _kuzzle_info: {
@@ -1723,7 +1723,7 @@ describe('Test: ElasticSearch service', () => {
         { index: { _id: 1 } },
         { firstName: 'foo' },
 
-        { index: { _id: 2 } },
+        { index: { _id: 2, _type: undefined } },
         { firstName: 'bar' },
 
         { update: { _id: 3 } },
@@ -2353,7 +2353,7 @@ describe('Test: ElasticSearch service', () => {
             {
               document: {
                 _id: 'liia',
-                body: { city: 'Ho Chi Minh City' }
+                body: { _kuzzle_info: undefined, city: 'Ho Chi Minh City' }
               },
               reason: 'document already exists',
               status: 400
@@ -2701,7 +2701,7 @@ describe('Test: ElasticSearch service', () => {
           ];
           const rejected = [
             {
-              document: { _id: undefined, body: { city: 'Ho Chi Minh City' } },
+              document: { _id: undefined, body: { _kuzzle_info:undefined, city: 'Ho Chi Minh City' } },
               reason: 'document _id must be a string',
               status: 400
             }
@@ -2819,7 +2819,7 @@ describe('Test: ElasticSearch service', () => {
           ];
           const rejected = [
             {
-              document: { _id: 'liia', body: { city: 'Ho Chi Minh City' } },
+              document: { _id: 'liia', body: { _kuzzle_info: undefined, city: 'Ho Chi Minh City' } },
               reason: 'document not found',
               status: 404
             }


### PR DESCRIPTION
<!--
  This template is optional.
  It simply serves to provide a guide to allow a better review of pull requests.
-->

<!--
  IMPORTANT
  Don't forget to add the corresponding "changelog:xxx" label to your PR.
  This is part of our release process in order to generate the change log.
-->


## What does this PR do ?

This PR intends to bring a little performance optimization by getting rid of the `delete` keyword that was used on objects.

For static objects as `requestsCacheById` (funnel), `currentStats` objects (statistics) and `connectionsById` (mqtt), they are now `Map`.
Those objects are often mutated, and being Maps increase performance on a large volume of addition/deletion 

<!-- Please fill this section -->

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

### How should this be manually tested?

<!--
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration
-->
  - Step 1 :
  - Step 2 :
  - Step 3 :  
  ...

### Other changes

<!--
  Please describe here all changes not directly linked to the main issue, but made because of it.
  For instance: issues spotted during this PR and fixed on-the-fly, dependencies update, and so on
-->

### Boyscout

<!--
  Describe here minor improvements in the code base and not directly linked to the main changes:
  typos fixes, better/new comments, small code simplification, new debug messages, and so on.
-->
