### PR TITLE
Fix usage of search_after

### DIFF
--- a/features-sdk/DocumentController.feature
+++ b/features-sdk/DocumentController.feature
@@ -29,7 +29,7 @@ Feature: Document Controller
       """
       {
         "match": {
-          "name": "document"
+          "name": "document1"
         }
       }
       """

--- a/features-sdk/DocumentController.feature
+++ b/features-sdk/DocumentController.feature
@@ -22,7 +22,7 @@ Feature: Document Controller
     Given an existing collection "nyc-open-data":"yellow-taxi"
     And I "create" the following documents:
       | _id          | body                               |
-      | "document-1" | { "name": "document", "age": 42 }  |
+      | "document-1" | { "name": "document1", "age": 42 } |
       | -            | { "name": "document2", "age": 21 } |
     And I refresh the collection
     When I search documents with the following query:
@@ -43,8 +43,35 @@ Feature: Document Controller
       """
     And I execute the search query
     Then I should receive a "hits" array of objects matching:
-      | _id          | highlight                           |
-      | "document-1" | { "name": [ "<em>document</em>" ] } |
+      | _id          | highlight                            |
+      | "document-1" | { "name": [ "<em>document1</em>" ] } |
+
+  @mappings
+  Scenario: Search with search_after
+    Given an existing collection "nyc-open-data":"yellow-taxi"
+    And I "create" the following documents:
+      | _id          | body                               |
+      | "document-1" | { "name": "document1", "age": 42 } |
+      | "document-2" | { "name": "document2", "age": 21 } |
+      | "document-3" | { "name": "document2", "age": 84 } |
+    And I refresh the collection
+    When I search documents with the following search body:
+      """
+      {
+        "search_after": [
+          42
+        ],
+        "sort": [
+          {
+            "age": "asc"
+          }
+        ]
+      }
+      """
+    And I execute the search query
+    Then I should receive a "hits" array of objects matching:
+      | _id          |
+      | "document-3" |
 
   # document:exists ============================================================
 

--- a/features-sdk/step_definitions/documents-steps.js
+++ b/features-sdk/step_definitions/documents-steps.js
@@ -136,6 +136,12 @@ Then('I search documents with the following query:', function (queryRaw) {
   this.props.searchBody = { query };
 });
 
+Then('I search documents with the following search body:', function (searchBodyRaw) {
+  const searchBody = JSON.parse(searchBodyRaw);
+
+  this.props.searchBody = searchBody;
+});
+
 Then('with the following highlights:', function (highlightsRaw) {
   const highlights = JSON.parse(highlightsRaw);
 

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -101,6 +101,7 @@ class ElasticSearch extends Service {
       'from',
       'highlight',
       'query',
+      'search_after',
       'search_timeout',
       'size',
       'sort',


### PR DESCRIPTION
## What does this PR do ?

We forgot to allow `search_after` when we built our whitelist for the search body.

This PR fix that.