### PR TITLE
Fix API key expiration on realtime subscription

### DIFF
--- a/bin/start-kuzzle-server
+++ b/bin/start-kuzzle-server
@@ -71,7 +71,7 @@ async function startKuzzle (options = {}) {
     }
   }
   catch (error) {
-    console.error(`[x] [ERROR] ${err.stack}`);
+    console.error(`[x] [ERROR] ${error.stack}`);
     process.exit(1);
   }
 }

--- a/lib/core/auth/tokenManager.js
+++ b/lib/core/auth/tokenManager.js
@@ -21,10 +21,9 @@
 
 'use strict';
 
-const
-  { models: { RequestContext } } = require('kuzzle-common-objects'),
-  SortedArray = require('sorted-array'),
-  Token = require('../models/security/token');
+const { models: { RequestContext } } = require('kuzzle-common-objects');
+const SortedArray = require('sorted-array');
+const Token = require('../models/security/token');
 
 /*
  Maximum delay of a setTimeout call. If larger than this value,
@@ -188,7 +187,8 @@ class TokenManager {
   async checkTokensValidity() {
     const arr = this.tokens.array;
 
-    if (arr.length > 0 && arr[0].expiresAt < Date.now()) {
+    // API key can never expire (-1)
+    if (arr.length > 0 && (arr[0].expiresAt > 0 && arr[0].expiresAt < Date.now())) {
       const connectionId = arr[0].connectionId;
 
       arr.shift();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/index.js",
   "bin": {

--- a/test/core/auth/tokenManager.test.js
+++ b/test/core/auth/tokenManager.test.js
@@ -271,6 +271,30 @@ describe('Test: token manager core component', () => {
       should(runTimerStub).be.calledOnce();
     });
 
+    it('should not expire API key', async () => {
+      const runTimerStub = sinon.stub(tokenManager, 'runTimer');
+
+      kuzzle.hotelClerk.customers.clear();
+
+      tokenManager.link(
+        new Token({_id: 'api-key-1', expiresAt: -1}),
+        'connectionId1',
+        'roomId1');
+
+      runTimerStub.resetHistory();
+
+      await tokenManager.checkTokensValidity();
+
+      clock.runAll();
+
+      should(kuzzle.hotelClerk.removeCustomerFromAllRooms).not.be.called();
+      should(kuzzle.notifier.notifyServer).not.be.called();
+
+      should(tokenManager.tokens.array.length).be.eql(1);
+      should(tokenManager.tokens.array[0]._id).be.eql('api-key-1');
+      should(runTimerStub).be.calledOnce();
+    });
+
     it('should not rerun a timer if the last token has been removed', async () => {
       const
         now = Date.now(),

--- a/test/core/auth/tokenManager.test.js
+++ b/test/core/auth/tokenManager.test.js
@@ -177,7 +177,7 @@ describe('Test: token manager core component', () => {
     let clock;
 
     beforeEach(() => {
-      clock = sinon.useFakeTimers();
+      clock = sinon.useFakeTimers(new Date());
     });
 
     afterEach(() => {


### PR DESCRIPTION
## What does this PR do ?

API key can never expire, so the `expiresAt` property of the token is `-1`.  

When a realtime subscription is open, Kuzzle checks regularly if the token associated to the subscription is still valid. This check compare the current date with the `expiresAt` property so a negative value is considered as an expired token.
