### PR TITLE
Fix defaulting for document.update and document.scroll options

### DIFF
--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -188,10 +188,11 @@ class ElasticSearch extends Service {
    */
   scroll (
     scrollId,
-    { scrollTTL=this._config.defaults.scrollTTL } = {})
+    { scrollTTL } = {})
   {
+    const _scrollTTL = scrollTTL || this._config.defaults.scrollTTL;
     const esRequest = {
-      scroll: scrollTTL,
+      scroll: _scrollTTL,
       scrollId
     };
 
@@ -207,7 +208,7 @@ class ElasticSearch extends Service {
         }
 
         // ms(scroll) may return undefined if in microseconds or in nanoseconds
-        const ttl = ms(scrollTTL) || ms(this._config.defaults.scrollTTL);
+        const ttl = ms(_scrollTTL) || ms(this._config.defaults.scrollTTL);
 
         return this._kuzzle.cacheEngine.internal.pexpire(cacheKey, ttl);
       })
@@ -516,7 +517,7 @@ class ElasticSearch extends Service {
     collection,
     id,
     content,
-    { refresh, userId=null, retryOnConflict=this._config.defaults.onUpdateConflictRetries } = {})
+    { refresh, userId=null, retryOnConflict } = {})
   {
     const esRequest = {
       _source: true,
@@ -524,7 +525,7 @@ class ElasticSearch extends Service {
       id,
       index: this._getESIndex(index, collection),
       refresh,
-      retryOnConflict
+      retryOnConflict: retryOnConflict || this._config.defaults.onUpdateConflictRetries
     };
 
     assertNoRouting(esRequest);
@@ -718,7 +719,7 @@ class ElasticSearch extends Service {
         document._source = undefined;
         document.body = changes;
       });
-      
+
       const response = await this.mUpdate(
         index,
         collection,

--- a/test/services/elasticsearch.test.js
+++ b/test/services/elasticsearch.test.js
@@ -137,6 +137,24 @@ describe('Test: ElasticSearch service', () => {
           should(elasticsearch._client.scroll).not.be.called();
         });
     });
+
+    it('should default an explictly null scrollTTL argument', async () => {
+      elasticsearch._client.scroll.resolves({
+        body: {
+          hits: { hits: [], total: { value: 0 } },
+          _scroll_id: 'azerty'
+        }
+      });
+
+      await elasticsearch.scroll('scroll-id', { scrollTTL: null });
+
+      should(kuzzle.cacheEngine.internal.exists).be.called();
+      should(kuzzle.cacheEngine.internal.pexpire).be.called();
+      should(elasticsearch._client.scroll.firstCall.args[0]).be.deepEqual({
+        scrollId: 'scroll-id',
+        scroll: elasticsearch.config.defaults.scrollTTL
+      });
+    });
   });
 
   describe('#search', () => {
@@ -644,6 +662,32 @@ describe('Test: ElasticSearch service', () => {
           should(elasticsearch._esWrapper.reject).be.calledWith(esClientError);
         });
     });
+
+    it('should default an explicitly null retryOnConflict', async () => {
+      await elasticsearch.update(
+        index,
+        collection,
+        'liia',
+        { city: 'Panipokari' },
+        { refresh: 'wait_for', userId: 'oh noes', retryOnConflict: null });
+
+      should(elasticsearch._client.update).be.calledWithMatch({
+        index: esIndexName,
+        body: {
+          doc: {
+            city: 'Panipokari',
+            _kuzzle_info: {
+              updatedAt: timestamp,
+              updater: 'oh noes'
+            }
+          }
+        },
+        id: 'liia',
+        refresh: 'wait_for',
+        _source: true,
+        retryOnConflict: elasticsearch.config.defaults.onUpdateConflictRetries
+      });
+    });
   });
 
   describe('#replace', () => {
@@ -841,7 +885,7 @@ describe('Test: ElasticSearch service', () => {
         errors: []
       });
 
-    
+
       elasticsearch._client.indices.refresh.resolves({
         body: { _shards: 1 }
       });
@@ -870,7 +914,7 @@ describe('Test: ElasticSearch service', () => {
         collection,
         { filter: { term: { name: 'Ok' } } },
         { name: 'bar' });
-      
+
       return promise
         .then(result => {
           should(elasticsearch.mUpdate).be.calledWithMatch(


### PR DESCRIPTION
# Description

Passing explicit null values for the following parameters ends up with unexpected errors:
* `retryOnConflict` for the `document:update` route
* `scrollTTL` for the `document:scroll` route

This bug occurs because we assign default values using destructuring syntax, but this works only if a property is undefined: `null` is a value and thus is not defaulted.

Demo:

```js
function foo ({oh = 'noes'} = {}) { 
  console.log(`oh = ${oh}`); 
}

// prints "oh = null"
foo({oh:  null});
```

# How to reproduce

1. Update:

```
kourou query index:create --arg index:foo
kourou query collection:create --arg index:foo --arg collection:bar
kourou query document:create --arg index:foo --arg collection:bar --arg _id:foo
kourou query document:update --arg index:foo --arg collection:bar --arg _id:foo --arg retryOnConflict:null
```

Result: `Failed to parse int parameter [retry_on_conflict] with value [null]`

2. Scroll
```
kourou query index:create --arg index:foo
kourou query collection:create --arg index:foo --arg collection:bar
kourou query document:search --arg index:foo --arg collection:bar --arg scroll:10m
kourou query document:scroll --arg index:foo --arg collection:bar --arg scrollId:<from previous request> --arg scroll:null
```

Result: `failed to parse setting [scroll] with value [null] as a time value: unit is missing or unrecognized`
