### PR TITLE
Change and deprecate default pagination for collection:list

### DIFF
--- a/doc/2/api/controllers/collection/list/index.md
+++ b/doc/2/api/controllers/collection/list/index.md
@@ -39,9 +39,10 @@ Method: GET
 - `collection`: collection name
 - `index`: index name
 
-<DeprecatedBadge since="2.1.4" />
 
 ### Optional:
+
+<DeprecatedBadge since="2.1.4" />
 
 - `from` and `size`: response pagination
 - `type`: filters the returned collections. Allowed values: `all`, `stored` and `realtime` (default : `all`).

--- a/doc/2/api/controllers/collection/list/index.md
+++ b/doc/2/api/controllers/collection/list/index.md
@@ -6,8 +6,6 @@ title: list
 
 # list
 
-
-
 Returns the list of collections associated to a provided index.
 
 The returned list is sorted in alphanumerical order.
@@ -19,7 +17,7 @@ The returned list is sorted in alphanumerical order.
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/<index>/_list[?type=<all|stored|realtime>][&from=0][&size=42]
+URL: http://kuzzle:7512/<index>/_list[?type=<all|stored|realtime>]
 Method: GET
 ```
 
@@ -30,9 +28,7 @@ Method: GET
   "index": "<index>",
   "controller": "collection",
   "action": "list",
-  "type": "stored",
-  "from": 0,
-  "size": 42
+  "type": "stored"
 }
 ```
 
@@ -42,6 +38,8 @@ Method: GET
 
 - `collection`: collection name
 - `index`: index name
+
+<DeprecatedBadge since="2.1.4" />
 
 ### Optional:
 

--- a/features-sdk/CollectionController.feature
+++ b/features-sdk/CollectionController.feature
@@ -152,6 +152,7 @@ Feature: Collection Controller
     Given an index "nyc-open-data"
     And a collection "nyc-open-data":"yellow-taxi"
     And a collection "nyc-open-data":"green-taxi"
+    And a collection "nyc-open-data":"green-taxi"
     And I list collections in index "nyc-open-data"
     Then I should receive a "collections" array of objects matching:
       | name          | type     |

--- a/lib/api/controllers/collection.js
+++ b/lib/api/controllers/collection.js
@@ -289,10 +289,10 @@ class CollectionController extends NativeController {
    * @returns {Promise.<Object>}
    */
   async list (request) {
-    const
-      index = this.getIndex(request),
-      { from, size } = this.getSearchParams(request),
-      type = this.getString(request, 'type', 'all');
+    const index = this.getIndex(request);
+    const from = this.getInteger(request, 'from', 0);
+    const size = this.getInteger(request, 'size', 42000);
+    const type = this.getString(request, 'type', 'all');
 
     if (['all', 'stored', 'realtime'].indexOf(type) === -1) {
       throw errorsManager.get('api', 'assert', 'invalid_argument', '"all", "stored", "realtime"');

--- a/lib/api/controllers/collection.js
+++ b/lib/api/controllers/collection.js
@@ -291,7 +291,7 @@ class CollectionController extends NativeController {
   async list (request) {
     const index = this.getIndex(request);
     const from = this.getInteger(request, 'from', 0);
-    const size = this.getInteger(request, 'size', 42000);
+    const size = this.getInteger(request, 'size', 0);
     const type = this.getString(request, 'type', 'all');
 
     if (['all', 'stored', 'realtime'].indexOf(type) === -1) {

--- a/lib/config/error-codes/services.json
+++ b/lib/config/error-codes/services.json
@@ -13,7 +13,7 @@
         "unknown_collection": {
           "description": "The provided data collection does not exist",
           "code": 2,
-          "message": "The collection \"%s\" does not exist.",
+          "message": "The collection \"%s\":\"%s\" does not exist.",
           "class": "PreconditionError"
         },
         "get_limit_exceeded": {

--- a/lib/core/storage/clientAdapter.js
+++ b/lib/core/storage/clientAdapter.js
@@ -200,7 +200,7 @@ class ClientAdapter {
     });
 
     if (! exists) {
-      throw errorsManager.get('unknown_collection', collection);
+      throw errorsManager.get('unknown_collection', index, collection);
     }
   }
 

--- a/lib/util/esWrapper.js
+++ b/lib/util/esWrapper.js
@@ -95,9 +95,8 @@ const errorMessagesMapping = [
   {
     // [index_not_found_exception] no such index, with { resource.type=index_or_alias & resource.id=foso & index=foso }
     regex: /^no such index \[([%&])(.*)\.(.*)\]$/,
-    subcode: 'unknown_index',
+    subcode: 'unknown_collection',
     getPlaceholders: (esError, matches) => [
-      matches[1] === '%' ? 'Internal' : 'User',
       matches[2],
       matches[3]
     ]


### PR DESCRIPTION
## What does this PR do ?

The collection:list method can be paginated with `from` and `size`.   
There is no reason to do that since it's only a list of string and also because an index will not contain thousands of collection.

This PR puts the default value very high and deprecate this usage

### Other changes

  - improve unknown collection error message