### PR TITLE
Add token hash in API key

### DIFF
--- a/doc/2/api/controllers/auth/create-api-key/index.md
+++ b/doc/2/api/controllers/auth/create-api-key/index.md
@@ -74,6 +74,7 @@ Returns an object containing the newly created API key:
   - `expiresAt`: expiration date in UNIX micro-timestamp format (`-1` if the token never expires)
   - `ttl`: original ttl
   - `description`: description
+  - `hash`: SHA256 hash of the authentication token
   - `token`: authentication token associated with this API key
 
 ::: warning
@@ -94,6 +95,7 @@ The authentication token `token` will never be returned by Kuzzle again. If you 
       "expiresAt": -1,
       "ttl": -1,
       "description": "Sigfox callback authentication token",
+      "hash": "4ee98cb8c614e99213e7695f822e42325d86c93cfaf39cb40e860939e784c8e6",
       "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJfaWQiOiJNeSIsImlhdCI6MTU3MzE4NTkzNSwiZXhwIjoxNTczMTg1OTM0fQ.08qAnSD03V0N1OcviGVUAZEjjv4DxULTgoQQwojn1PA"
     }
   }

--- a/doc/2/api/controllers/auth/create-api-key/index.md
+++ b/doc/2/api/controllers/auth/create-api-key/index.md
@@ -74,7 +74,7 @@ Returns an object containing the newly created API key:
   - `expiresAt`: expiration date in UNIX micro-timestamp format (`-1` if the token never expires)
   - `ttl`: original ttl
   - `description`: description
-  - `hash`: SHA256 hash of the authentication token
+  - `fingerprint`: SHA256 hash of the authentication token
   - `token`: authentication token associated with this API key
 
 ::: warning
@@ -95,7 +95,7 @@ The authentication token `token` will never be returned by Kuzzle again. If you 
       "expiresAt": -1,
       "ttl": -1,
       "description": "Sigfox callback authentication token",
-      "hash": "4ee98cb8c614e99213e7695f822e42325d86c93cfaf39cb40e860939e784c8e6",
+      "fingerprint": "4ee98cb8c614e99213e7695f822e42325d86c93cfaf39cb40e860939e784c8e6",
       "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJfaWQiOiJNeSIsImlhdCI6MTU3MzE4NTkzNSwiZXhwIjoxNTczMTg1OTM0fQ.08qAnSD03V0N1OcviGVUAZEjjv4DxULTgoQQwojn1PA"
     }
   }

--- a/doc/2/api/controllers/auth/search-api-keys/index.md
+++ b/doc/2/api/controllers/auth/search-api-keys/index.md
@@ -9,7 +9,7 @@ title: searchApiKeys
 Searches for API keys.
 
 ::: info
-To search for an API key corresponding to a token you can search on the `hash` property which is a SHA256 hash of the token.
+To search for an API key corresponding to a token you can search on the `fingerprint` property which is a SHA256 hash of the token.
 :::
 
 ---

--- a/doc/2/api/controllers/auth/search-api-keys/index.md
+++ b/doc/2/api/controllers/auth/search-api-keys/index.md
@@ -8,6 +8,10 @@ title: searchApiKeys
 
 Searches for API keys.
 
+::: info
+To search for an API key corresponding to a token you can search on the `hash` property which is a SHA256 hash of the token.
+:::
+
 ---
 
 ## Query Syntax

--- a/doc/2/api/controllers/security/create-api-key/index.md
+++ b/doc/2/api/controllers/security/create-api-key/index.md
@@ -77,6 +77,7 @@ Returns an object containing the newly created API key:
   - `expiresAt`: expiration date in UNIX micro-timestamp format (`-1` if the token never expires)
   - `ttl`: original ttl
   - `description`: description
+  - `hash`: SHA256 hash of the authentication token
   - `token`: authentication token associated with this API key
 
 ::: warning
@@ -97,6 +98,7 @@ The authentication token `token` will never be returned by Kuzzle again. If you 
       "expiresAt": -1,
       "ttl": -1,
       "description": "Sigfox callback authentication token",
+      "hash": "4ee98cb8c614e99213e7695f822e42325d86c93cfaf39cb40e860939e784c8e6",
       "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJfaWQiOiJNeSIsImlhdCI6MTU3MzE4NTkzNSwiZXhwIjoxNTczMTg1OTM0fQ.08qAnSD03V0N1OcviGVUAZEjjv4DxULTgoQQwojn1PA"
     }
   }

