### PR TITLE
Fix: invalid context on plugin pipes declared with a function name

### DIFF
--- a/features-sdk/PluginEvents.feature
+++ b/features-sdk/PluginEvents.feature
@@ -288,3 +288,11 @@ Feature: Plugin Events
     When I delete the document "bus-3"
     Then I should receive a "string" result equals to "confidential"
     Then The document "bus-3-vn" should not exist
+
+  # pipes declared with a function name
+  @events
+  Scenario: Trigger a pipe declared with a function name
+    Given I "activate" the pipe on "server:afterNow" without changes
+    When I successfully call the route "server":"now"
+    Then I should receive a result matching:
+      | lyrics     | "_STRING_"    |

--- a/features-sdk/step_definitions/plugin-events-steps.js
+++ b/features-sdk/step_definitions/plugin-events-steps.js
@@ -1,21 +1,25 @@
 'use strict';
 
-const
-  {
-    Given
-  } = require('cucumber');
-
+const { Given } = require('cucumber');
 
 Given('I {string} the pipe on {string} with the following changes:', async function (state, event, dataTable) {
-  const
-    payload = this.parseObject(dataTable),
-    request = {
-      controller: 'functional-test-plugin/pipes',
-      action: 'manage',
-      state,
-      event,
-      body: payload
-    };
+  const payload = this.parseObject(dataTable);
+  const request = {
+    controller: 'functional-test-plugin/pipes',
+    action: 'manage',
+    state,
+    event,
+    body: payload
+  };
 
   await this.sdk.query(request);
+});
+
+Given('I {string} the pipe on {string} without changes', async function (state, event) {
+  await this.sdk.query({
+    controller: 'functional-test-plugin/pipes',
+    action: 'manage',
+    state,
+    event
+  });
 });

