### PR TITLE
Optimization: replaces lodash's memoize with a custom, much faster one

### DIFF
--- a/lib/kuzzle.js
+++ b/lib/kuzzle.js
@@ -52,6 +52,7 @@ const StorageEngine = require('./core/storage/storageEngine');
 const runShutdown = require('./util/shutdown');
 const Logger = require('./util/log');
 const Promback = require('./util/promback');
+const memoize = require('./util/memoize');
 
 
 /**
@@ -85,7 +86,7 @@ function pipeCallback (error, updated) {
  * @param {String} event
  * @returns {Array<String>} wildcard events
  */
-const getWildcardEvents = _.memoize(event => {
+const getWildcardEvents = memoize(event => {
   const
     events = [event],
     delimIndex = event.lastIndexOf(':');

--- a/lib/util/memoize.js
+++ b/lib/util/memoize.js
@@ -1,0 +1,47 @@
+/*
+ * Kuzzle, a backend software, self-hostable and ready to use
+ * to power modern apps
+ *
+ * Copyright 2015-2020 Kuzzle
+ * mailto: support AT kuzzle.io
+ * website: http://kuzzle.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+function memoize (fn, resolver = null) {
+  const memoized = (...args) => {
+    const key = memoized.resolver !== null
+      ? memoized.resolver(args)
+      : args[0];
+
+    let result = memoized.cache.get(key);
+
+    if (result === undefined) {
+      result = memoized.fn(...args);
+      memoized.cache.set(key, result);
+    }
+
+    return result;
+  };
+
+  memoized.fn = fn;
+  memoized.cache = new Map();
+  memoized.resolver = resolver;
+
+  return memoized;
+}
+
+module.exports = memoize;

--- a/test/util/memoize.test.js
+++ b/test/util/memoize.test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const should = require('should');
+const sinon = require('sinon');
+const memoize = require('../../lib/util/memoize');
+
+describe('#memoize', () => {
+  it('should return a function', () => {
+    const memoized = memoize(Math.random);
+    should(memoized).be.a.Function();
+  });
+
+  it('should invoke the underlying function only once for a same argument', () => {
+    const spiedFunction = sinon.stub().callsFake(Math.random);
+    const memoized = memoize(spiedFunction);
+    const result = memoized('foo');
+
+    should(memoized('foo')).eql(result);
+    should(memoized('foo')).eql(result);
+    should(memoized('foo')).eql(result);
+
+    should(spiedFunction).calledOnce().calledWith('foo');
+  });
+
+  it('should invoke the underlying function using the provided resolver', () => {
+    const spiedFunction = sinon.stub().callsFake(Math.random);
+    const memoized = memoize(spiedFunction, () => 'bar');
+
+    const result = memoized('foo');
+
+    should(memoized('foo')).eql(result);
+    should(memoized('baz')).eql(result);
+    should(memoized('qux')).eql(result);
+
+    // only invoked once, other calls are using the cache since the resolver
+    // always returns the same key
+    should(spiedFunction).calledOnce().calledWith('foo');
+  });
+
+  it('should work with functions returning promises', async () => {
+    const spiedFunction = sinon.stub().callsFake(async () => Math.random());
+    const memoized = memoize(spiedFunction);
+
+    const promise = memoized('foo');
+
+    should(promise).be.a.Promise();
+
+    const result = await promise;
+
+    should(memoized('foo')).fulfilledWith(result);
+    should(memoized('foo')).fulfilledWith(result);
+    should(memoized('foo')).fulfilledWith(result);
+
+    should(spiedFunction).calledOnce().calledWith('foo');
+  });
+});

--- a/test/util/memoize.test.js
+++ b/test/util/memoize.test.js
@@ -13,13 +13,21 @@ describe('#memoize', () => {
   it('should invoke the underlying function only once for a same argument', () => {
     const spiedFunction = sinon.stub().callsFake(Math.random);
     const memoized = memoize(spiedFunction);
-    const result = memoized('foo');
 
-    should(memoized('foo')).eql(result);
-    should(memoized('foo')).eql(result);
-    should(memoized('foo')).eql(result);
+    const foo = memoized('foo');
+    const bar = memoized('bar');
 
-    should(spiedFunction).calledOnce().calledWith('foo');
+    should(memoized('foo')).eql(foo);
+    should(memoized('foo')).eql(foo);
+    should(memoized('bar')).eql(bar);
+    should(memoized('bar')).eql(bar);
+    should(memoized('foo')).eql(foo);
+    should(memoized('bar')).eql(bar);
+
+    should(spiedFunction)
+      .calledTwice()
+      .calledWith('foo')
+      .calledWith('bar');
   });
 
   it('should invoke the underlying function using the provided resolver', () => {


### PR DESCRIPTION
# Description

We use [memoization](https://en.wikipedia.org/wiki/Memoization) to skip calculation on one function in a critical section of our code (note for later: this should definitly be used at more than one place).

Until now we were using lodash's [memoize](https://lodash.com/docs/4.17.15#memoize). This PR replaces it with a (much) faster version of it.

# Benchmarks

```
custom memoize x 96,849,274 ops/sec ±0.65% (96 runs sampled)
custom memoize with resolver x 107,643,904 ops/sec ±0.93% (94 runs sampled)
_.memoize x 24,907,495 ops/sec ±0.86% (94 runs sampled)
_.memoize with resolver x 18,251,824 ops/sec ±0.54% (94 runs sampled)
```