--- a/doc/2/api/controllers/security/create-api-key/index.md
+++ b/doc/2/api/controllers/security/create-api-key/index.md
@@ -77,7 +77,7 @@ Returns an object containing the newly created API key:
   - `expiresAt`: expiration date in UNIX micro-timestamp format (`-1` if the token never expires)
   - `ttl`: original ttl
   - `description`: description
-  - `hash`: SHA256 hash of the authentication token
+  - `fingerprint`: SHA256 hash of the authentication token
   - `token`: authentication token associated with this API key
 
 ::: warning
@@ -98,7 +98,7 @@ The authentication token `token` will never be returned by Kuzzle again. If you 
       "expiresAt": -1,
       "ttl": -1,
       "description": "Sigfox callback authentication token",
-      "hash": "4ee98cb8c614e99213e7695f822e42325d86c93cfaf39cb40e860939e784c8e6",
+      "fingerprint": "4ee98cb8c614e99213e7695f822e42325d86c93cfaf39cb40e860939e784c8e6",
       "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJfaWQiOiJNeSIsImlhdCI6MTU3MzE4NTkzNSwiZXhwIjoxNTczMTg1OTM0fQ.08qAnSD03V0N1OcviGVUAZEjjv4DxULTgoQQwojn1PA"
     }
   }

--- a/doc/2/api/controllers/security/search-api-keys/index.md
+++ b/doc/2/api/controllers/security/search-api-keys/index.md
@@ -8,6 +8,10 @@ title: searchApiKeys
 
 Searches for a user API keys.
 
+::: info
+To search for an API key corresponding to a token you can search on the `hash` property which is a SHA256 hash of the token.
+:::
+
 ---
 
 ## Query Syntax

--- a/doc/2/api/controllers/security/search-api-keys/index.md
+++ b/doc/2/api/controllers/security/search-api-keys/index.md
@@ -9,7 +9,7 @@ title: searchApiKeys
 Searches for a user API keys.
 
 ::: info
-To search for an API key corresponding to a token you can search on the `hash` property which is a SHA256 hash of the token.
+To search for an API key corresponding to a token you can search on the `fingerprint` property which is a SHA256 hash of the token.
 :::
 
 ---

--- a/features-sdk/AuthController.feature
+++ b/features-sdk/AuthController.feature
@@ -17,7 +17,7 @@ Feature: Auth Controller
     And I can login with the previously created API key
     And I successfully call the route "auth":"searchApiKeys"
     Then I should receive a "hits" array of objects matching:
-      | _id        | _source.userId | _source.ttl | _source.expiresAt | _source.description | _source.hash |
+      | _id        | _source.userId | _source.ttl | _source.expiresAt | _source.description | _source.fingerprint |
       | "_STRING_" | "test-admin"   | -1          | -1                | "Sigfox API key"    | "_STRING_"   |
 
   # auth:searchApiKeys =====================================================
@@ -43,7 +43,7 @@ Feature: Auth Controller
     When I successfully call the route "auth":"searchApiKeys" with args:
       | body | { "match": { "description": "Lora" } } |
     Then I should receive a "hits" array of objects matching:
-      | _id        | _source.userId | _source.ttl | _source.expiresAt | _source.description | _source.hash |
+      | _id        | _source.userId | _source.ttl | _source.expiresAt | _source.description | _source.fingerprint |
       | "_STRING_" | "test-admin"   | -1          | -1                | "Lora API key"      | "_STRING_"   |
       | "_STRING_" | "test-admin"   | -1          | -1                | "Lora API key 2"    | "_STRING_"   |
 

--- a/features-sdk/AuthController.feature
+++ b/features-sdk/AuthController.feature
@@ -17,8 +17,8 @@ Feature: Auth Controller
     And I can login with the previously created API key
     And I successfully call the route "auth":"searchApiKeys"
     Then I should receive a "hits" array of objects matching:
-      | _id        | _source.userId | _source.ttl | _source.expiresAt | _source.description |
-      | "_STRING_" | "test-admin"   | -1          | -1                | "Sigfox API key"    |
+      | _id        | _source.userId | _source.ttl | _source.expiresAt | _source.description | _source.hash |
+      | "_STRING_" | "test-admin"   | -1          | -1                | "Sigfox API key"    | "_STRING_"   |
 
   # auth:searchApiKeys =====================================================
 
@@ -43,9 +43,9 @@ Feature: Auth Controller
     When I successfully call the route "auth":"searchApiKeys" with args:
       | body | { "match": { "description": "Lora" } } |
     Then I should receive a "hits" array of objects matching:
