### PR TITLE
Install dependencies when starting a new development stack

### DIFF
--- a/docker-compose/scripts/run-dev.sh
+++ b/docker-compose/scripts/run-dev.sh
@@ -8,11 +8,23 @@ fi
 
 elastic_host=${kuzzle_services__storageEngine__client__node:-http://elasticsearch:9200}
 
-if [ ! -z "$TRAVIS" ] || [ ! -z "$REBUILD" ] || [ -d "node_modules/" ]; then
+if [ ! -d "./node_modules/" ]; then
+    git submodule init
+    git submodule update
+    npm ci --unsafe-perm
+    ./docker-compose/scripts/install-plugins.sh
+fi
+
+if [ ! -z "$TRAVIS" ] || [ ! -z "$REBUILD" ]; then
     npm ci --unsafe-perm
     chmod -R 777 node_modules/
     npm rebuild all --unsafe-perm
     docker-compose/scripts/install-plugins.sh
+elif [ ! -d "./node_modules/" ]; then
+    git submodule init
+    git submodule update
+    npm ci --unsafe-perm
+    ./docker-compose/scripts/install-plugins.sh
 fi
 
 spinner="/"

--- a/docker-compose/scripts/run-dev.sh
+++ b/docker-compose/scripts/run-dev.sh
@@ -8,7 +8,7 @@ fi
 
 elastic_host=${kuzzle_services__storageEngine__client__node:-http://elasticsearch:9200}
 
-if [ ! -z "$TRAVIS" ] || [ ! -z "$REBUILD" ]; then
+if [ ! -z "$TRAVIS" ] || [ ! -z "$REBUILD" ] || [ ! -d "node_modules" ]; then
     npm ci --unsafe-perm
     chmod -R 777 node_modules/
     npm rebuild all --unsafe-perm

--- a/docker-compose/scripts/run-dev.sh
+++ b/docker-compose/scripts/run-dev.sh
@@ -8,13 +8,6 @@ fi
 
 elastic_host=${kuzzle_services__storageEngine__client__node:-http://elasticsearch:9200}
 
-if [ ! -d "./node_modules/" ]; then
-    git submodule init
-    git submodule update
-    npm ci --unsafe-perm
-    ./docker-compose/scripts/install-plugins.sh
-fi
-
 if [ ! -z "$TRAVIS" ] || [ ! -z "$REBUILD" ]; then
     npm ci --unsafe-perm
     chmod -R 777 node_modules/

--- a/docker-compose/scripts/run-dev.sh
+++ b/docker-compose/scripts/run-dev.sh
@@ -8,7 +8,7 @@ fi
 
 elastic_host=${kuzzle_services__storageEngine__client__node:-http://elasticsearch:9200}
 
-if [ ! -z "$TRAVIS" ] || [ ! -z "$REBUILD" ] || [ ! -d "node_modules" ]; then
+if [ ! -z "$TRAVIS" ] || [ ! -z "$REBUILD" ] || [ -d "node_modules/" ]; then
     npm ci --unsafe-perm
     chmod -R 777 node_modules/
     npm rebuild all --unsafe-perm


### PR DESCRIPTION
## What does this PR do ?

Makes the _run-dev.sh_ script which is executed inside docker, install all dependencies (core & plugins) if they haven't been installed yet.

### How should this be manually tested?

To run the stack, you would only need to clone and launch with docker-compose:

`git clone -b feature/automatic-dependencies-install https://github.com/kuzzleio/kuzzle.git && cd kuzzle && docker-compose up`
