### PR TITLE
Install guide: fix min. python version

### DIFF
--- a/doc/2/guides/essentials/installing-kuzzle/index.md
+++ b/doc/2/guides/essentials/installing-kuzzle/index.md
@@ -150,7 +150,7 @@ The following operating systems are actively supported (64-bit versions only):
 - [Redis](http://redis.io) version 5.x or higher
 - [Node.js](https://nodejs.org/en/download/package-manager) version 12.x or higher
 - [NPM](https://www.npmjs.com) version 6 or higher
-- [Python](https://www.python.org) version 2.7 preferred
+- [Python](https://www.python.org) 2.7, 3.5 or higher
 - [GDB](https://www.gnu.org/software/gdb) version 7.7 or higher
 - a C++11 compatible compiler
 - it's strongly advised that the system value for the maximum number of opened files (`ulimit -n` on most Unix systems) is set to a high value (i.e. 65535 is a good min. value)


### PR DESCRIPTION
# Description

The Python requirement comes from [node-gyp](https://github.com/nodejs/node-gyp). 
Older versions did require Python 2.7, but for quite some time now, Python 3 is also supported.