-      | _id        | _source.userId | _source.ttl | _source.expiresAt | _source.description |
-      | "_STRING_" | "test-admin"   | -1          | -1                | "Lora API key"      |
-      | "_STRING_" | "test-admin"   | -1          | -1                | "Lora API key 2"    |
+      | _id        | _source.userId | _source.ttl | _source.expiresAt | _source.description | _source.hash |
+      | "_STRING_" | "test-admin"   | -1          | -1                | "Lora API key"      | "_STRING_"   |
+      | "_STRING_" | "test-admin"   | -1          | -1                | "Lora API key 2"    | "_STRING_"   |
 
   # auth:deleteApiKey =======================================================
 

--- a/features-sdk/SecurityController.feature
+++ b/features-sdk/SecurityController.feature
@@ -43,8 +43,8 @@ Feature: Security Controller
     And I successfully call the route "security":"searchApiKeys" with args:
       | userId | "My" |
     Then I should receive a "hits" array of objects matching:
-      | _id        | _source.userId | _source.ttl | _source.expiresAt | _source.description |
-      | "_STRING_" | "My"           | -1          | -1                | "Le Huong"          |
+      | _id        | _source.userId | _source.ttl | _source.expiresAt | _source.description | _source.hash |
+      | "_STRING_" | "My"           | -1          | -1                | "Le Huong"          | "_STRING_"   |
 
   # security:searchApiKeys =====================================================
 
@@ -73,9 +73,9 @@ Feature: Security Controller
       | userId | "test-admin"                           |
       | body   | { "match": { "description": "Lora" } } |
     Then I should receive a "hits" array of objects matching:
-      | _id        | _source.userId | _source.ttl | _source.expiresAt | _source.description |
-      | "_STRING_" | "test-admin"   | -1          | -1                | "Lora API key"      |
-      | "_STRING_" | "test-admin"   | -1          | -1                | "Lora API key 2"    |
+      | _id        | _source.userId | _source.ttl | _source.expiresAt | _source.description | _source.hash |
+      | "_STRING_" | "test-admin"   | -1          | -1                | "Lora API key"      | "_STRING_"   |
+      | "_STRING_" | "test-admin"   | -1          | -1                | "Lora API key 2"    | "_STRING_"   |
 
   # security:deleteApiKey =======================================================
 

--- a/features-sdk/SecurityController.feature
+++ b/features-sdk/SecurityController.feature
@@ -43,7 +43,7 @@ Feature: Security Controller
     And I successfully call the route "security":"searchApiKeys" with args:
       | userId | "My" |
     Then I should receive a "hits" array of objects matching:
-      | _id        | _source.userId | _source.ttl | _source.expiresAt | _source.description | _source.hash |
+      | _id        | _source.userId | _source.ttl | _source.expiresAt | _source.description | _source.fingerprint |
       | "_STRING_" | "My"           | -1          | -1                | "Le Huong"          | "_STRING_"   |
 
   # security:searchApiKeys =====================================================
@@ -73,7 +73,7 @@ Feature: Security Controller
       | userId | "test-admin"                           |
       | body   | { "match": { "description": "Lora" } } |
     Then I should receive a "hits" array of objects matching:
-      | _id        | _source.userId | _source.ttl | _source.expiresAt | _source.description | _source.hash |
+      | _id        | _source.userId | _source.ttl | _source.expiresAt | _source.description | _source.fingerprint |
       | "_STRING_" | "test-admin"   | -1          | -1                | "Lora API key"      | "_STRING_"   |
       | "_STRING_" | "test-admin"   | -1          | -1                | "Lora API key 2"    | "_STRING_"   |
 

--- a/lib/core/storage/models/apiKey.js
+++ b/lib/core/storage/models/apiKey.js
@@ -21,10 +21,15 @@
 
 'use strict';
 