--- a/lib/core/plugin/manager.js
+++ b/lib/core/plugin/manager.js
@@ -401,10 +401,10 @@ class PluginsManager {
    * @param {string|function} fn - function to attach
    */
   registerPipe (plugin, warnDelay, event, fn) {
+    // function names need to be bound to their object of origin to prevent
+    // invalid context execution
     const _fn = typeof fn === 'function'
       ? fn
-      // function names need to be bound to their object of origin to prevent
-      // invalid context execution
       : plugin.object[fn].bind(plugin.object);
     const name = plugin.manifest.name;
 

--- a/lib/core/plugin/manager.js
+++ b/lib/core/plugin/manager.js
@@ -401,7 +401,11 @@ class PluginsManager {
    * @param {string|function} fn - function to attach
    */
   registerPipe (plugin, warnDelay, event, fn) {
-    const _fn = typeof fn === 'function' ? fn : plugin.object[fn];
+    const _fn = typeof fn === 'function'
+      ? fn
+      // function names need to be bound to their object of origin to prevent
+      // invalid context execution
+      : plugin.object[fn].bind(plugin.object);
     const name = plugin.manifest.name;
 
     debug('[%s] registering pipe on event "%s"', name, event);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:functional:sdk": "bash features-sdk/run.sh",
     "cucumber": "cucumber.js --fail-fast",
     "codecov": "codecov",
-    "test:lint": "eslint --max-warnings=0 ./lib ./test ./features ./bin ./features-sdk ./doc/build-error-codes.js",
+    "test:lint": "eslint --max-warnings=0 ./lib ./test ./features ./bin ./features-sdk ./doc/build-error-codes.js ./plugins/available/functional-test-plugin",
     "test:lint:fix": "eslint --max-warnings=0 --fix ./lib ./test ./features ./bin ./features-sdk ./doc/build-error-codes.js",
     "doc-prepare": "kuzdoc framework:install",
     "doc-dev": "kuzdoc repo:dev -d /core/2/ -v 2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/kuzzle",
   "bin": {

--- a/plugins/available/functional-test-plugin/index.js
+++ b/plugins/available/functional-test-plugin/index.js
@@ -1,6 +1,7 @@
-const
-  should = require('should'),
-   _ = require('lodash');
+'use strict';
+
+const should = require('should');
+const _ = require('lodash');
 
 class FunctionalTestPlugin {
   constructor () {
@@ -12,38 +13,72 @@ class FunctionalTestPlugin {
 
     this.controllers.constructors = { ESClient: 'testConstructorsESClient' };
 
-    this.routes.push({ verb: 'post', url: '/constructors/esclient/:index', controller: 'constructors', action: 'ESClient' });
+    this.routes.push({
+      action: 'ESClient',
+      controller: 'constructors',
+      url: '/constructors/esclient/:index',
+      verb: 'post',
+    });
 
     // context.secrets related declarations ====================================
 
     this.controllers.secrets = { test: 'testSecrets' };
 
-    this.routes.push({ verb: 'post', url: '/secrets', controller: 'secrets', action: 'test' })
+    this.routes.push({
+      action: 'test',
+      controller: 'secrets',
+      url: '/secrets',
+      verb: 'post',
+    });
 
     // pipes related declarations ==============================================
 
     this.activatedPipes = {};
 
     this.controllers.pipes = {
-      manage: 'pipesManage',
       deactivateAll: 'pipesDeactivateAll',
-      testReturn: 'pipesTestReturn'
+      manage: 'pipesManage',
+      testReturn: 'pipesTestReturn',
     };
 
-    this.routes.push({ verb: 'post', url: '/pipes/:event/:state', controller: 'pipes', action: 'manage' });
-    this.routes.push({ verb: 'delete', url: '/pipes', controller: 'pipes', action: 'deactivateAll' });
-    this.routes.push({ verb: 'post', url: '/pipes/test-return/:name', controller: 'pipes', action: 'testReturn' });
+    this.routes.push({
+      action: 'manage',
+      controller: 'pipes',
+      url: '/pipes/:event/:state',
+      verb: 'post',
+    });
+    this.routes.push({
+      action: 'deactivateAll',
+      controller: 'pipes',
+      url: '/pipes',
+      verb: 'delete',
+    });
+    this.routes.push({
+      action: 'testReturn',
+      controller: 'pipes',
+      url: '/pipes/test-return/:name',
+      verb: 'post',
+    });
 
-    this.pipes['generic:document:beforeWrite'] = (...args) => this.genericDocumentEvent('beforeWrite', ...args);
-    this.pipes['generic:document:afterWrite'] = (...args) => this.genericDocumentEvent('afterWrite', ...args);
-    this.pipes['generic:document:beforeUpdate'] = (...args) => this.genericDocumentEvent('beforeUpdate', ...args);
-    this.pipes['generic:document:afterUpdate'] = (...args) => this.genericDocumentEvent('afterUpdate', ...args);
-    this.pipes['generic:document:beforeGet'] = (...args) => this.genericDocumentEvent('beforeGet', ...args);
-    this.pipes['generic:document:afterGet'] = (...args) => this.genericDocumentEvent('afterGet', ...args);
-    this.pipes['generic:document:beforeDelete'] = (...args) => this.genericDocumentEvent('beforeDelete', ...args);
-    this.pipes['generic:document:afterDelete'] = (...args) => this.genericDocumentEvent('afterDelete', ...args);
+    this.pipes['generic:document:beforeWrite'] =
+      (...args) => this.genericDocumentEvent('beforeWrite', ...args);
+    this.pipes['generic:document:afterWrite'] =
+      (...args) => this.genericDocumentEvent('afterWrite', ...args);
+    this.pipes['generic:document:beforeUpdate'] =
+      (...args) => this.genericDocumentEvent('beforeUpdate', ...args);
+    this.pipes['generic:document:afterUpdate'] =
+      (...args) => this.genericDocumentEvent('afterUpdate', ...args);
+    this.pipes['generic:document:beforeGet'] =
+      (...args) => this.genericDocumentEvent('beforeGet', ...args);
+    this.pipes['generic:document:afterGet'] =
+      (...args) => this.genericDocumentEvent('afterGet', ...args);
+    this.pipes['generic:document:beforeDelete'] =
+      (...args) => this.genericDocumentEvent('beforeDelete', ...args);
+    this.pipes['generic:document:afterDelete'] =
+      (...args) => this.genericDocumentEvent('afterDelete', ...args);
 
-    this.pipes['plugin-functional-test-plugin:testPipesReturn'] = async name => `Hello, ${name}`;
+    this.pipes['plugin-functional-test-plugin:testPipesReturn'] =
+      async name => `Hello, ${name}`;
   }
 
   init (config, context) {
@@ -57,9 +92,9 @@ class FunctionalTestPlugin {
     const
       client = new this.context.constructors.ESClient(),
       esRequest = {
+        body: request.input.body,
         id: request.input.resource._id,
         index: request.input.resource.index,
-        body: request.input.body
       };
 
     const { body } = await client.index(esRequest);
@@ -86,8 +121,8 @@ class FunctionalTestPlugin {
       event = request.input.args.event;
 
     this.activatedPipes[event] = {
+      payload,
       state,
-      payload
     };
 
     return null;
@@ -101,7 +136,7 @@ class FunctionalTestPlugin {
     return null;
   }
 
-  async genericDocumentEvent (event, documents, request) {
+  async genericDocumentEvent (event, documents) {
     const pipe = this.activatedPipes[`generic:document:${event}`];
 
     if (!pipe || pipe.state === 'off') {
@@ -110,6 +145,7 @@ class FunctionalTestPlugin {
 
     for (const document of documents) {
       for (const [field, value] of Object.entries(pipe.payload)) {
+        /* eslint-disable-next-line no-eval */
         _.set(document, field, eval(value));
       }
     }
@@ -118,7 +154,8 @@ class FunctionalTestPlugin {
   }
 
   /**
-   * Tests that the context.accessors.trigger method returns the results of the pipe chain
+   * Tests that the context.accessors.trigger method returns the results of the
+   * pipe chain
    */
   async pipesTestReturn (request) {
     const helloName = await this.context.accessors.trigger(

--- a/plugins/available/functional-test-plugin/index.js
+++ b/plugins/available/functional-test-plugin/index.js
@@ -79,6 +79,9 @@ class FunctionalTestPlugin {
 
     this.pipes['plugin-functional-test-plugin:testPipesReturn'] =
       async name => `Hello, ${name}`;
+
+    // Pipe declared with a function name
+    this.pipes['server:afterNow'] = 'afterNowPipe';
   }
 
   init (config, context) {
@@ -115,10 +118,9 @@ class FunctionalTestPlugin {
   // pipes related methods =====================================================
 
   async pipesManage (request) {
-    const
-      payload = request.input.body,
-      state = request.input.args.state,
-      event = request.input.args.event;
+    const payload = request.input.body;
+    const state = request.input.args.state;
+    const event = request.input.args.event;
 
     this.activatedPipes[event] = {
       payload,
@@ -151,6 +153,17 @@ class FunctionalTestPlugin {
     }
 
     return documents;
+  }
+
+  async afterNowPipe (request) {
+    const pipe = this.activatedPipes['server:afterNow'];
+
+    if (pipe && pipe.state !== 'off') {
+      const response = request.response.result;
+      response.lyrics = 'The distant future, The year 2000. The humans are dead.';
+    }
+
+    return request;
   }
 
   /**


### PR DESCRIPTION
# Description

This is an emergency patch, fixing a behavior broken by #1613 
Plugins can attach either functions or function names to pipe events. 

When using function names, plugin developpers have no way of controlling the context used to invoke their functions, and Kuzzle expects the function to exist within the plugin main object (this is verified with assertions when plugins are loaded by Kuzzle).

With Kuzzle 2.2.0, plugin pipes defined using function names are invoked with an undefined context, breaking existing implementations.

This PR fixes that by binding the plugin pipe function to its object of origin, when loading the plugin. 

This is only applied to plugin pipes defined with function names: when using functions, plugin developpers are responsible of the function's context, as Kuzzle has no way of knowing in what object the function belongs.

# How to test

Load a plugin with a pipe function declared using a function name, and use `this` in the function.

Example:

```js
'use strict';

class Foo {
  constructor() {
    this.foo = 'bar';
  }

  async init (config, context) {
    this.config = config;
    this.context = context;
    this.pipes = {
      'server:beforeNow': '_lol'
    };
  }

  async _lol (rq) {
    console.log('============= LOL: ', this.foo);
    return rq;
  }
}

module.exports = Foo;
```

Without this fix, this fails with a `PluginImplementationError` stating that the `foo` property cannot be read from `undefined`.
With the fix, this pipe runs as expected.

# Other changes

* Simplify unit tests a bit