### PR TITLE
Allows inter-plugins method calls with side-effect

### DIFF
--- a/doc/2/api/essentials/error-codes/plugin/index.md
+++ b/doc/2/api/essentials/error-codes/plugin/index.md
@@ -114,7 +114,6 @@ description: error codes definitions
 | plugin.context.invalid_callback<br/><pre>0x04060004</pre> | [PluginImplementationError](/core/2/api/essentials/error-handling#pluginimplementationerror) <pre>(500)</pre> | A non-function callback has been provided |
 | plugin.context.missing_request<br/><pre>0x04060005</pre> | [PluginImplementationError](/core/2/api/essentials/error-handling#pluginimplementationerror) <pre>(500)</pre> | A Request object is required, but none was supplied |
 | plugin.context.missing_request_data<br/><pre>0x04060006</pre> | [PluginImplementationError](/core/2/api/essentials/error-handling#pluginimplementationerror) <pre>(500)</pre> | A Request object and/or request data must be provided |
-| plugin.context.invalid_event<br/><pre>0x04060007</pre> | [PluginImplementationError](/core/2/api/essentials/error-handling#pluginimplementationerror) <pre>(500)</pre> | Invalid event name (colons are not allowed in event names) |
 | plugin.context.missing_authenticator<br/><pre>0x04060008</pre> | [PluginImplementationError](/core/2/api/essentials/error-handling#pluginimplementationerror) <pre>(500)</pre> | Missing "strategy.config.authenticator" property |
 
 ---

--- a/doc/2/plugins/plugin-context/accessors/trigger/index.md
+++ b/doc/2/plugins/plugin-context/accessors/trigger/index.md
@@ -12,6 +12,7 @@ This allows interactions with other plugins using [hooks](/core/2/plugins/guides
 
 ::: info
 If the event is listened by pipes, the result of the pipe chain will be returned in a promise.
+If there is no listener, the result will be the same payload.
 This behavior can be used for a Remote Procedure Call (RPC) system between plugins.
 :::
 

--- a/doc/2/plugins/plugin-context/accessors/trigger/index.md
+++ b/doc/2/plugins/plugin-context/accessors/trigger/index.md
@@ -6,11 +6,14 @@ title: trigger
 
 # trigger
 
-
-
 Triggers a custom event.
 
 This allows interactions with other plugins using [hooks](/core/2/plugins/guides/hooks) or [pipes](/core/2/plugins/guides/pipes).
+
+::: info
+If the event is listened by pipes, the result of the pipe chain will be returned in a promise.
+This behavior can be used for a Remote Procedure Call (RPC) system between plugins.
+:::
 
 ## Arguments
 
@@ -30,21 +33,21 @@ trigger(event, [payload]);
 ## Example
 
 ```js
-// Emitting plugin, named "some-plugin"
-context.accessors.trigger('someEvent', {
-  someAttribute: 'someValue'
-});
+// somewhere in the emitting plugin, named "emitting-plugin" in the manifest
+
+const result = await context.accessors.trigger('sayHello', 'World');
+// => "Hello, World"
+
+// [...]
 
 // Listening plugin
 class ListeningPlugin {
   constructor() {
-    this.hooks = {
-      'plugin-some-plugin:someEvent': 'someEventListener'
+    this.pipes = {
+      'plugin-emitting-plugin:sayHello': async name => {
+        return `Hello, ${name}`;
+      }
     };
-  }
-
-  someEventListener(payload) {
-    this.doSomething(payload);
   }
 }
 ```

--- a/features-sdk/PluginContext.feature
+++ b/features-sdk/PluginContext.feature
@@ -19,3 +19,11 @@ Feature: Plugin context
       | body | {  "awsAccessKey": "I am the access key" } |
     Then I should receive a result matching:
       | result | true |
+
+  # accessors.trigger
+
+  Scenario: Trigger returns the pipe chain result
+    When I successfully call the route "functional-test-plugin/pipes":"testReturn" with args:
+      | name | "Mr Freeman" |
+    Then I should receive a result matching:
+      | result | "Hello, Mr Freeman" |

--- a/lib/config/error-codes/plugin.json
+++ b/lib/config/error-codes/plugin.json
@@ -379,6 +379,7 @@
         },
         "invalid_event": {
           "description": "Invalid event name (colons are not allowed in event names)",
+          "deprecated": true,
           "code": 7,
           "message": "Custom event invalid name (%s). Colons are not allowed in custom events.",
           "class": "PluginImplementationError"

--- a/lib/core/plugins/context.js
+++ b/lib/core/plugins/context.js
@@ -282,7 +282,7 @@ function curryTrigger (kuzzle, pluginName) {
   /**
    * @this   {Kuzzle}
    * @param  {String} eventName The name of the custom event to trigger.
-   * @param  {Object} payload   The payload of the event.
+   * @param  {Any} payload      The payload of the event.
    */
   return function trigger (eventName, payload) {
     if (eventName.indexOf(':') !== -1) {
@@ -290,7 +290,7 @@ function curryTrigger (kuzzle, pluginName) {
       return;
     }
 
-    kuzzle.pipe(`plugin-${pluginName}:${eventName}`, payload);
+    return kuzzle.pipe(`plugin-${pluginName}:${eventName}`, payload);
   };
 }
 

--- a/lib/core/plugins/context.js
+++ b/lib/core/plugins/context.js
@@ -286,8 +286,9 @@ function curryTrigger (kuzzle, pluginName) {
    */
   return function trigger (eventName, payload) {
     if (eventName.indexOf(':') !== -1) {
-      kuzzle.log.error(contextError.get('invalid_event', eventName));
-      return;
+      const error = contextError.get('invalid_event', eventName);
+
+      return Promise.reject(error);
     }
 
     return kuzzle.pipe(`plugin-${pluginName}:${eventName}`, payload);

--- a/lib/core/plugins/context.js
+++ b/lib/core/plugins/context.js
@@ -174,7 +174,9 @@ class PluginContext {
 
       Reflect.defineProperty(this.accessors, 'trigger', {
         enumerable: true,
-        get: () => curryTrigger(kuzzle, pluginName)
+        get: () => (eventName, payload) => (
+          kuzzle.pipe(`plugin-${pluginName}:${eventName}`, payload)
+        )
       });
 
       const kuzzleSdk = new KuzzleSDK(new FunnelProtocol(kuzzle.funnel));
@@ -264,35 +266,6 @@ function execute (kuzzle, request, callback) {
     });
 
   return promback.deferred;
-}
-
-/**
- * Returns a currified version of kuzzle.pipe
- * The pluginName param
- * is injected in the returned function as it is prepended to the custom event
- * name. This is done to avoid colliding with the kuzzle native events.
- *
- * @param  {Kuzzle} kuzzle
- * @param  {String} pluginName The name of the plugin calling trigger.
- * @return {Function}          A trigger function that makes some checks on the
- *                             event name and prepends the plugin name to the
- *                             event name.
- */
-function curryTrigger (kuzzle, pluginName) {
-  /**
-   * @this   {Kuzzle}
-   * @param  {String} eventName The name of the custom event to trigger.
-   * @param  {Any} payload      The payload of the event.
-   */
-  return function trigger (eventName, payload) {
-    if (eventName.indexOf(':') !== -1) {
-      const error = contextError.get('invalid_event', eventName);
-
-      return Promise.reject(error);
-    }
-
-    return kuzzle.pipe(`plugin-${pluginName}:${eventName}`, payload);
-  };
 }
 
 /**

--- a/plugins/available/functional-test-plugin/index.js
+++ b/plugins/available/functional-test-plugin/index.js
@@ -26,11 +26,13 @@ class FunctionalTestPlugin {
 
     this.controllers.pipes = {
       manage: 'pipesManage',
-      deactivateAll: 'pipesDeactivateAll'
+      deactivateAll: 'pipesDeactivateAll',
+      testReturn: 'pipesTestReturn'
     };
 
     this.routes.push({ verb: 'post', url: '/pipes/:event/:state', controller: 'pipes', action: 'manage' });
     this.routes.push({ verb: 'delete', url: '/pipes', controller: 'pipes', action: 'deactivateAll' });
+    this.routes.push({ verb: 'post', url: '/pipes/test-return/:name', controller: 'pipes', action: 'testReturn' });
 
     this.pipes['generic:document:beforeWrite'] = (...args) => this.genericDocumentEvent('beforeWrite', ...args);
     this.pipes['generic:document:afterWrite'] = (...args) => this.genericDocumentEvent('afterWrite', ...args);
@@ -40,6 +42,8 @@ class FunctionalTestPlugin {
     this.pipes['generic:document:afterGet'] = (...args) => this.genericDocumentEvent('afterGet', ...args);
     this.pipes['generic:document:beforeDelete'] = (...args) => this.genericDocumentEvent('beforeDelete', ...args);
     this.pipes['generic:document:afterDelete'] = (...args) => this.genericDocumentEvent('afterDelete', ...args);
+
+    this.pipes['plugin-functional-test-plugin:testPipesReturn'] = async name => `Hello, ${name}`;
   }
 
   init (config, context) {
@@ -70,9 +74,7 @@ class FunctionalTestPlugin {
 
     should(this.context.secrets).match(expectedSecrets);
 
-    return {
-      result: true
-    };
+    return { result: true };
   }
 
   // pipes related methods =====================================================
@@ -113,6 +115,17 @@ class FunctionalTestPlugin {
     }
 
     return documents;
+  }
+
+  /**
+   * Tests that the context.accessors.trigger method returns the results of the pipe chain
+   */
+  async pipesTestReturn (request) {
+    const helloName = await this.context.accessors.trigger(
+      'testPipesReturn',
+      request.input.args.name);
+
+    return { result: helloName };
   }
 }
 

--- a/test/core/plugins/context/context.test.js
+++ b/test/core/plugins/context/context.test.js
@@ -352,19 +352,21 @@ describe('Plugin Context', () => {
         should(kuzzle.log.error).be.calledOnce();
       });
 
-      it('should call trigger with the given event name and payload', () => {
-        const
-          eventName = 'backHome',
-          payload = {
-            question: 'whose motorcycle is this?',
-            answer: 'it\'s a chopper, baby.',
-            anotherQuestion: 'whose chopper is this, then?',
-            anotherAnswer: 'it\'s Zed\'s',
-            yetAnotherQuestion: 'who\'s Zed?',
-            yetAnotherAnswer: 'Zed\'s dead, baby, Zed\'s dead.'
-          };
+      it('should call trigger with the given event name and payload and return pipe chain result', () => {
+        kuzzle.pipe.returns('pipe chain result');
+        const eventName = 'backHome';
+        const payload = {
+          question: 'whose motorcycle is this?',
+          answer: 'it\'s a chopper, baby.',
+          anotherQuestion: 'whose chopper is this, then?',
+          anotherAnswer: 'it\'s Zed\'s',
+          yetAnotherQuestion: 'who\'s Zed?',
+          yetAnotherAnswer: 'Zed\'s dead, baby, Zed\'s dead.'
+        };
 
-        context.accessors.trigger(eventName, payload);
+        const result = context.accessors.trigger(eventName, payload);
+
+        should(result).be.eql('pipe chain result');
         should(kuzzle.pipe)
           .be.calledWithExactly(`plugin-pluginName:${eventName}`, payload);
       });

--- a/test/core/plugins/context/context.test.js
+++ b/test/core/plugins/context/context.test.js
@@ -347,13 +347,12 @@ describe('Plugin Context', () => {
     });
 
     describe('#trigger', () => {
-      it('should log an error if the event name contains a colon', () => {
-        context.accessors.trigger('event:with:colons');
-        should(kuzzle.log.error).be.calledOnce();
+      it('should rejects if the event name contains a colon', () => {
+        return should(context.accessors.trigger('event:with:colons')).be.rejected();
       });
 
-      it('should call trigger with the given event name and payload and return pipe chain result', () => {
-        kuzzle.pipe.returns('pipe chain result');
+      it('should call trigger with the given event name and payload and return pipe chain result', async () => {
+        kuzzle.pipe.resolves('pipe chain result');
         const eventName = 'backHome';
         const payload = {
           question: 'whose motorcycle is this?',
@@ -364,7 +363,7 @@ describe('Plugin Context', () => {
           yetAnotherAnswer: 'Zed\'s dead, baby, Zed\'s dead.'
         };
 
-        const result = context.accessors.trigger(eventName, payload);
+        const result = await context.accessors.trigger(eventName, payload);
 
         should(result).be.eql('pipe chain result');
         should(kuzzle.pipe)

--- a/test/core/plugins/context/context.test.js
+++ b/test/core/plugins/context/context.test.js
@@ -347,10 +347,6 @@ describe('Plugin Context', () => {
     });
 
     describe('#trigger', () => {
-      it('should rejects if the event name contains a colon', () => {
-        return should(context.accessors.trigger('event:with:colons')).be.rejected();
-      });
-
       it('should call trigger with the given event name and payload and return pipe chain result', async () => {
         kuzzle.pipe.resolves('pipe chain result');
         const eventName = 'backHome';


### PR DESCRIPTION
## What does this PR do ?

The [context.accessors.trigger](https://docs.kuzzle.io/core/2/plugins/plugin-context/accessors/trigger/)  method trigger an event with `kuzzle.pipe` but does not return the result.  

Because of this we can't use properly use this method for plugin communication because if the plugin A want to call some method from plugin B, it will not be able to apply any side effect from plugin B method.

This PR allows the plugin context to returns the pipe chain result in plugin context trigger method.

You can have a look on the functional test to see an example.

_PR name is open to debate_

IMHO we should expose the new event system to plugin so they can have a proper inter-plugin communication system but in the meantime this quickwin allow to do the same