### PR TITLE
Adds admin:reloadIndexCache

### DIFF
--- a/doc/2/api/controllers/admin/load-fixtures/index.md
+++ b/doc/2/api/controllers/admin/load-fixtures/index.md
@@ -48,6 +48,7 @@ Body:
 {
   "controller": "admin",
   "action": "loadFixtures",
+  
   "body": {
     "index-name": {
       "collection-name": [

--- a/doc/2/api/controllers/admin/load-mappings/index.md
+++ b/doc/2/api/controllers/admin/load-mappings/index.md
@@ -50,6 +50,7 @@ Body:
 {
   "controller": "admin",
   "action": "loadMappings",
+  
   "body": {
     "index-name": {
       "collection-name": {

--- a/doc/2/api/controllers/admin/load-securities/index.md
+++ b/doc/2/api/controllers/admin/load-securities/index.md
@@ -62,6 +62,7 @@ Body:
 {
   "controller": "admin",
   "action": "loadSecurities",
+  
   "body": {
     "roles": {
       "role-id": {

--- a/doc/2/api/controllers/admin/refresh-index-cache/index.md
+++ b/doc/2/api/controllers/admin/refresh-index-cache/index.md
@@ -1,0 +1,42 @@
+---
+type: page
+
+code: true
+title: refreshIndexCache
+---
+
+# refreshIndexCache
+
+<SinceBadge version="2.2.0" />
+
+Refresh the internal index cache with actual Elasticsearch indexes.  
+
+::: info
+This method is useful after importing a dump directly into Elasticsearch
+:::
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/admin/_refreshIndexCache
+Method: POST
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "admin",
+  "action": "refreshIndexCache"
+}
+```
+
+---
+
+## Response
+
+Returns a 200 status when the index cache is successfully refreshed.

--- a/doc/2/api/controllers/admin/reset-cache/index.md
+++ b/doc/2/api/controllers/admin/reset-cache/index.md
@@ -26,6 +26,9 @@ Method: POST
 
 ```js
 {
+  "controller": "admin",
+  "action": "refreshIndexCache",
+
   "database": "internalCache"
 }
 ```

--- a/doc/2/api/essentials/error-codes/services/index.md
+++ b/doc/2/api/essentials/error-codes/services/index.md
@@ -17,7 +17,7 @@ description: error codes definitions
 | Id | Error Type (Status Code)             | Message           |
 | ------ | -----------------| ------------------ | ------------------ |
 | services.storage.unknown_index<br/><pre>0x01010001</pre> | [PreconditionError](/core/2/api/essentials/error-handling#preconditionerror) <pre>(412)</pre> | The provided data index does not exist |
-| services.storage.unknown_collection<br/><pre>0x01010002</pre> | [PreconditionError](/core/2/api/essentials/error-handling#preconditionerror) <pre>(412)</pre> | The provided data collection does not exist in the index |
+| services.storage.unknown_collection<br/><pre>0x01010002</pre> | [PreconditionError](/core/2/api/essentials/error-handling#preconditionerror) <pre>(412)</pre> | The provided data collection does not exist in the provided index |
 | services.storage.get_limit_exceeded<br/><pre>0x01010003</pre> | [SizeLimitError](/core/2/api/essentials/error-handling#sizelimiterror) <pre>(413)</pre> | The number of documents returned by this request exceeds the configured server limit |
 | services.storage.write_limit_exceeded<br/><pre>0x01010004</pre> | [SizeLimitError](/core/2/api/essentials/error-handling#sizelimiterror) <pre>(413)</pre> | The number of documents edited by this request exceeds the configured server limit |
 | services.storage.import_failed<br/><pre>0x01010005</pre> | [PartialError](/core/2/api/essentials/error-handling#partialerror) <pre>(206)</pre> | Failed to import some or all documents |

--- a/doc/2/api/essentials/error-codes/services/index.md
+++ b/doc/2/api/essentials/error-codes/services/index.md
@@ -17,7 +17,7 @@ description: error codes definitions
 | Id | Error Type (Status Code)             | Message           |
 | ------ | -----------------| ------------------ | ------------------ |
 | services.storage.unknown_index<br/><pre>0x01010001</pre> | [PreconditionError](/core/2/api/essentials/error-handling#preconditionerror) <pre>(412)</pre> | The provided data index does not exist |
-| services.storage.unknown_collection<br/><pre>0x01010002</pre> | [PreconditionError](/core/2/api/essentials/error-handling#preconditionerror) <pre>(412)</pre> | The provided data collection does not exist |
+| services.storage.unknown_collection<br/><pre>0x01010002</pre> | [PreconditionError](/core/2/api/essentials/error-handling#preconditionerror) <pre>(412)</pre> | The provided data collection does not exist in the index |
 | services.storage.get_limit_exceeded<br/><pre>0x01010003</pre> | [SizeLimitError](/core/2/api/essentials/error-handling#sizelimiterror) <pre>(413)</pre> | The number of documents returned by this request exceeds the configured server limit |
 | services.storage.write_limit_exceeded<br/><pre>0x01010004</pre> | [SizeLimitError](/core/2/api/essentials/error-handling#sizelimiterror) <pre>(413)</pre> | The number of documents edited by this request exceeds the configured server limit |
 | services.storage.import_failed<br/><pre>0x01010005</pre> | [PartialError](/core/2/api/essentials/error-handling#partialerror) <pre>(206)</pre> | Failed to import some or all documents |

--- a/lib/api/controllers/admin.js
+++ b/lib/api/controllers/admin.js
@@ -39,6 +39,7 @@ class AdminController extends NativeController {
       'loadFixtures',
       'loadMappings',
       'loadSecurities',
+      'refreshIndexCache',
       'resetCache',
       'resetDatabase',
       'resetSecurity',
@@ -176,6 +177,14 @@ class AdminController extends NativeController {
     const promise = this.kuzzle.janitor.loadSecurities(securities, user);
 
     return this._waitForAction(request, promise, { acknowledge: true });
+  }
+
+  /**
+   * Reloads the index cache with newly added indexes and collections.
+   * This is useful after importing a dump directly into ES.
+   */
+  refreshIndexCache () {
+    return this.kuzzle.storageEngine.populateIndexCache();
   }
 
   _lockAction (request, message) {

--- a/lib/config/error-codes/services.json
+++ b/lib/config/error-codes/services.json
@@ -11,9 +11,9 @@
           "class": "PreconditionError"
         },
         "unknown_collection": {
-          "description": "The provided data collection does not exist",
+          "description": "The provided data collection does not exist in the index",
           "code": 2,
-          "message": "The collection \"%s\" does not exist.",
+          "message": "The collection \"%s\" does not exist in index \"%s\".",
           "class": "PreconditionError"
         },
         "get_limit_exceeded": {

--- a/lib/config/error-codes/services.json
+++ b/lib/config/error-codes/services.json
@@ -11,7 +11,7 @@
           "class": "PreconditionError"
         },
         "unknown_collection": {
-          "description": "The provided data collection does not exist in the index",
+          "description": "The provided data collection does not exist in the provided index",
           "code": 2,
           "message": "The collection \"%s\" does not exist in index \"%s\".",
           "class": "PreconditionError"

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -49,6 +49,7 @@ module.exports = [
   {verb: 'post', url: '/admin/_loadFixtures', controller: 'admin', action: 'loadFixtures'},
   {verb: 'post', url: '/admin/_loadMappings', controller: 'admin', action: 'loadMappings'},
   {verb: 'post', url: '/admin/_loadSecurities', controller: 'admin', action: 'loadSecurities'},
+  {verb: 'post', url: '/admin/_refreshIndexCache', controller: 'admin', action: 'refreshIndexCache'},
 
   {verb: 'get', url: '/:index/:collection', controller: 'document', action: 'search'},
   {verb: 'get', url: '/:index/:collection/:_id', controller: 'document', action: 'get'},

--- a/lib/core/storage/clientAdapter.js
+++ b/lib/core/storage/clientAdapter.js
@@ -174,7 +174,7 @@ class ClientAdapter {
     });
 
     if (! exists) {
-      throw errorsManager.get('unknown_collection', collection);
+      throw errorsManager.get('unknown_collection', collection, index);
     }
   }
 

--- a/lib/core/storage/storageEngine.js
+++ b/lib/core/storage/storageEngine.js
@@ -90,9 +90,48 @@ class StorageEngine {
 
     await Bluebird.all(promises);
 
-    await this._populateIndexCache();
+    await this.populateIndexCache();
 
     BaseModel.init(this._kuzzle);
+  }
+
+  /**
+   * Populates the index cache with existing index/collection and aliases.
+   * Also checks for duplicated index names.
+   *
+   * @returns {Promise}
+   */
+  async populateIndexCache () {
+    let publicIndexes;
+    let internalIndexes;
+
+    const promises = [];
+
+    promises.push(
+      this._internalClient.listIndexes()
+        .then(indexes => {
+          internalIndexes = indexes;
+
+          return this._addCollections(indexes, 'internal');
+        }));
+
+    promises.push(
+      this._publicClient.listIndexes()
+        .then(indexes => {
+          publicIndexes = indexes;
+
+          return this._addCollections(indexes, 'public');
+        }));
+
+    await Bluebird.all(promises);
+
+    for (const publicIndex of publicIndexes) {
+      if (internalIndexes.includes(publicIndex)) {
+        throw errorsManager.get('index_already_exists', 'public', publicIndex);
+      }
+    }
+
+    await this._addCollectionsAliases();
   }
 
   /**
@@ -168,46 +207,6 @@ class StorageEngine {
     }
 
     return modified;
-  }
-
-  /**
-   * Populates the index cache with existing index/collection and aliases.
-   * Also checks for duplicated index names.
-   *
-   * @returns {Promise}
-   */
-  async _populateIndexCache () {
-    let
-      publicIndexes,
-      internalIndexes;
-
-    const promises = [];
-
-    promises.push(
-      this._internalClient.listIndexes()
-        .then(indexes => {
-          internalIndexes = indexes;
-
-          return this._addCollections(indexes, 'internal');
-        }));
-
-    promises.push(
-      this._publicClient.listIndexes()
-        .then(indexes => {
-          publicIndexes = indexes;
-
-          return this._addCollections(indexes, 'public');
-        }));
-
-    await Bluebird.all(promises);
-
-    for (const publicIndex of publicIndexes) {
-      if (internalIndexes.includes(publicIndex)) {
-        throw errorsManager.get('index_already_exists', 'public', publicIndex);
-      }
-    }
-
-    await this._addCollectionsAliases();
   }
 
   /**

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -984,7 +984,7 @@ class ElasticSearch extends Service {
       const allowedSettings = {
         index: _.omit(
           esIndexSettings.index,
-          ['creation_date', 'provided_name', 'uuid', 'version'])
+          ['creation_date', 'provided_name', 'uuid', 'version', 'number_of_shards'])
       };
 
       // Rollback to previous settings

--- a/test/api/controllers/admin.test.js
+++ b/test/api/controllers/admin.test.js
@@ -34,6 +34,14 @@ describe('AdminController', () => {
     });
   });
 
+  describe('#refreshIndexCache', () => {
+    it('should call underlaying storageEngine method', async () => {
+      await adminController.refreshIndexCache();
+
+      should(kuzzle.storageEngine.populateIndexCache).be.calledOnce();
+    });
+  });
+
   describe('#resetCache', () => {
     let flushdbStub = sinon.stub();
 

--- a/test/core/storage/bootstrap/internalIndexBootstrap.test.js
+++ b/test/core/storage/bootstrap/internalIndexBootstrap.test.js
@@ -38,8 +38,6 @@ describe('InternalIndexBootstrap', () => {
     StorageEngine = mockrequire.reRequire('../../../../lib/core/storage/storageEngine');
     storageEngine = new StorageEngine(kuzzle);
 
-    storageEngine._populateIndexCache = sinon.stub().resolves();
-
     return storageEngine.init();
   });
 

--- a/test/core/storage/models/apiKey.test.js
+++ b/test/core/storage/models/apiKey.test.js
@@ -23,8 +23,6 @@ describe('ApiKey', () => {
     StorageEngine = mockrequire.reRequire('../../../../lib/core/storage/storageEngine');
     storageEngine = new StorageEngine(kuzzle);
 
-    storageEngine._populateIndexCache = sinon.stub().resolves();
-
     return storageEngine.init();
   });
 

--- a/test/core/storage/models/baseModel.test.js
+++ b/test/core/storage/models/baseModel.test.js
@@ -40,8 +40,6 @@ describe('BaseModel', () => {
     StorageEngine = mockrequire.reRequire('../../../../lib/core/storage/storageEngine');
     storageEngine = new StorageEngine(kuzzle);
 
-    storageEngine._populateIndexCache = sinon.stub().resolves();
-
     return storageEngine.init();
   });
 

--- a/test/core/storage/storageEngine.test.js
+++ b/test/core/storage/storageEngine.test.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const
-  should = require('should'),
-  mockrequire = require('mock-require'),
-  KuzzleMock = require('../../mocks/kuzzle.mock'),
-  BaseModel = require('../../../lib/core/storage/models/baseModel'),
-  ClientAdapterMock = require('../../mocks/clientAdapter.mock');
+const sinon = require('sinon');
+const should = require('should');
+const mockrequire = require('mock-require');
+const KuzzleMock = require('../../mocks/kuzzle.mock');
+const BaseModel = require('../../../lib/core/storage/models/baseModel');
+const ClientAdapterMock = require('../../mocks/clientAdapter.mock');
 
 describe('StorageEngine', () => {
   let
@@ -41,6 +41,8 @@ describe('StorageEngine', () => {
 
   describe('#init', () => {
     it('should initialize storage clients, models and populate cache', async () => {
+      sinon.stub(storageEngine, 'populateIndexCache').resolves();
+
       await storageEngine.init();
 
       should(storageEngine._publicClient.init).be.called();

--- a/test/core/storage/storageEngine.test.js
+++ b/test/core/storage/storageEngine.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const
-  sinon = require('sinon'),
   should = require('should'),
   mockrequire = require('mock-require'),
   KuzzleMock = require('../../mocks/kuzzle.mock'),
@@ -42,19 +41,17 @@ describe('StorageEngine', () => {
 
   describe('#init', () => {
     it('should initialize storage clients, models and populate cache', async () => {
-      storageEngine._populateIndexCache = sinon.stub().resolves();
-
       await storageEngine.init();
 
       should(storageEngine._publicClient.init).be.called();
       should(storageEngine._internalClient.init).be.called();
-      should(storageEngine._populateIndexCache).be.called();
+      should(storageEngine.populateIndexCache).be.called();
       should(BaseModel.kuzzle).be.eql(kuzzle);
       should(BaseModel.indexStorage).be.eql(kuzzle.internalIndex);
     });
   });
 
-  describe('#_populateIndexCache', () => {
+  describe('#populateIndexCache', () => {
     beforeEach(() => {
       storageEngine._internalClient.listIndexes.resolves(['foobar']);
       storageEngine._internalClient.listCollections.resolves(['foolection']);

--- a/test/mocks/clientAdapter.mock.js
+++ b/test/mocks/clientAdapter.mock.js
@@ -28,9 +28,9 @@ class ClientAdapterMock extends ClientAdapter {
     this.updateMapping = sinon.stub().resolves();
     this.truncateCollection = sinon.stub().resolves();
     this.import = sinon.stub().resolves();
-    this.listCollections = sinon.stub().resolves();
-    this.listIndexes = sinon.stub().resolves();
-    this.listAliases = sinon.stub().resolves();
+    this.listCollections = sinon.stub().resolves([]);
+    this.listIndexes = sinon.stub().resolves([]);
+    this.listAliases = sinon.stub().resolves([]);
     this.deleteIndexes = sinon.stub().resolves();
     this.deleteIndex = sinon.stub().resolves();
     this.refreshCollection = sinon.stub().resolves();

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -124,6 +124,7 @@ class KuzzleMock extends Kuzzle {
 
     this.storageEngine = {
       init: sinon.stub().resolves(),
+      populateIndexCache: sinon.stub().resolves(),
       indexCache: {
         add: sinon.stub().resolves(),
         remove: sinon.stub().resolves(),


### PR DESCRIPTION
## Use case / Pain point

After loading a dump directly in Elasticsearch, Kuzzle index cache is obsolete and the new index/collections could not be used before Kuzzle restarts. 

## Feature

Adds a new API method: `admin:refreshIndexCache` to force a refresh of the internal index cache.  

I didn't adds functional tests on purpose since the feature is already tested when Kuzzle starts and it will be very costly to test this new API route (elasticdump, dump ES, restore ES..)

### How should this be manually tested?

  - Step 1 :
  - Step 2 :
  - Step 3 :  

### Other changes

 - improve error message when collection does not exists

### Boyscout

 - some nitpicking on the documentation
