### PR TITLE
Add an empty updateByQuery after collection:update

### DIFF
--- a/doc/2/api/controllers/collection/update/index.md
+++ b/doc/2/api/controllers/collection/update/index.md
@@ -16,6 +16,10 @@ You can update the collection [mappings](/core/2/guides/essentials/database-mapp
 While updating the collection [settings](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/index-modules.html#index-modules-settings), the collection will be [closed](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-close.html) until the new configuration has been applied.
 :::
 
+::: info
+The search index is automatically refreshed, so you can perform a `document:search` on [new properties](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html#picking-up-a-new-property) right after.
+:::
+
 ---
 
 ## Query Syntax

--- a/features-sdk/CollectionController.feature
+++ b/features-sdk/CollectionController.feature
@@ -19,13 +19,13 @@ Feature: Collection Controller
   Scenario: Update a collection and search document
     Given an index "nyc-open-data"
     And I "create" the collection "nyc-open-data":"green-taxi" with:
-      | mappings | { "dynamic": "false", "properties": { "name": { "type": "keyword" } } } |
+      | mappings | { "dynamic": "true", "properties": { "name": { "type": "keyword" }, "metadata": {"properties": {}, "dynamic": "false"} } } |
     And I "create" the following documents:
       | _id          | body        |
-      | "document-1" | {"age": 2 } |
+      | "document-1" | {"age": 2} |
     And I refresh the collection
     When I "update" the collection "nyc-open-data":"green-taxi" with:
-      | mappings | { "properties": { "age": { "type": "integer" } } } |
+      | mappings | { "properties": { "age": { "type": "long" } } } |
     When I search documents with the following query:
       """
       {

--- a/features-sdk/CollectionController.feature
+++ b/features-sdk/CollectionController.feature
@@ -16,6 +16,29 @@ Feature: Collection Controller
     And I should receive a result matching:
       | properties | { "name": { "type": "keyword" }, "age": { "type": "integer" } } |
 
+  Scenario: Update a collection and search document
+    Given an index "nyc-open-data"
+    And I "create" the collection "nyc-open-data":"green-taxi" with:
+      | mappings | { "dynamic": "false", "properties": { "name": { "type": "keyword" } } } |
+    And I "create" the following documents:
+      | _id          | body        |
+      | "document-1" | {"age": 2 } |
+    And I refresh the collection
+    When I "update" the collection "nyc-open-data":"green-taxi" with:
+      | mappings | { "properties": { "age": { "type": "integer" } } } |
+    When I search documents with the following query:
+      """
+      {
+        "match": {
+          "age": 2
+        }
+      }
+      """
+    And I execute the search query
+    Then I should receive a "hits" array of objects matching:
+      | _id          | _source      |
+      | "document-1" | { "age": 2 } |
+
   # collection:truncate ========================================================
 
   Scenario: Truncate a collection

--- a/lib/api/controllers/collection.js
+++ b/lib/api/controllers/collection.js
@@ -371,7 +371,7 @@ class CollectionController extends NativeController {
       { index, collection } = this.getIndexAndCollection(request);
 
     await this.publicStorage.updateCollection(index, collection, config);
-
+    
     return null;
   }
 

--- a/lib/api/controllers/collection.js
+++ b/lib/api/controllers/collection.js
@@ -371,7 +371,7 @@ class CollectionController extends NativeController {
       { index, collection } = this.getIndexAndCollection(request);
 
     await this.publicStorage.updateCollection(index, collection, config);
-    
+
     return null;
   }
 

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -1004,6 +1004,7 @@ class ElasticSearch extends Service {
     try {
       if (!_.isEmpty(mappings)) {
         await this.updateMapping(index, collection, mappings);
+        await this.updateSearchIndex(index, collection);
       }
     }
     catch (error) {
@@ -1022,6 +1023,36 @@ class ElasticSearch extends Service {
     }
 
     return null;
+  }
+
+  /**
+  * Sends an empty UpdateByQuery request to update the search index
+  *
+  * @param {String} index - Index name
+  * @param {String} collection - Collection name
+  * @returns {Promise.<Object>} {}
+  */
+  async updateSearchIndex(
+    index,
+    collection) {
+
+    let esRequest;
+    try {
+      esRequest = {
+        body: {},
+        index: this._getESIndex(index, collection),
+        refresh: true
+      };
+    }
+    catch (error) {
+      throw this._esWrapper.formatESError(error);
+    }
+
+    debug('UpdateByQuery: %o', esRequest);
+
+    await this._client.update_by_query(esRequest);
+
+    return;
   }
 
   /**

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -1005,7 +1005,7 @@ class ElasticSearch extends Service {
       if (!_.isEmpty(mappings)) {
         const previousMappings = await this.getMapping(index, collection);
         await this.updateMapping(index, collection, mappings);
-        if (_.isMatch(previousMappings, { dynamic: 'false'})) {
+        if (JSON.stringify(previousMappings).includes('"dynamic":"false"')) {
           await this.updateSearchIndex(index, collection);
         }
       }

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -1051,8 +1051,6 @@ class ElasticSearch extends Service {
     debug('UpdateByQuery: %o', esRequest);
 
     await this._client.update_by_query(esRequest);
-
-    return;
   }
 
   /**

--- a/lib/services/elasticsearch.js
+++ b/lib/services/elasticsearch.js
@@ -1003,8 +1003,11 @@ class ElasticSearch extends Service {
 
     try {
       if (!_.isEmpty(mappings)) {
+        const previousMappings = await this.getMapping(index, collection);
         await this.updateMapping(index, collection, mappings);
-        await this.updateSearchIndex(index, collection);
+        if (_.isMatch(previousMappings, { dynamic: 'false'})) {
+          await this.updateSearchIndex(index, collection);
+        }
       }
     }
     catch (error) {
@@ -1036,21 +1039,18 @@ class ElasticSearch extends Service {
     index,
     collection) {
 
-    let esRequest;
     try {
-      esRequest = {
+      const esRequest = {
         body: {},
         index: this._getESIndex(index, collection),
         refresh: true
       };
+      debug('UpdateByQuery: %o', esRequest);
+      await this._client.update_by_query(esRequest);
     }
     catch (error) {
       throw this._esWrapper.formatESError(error);
     }
-
-    debug('UpdateByQuery: %o', esRequest);
-
-    await this._client.update_by_query(esRequest);
   }
 
   /**

--- a/test/services/elasticsearch.test.js
+++ b/test/services/elasticsearch.test.js
@@ -1583,12 +1583,14 @@ describe('Test: ElasticSearch service', () => {
       elasticsearch._client.indices.getSettings.resolves(oldSettings);
       elasticsearch.updateMapping = sinon.stub().resolves();
       elasticsearch.updateSettings = sinon.stub().resolves();
+      elasticsearch.updateSearchIndex = sinon.stub().resolves();
     });
-    it('should call updateSettings and updateMapping', async () => {
+    it('should call updateSettings, updateMapping and UpdateSearchIndex', async () => {
       await elasticsearch.updateCollection(index, collection, { mappings, settings });
 
       should(elasticsearch.updateSettings).be.calledWith(index, collection, settings);
       should(elasticsearch.updateMapping).be.calledWith(index, collection, mappings);
+      should(elasticsearch.updateSearchIndex).be.calledWith(index, collection);
     });
 
     it('should revert settings if updateMapping fail', () => {

--- a/test/services/elasticsearch.test.js
+++ b/test/services/elasticsearch.test.js
@@ -1585,7 +1585,7 @@ describe('Test: ElasticSearch service', () => {
       elasticsearch.updateSettings = sinon.stub().resolves();
       elasticsearch.updateSearchIndex = sinon.stub().resolves();
     });
-    it('should call updateSettings, updateMapping and UpdateSearchIndex', async () => {
+    it('should call updateSettings, updateMapping and updateSearchIndex', async () => {
       await elasticsearch.updateCollection(index, collection, { mappings, settings });
 
       should(elasticsearch.updateSettings).be.calledWith(index, collection, settings);

--- a/test/services/elasticsearch.test.js
+++ b/test/services/elasticsearch.test.js
@@ -1586,6 +1586,7 @@ describe('Test: ElasticSearch service', () => {
       elasticsearch.updateSearchIndex = sinon.stub().resolves();
     });
     it('should call updateSettings, updateMapping and updateSearchIndex', async () => {
+      elasticsearch.getMapping = sinon.stub().resolves({ dynamic: 'false', properties: { city: { type: 'keyword' } } });
       await elasticsearch.updateCollection(index, collection, { mappings, settings });
 
       should(elasticsearch.updateSettings).be.calledWith(index, collection, settings);
@@ -1593,7 +1594,17 @@ describe('Test: ElasticSearch service', () => {
       should(elasticsearch.updateSearchIndex).be.calledWith(index, collection);
     });
 
+    it('should call updateSettings and updateMapping', async () => {
+      elasticsearch.getMapping = sinon.stub().resolves({ dynamic: 'true', properties: { city: { type: 'keyword' } } });
+      await elasticsearch.updateCollection(index, collection, { mappings, settings });
+
+      should(elasticsearch.updateSettings).be.calledWith(index, collection, settings);
+      should(elasticsearch.updateMapping).be.calledWith(index, collection, mappings);
+      should(elasticsearch.updateSearchIndex).not.be.called();
+    });
+
     it('should revert settings if updateMapping fail', () => {
+      elasticsearch.getMapping = sinon.stub().resolves({ dynamic: 'true', properties: { city: { type: 'keyword' } } });
       elasticsearch.updateMapping.rejects();
 
       const promise = elasticsearch.updateCollection(index, collection, { mappings, settings });

--- a/test/services/elasticsearch.test.js
+++ b/test/services/elasticsearch.test.js
@@ -1586,6 +1586,15 @@ describe('Test: ElasticSearch service', () => {
       elasticsearch.updateSearchIndex = sinon.stub().resolves();
     });
     it('should call updateSettings, updateMapping and updateSearchIndex', async () => {
+      elasticsearch.getMapping = sinon.stub().resolves({dynamic: 'true', properties: { city: { type: 'keyword' }, dynamic: 'false' } });
+      await elasticsearch.updateCollection(index, collection, { mappings, settings });
+
+      should(elasticsearch.updateSettings).be.calledWith(index, collection, settings);
+      should(elasticsearch.updateMapping).be.calledWith(index, collection, mappings);
+      should(elasticsearch.updateSearchIndex).be.calledWith(index, collection);
+    });
+
+    it('should call updateSettings, updateMapping and updateSearchIndex', async () => {
       elasticsearch.getMapping = sinon.stub().resolves({ dynamic: 'false', properties: { city: { type: 'keyword' } } });
       await elasticsearch.updateCollection(index, collection, { mappings, settings });
 


### PR DESCRIPTION
<!--
  This template is optional.
  It simply serves to provide a guide to allow a better review of pull requests.
-->

<!--
  IMPORTANT
  Don't forget to add the corresponding "changelog:xxx" label to your PR.
  This is part of our release process in order to generate the change log.
-->


## What does this PR do ?
This PR adds an empty `updateByQuery` request after a `collection:update` in order to be able to perform `search` queries on properties that was not included in the mapping before being updated.

### How should this be manually tested?

Functional test.
Create a collection with a mapping having `dynamic:false`
Create a document with a property not present in the mapping.
Update the mapping with a the same property/type

Before: The search query did not retrieve those documents.
Now : The search index is updated, the search query retrieve documents.

### Other changes

<!--
  Please describe here all changes not directly linked to the main issue, but made because of it.
  For instance: issues spotted during this PR and fixed on-the-fly, dependencies update, and so on
-->

### Boyscout

<!--
  Describe here minor improvements in the code base and not directly linked to the main changes:
  typos fixes, better/new comments, small code simplification, new debug messages, and so on.
-->
