### PR TITLE
Use index cache for index/collection listing

### DIFF
--- a/doc/2/api/controllers/index/list/index.md
+++ b/doc/2/api/controllers/index/list/index.md
@@ -17,7 +17,7 @@ Returns the complete list of indexes.
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/_list
+URL: http://kuzzle:7512/_list[?countCollections]
 Method: GET
 ```
 
@@ -26,15 +26,27 @@ Method: GET
 ```js
 {
   "controller": "index",
-  "action": "list"
+  "action": "list",
+
+  "countCollection": true
 }
 ```
 
 ---
 
+## Arguments
+
+### Optional:
+
+- `countCollections`: if set to true, will returns the number of collections in each index
+
+---
+
 ## Response
 
-Returns a `indexes` array listing all existing index names.
+Returns an object containing an `indexes` array containing the indexes names.  
+
+If the `countCollections` argument has been set to `true`, then the object contains an `collections` object containing the number of collection in each index.
 
 ```js
 {
@@ -49,7 +61,13 @@ Returns a `indexes` array listing all existing index names.
       "index_2",
       "index_...",
       "index_n"
-    ]
+    ],
+    
+    // only when countCollections is set to true
+    "collections": {
+      "index_1": 42,
+      "index_2": 21
+    }
   }
 }
 ```

--- a/doc/2/api/controllers/index/list/index.md
+++ b/doc/2/api/controllers/index/list/index.md
@@ -6,8 +6,6 @@ title: list
 
 # list
 
-
-
 Returns the complete list of indexes.
 
 ---
@@ -62,7 +60,7 @@ If the `countCollections` argument has been set to `true`, then the object conta
       "index_...",
       "index_n"
     ],
-    
+
     // only when countCollections is set to true
     "collections": {
       "index_1": 42,

--- a/features-sdk/CollectionController.feature
+++ b/features-sdk/CollectionController.feature
@@ -157,3 +157,17 @@ Feature: Collection Controller
       | name          | type     |
       | "green-taxi"  | "stored" |
       | "yellow-taxi" | "stored" |
+
+  # collection:exists ==========================================================
+
+  Scenario: Test if a collection exists
+    Given an index "nyc-open-data"
+    And a collection "nyc-open-data":"yellow-taxi"
+    When I successfully call the route "collection":"exists" with args:
+    | index | "nyc-open-data" |
+    | collection | "yellow-taxi" |
+    Then The result should be "true"
+    When I successfully call the route "collection":"exists" with args:
+    | index | "nyc-open-data" |
+    | collection | "green-taxi" |
+    Then The result should be "false"

--- a/features-sdk/IndexController.feature
+++ b/features-sdk/IndexController.feature
@@ -31,3 +31,24 @@ Feature: Index Controller
       | index | "kuz.zle" |
     Then I should receive an error matching:
       | status | 400 |
+
+  # index:exists ===============================================================
+
+  Scenario: Test index existence
+    Given an index "nyc-open-data"
+    When I successfully call the route "index":"exists" with args:
+      | index | "nyc-open-data" |
+    Then The result should be "true"
+    When I successfully call the route "index":"exists" with args:
+      | index | "mtp-open-data" |
+    Then The result should be "false"
+
+  # index:list =================================================================
+
+  Scenario: List indexes
+    Given an index "nyc-open-data"
+    And an index "mtp-open-data"
+    When I successfully call the route "index":"list"
+    Then I should receive a result matching:
+      | indexes | ["nyc-open-data", "mtp-open-data"] |
+

--- a/features-sdk/IndexController.feature
+++ b/features-sdk/IndexController.feature
@@ -52,3 +52,14 @@ Feature: Index Controller
     Then I should receive a result matching:
       | indexes | ["nyc-open-data", "mtp-open-data"] |
 
+  Scenario: List indexes with collection count
+    Given an index "nyc-open-data"
+    And a collection "nyc-open-data":"yellow-taxi"
+    And a collection "nyc-open-data":"green-taxi"
+    And an index "mtp-open-data"
+    And a collection "mtp-open-data":"red-taxi"
+    When I successfully call the route "index":"list" with args:
+      | countCollection | true |
+    Then I should receive a result matching:
+      | indexes | ["nyc-open-data", "mtp-open-data"] |
+      | collections | { "nyc-open-data": 2, "mtp-open-data": 1 } |

--- a/features-sdk/step_definitions/controllers-steps.js
+++ b/features-sdk/step_definitions/controllers-steps.js
@@ -78,6 +78,12 @@ Then('The property {string} of the result should match:', function (path, dataTa
   }
 });
 
+Then('The result should be {string}', function (rawValue) {
+  const expectedValue = JSON.parse(rawValue);
+
+  should(this.props.result).be.eql(expectedValue);
+});
+
 Then('The result should contain a property {string} of type {string}', function (path, type) {
   const property = _.get(this.props.result, path);
 
@@ -118,7 +124,7 @@ Then('I should receive an error matching:', function (dataTable) {
 
 Then('I debug {string}', function (path) {
   const prop = _.get(this.props, path);
-  
+
   try {
     console.log(JSON.stringify(prop, null, 2));
   }

--- a/features/kuzzle.feature
+++ b/features/kuzzle.feature
@@ -285,24 +285,6 @@ Feature: Kuzzle functional tests
     And I get all statistics frames
     Then I get at least 1 statistic frame
 
-  Scenario: list known stored collections
-    When I write the document "documentGrace"
-    And I list "stored" data collections
-    Then I can find a stored collection kuzzle-collection-test
-
-  Scenario: Index and collection existence
-    When I check if index "%kuzzle" exists
-    Then The result should match the json false
-    When I check if index "idontexist" exists
-    Then The result should match the json false
-    When I check if collection "users" exists on index "%kuzzle"
-    Then The result should match the json false
-    When I write the document "documentGrace"
-    When I check if index "kuzzle-test-index" exists
-    Then The result should match the json true
-    When I check if collection "kuzzle-collection-test" exists on index "kuzzle-test-index"
-    Then The result should match the json true
-
   @realtime
   Scenario: list known realtime collections
     Given A room subscription listening to "lastName" having value "Hopper"

--- a/lib/api/controllers/index.js
+++ b/lib/api/controllers/index.js
@@ -97,14 +97,32 @@ class IndexController extends NativeController {
   /**
    * Lists indexes
    *
-   * @returns {Promise.<String[]>}
    */
-  list () {
-    return this.publicStorage.listIndexes()
-      .then(indexes => ({
-        indexes
-      }));
+  async list (request) {
+    const countCollection = this.getBoolean(request, 'countCollection');
+
+    const indexes = await this.publicStorage.listIndexes();
+
+    const response = {
+      indexes
+    };
+
+    if (countCollection) {
+      response.collections = {};
+
+      const promises = [];
+
+      for (const index of indexes) {
+        promises.push(
+          this.publicStorage.listCollections(index)
+            .then(collections => response.collections[index] = collections.length)
+        );
+      }
+    }
+
+    return response;
   }
+
 
   /**
    * Tells if an index exists

--- a/lib/api/controllers/index.js
+++ b/lib/api/controllers/index.js
@@ -115,9 +115,13 @@ class IndexController extends NativeController {
       for (const index of indexes) {
         promises.push(
           this.publicStorage.listCollections(index)
-            .then(collections => response.collections[index] = collections.length)
+            .then(collections => {
+              response.collections[index] = collections.length;
+            })
         );
       }
+
+      await Promise.all(promises);
     }
 
     return response;

--- a/lib/core/storage/clientAdapter.js
+++ b/lib/core/storage/clientAdapter.js
@@ -90,7 +90,7 @@ class ClientAdapter {
       'indexExists',
       'listCollections',
       'listIndexes'
-    ]
+    ];
 
     for (const method of this._assertIndexAndCollectionMethods) {
       this[method] = (index, collection, ...args) => {
@@ -166,7 +166,7 @@ class ClientAdapter {
     this._assertIndexExists(index);
 
     if (fromCache) {
-      return this._indexCache.exists({ index, collection, scope: this._client.scope });
+      return this._indexCache.exists({ collection, index, scope: this._client.scope });
     }
 
     return this._client.collectionExists(index, collection);

--- a/lib/core/storage/clientAdapter.js
+++ b/lib/core/storage/clientAdapter.js
@@ -21,8 +21,7 @@
 
 'use strict';
 
-const
-  errorsManager = require('../../util/errors').wrap('services', 'storage');
+const errorsManager = require('../../util/errors').wrap('services', 'storage');
 
 /**
  * Storage client adapter to perform validation on index/collection existence
@@ -65,21 +64,13 @@ class ClientAdapter {
       'updateMapping'
     ];
 
-    // Methods that needs to assert index existence
-    this._assertIndexMethods = [
-      'listCollections'
-    ];
-
     // Methods directly bound to the storageClient
     this._rawMethods = [
-      'collectionExists',
-      'indexExists',
       'info',
       'init',
       'isCollectionNameValid',
       'isIndexNameValid',
       'listAliases',
-      'listIndexes',
       'scroll'
     ];
 
@@ -93,6 +84,14 @@ class ClientAdapter {
       'deleteCollection'
     ];
 
+    // Methods that can use directly the index cache content
+    this._canUseIndexCache = [
+      'collectionExists',
+      'indexExists',
+      'listCollections',
+      'listIndexes'
+    ]
+
     for (const method of this._assertIndexAndCollectionMethods) {
       this[method] = (index, collection, ...args) => {
         this._assertIndexAndCollectionExists(index, collection);
@@ -100,15 +99,6 @@ class ClientAdapter {
         return this._client[method](index, collection, ...args);
       };
     }
-
-    for (const method of this._assertIndexMethods) {
-      this[method] = (index, ...args) => {
-        this._assertIndexExists(index);
-
-        return this._client[method](index, ...args);
-      };
-    }
-
     for (const method of this._rawMethods) {
       this[method] = (...args) => this._client[method](...args);
     }
@@ -162,6 +152,42 @@ class ClientAdapter {
     this._indexCache.remove({ collection, index, scope: this._client.scope });
 
     return response;
+  }
+
+  async indexExists (index, { fromCache = true } = {}) {
+    if (fromCache) {
+      return this._indexCache.exists({ index, scope: this._client.scope });
+    }
+
+    return this._client.indexExists(index);
+  }
+
+  async collectionExists (index, collection, { fromCache = true } = {}) {
+    this._assertIndexExists(index);
+
+    if (fromCache) {
+      return this._indexCache.exists({ index, collection, scope: this._client.scope });
+    }
+
+    return this._client.collectionExists(index, collection);
+  }
+
+  async listIndexes ({ fromCache = true } = {}) {
+    if (fromCache) {
+      return this._indexCache.listIndexes({ scope: this._client.scope });
+    }
+
+    return this._client.listIndexes();
+  }
+
+  async listCollections (index, { fromCache = true } = {}) {
+    this._assertIndexExists(index);
+
+    if (fromCache) {
+      return this._indexCache.listCollections({ index, scope: this._client.scope });
+    }
+
+    return this._client.listCollections(index);
   }
 
   _assertIndexAndCollectionExists (index, collection) {

--- a/lib/core/storage/storageEngine.js
+++ b/lib/core/storage/storageEngine.js
@@ -21,12 +21,11 @@
 
 'use strict';
 
-const
-  Elasticsearch = require('../../services/elasticsearch'),
-  errorsManager = require('../../util/errors').wrap('services', 'storage'),
-  ClientAdapter = require('./clientAdapter'),
-  BaseModel = require('./models/baseModel'),
-  Bluebird = require('bluebird');
+const Elasticsearch = require('../../services/elasticsearch');
+const errorsManager = require('../../util/errors').wrap('services', 'storage');
+const ClientAdapter = require('./clientAdapter');
+const BaseModel = require('./models/baseModel');
+const Bluebird = require('bluebird');
 
 class IndexCache {
   constructor (scope) {
@@ -47,7 +46,9 @@ class StorageEngine {
     this._indexCache = {
       add: (...args) => this._add(...args),
       exists: (...args) => this._exists(...args),
-      remove: (...args) => this._remove(...args)
+      remove: (...args) => this._remove(...args),
+      listIndexes: (...args) => this._listIndexes(...args),
+      listCollections: (...args) => this._listCollections(...args),
     };
 
     // Storage client for public indexes only
@@ -150,7 +151,7 @@ class StorageEngine {
    *
    * @returns {boolean}
    */
-  _remove ({ index, collection, scope='public', notify=true }) {
+  _remove ({ index, collection, scope='public', notify=true } = {}) {
     let modified = false;
     const indexCache = this._indexes.get(index);
 
@@ -171,6 +172,38 @@ class StorageEngine {
   }
 
   /**
+   * Lists the indexes contained in the index cache
+   *
+   * @param {Object} arguments - scope (public)
+   *
+   * @returns {String[]}
+   */
+  _listIndexes ({ scope='public' } = {}) {
+    const indexes = [];
+
+    for (const [name, content] of this._indexes.entries()) {
+      if (content.scope === scope) {
+        indexes.push(name);
+      }
+    }
+
+    return indexes;
+  }
+
+  /**
+   * Lists collections contained in an index
+   *
+   * @param {Object} arguments - index, scope (public)
+   */
+  _listCollections ({ index, scope='public'} = {}) {
+    if (! this._exists({ index, scope })) {
+      throw errorsManager.get('unknown_index', index);
+    }
+
+    return Array.from(this._indexes.get(index).collections);
+  }
+
+  /**
    * Populates the index cache with existing index/collection and aliases.
    * Also checks for duplicated index names.
    *
@@ -184,7 +217,7 @@ class StorageEngine {
     const promises = [];
 
     promises.push(
-      this._internalClient.listIndexes()
+      this._internalClient.listIndexes({ fromCache: false })
         .then(indexes => {
           internalIndexes = indexes;
 
@@ -192,7 +225,7 @@ class StorageEngine {
         }));
 
     promises.push(
-      this._publicClient.listIndexes()
+      this._publicClient.listIndexes({ fromCache: false })
         .then(indexes => {
           publicIndexes = indexes;
 
@@ -243,7 +276,7 @@ class StorageEngine {
       this._indexes.set(index, new IndexCache(scope));
 
       promises.push(
-        storageClient.listCollections(index)
+        storageClient.listCollections(index, { fromCache: false })
           .then(collections => {
             for (const collection of collections) {
               this._indexes.get(index).collections.add(collection);

--- a/lib/core/storage/storageEngine.js
+++ b/lib/core/storage/storageEngine.js
@@ -46,9 +46,9 @@ class StorageEngine {
     this._indexCache = {
       add: (...args) => this._add(...args),
       exists: (...args) => this._exists(...args),
-      remove: (...args) => this._remove(...args),
-      listIndexes: (...args) => this._listIndexes(...args),
       listCollections: (...args) => this._listCollections(...args),
+      listIndexes: (...args) => this._listIndexes(...args),
+      remove: (...args) => this._remove(...args)
     };
 
     // Storage client for public indexes only

--- a/test/core/storage/storageEngine.test.js
+++ b/test/core/storage/storageEngine.test.js
@@ -1,12 +1,11 @@
 'use strict';
 
-const
-  sinon = require('sinon'),
-  should = require('should'),
-  mockrequire = require('mock-require'),
-  KuzzleMock = require('../../mocks/kuzzle.mock'),
-  BaseModel = require('../../../lib/core/storage/models/baseModel'),
-  ClientAdapterMock = require('../../mocks/clientAdapter.mock');
+const sinon = require('sinon');
+const should = require('should');
+const mockrequire = require('mock-require');
+const KuzzleMock = require('../../mocks/kuzzle.mock');
+const BaseModel = require('../../../lib/core/storage/models/baseModel');
+const ClientAdapterMock = require('../../mocks/clientAdapter.mock');
 
 describe('StorageEngine', () => {
   let
@@ -245,6 +244,53 @@ describe('StorageEngine', () => {
 
       should(indexExists).be.false();
       should(collectionExists).be.false();
+    });
+  });
+
+  describe('#listIndexes', () => {
+    beforeEach(() => {
+      storageEngine.indexCache.add({ index: 'covid-19', scope: 'public' });
+      storageEngine.indexCache.add({ index: 'foobar', scope: 'public' });
+
+      storageEngine.indexCache.add({ index: 'barfoo', scope: 'internal' });
+    });
+
+    it('should returns the public index list by default', () => {
+      const indexes = storageEngine.indexCache.listIndexes();
+
+      should(indexes).be.eql(['covid-19', 'foobar']);
+    });
+
+    it('should accept scope argument', () => {
+      const indexes = storageEngine.indexCache.listIndexes({ scope: 'internal' });
+
+      should(indexes).be.eql(['barfoo']);
+    });
+  });
+
+  describe('#listCollections', () => {
+    beforeEach(() => {
+      storageEngine.indexCache.add(
+        { index: 'covid-19', collection: 'france', scope: 'public' });
+      storageEngine.indexCache.add(
+        { index: 'covid-19', collection: 'italia', scope: 'public' });
+
+      storageEngine.indexCache.add(
+        { index: 'barfoo', collection: 'deutschland', scope: 'internal' });
+    });
+
+    it('should returns the public index list by default', () => {
+      const collections = storageEngine.indexCache.listCollections(
+        { index: 'covid-19'});
+
+      should(collections).be.eql(['france', 'italia']);
+    });
+
+    it('should accept scope argument', () => {
+      const collections = storageEngine.indexCache.listCollections(
+        { index: 'barfoo', scope: 'internal' });
+
+      should(collections).be.eql(['deutschland']);
     });
   });
 });

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -128,6 +128,8 @@ class KuzzleMock extends Kuzzle {
         add: sinon.stub().resolves(),
         remove: sinon.stub().resolves(),
         exists: sinon.stub().resolves(),
+        listIndexes: sinon.stub().resolves(),
+        listCollections: sinon.stub().resolves()
       },
       public: new ClientAdapterMock(),
       internal: new ClientAdapterMock(),


### PR DESCRIPTION
## Pain point

Listing indexes and collection or testing existence is quite slow because we have to query ES.  

## Enhancement

We can query directly the index cache in the RAM instead of doing a network trip.

### Other changes
 
 - the method index:list can also returns the number of collections in each index

```
GET http://kuzzle:7512/_list?countCollections
{
    "indexes": [
      "index_1",
      "index_2"
    ],
    "collections": {
      "index_1": 42,
      "index_2": 21
    }
  }  
}
```
