### PR TITLE
fix security methods not throwing Kuzzle errors

### DIFF
--- a/lib/api/controllers/security.js
+++ b/lib/api/controllers/security.js
@@ -133,14 +133,15 @@ const persistUser = Bluebird.coroutine(
           strategy,
           false);
       } catch (error) {
-        if (! (error instanceof KuzzleError)) {
-          throw errorsManager.getFrom(
-            error,
-            'security',
-            'credentials',
-            'rejected',
-            error.message);
+        if (error instanceof KuzzleError) {
+          throw error;
         }
+        throw errorsManager.getFrom(
+          error,
+          'security',
+          'credentials',
+          'rejected',
+          error.message);
       }
     }
 


### PR DESCRIPTION
Bug fix to re-throw errors issued by a strategy `validate` method.