### PR TITLE
Better error message on 401 and 403

### DIFF
--- a/doc/2/api/essentials/error-codes/security/index.md
+++ b/doc/2/api/essentials/error-codes/security/index.md
@@ -42,7 +42,7 @@ description: error codes definitions
 
 | Id | Error Type (Status Code)             | Message           |
 | ------ | -----------------| ------------------ | ------------------ |
-| security.rights.unauthorized<br/><pre>0x07030001</pre> | [UnauthorizedError](/core/2/api/essentials/error-handling#unauthorizederror) <pre>(401)</pre> | Authentication required |
+| security.rights.unauthorized<br/><pre>0x07030001</pre> | [UnauthorizedError](/core/2/api/essentials/error-handling#unauthorizederror) <pre>(401)</pre> | Authentication required to execute this action |
 | security.rights.forbidden<br/><pre>0x07030002</pre> | [ForbiddenError](/core/2/api/essentials/error-handling#forbiddenerror) <pre>(403)</pre> | Insufficient permissions to execute this action |
 
 ---

--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -397,7 +397,9 @@ class Funnel {
       const error = errorsManager.get(
         'security',
         'rights',
-        userId === -1 ? 'unauthorized' : 'forbidden');
+        userId === -1 ? 'unauthorized' : 'forbidden',
+        request.input.controller,
+        request.input.action);
 
       request.setError(error);
 

--- a/lib/config/error-codes/security.json
+++ b/lib/config/error-codes/security.json
@@ -75,15 +75,15 @@
       "code": 3,
       "errors": {
         "unauthorized": {
-          "description": "Authentication required",
+          "description": "Authentication required to execute this action",
           "code": 1,
-          "message": "Unauthorized: authentication required.",
+          "message": "Unauthorized: authentication required to execute the action \"%s:%s\".",
           "class": "UnauthorizedError"
         },
         "forbidden": {
           "description": "Insufficient permissions to execute this action",
           "code": 2,
-          "message": "Insufficient permissions to execute this action.",
+          "message": "Insufficient permissions to execute the action \"%s:%s\".",
           "class": "ForbiddenError"
         }
       }

--- a/lib/config/error-codes/services.json
+++ b/lib/config/error-codes/services.json
@@ -13,7 +13,7 @@
         "unknown_collection": {
           "description": "The provided data collection does not exist",
           "code": 2,
-          "message": "The collection \"%s:%s\" does not exist.",
+          "message": "The collection \"%s\":\"%s\" does not exist.",
           "class": "PreconditionError"
         },
         "get_limit_exceeded": {
@@ -55,7 +55,7 @@
         "not_found": {
           "description": "Document not found",
           "code": 11,
-          "message": "Document \"%s\" not found in \"%s:%s\".",
+          "message": "Document \"%s\" not found in \"%s\":\"%s\".",
           "class": "NotFoundError"
         },
         "bootstrap_timeout": {

--- a/lib/config/error-codes/services.json
+++ b/lib/config/error-codes/services.json
@@ -13,7 +13,7 @@
         "unknown_collection": {
           "description": "The provided data collection does not exist",
           "code": 2,
-          "message": "The collection \"%s\" does not exist.",
+          "message": "The collection \"%s:%s\" does not exist.",
           "class": "PreconditionError"
         },
         "get_limit_exceeded": {
@@ -55,7 +55,7 @@
         "not_found": {
           "description": "Document not found",
           "code": 11,
-          "message": "Document \"%s\" not found.",
+          "message": "Document \"%s\" not found in \"%s:%s\".",
           "class": "NotFoundError"
         },
         "bootstrap_timeout": {

--- a/lib/core/storage/clientAdapter.js
+++ b/lib/core/storage/clientAdapter.js
@@ -200,7 +200,7 @@ class ClientAdapter {
     });
 
     if (! exists) {
-      throw errorsManager.get('unknown_collection', collection);
+      throw errorsManager.get('unknown_collection', index, collection);
     }
   }
 

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -613,7 +613,7 @@ class ElasticSearch extends Service {
     return this._client.exists({ id, index: esIndex })
       .then(({ body: exists }) => {
         if (! exists) {
-          throw errorsManager.get('not_found', id);
+          throw errorsManager.get('not_found', id, index, collection);
         }
 
         debug('Replace document: %o', esRequest);

--- a/test/util/errors.test.js
+++ b/test/util/errors.test.js
@@ -52,12 +52,12 @@ describe('#errorsManager', () => {
   });
 
   it('should return a NotFoundError with default name, msg and code', () => {
-    const err = errorsManager.get('services', 'storage', 'not_found', 'fake_id');
+    const err = errorsManager.get('services', 'storage', 'not_found', 'fake_id', 'index', 'collection');
     should(err).be.instanceOf(NotFoundError);
     should(err).match({
       id: 'services.storage.not_found',
       code: parseInt('0101000b', 16),
-      message: 'Document "fake_id" not found.'
+      message: 'Document "fake_id" not found in "index":"collection".'
     });
   });
 


### PR DESCRIPTION
## What does this PR do ?

Better error message on 401 or 403 error.  

The former message was not helpful for the user:
![image](https://user-images.githubusercontent.com/4447392/78321448-3edfe600-756c-11ea-9183-a781b4795497.png)

### How should this be manually tested?

Restrain anonymous user right on your Kuzzle and then run a query `kourou query server:now`

### Other changes
 - Also improve the document not found message with index and collection