### PR TITLE
Keep the number of opened scroll contexts in check

### DIFF
--- a/lib/api/controllers/admin.js
+++ b/lib/api/controllers/admin.js
@@ -73,43 +73,36 @@ class AdminController extends NativeController {
   /**
    * Reset all roles, profiles and users
    */
-  resetSecurity (request) {
+  async resetSecurity (request) {
     this._lockAction(
       request,
       'Kuzzle is already reseting roles, profiles and users.');
 
-    const
-      options = { refresh: 'wait_for' },
-      result = {};
+    const result = {};
 
-    return this.kuzzle.repositories.user.truncate(options)
-      .then(deletedUsers => {
-        result.deletedUsers = deletedUsers;
-        return this.kuzzle.repositories.profile.truncate(options);
-      })
-      .then(deletedProfiles => {
-        result.deletedProfiles = deletedProfiles;
-        return this.kuzzle.repositories.role.truncate(options);
-      })
-      .then(deletedRoles => {
-        result.deletedRoles = deletedRoles;
-        return this.kuzzle.internalIndex.bootstrap.createInitialSecurities();
-      })
-      .then(({ profileIds, roleIds }) => (
-        Bluebird.all([
-          this.kuzzle.repositories.profile.loadProfiles(profileIds, { resetCache: true }),
-          this.kuzzle.repositories.role.loadRoles(roleIds, { resetCache: true })
-        ])
-      ))
-      .then(() => {
-        delete _locks.resetSecurity;
+    try {
+      const repositories = this.kuzzle.repositories;
 
-        return result;
-      })
-      .catch(error => {
-        delete _locks.resetSecurity;
-        throw error;
-      });
+      const options = { refresh: 'wait_for' };
+
+      result.deletedUsers = await repositories.user.truncate(options);
+      result.deletedProfiles = await repositories.profile.truncate(options);
+      result.deletedRoles = await repositories.role.truncate(options);
+
+      const { profileIds, roleIds } = await this.kuzzle.internalIndex
+        .bootstrap
+        .createInitialSecurities();
+
+      await Bluebird.all([
+        repositories.profile.loadProfiles(profileIds, { resetCache: true }),
+        repositories.role.loadRoles(roleIds, { resetCache: true })
+      ]);
+    }
+    finally {
+      delete _locks.resetSecurity;
+    }
+
+    return result;
   }
 
   /**

--- a/lib/core/models/repositories/repository.js
+++ b/lib/core/models/repositories/repository.js
@@ -414,42 +414,37 @@ class Repository {
    * @param {object} part
    * @returns {Promise<integer>} total deleted objects
    */
-  truncate (options, part = null) {
+  async truncate (options, part = null) {
     if (part === null) {
-      return this.search({}, { scroll: '5s', size: 100 })
-        .then(objects => {
-          return this._truncatePart(objects, options)
-            .then(deletedObjects => {
+      const objects = await this.search({}, { scroll: '5s', size: 100 });
+      const deleted = await this._truncatePart(objects, options);
 
-              if (objects.hits.length < objects.total) {
-                return this.truncate(options, {
-                  fetched: objects.hits.length,
-                  scrollId: objects.scrollId,
-                  total: objects.total
-                }).then(total => deletedObjects + total);
-              }
-
-              return deletedObjects;
-            });
+      if (objects.hits.length < objects.total) {
+        const total = await this.truncate(options, {
+          fetched: objects.hits.length,
+          scrollId: objects.scrollId,
+          total: objects.total
         });
+
+        return deleted + total;
+      }
+
+      return deleted;
     }
 
-    return this.scroll(part.scrollId, '5s')
-      .then(objects => {
-        return this._truncatePart(objects, options)
-          .then(deletedObjects => {
-            part.fetched += objects.hits.length;
+    const objects = await this.scroll(part.scrollId, '5s');
+    const deleted = await this._truncatePart(objects, options);
 
-            if (part.fetched < part.total) {
-              part.scrollId = objects.scrollId;
+    part.fetched += objects.hits.length;
 
-              return this.truncate(options, part)
-                .then(total => deletedObjects + total);
-            }
+    if (part.fetched < part.total) {
+      part.scrollId = objects.scrollId;
 
-            return deletedObjects;
-          });
-      });
+      const total = await this.truncate(options, part);
+      return deleted + total;
+    }
+
+    return deleted;
   }
 
   /**
@@ -458,22 +453,26 @@ class Repository {
    * @returns {Promise<integer>} count of deleted objects
    * @private
    */
-  _truncatePart(objects, options) {
-    return Bluebird.map(objects.hits, object => {
-      // profile and role repositories have protected objects, we can't delete them
-      const protectedObjects = ['profiles', 'roles']
-        .indexOf(this.collection) !== -1
-        ? ['admin', 'default', 'anonymous']
-        : [];
+  async _truncatePart(objects, options) {
+    return Bluebird
+      .map(objects.hits, async object => {
+        // profile and role repositories have protected objects, we can't delete
+        // them
+        const protectedObjects = ['profiles', 'roles']
+          .indexOf(this.collection) !== -1
+          ? ['admin', 'default', 'anonymous']
+          : [];
 
-      if (protectedObjects.indexOf(object._id) !== -1) {
-        return 0;
-      }
+        if (protectedObjects.indexOf(object._id) !== -1) {
+          return 0;
+        }
 
-      return this.load(object._id)
-        .then(obj => this.delete(obj, options))
-        .then(() => 1);
-    }).reduce((total, deleted) => total + deleted, 0);
+        const loaded = await this.load(object._id);
+        await this.delete(loaded, options);
+
+        return 1;
+      })
+      .reduce((total, deleted) => total + deleted, 0);
   }
 
   /**

--- a/lib/core/models/repositories/userRepository.js
+++ b/lib/core/models/repositories/userRepository.js
@@ -22,7 +22,6 @@
 'use strict';
 
 const debug = require('../../../util/debug')('kuzzle:repositories:user');
-const Bluebird = require('bluebird');
 const {v4: uuid} = require('uuid');
 const User = require('../security/user');
 const Repository = require('./repository');

--- a/lib/core/models/repositories/userRepository.js
+++ b/lib/core/models/repositories/userRepository.js
@@ -21,55 +21,14 @@
 
 'use strict';
 
-const
-  debug = require('../../../util/debug')('kuzzle:repositories:user'),
-  Bluebird = require('bluebird'),
-  {v4: uuid} = require('uuid'),
-  User = require('../security/user'),
-  Repository = require('./repository'),
-  errorsManager = require('../../../util/errors'),
-  ApiKey = require('../../storage/models/apiKey'),
-  { Request } = require('kuzzle-common-objects');
-
-/**
- * @param {Kuzzle} kuzzle
- * @param {User} user
- */
-const removeUserStrategies = Bluebird.coroutine(function* removeUserGenerator (kuzzle, user) {
-  const
-    availableStrategies = kuzzle.pluginsManager.listStrategies(),
-    userStrategies = [],
-    errors = [],
-    request = new Request({ _id: user._id });
-
-  for (const strategy of availableStrategies) {
-    const
-      existsMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'exists'),
-      existStrategy = yield existsMethod(request, user._id, strategy);
-
-    if (existStrategy) {
-      userStrategies.push(strategy);
-    }
-  }
-
-  if (userStrategies.length > 0) {
-    for (const strategy of userStrategies) {
-      const
-        deleteMethod = kuzzle.pluginsManager.getStrategyMethod(strategy, 'delete');
-
-      // We catch any error produced by delete as we want to make as much cleanup as possible
-      yield deleteMethod(request, user._id, strategy)
-        .catch(error => {
-          errors.push(error);
-          return Bluebird.reject(error);
-        });
-    }
-  }
-
-  if (errors.length > 0) {
-    throw errorsManager.get('security', 'credentials', 'rejected', errors.join('\n\t- '));
-  }
-});
+const debug = require('../../../util/debug')('kuzzle:repositories:user');
+const Bluebird = require('bluebird');
+const {v4: uuid} = require('uuid');
+const User = require('../security/user');
+const Repository = require('./repository');
+const errorsManager = require('../../../util/errors');
+const ApiKey = require('../../storage/models/apiKey');
+const { Request } = require('kuzzle-common-objects');
 
 /**
  * @class UserRepository
@@ -188,14 +147,57 @@ class UserRepository extends Repository {
    * @param {object} [options]
    * @returns {Promise}
    */
-  delete (user, options = {}) {
+  async delete (user, options = {}) {
     debug('Delete user %a', user);
 
-    return super.delete(user, options)
-      .then(() => removeUserStrategies(this.kuzzle, user))
-      .then(() => ApiKey.deleteByUser(user, options))
-      .then(() => this.kuzzle.repositories.token.deleteByUserId(user._id))
-      .then(() => ({ _id: user._id }));
+    await super.delete(user, options);
+    await this._removeUserStrategies(user);
+    await ApiKey.deleteByUser(user, options);
+    await this.kuzzle.repositories.token.deleteByUserId(user._id);
+
+    return { _id: user._id };
+  }
+
+  async _removeUserStrategies (user) {
+    const availableStrategies = this.kuzzle.pluginsManager.listStrategies();
+    const userStrategies = [];
+    const request = new Request({ _id: user._id });
+
+    for (const strategy of availableStrategies) {
+      const existStrategy = this.kuzzle.pluginsManager.getStrategyMethod(
+        strategy,
+        'exists');
+
+      if (await existStrategy(request, user._id, strategy)) {
+        userStrategies.push(strategy);
+      }
+    }
+
+    const errors = [];
+    if (userStrategies.length > 0) {
+      for (const strategy of userStrategies) {
+        const deleteStrategy = this.kuzzle.pluginsManager.getStrategyMethod(
+          strategy,
+          'delete');
+
+        // We catch any error produced by delete as we want to make as much
+        // cleanup as possible
+        try {
+          await deleteStrategy(request, user._id, strategy);
+        }
+        catch (error) {
+          errors.push(error);
+        }
+      }
+    }
+
+    if (errors.length > 0) {
+      throw errorsManager.get(
+        'security',
+        'credentials',
+        'rejected',
+        errors.join('\n\t- '));
+    }
   }
 }
 

--- a/lib/core/storage/models/baseModel.js
+++ b/lib/core/storage/models/baseModel.js
@@ -193,31 +193,17 @@ class BaseModel {
    * Deletes all instances matching the given query.
    *  - the instance delete method will be called on each occurence
    *
-   * @param {Object} query - Query to march (eg: { match_all: {} })
+   * @param {Object} query - Search query (e.g. { match_all: {} })
    * @param {Object} options - refresh (undefined)
    *
    * @returns {Promise}
    */
   static async deleteByQuery (query, { refresh } = {}) {
-    const promises = [];
-
-    await this.batchExecute(
-      query,
-      documents => {
-        for (const document of documents) {
-          const model = this._instantiateFromDb(document);
-          promises.push(model.delete());
-        }
-      });
-
-    const promise = Bluebird.all(promises);
+    await BaseModel.indexStorage.deleteByQuery(this.collection, query);
 
     if (refresh) {
-      await promise;
       return BaseModel.indexStorage.refreshCollection(this.collection);
     }
-
-    return promise;
   }
 
   /**

--- a/lib/core/storage/models/baseModel.js
+++ b/lib/core/storage/models/baseModel.js
@@ -209,7 +209,7 @@ class BaseModel {
       {concurrency: 10}); // limits the load on storage services
 
     if (refresh) {
-      return BaseModel.indexStorage.refreshCollection(this.collection);
+      await BaseModel.indexStorage.refreshCollection(this.collection);
     }
   }
 

--- a/lib/core/storage/models/baseModel.js
+++ b/lib/core/storage/models/baseModel.js
@@ -199,7 +199,14 @@ class BaseModel {
    * @returns {Promise}
    */
   static async deleteByQuery (query, { refresh } = {}) {
-    await BaseModel.indexStorage.deleteByQuery(this.collection, query);
+    const { documents } = await BaseModel.indexStorage.deleteByQuery(
+      this.collection,
+      query);
+
+    await Bluebird.map(
+      documents,
+      document => this._instantiateFromDb(document)._afterDelete(),
+      {concurrency: 10}); // limits the load on storage services
 
     if (refresh) {
       return BaseModel.indexStorage.refreshCollection(this.collection);

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -213,11 +213,12 @@ class ElasticSearch extends Service {
     }
 
     let fetched = await this._kuzzle.cacheEngine.internal.get(cacheKey);
-    fetched = Number.parseInt(fetched);
 
     if (!fetched) {
       throw errorsManager.get('unknown_scroll_id');
     }
+
+    fetched = Number.parseInt(fetched);
 
     try {
       const { body } = await this._client.scroll(esRequest);
@@ -808,13 +809,13 @@ class ElasticSearch extends Service {
     }
 
     const client = this._client;
-    const results = [];
+    let results = [];
 
     let processed = 0;
     let scrollId = null;
 
     try {
-      await new Bluebird((resolve, reject) => {
+      results = await new Bluebird((resolve, reject) => {
         this._client.search(
           esRequest,
           async function getMoreUntilDone(error, { body: { hits, _scroll_id } }) {
@@ -845,6 +846,8 @@ class ElasticSearch extends Service {
     finally {
       this.clearScroll(scrollId);
     }
+
+    return results;
   }
 
   /**

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -36,7 +36,6 @@ const { assertIsObject } = require('../util/requestAssertions');
 const errorsManager = require('../util/errors').wrap('services', 'storage');
 const { isPlainObject } = require('../util/safeObject');
 
-
 const SCROLL_CACHE_PREFIX = '_docscroll_';
 
 const ROOT_MAPPING_PROPERTIES = ['properties', '_meta', 'dynamic', 'dynamic_templates'];
@@ -184,17 +183,16 @@ class ElasticSearch extends Service {
   }
 
   /**
-   * Scrolls results from previous elasticsearch query
+   * Scrolls results from previous elasticsearch query.
+   * Automatically clears the scroll context after the last result page has
+   * been fetched.
    *
    * @param {String} scrollId - Scroll identifier
    * @param {Object} options - scrollTTL (default scrollTTL)
    *
    * @returns {Promise.<Object>} { scrollId, hits, aggregations, total }
    */
-  async scroll (
-    scrollId,
-    { scrollTTL } = {})
-  {
+  async scroll (scrollId, { scrollTTL } = {}) {
     const _scrollTTL = scrollTTL || this._config.defaults.scrollTTL;
     const esRequest = {
       scroll: _scrollTTL,
@@ -214,19 +212,29 @@ class ElasticSearch extends Service {
       }
     }
 
-    const exists = await this._kuzzle.cacheEngine.internal.exists(cacheKey);
+    let fetched = await this._kuzzle.cacheEngine.internal.get(cacheKey);
+    fetched = Number.parseInt(fetched);
 
-    if (exists === 0) {
+    if (!fetched) {
       throw errorsManager.get('unknown_scroll_id');
     }
 
-    // ms(scroll) may return undefined if in microseconds or in nanoseconds
-    const ttl = ms(_scrollTTL) || this.scrollTTL;
-
-    await this._kuzzle.cacheEngine.internal.pexpire(cacheKey, ttl);
-
     try {
       const { body } = await this._client.scroll(esRequest);
+
+      fetched += body.hits.hits.length;
+
+      if (fetched >= body.hits.total.value) {
+        debug('Last scroll page fetched: deleting scroll %s', body._scroll_id);
+        await this._kuzzle.cacheEngine.internal.del(cacheKey);
+        await this.clearScroll(body._scroll_id);
+      }
+      else {
+        await this._kuzzle.cacheEngine.internal.psetex(
+          cacheKey,
+          ms(_scrollTTL) || this.scrollTTL,
+          fetched);
+      }
 
       return this._formatSearchResult(body);
     }
@@ -275,9 +283,11 @@ class ElasticSearch extends Service {
       if (body._scroll_id) {
         const ttl = esRequest.scroll && ms(esRequest.scroll)
           || ms(this._config.defaults.scrollTTL);
-        const key = SCROLL_CACHE_PREFIX + this._kuzzle.constructor.hash(body._scroll_id);
 
-        await this._kuzzle.cacheEngine.internal.psetex(key, ttl, 0);
+        await this._kuzzle.cacheEngine.internal.psetex(
+          SCROLL_CACHE_PREFIX + this._kuzzle.constructor.hash(body._scroll_id),
+          ttl,
+          body.hits.hits.length);
       }
 
       return this._formatSearchResult(body);
@@ -684,6 +694,8 @@ class ElasticSearch extends Service {
       throw errorsManager.get('missing_argument', 'body.query');
     }
 
+    debug('delete by query: %o', esRequest);
+
     await this.refreshCollection(index, collection);
 
     try {
@@ -776,7 +788,7 @@ class ElasticSearch extends Service {
    *
    * @returns {Promise.<any[]>} Array of results returned by the callback
    */
-  batchExecute (
+  async batchExecute (
     index,
     collection,
     query,
@@ -792,40 +804,47 @@ class ElasticSearch extends Service {
     };
 
     if (! _.isPlainObject(query)) {
-      return errorsManager.reject('missing_argument', 'body.query');
+      throw errorsManager.get('missing_argument', 'body.query');
     }
 
-    const
-      client = this._client,
-      results = [];
+    const client = this._client;
+    const results = [];
 
     let processed = 0;
+    let scrollId = null;
 
-    return new Bluebird((resolve, reject) => {
-      this._client.search(
-        esRequest,
-        async function getMoreUntilDone(error, { body: { hits, _scroll_id } }) {
-          if (error) {
-            reject(error);
-            return;
-          }
+    try {
+      await new Bluebird((resolve, reject) => {
+        this._client.search(
+          esRequest,
+          async function getMoreUntilDone(error, { body: { hits, _scroll_id } }) {
+            if (error) {
+              reject(error);
+              return;
+            }
 
-          const ret = callback(hits.hits);
+            scrollId = _scroll_id;
 
-          results.push(await ret);
-          processed += hits.hits.length;
+            const ret = callback(hits.hits);
 
-          if (hits.total.value !== processed) {
-            client.scroll({
-              scroll: esRequest.scroll,
-              scrollId: _scroll_id
-            }, getMoreUntilDone);
-          }
-          else {
-            resolve(results);
-          }
-        });
-    });
+            results.push(await ret);
+            processed += hits.hits.length;
+
+            if (hits.total.value !== processed) {
+              client.scroll({
+                scroll: esRequest.scroll,
+                scrollId: _scroll_id
+              }, getMoreUntilDone);
+            }
+            else {
+              resolve(results);
+            }
+          });
+      });
+    }
+    finally {
+      this.clearScroll(scrollId);
+    }
   }
 
   /**
@@ -2196,7 +2215,7 @@ class ElasticSearch extends Service {
     let documents = hits.hits.map(h => ({ _id: h._id, _source: h._source }));
 
     while (hits.total.value !== documents.length) {
-      ({ body: { hits, _scroll_id } } = await this._client.scroll({ //NOSONAR
+      ({ body: { hits, _scroll_id } } = await this._client.scroll({
         scroll: esRequest.scroll,
         scrollId: _scroll_id
       }));
@@ -2206,6 +2225,8 @@ class ElasticSearch extends Service {
         _source: h._source
       })));
     }
+
+    await this.clearScroll(_scroll_id);
 
     return documents;
   }
@@ -2249,6 +2270,18 @@ class ElasticSearch extends Service {
    */
   isIndexNameValid (name) {
     return _isObjectNameValid(name);
+  }
+
+  /**
+   * Clears an allocated scroll
+   * @param  {[type]} id [description]
+   * @return {[type]}    [description]
+   */
+  async clearScroll (id) {
+    if (id) {
+      debug('clearing scroll: %s', id);
+      await this._client.clearScroll({scrollId: id});
+    }
   }
 
   /**

--- a/test/core/storage/models/baseModel.test.js
+++ b/test/core/storage/models/baseModel.test.js
@@ -1,12 +1,11 @@
 'use strict';
 
-const
-  should = require('should'),
-  sinon = require('sinon'),
-  mockrequire = require('mock-require'),
-  KuzzleMock = require('../../../mocks/kuzzle.mock'),
-  ClientAdapterMock = require('../../../mocks/clientAdapter.mock'),
-  BaseModel = require('../../../../lib/core/storage/models/baseModel');
+const should = require('should');
+const sinon = require('sinon');
+const mockrequire = require('mock-require');
+const KuzzleMock = require('../../../mocks/kuzzle.mock');
+const ClientAdapterMock = require('../../../mocks/clientAdapter.mock');
+const BaseModel = require('../../../../lib/core/storage/models/baseModel');
 
 class Model extends BaseModel {
   constructor (_source, _id) {
@@ -25,10 +24,9 @@ class Model extends BaseModel {
 BaseModel.register(Model);
 
 describe('BaseModel', () => {
-  let
-    StorageEngine,
-    storageEngine,
-    kuzzle;
+  let StorageEngine;
+  let storageEngine;
+  let kuzzle;
 
   beforeEach(() => {
     Model.prototype._afterDelete = sinon.stub().resolves();
@@ -125,30 +123,25 @@ describe('BaseModel', () => {
   });
 
   describe('BaseModel.deleteByQuery', () => {
-    let
-      documents,
-      deleteStub;
+    let documents;
 
     beforeEach(() => {
-      deleteStub = sinon.stub(Model.prototype, 'delete').resolves();
-
       documents = [
         { _id: 'mylehuong', _source: {} },
         { _id: 'thehive', _source: {} }
       ];
 
-      BaseModel.indexStorage.batchExecute =
-        sinon.stub().callsArgWith(2, documents);
+      BaseModel.indexStorage.deleteByQuery = sinon.stub().resolves({documents});
     });
 
-    it('should call batchExecute and delete each instantiated model', async () => {
+    it('should call the driver\'s deleteByQuery', async () => {
       await Model.deleteByQuery({ match_all: {} });
 
-      should(BaseModel.indexStorage.batchExecute).be.calledOnce();
-      const [ collection, query ] = BaseModel.indexStorage.batchExecute.getCall(0).args;
+      should(BaseModel.indexStorage.deleteByQuery).be.calledOnce();
+      const [ collection, query ] = BaseModel.indexStorage.deleteByQuery.getCall(0).args;
       should(collection).be.eql('models');
       should(query).be.eql({ match_all: {} });
-      should(deleteStub).be.calledTwice();
+      should(Model.prototype._afterDelete).be.calledTwice();
     });
 
     it('should refresh the collection if the option.refresh is set', async () => {

--- a/test/mocks/elasticsearch.mock.js
+++ b/test/mocks/elasticsearch.mock.js
@@ -1,8 +1,7 @@
 'use strict';
 
-const
-  sinon = require('sinon'),
-  Elasticsearch = require('../../lib/services/elasticsearch');
+const sinon = require('sinon');
+const Elasticsearch = require('../../lib/services/elasticsearch');
 
 class ElasticsearchMock extends Elasticsearch {
   constructor (kuzzle, config, scope) {
@@ -42,6 +41,7 @@ class ElasticsearchMock extends Elasticsearch {
     this.mReplace = sinon.stub().resolves();
     this.mDelete = sinon.stub().resolves();
     this.deleteCollection = sinon.stub().resolves();
+    this.clearScroll = sinon.stub().resolves();
   }
 }
 

--- a/test/mocks/services/elasticsearchClient.mock.js
+++ b/test/mocks/services/elasticsearchClient.mock.js
@@ -59,6 +59,7 @@ class ElasticsearchClientMock {
     this.mreplace = sinon.stub().resolves();
     this.mcreateOrReplace = sinon.stub().resolves();
     this.mdelete = sinon.stub().resolves();
+    this.clearScroll = sinon.stub().resolves();
   }
 }
 


### PR DESCRIPTION
# Description

Elasticsearch's scroll contexts are very expensive to maintain. So much in fact that ES impose a (configurable) limit on how many scroll contexts can exist at any given time([500 by default](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/search-request-body.html#scroll-search-context)).

ES API contains the [clearScroll](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/search-request-body.html#_clear_scroll_api) route, allowing to destroy an active scroll context.

This is especially useful when Kuzzle performs large numbers of search operations, such as done by `admin:resetSecurity`: I ran into a problem running that route with thousands of users in ES, each one containing 1 API Key. The command always failed with an ES error because there were too many scroll contexts opened. All by Kuzzle itself.

# The actual fix

There are multiple fixes:
1. Limit the number of scroll contexts opened by `repositories.user.truncate` (invoked by `admin:resetSecurity`) and in particular, get rid of `batchExecute` for removing API keys. Instead, use `deleteByQuery`. Also, `batchExecute` now clears the scroll context it creates.
1. Keep track of items fetched by scroll invocations: we already store a Redis key whenever a scroll ID is created to track what scroll contexts are used, and with what Kuzzle API route. Instead of having only the key existing or not, it now stores the number of items fetched. Once all items have been fetched through scroll calls, Kuzzle now destroys the scroll context immediately

All search/scroll queries executed by Kuzzle use their ES service counterpart, so all scroll contexts created by Kuzzle should now automatically be destroyed once all results have been fetched.

# How to reproduce

Load thousands of users, each one with an API key, into Kuzzle. Then run `admin:resetSecurity`.

Before this fix, the route fails (quite quickly) on an ES error because too many scroll contexts are opened.
This doesn't happen anymore with this fix.

# A word about tests

Normally, we would need test reproducing the bug, to prove that it is fixed. Due to the nature of this bug, only unit tests are ensuring that scroll contexts are correctly managed, but there is no actual test reproducing this specific bug.
