### PR TITLE
Returns a token expired error when using expired jwt

### DIFF
--- a/lib/core/security/tokenRepository.js
+++ b/lib/core/security/tokenRepository.js
@@ -110,12 +110,11 @@ class TokenRepository extends Repository {
       signOptions.expiresIn = expiresIn;
     }
     else if (parsedExpiresIn !== -1) {
-      // -1 mean infite duration, so we don't pass the expiresIn option to jwt.sign
-      signOptions.expiresIn = parsedExpiresIn;
+      signOptions.expiresIn = parsedExpiresIn / 1000;
     }
+    // -1 mean infite duration, so we don't pass the expiresIn option to jwt.sign
 
     let encodedToken;
-
     try {
       encodedToken = jwt.sign(
         { _id: user._id },

--- a/test/core/security/tokenRepository.test.js
+++ b/test/core/security/tokenRepository.test.js
@@ -194,7 +194,7 @@ describe('Test: security/tokenRepository', () => {
           kuzzle.config.security.jwt.secret,
           {
             algorithm: kuzzle.config.security.jwt.algorithm,
-            expiresIn: ms(kuzzle.config.security.jwt.expiresIn)
+            expiresIn: ms(kuzzle.config.security.jwt.expiresIn) / 1000
           });
       user._id = 'userInCache';
       const persistForUserSpy = sinon.spy(tokenRepository, 'persistForUser');
@@ -281,10 +281,6 @@ describe('Test: security/tokenRepository', () => {
         { expiresIn: 'ehh' });
 
       await should(promise).be.rejectedWith(KuzzleInternalError);
-    });
-
-    it('should call #persistForUser', () => {
-
     });
   });
 


### PR DESCRIPTION
## What does this PR do ?

Token expiration can be provided with a `ms` string or in milliseconds but the JWT specification expect an expiration delay in seconds.

Token were correctly expired from the Kuzzle point of view (eg: deleted from Redis) but the JWT library still consider them as valid so instead of responding to the request with a `security.token.expired`, the error id was `security.token.invalid`
