### PR TITLE
Add kourou to plugin-dev image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ RUN  set -x \
   && mkdir -p /var/app \
   && npm install -g npm \
   && npm set progress=false \
-  && npm install -g \
-    pm2 \
+  && npm install -g --unsafe-perm\
+    pm2 kourou \
   && echo "" > /opt/node-v$NODE_VERSION-linux-x64/lib/node_modules/pm2/lib/keymetrics \
   && rm -rf /var/lib/apt/lists/* \
   && echo "alias ll=\"ls -lahF --color\"" >> ~/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM debian:stretch-slim as plugin-dev
 LABEL io.kuzzle.vendor="Kuzzle <support@kuzzle.io>"
 LABEL description="Develop new plugin or protocol for Kuzzle with ease"
 
-ENV NODE_VERSION=12.15.0
+ENV NODE_VERSION=12.16.1
 ENV PATH=/opt/node-v$NODE_VERSION-linux-x64/bin:$PATH
 
 ADD https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz /tmp/
@@ -54,7 +54,7 @@ FROM debian:stretch-slim as kuzzle
 LABEL io.kuzzle.vendor="Kuzzle <support@kuzzle.io>"
 LABEL description="Run your Kuzzle backend in production mode"
 
-ENV NODE_VERSION=12.15.0
+ENV NODE_VERSION=12.16.1
 ENV NODE_ENV=production
 ENV PATH=/opt/node-v$NODE_VERSION-linux-x64/bin:$PATH
 


### PR DESCRIPTION
## What does this PR do ?

Add kourou inside the `kuzzleio/plugin-dev` image

Also bumb node version to 12.16.1