-const
-  debug = require('../../../util/debug')('kuzzle:models:apiKey'),
-  errorsManager = require('../../../util/errors'),
-  BaseModel = require('./baseModel');
+const debug = require('../../../util/debug')('kuzzle:models:apiKey');
+const errorsManager = require('../../../util/errors');
+const BaseModel = require('./baseModel');
+const crypto = require('crypto');
+
+function sha256 (string) {
+  return crypto.createHash('sha256').update(string).digest('hex');
+}
+
 class ApiKey extends BaseModel {
   constructor (_source, _id = null) {
     super(_source, _id);
@@ -66,7 +71,7 @@ class ApiKey extends BaseModel {
    * @override
    */
   static get fields () {
-    return ['userId', 'description', 'expiresAt', 'ttl', 'token'];
+    return ['userId', 'description', 'expiresAt', 'ttl', 'token', 'hash'];
   }
 
   /**
@@ -87,20 +92,20 @@ class ApiKey extends BaseModel {
     description,
     { creatorId=null, apiKeyId=null, refresh } = {}
   ) {
-    const
-      token = await BaseModel.kuzzle.repositories.token.generateToken(
-        user,
-        connectionId,
-        { bypassMaxTTL: true, expiresIn }),
-      apiKey = new ApiKey(
-        {
-          description,
-          expiresAt: token.expiresAt,
-          token: token.jwt,
-          ttl: token.ttl,
-          userId: user._id
-        },
-        apiKeyId);
+    const token = await BaseModel.kuzzle.repositories.token.generateToken(
+      user,
+      connectionId,
+      { bypassMaxTTL: true, expiresIn });
+    const apiKey = new ApiKey(
+      {
+        description,
+        expiresAt: token.expiresAt,
+        hash: sha256(token.jwt),
+        token: token.jwt,
+        ttl: token.ttl,
+        userId: user._id
+      },
+      apiKeyId);
 
     await apiKey.save({ refresh, userId: creatorId });
 

--- a/lib/core/storage/models/apiKey.js
+++ b/lib/core/storage/models/apiKey.js
@@ -71,7 +71,7 @@ class ApiKey extends BaseModel {
    * @override
    */
   static get fields () {
-    return ['userId', 'description', 'expiresAt', 'ttl', 'token', 'hash'];
+    return ['userId', 'description', 'expiresAt', 'ttl', 'token', 'fingerprint'];
   }
 
   /**
@@ -100,7 +100,7 @@ class ApiKey extends BaseModel {
       {
         description,
         expiresAt: token.expiresAt,
-        hash: sha256(token.jwt),
+        fingerprint: sha256(token.jwt),
         token: token.jwt,
         ttl: token.ttl,
         userId: user._id

--- a/lib/util/esWrapper.js
+++ b/lib/util/esWrapper.js
@@ -205,14 +205,18 @@ class ESWrapper {
   _handleNotFoundError (error, message) {
     let errorMessage = message;
 
+    // _index= "&nyc-open-data.yellow-taxi"
+    const index = error.body._index.split('.')[0].slice(1);
+    const collection = error.body._index.split('.')[1];
+
     // 404 on a GET document
     if (error.body.found === false) {
-      return errorsManager.get('not_found', error.body._id);
+      return errorsManager.get('not_found', error.body._id, index, collection);
     }
 
     // 404 on DELETE document (ES error payloads are so cool!)
     if (error.meta.body._id) {
-      return errorsManager.get('not_found', error.meta.body._id);
+      return errorsManager.get('not_found', error.meta.body._id, index, collection);
     }
 
     if (error.meta.body && error.meta.body.error) {

--- a/test/core/storage/models/apiKey.test.js
+++ b/test/core/storage/models/apiKey.test.js
@@ -68,7 +68,7 @@ describe('ApiKey', () => {
       should(saveStub)
         .be.calledWith({ userId: 'aschen', refresh: 'wait_for' });
 
-      should(apiKey._source).be.eql({
+      should(apiKey._source).match({
         description: 'Sigfox API key',
         userId: 'mylehuong',
         expiresAt: 42,

--- a/test/util/esWrapper.test.js
+++ b/test/util/esWrapper.test.js
@@ -55,6 +55,7 @@ describe('Test: ElasticSearch Wrapper', () => {
       const error = new Error('test');
       error.meta = { statusCode: 404 };
       error.body = {
+        _index: '&nyc-open-data.yellow-taxi',
         found: false,
         _id: 'mehry',
         error: {
@@ -66,6 +67,7 @@ describe('Test: ElasticSearch Wrapper', () => {
       const formatted = esWrapper.formatESError(error);
 
       should(formatted).be.match({
+        message: 'Document "mehry" not found in "nyc-open-data":"yellow-taxi".',
         id: 'services.storage.not_found'
       });
     });


### PR DESCRIPTION
## What does this PR do ?

This PR adds an `hash` property corresponding to the SHA256 hash of the associated authentication token into the API key documents.  

This will allows users to search for an API key when they only got the authentication token.

### How should this be manually tested?

```
$ kourou query auth:createApiKey --body '{ description: "API Key" }'
# Keep the token value 
$ echo -n <token> | sha256sum
# Then search
$ kourou query auth:searchApiKeys --body '{ term: { hash: "<hash>" }}'
```

### Other changes

 - fix `services.storage.not_found` error message (add index and collection)
