### PR TITLE
Implement source argument on document:delete & document:deleteByQuery

### DIFF
--- a/doc/2/api/controllers/document/delete-by-query/index.md
+++ b/doc/2/api/controllers/document/delete-by-query/index.md
@@ -6,7 +6,7 @@ title: deleteByQuery
 
 # deleteByQuery
 
-Deletes documents matching the provided search query. 
+Deletes documents matching the provided search query.
 
 Documents removed that way trigger real-time notifications.
 
@@ -31,7 +31,7 @@ To remove all documents from a collection, use [collection:truncate](/core/2/api
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/<index>/<collection>/_query[?refresh=wait_for]
+URL: http://kuzzle:7512/<index>/<collection>/_query[?refresh=wait_for][&source]
 Method: DELETE
 Body:
 ```
@@ -71,7 +71,7 @@ Body:
 ### Optional
 
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the deleted documents are removed from the search indexes
-
+- `source`: if set to `true` Kuzzle will return each deleted document body in the response.
 ---
 
 ## Body properties
@@ -82,7 +82,10 @@ Body:
 
 ## Response
 
-Returns a `ids` array containing the list of deleted document identifiers.
+Returns information about the deleted documents:
+
+- `ids`: an array containing the list of deleted documents identifier. Present only if `source` is either not set or set to false.
+- `documents`: an array containing the list of deleted documents source. Present only if `source` is set to `true`.
 
 ```js
 {
@@ -94,11 +97,21 @@ Returns a `ids` array containing the list of deleted document identifiers.
   "action": "deleteByQuery",
   "requestId": "<unique request identifier>",
   "result": {
+    // Present only if 'source' parameter is not set, or set to false.
     "ids": [
       "id 1",
       "id 2",
       "id ...",
       "id n"
+    ],
+    // Present only if 'source' parameter is set to true.
+    "documents": [
+     {
+      "_id": "<deleted document unique identifier>",
+      "_source": {
+        // document content
+      }
+     }
     ]
   }
 }

--- a/doc/2/api/controllers/document/delete-by-query/index.md
+++ b/doc/2/api/controllers/document/delete-by-query/index.md
@@ -82,10 +82,12 @@ Body:
 
 ## Response
 
-Returns information about the deleted documents:
+Returns an object containing information about the deleted documents:
 
-- `ids`: an array containing the list of deleted documents identifier. Present only if `source` is either not set or set to false.
-- `documents`: an array containing the list of deleted documents source. Present only if `source` is set to `true`.
+<DeprecatedBadge version="2.2.1">
+- `ids`: an array containing the list of each deleted documents identifier.
+</DeprecatedBadge>
+- `documents` an array of the deleted documents. These contain their respective contents if the `source` is set to `true`.
 
 ```js
 {
@@ -97,21 +99,20 @@ Returns information about the deleted documents:
   "action": "deleteByQuery",
   "requestId": "<unique request identifier>",
   "result": {
-    // Present only if 'source' parameter is not set, or set to false.
+    "documents": [
+     {
+      "_id": "<deleted document unique identifier>",
+      "_source": {
+        // Document content, Present only if 'source' parameter is set to true.
+      }
+     }
+    ],
+    // Deprecated since 2.2.1, use the documents array instead.
     "ids": [
       "id 1",
       "id 2",
       "id ...",
       "id n"
-    ],
-    // Present only if 'source' parameter is set to true.
-    "documents": [
-     {
-      "_id": "<deleted document unique identifier>",
-      "_source": {
-        // document content
-      }
-     }
     ]
   }
 }

--- a/doc/2/api/controllers/document/delete/index.md
+++ b/doc/2/api/controllers/document/delete/index.md
@@ -17,7 +17,7 @@ Deletes a document.
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/<index>/<collection>/<documentId>[?refresh=wait_for]
+URL: http://kuzzle:7512/<index>/<collection>/<documentId>[?refresh=wait_for][&source]
 Method: DELETE
 ```
 
@@ -44,12 +44,15 @@ Method: DELETE
 ### Optional:
 
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the deletion has been indexed
-
+- `source`: if set to `true` Kuzzle will return the deleted document body in the response.
 ---
 
 ## Response
 
-Returns an `_id` property with the deleted document unique ID.
+Returns information about the deleted document:
+
+- `_id`: document unique identifier
+- `_source`: deleted document source, only if option `source` is set to `true`
 
 ```js
 {
@@ -61,7 +64,8 @@ Returns an `_id` property with the deleted document unique ID.
   "action": "delete",
   "requestId": "<unique request identifier>",
   "result": {
-    "_id": "<documentId>"
+    "_id": "<documentId>",
+    "_source": "<deleted document>" // If `source` option is set to true
   }
 }
 ```

--- a/features-sdk/DocumentController.feature
+++ b/features-sdk/DocumentController.feature
@@ -457,6 +457,27 @@ Feature: Document Controller
       | age | 21 |
 
   @mappings
+  Scenario: deleteByQuery and retrieve sources
+    Given an existing collection "nyc-open-data":"yellow-taxi"
+    And I "create" the following documents:
+      | _id | body                               |
+      | -   | { "name": "document1", "age": 42 } |
+      | -   | { "name": "document2", "age": 84 } |
+      | -   | { "name": "document2", "age": 21 } |
+    And I refresh the collection
+    When I successfully call the route "document":"deleteByQuery" with args:
+      | index      | "nyc-open-data"                                   |
+      | collection | "yellow-taxi"                                     |
+      | source     | true                                              |
+      | body       | { "query": { "range": { "age": { "gt": 21 } } } } |
+    Then I should receive a "documents" array of objects matching:
+      | _source                            |
+      | { "name": "document1", "age": 42 } |
+      | { "name": "document2", "age": 84 } |
+    And I count 1 documents matching:
+      | age | 21 |
+
+  @mappings
   Scenario: updateByQuery
     Given an existing collection "nyc-open-data":"yellow-taxi"
     And I "create" the following documents:

--- a/features-sdk/DocumentController.feature
+++ b/features-sdk/DocumentController.feature
@@ -424,6 +424,22 @@ Feature: Document Controller
     Then The document "document-2" should exist
 
   @mappings
+  Scenario: Delete document and retrieve its source
+    Given an existing collection "nyc-open-data":"yellow-taxi"
+    And I "create" the following documents:
+      | _id          | body                    |
+      | "document-1" | { "name": "document1" } |
+    When I successfully call the route "document":"delete" with args:
+      | index      | "nyc-open-data"        |
+      | collection | "yellow-taxi"          |
+      | _id        | "document-1"           |
+      | source     | true                   |
+    Then I should receive a result matching:
+      | _id     | "document-1"            |
+      | _source | { "name": "document1" } |
+    Then The document "document-1" should not exist
+
+  @mappings
   Scenario: updateByQuery
     Given an existing collection "nyc-open-data":"yellow-taxi"
     And I "create" the following documents:

--- a/features-sdk/DocumentController.feature
+++ b/features-sdk/DocumentController.feature
@@ -452,7 +452,7 @@ Feature: Document Controller
       | index      | "nyc-open-data"                                   |
       | collection | "yellow-taxi"                                     |
       | body       | { "query": { "range": { "age": { "gt": 21 } } } } |
-    Then I should receive a "ids" array containing 2 elements
+    Then I should receive a "documents" array containing 2 elements
     And I count 1 documents matching:
       | age | 21 |
 

--- a/features-sdk/DocumentController.feature
+++ b/features-sdk/DocumentController.feature
@@ -440,6 +440,23 @@ Feature: Document Controller
     Then The document "document-1" should not exist
 
   @mappings
+  Scenario: deleteByQuery
+    Given an existing collection "nyc-open-data":"yellow-taxi"
+    And I "create" the following documents:
+      | _id | body                               |
+      | -   | { "name": "document1", "age": 42 } |
+      | -   | { "name": "document2", "age": 84 } |
+      | -   | { "name": "document2", "age": 21 } |
+    And I refresh the collection
+    When I successfully call the route "document":"deleteByQuery" with args:
+      | index      | "nyc-open-data"                                   |
+      | collection | "yellow-taxi"                                     |
+      | body       | { "query": { "range": { "age": { "gt": 21 } } } } |
+    Then I should receive a "ids" array containing 2 elements
+    And I count 1 documents matching:
+      | age | 21 |
+
+  @mappings
   Scenario: updateByQuery
     Given an existing collection "nyc-open-data":"yellow-taxi"
     And I "create" the following documents:

--- a/lib/api/controller/document.js
+++ b/lib/api/controller/document.js
@@ -437,18 +437,21 @@ class DocumentController extends NativeController {
     const source = this.getBoolean(request, 'source');
     const { index, collection } = this.getIndexAndCollection(request);
 
-    const { documents } = await this.publicStorage.deleteByQuery(
+    const result = await this.publicStorage.deleteByQuery(
       index,
       collection,
       query,
       { refresh });
 
-    await this.kuzzle.notifier.notifyDocumentMDelete(request, documents);
+    await this.kuzzle.notifier.notifyDocumentMDelete(request, result.documents);
 
     if (!source) {
-      return { ids: documents.map(d => d._id) };
+      result.documents.forEach(d => (d._source = undefined));
     }
-    return { documents };
+    return {
+      documents: result.documents,
+      ids: result.documents.map(d => d._id)
+    };
   }
 
   /**

--- a/lib/api/controller/document.js
+++ b/lib/api/controller/document.js
@@ -21,13 +21,9 @@
 
 'use strict';
 
-const
-  kerror = require('../../kerror'),
-  { NativeController } = require('./base'),
-  {
-    assertHasBody,
-    assertHasIndexAndCollection,
-  } = require('../../util/requestAssertions');
+const kerror = require('../../kerror');
+const { NativeController } = require('./base');
+const { assertHasBody, assertHasIndexAndCollection } = require('../../util/requestAssertions');
 
 /**
  * @class DocumentController
@@ -63,9 +59,8 @@ class DocumentController extends NativeController {
    * @returns {Promise<Object>}
    */
   search (request) {
-    const
-      { from, size, scrollTTL, searchBody } = this.getSearchParams(request),
-      { index, collection } = this.getIndexAndCollection(request);
+    const { from, size, scrollTTL, searchBody } = this.getSearchParams(request);
+    const { index, collection } = this.getIndexAndCollection(request);
 
     if ( [',', '*', '+'].some(searchValue => index.indexOf(searchValue) !== -1)
       || index === '_all'
@@ -99,9 +94,8 @@ class DocumentController extends NativeController {
    * @returns {Promise<Object>}
    */
   scroll (request) {
-    const
-      scrollTTL = this.getScrollTTLParam(request),
-      _scrollId = this.getString(request, 'scrollId');
+    const scrollTTL = this.getScrollTTLParam(request);
+    const _scrollId = this.getString(request, 'scrollId');
 
     return this.publicStorage.scroll(_scrollId, { scrollTTL })
       .then(({ scrollId, hits, total }) => ({
@@ -116,9 +110,8 @@ class DocumentController extends NativeController {
    * @returns {Promise<Boolean>}
    */
   exists (request) {
-    const
-      id = this.getId(request),
-      { index, collection } = this.getIndexAndCollection(request);
+    const id = this.getId(request);
+    const { index, collection } = this.getIndexAndCollection(request);
 
     return this.publicStorage.exists(index, collection, id);
   }
@@ -128,9 +121,8 @@ class DocumentController extends NativeController {
    * @returns {Promise<Object>}
    */
   get (request) {
-    const
-      id = this.getId(request),
-      { index, collection } = this.getIndexAndCollection(request);
+    const id = this.getId(request);
+    const { index, collection } = this.getIndexAndCollection(request);
 
     return this.publicStorage.get(index, collection, id)
       .then(({ _id, _version, _source}) => ({
@@ -175,9 +167,8 @@ class DocumentController extends NativeController {
    * @returns {Promise<Object>}
    */
   count (request) {
-    const
-      { searchBody } = this.getSearchParams(request),
-      { index, collection } = this.getIndexAndCollection(request);
+    const { searchBody } = this.getSearchParams(request);
+    const { index, collection } = this.getIndexAndCollection(request);
 
     return this.publicStorage.count(index, collection, searchBody)
       .then(count => ({
@@ -192,16 +183,14 @@ class DocumentController extends NativeController {
    * @returns {Promise<Object>}
    */
   create (request) {
-    let
-      modifiedRequest,
-      response;
+    let modifiedRequest;
+    let response;
 
-    const
-      id = request.input.resource._id,
-      content = this.getBody(request),
-      userId = this.getUserId(request),
-      refresh = this.getString(request, 'refresh', 'false'),
-      { index, collection } = this.getIndexAndCollection(request);
+    const id = request.input.resource._id;
+    const content = this.getBody(request);
+    const userId = this.getUserId(request);
+    const refresh = this.getString(request, 'refresh', 'false');
+    const { index, collection } = this.getIndexAndCollection(request);
 
     return this.kuzzle.validation.validate(request, false)
       .then(newRequest => {
@@ -242,16 +231,14 @@ class DocumentController extends NativeController {
    * @returns {Promise<Object>}
    */
   createOrReplace (request) {
-    let
-      modifiedRequest,
-      response;
+    let modifiedRequest;
+    let response;
 
-    const
-      id = this.getId(request),
-      content = this.getBody(request),
-      userId = this.getUserId(request),
-      refresh = this.getString(request, 'refresh', 'false'),
-      { index, collection } = this.getIndexAndCollection(request);
+    const id = this.getId(request);
+    const content = this.getBody(request);
+    const userId = this.getUserId(request);
+    const refresh = this.getString(request, 'refresh', 'false');
+    const { index, collection } = this.getIndexAndCollection(request);
 
     return this.kuzzle.validation.validate(request, false)
       .then(newRequest => {
@@ -297,16 +284,16 @@ class DocumentController extends NativeController {
    * @returns {Promise<Object>}
    */
   update (request) {
-    let modifiedRequest, response;
+    let modifiedRequest;
+    let response;
 
-    const
-      id = this.getId(request),
-      content = this.getBody(request),
-      userId = this.getUserId(request),
-      refresh = this.getString(request, 'refresh', 'false'),
-      retryOnConflict = request.input.args.retryOnConflict,
-      source = this.getBoolean(request, 'source'),
-      { index, collection } = this.getIndexAndCollection(request);
+    const id = this.getId(request);
+    const content = this.getBody(request);
+    const userId = this.getUserId(request);
+    const refresh = this.getString(request, 'refresh', 'false');
+    const retryOnConflict = request.input.args.retryOnConflict;
+    const source = this.getBoolean(request, 'source');
+    const { index, collection } = this.getIndexAndCollection(request);
 
     return this.kuzzle.validation.validate(request, false)
       .then(newRequest => {
@@ -320,7 +307,6 @@ class DocumentController extends NativeController {
           { refresh, retryOnConflict, userId });
       })
       .then(_response => {
-        // response: { _id, _version, _source }
         response = _response;
         return this.kuzzle.notifier.notifyDocumentUpdate(modifiedRequest, response);
       })
@@ -350,16 +336,14 @@ class DocumentController extends NativeController {
    * @returns {Promise<Object>}
    */
   replace (request) {
-    let
-      modifiedRequest,
-      response;
+    let modifiedRequest;
+    let response;
 
-    const
-      id = this.getId(request),
-      content = this.getBody(request),
-      userId = this.getUserId(request),
-      refresh = this.getString(request, 'refresh', 'false'),
-      { index, collection } = this.getIndexAndCollection(request);
+    const id = this.getId(request);
+    const content = this.getBody(request);
+    const userId = this.getUserId(request);
+    const refresh = this.getString(request, 'refresh', 'false');
+    const { index, collection } = this.getIndexAndCollection(request);
 
     return this.kuzzle.validation.validate(request, false)
       .then(newRequest => {
@@ -373,7 +357,6 @@ class DocumentController extends NativeController {
           { refresh, userId });
       })
       .then(_response => {
-        // response: { _id, _version, _source }
         response = _response;
 
         return this.kuzzle.notifier.notifyDocumentReplace(modifiedRequest);
@@ -424,10 +407,9 @@ class DocumentController extends NativeController {
    * @returns {Promise<Object>}
    */
   async mDelete (request) {
-    const
-      ids = this.getBodyArray(request, 'ids'),
-      refresh = this.getString(request, 'refresh', 'false'),
-      { index, collection } = this.getIndexAndCollection(request);
+    const ids = this.getBodyArray(request, 'ids');
+    const refresh = this.getString(request, 'refresh', 'false');
+    const { index, collection } = this.getIndexAndCollection(request);
 
     const { documents, errors } = await this.publicStorage.mDelete(
       index,
@@ -476,12 +458,11 @@ class DocumentController extends NativeController {
    * @returns {Promise<Object}
    */
   async updateByQuery (request) {
-    const
-      query = this.getBodyObject(request, 'query'),
-      changes = this.getBodyObject(request, 'changes'),
-      refresh = this.getString(request, 'refresh', 'false'),
-      source = this.getBoolean(request, 'source'),
-      { index, collection } = this.getIndexAndCollection(request);
+    const query = this.getBodyObject(request, 'query');
+    const changes = this.getBodyObject(request, 'changes');
+    const refresh = this.getString(request, 'refresh', 'false');
+    const source = this.getBoolean(request, 'source');
+    const { index, collection } = this.getIndexAndCollection(request);
 
     const result = await this.publicStorage.updateByQuery(
       index,
@@ -522,11 +503,10 @@ class DocumentController extends NativeController {
    * @return {Promise.<Object>} { successes, errors }
    */
   async _mChanges (request, methodName, cached) {
-    const
-      refresh = this.getString(request, 'refresh', 'false'),
-      userId = this.getUserId(request),
-      documents = this.getBodyArray(request, 'documents'),
-      { index, collection } = this.getIndexAndCollection(request);
+    const refresh = this.getString(request, 'refresh', 'false');
+    const userId = this.getUserId(request);
+    const documents = this.getBodyArray(request, 'documents');
+    const { index, collection } = this.getIndexAndCollection(request);
 
     this.assertNotExceedMaxWrite(documents.length);
 

--- a/lib/api/controller/document.js
+++ b/lib/api/controller/document.js
@@ -401,6 +401,7 @@ class DocumentController extends NativeController {
   async delete (request) {
     const id = this.getId(request);
     const refresh = this.getString(request, 'refresh', 'false');
+    const source = this.getBoolean(request, 'source');
     const { index, collection } = this.getIndexAndCollection(request);
 
     const document = await this.publicStorage.get(index, collection, id);
@@ -409,9 +410,10 @@ class DocumentController extends NativeController {
 
     await this.kuzzle.notifier.notifyDocumentMDelete(request, [document]);
 
-    return {
-      _id: document._id
-    };
+    if (!source) {
+      return { _id: document._id };
+    }
+    return document;
   }
 
   /**
@@ -448,10 +450,10 @@ class DocumentController extends NativeController {
    * @returns {Promise<Object>}
    */
   async deleteByQuery (request) {
-    const
-      query = this.getBodyObject(request, 'query'),
-      refresh = this.getString(request, 'refresh', 'false'),
-      { index, collection } = this.getIndexAndCollection(request);
+    const query = this.getBodyObject(request, 'query');
+    const refresh = this.getString(request, 'refresh', 'false');
+    const source = this.getBoolean(request, 'source');
+    const { index, collection } = this.getIndexAndCollection(request);
 
     const { documents } = await this.publicStorage.deleteByQuery(
       index,
@@ -461,7 +463,10 @@ class DocumentController extends NativeController {
 
     await this.kuzzle.notifier.notifyDocumentMDelete(request, documents);
 
-    return { ids: documents.map(d => d._id) };
+    if (!source) {
+      return { ids: documents.map(d => d._id) };
+    }
+    return { documents };
   }
 
   /**

--- a/test/api/controller/document.test.js
+++ b/test/api/controller/document.test.js
@@ -834,7 +834,7 @@ describe('DocumentController', () => {
     });
   });
 
-  describe('#deleteByQuery', () => {
+  describe.only('#deleteByQuery', () => {
     beforeEach(() => {
       documentController.publicStorage.deleteByQuery.resolves(({
         documents: [
@@ -862,11 +862,15 @@ describe('DocumentController', () => {
       should(kuzzle.notifier.notifyDocumentMDelete).be.calledWith(
         request,
         [
-          { _id: 'id1', _source: '_source1' },
-          { _id: 'id2', _source: '_source2' }
+          { _id: 'id1', _source: undefined },
+          { _id: 'id2', _source: undefined }
         ]);
 
-      should(response).be.eql({ ids: ['id1', 'id2'] });
+      should(response).match({
+        documents: [
+          { _id: 'id1', _source: undefined },
+          { _id: 'id2', _source: undefined }
+        ]});
     });
 
     it('should call publicStorage deleteByQuery method, notify the changes and retrieve all sources', async () => {
@@ -889,7 +893,7 @@ describe('DocumentController', () => {
           { _id: 'id2', _source: '_source2' }
         ]);
 
-      should(response).be.eql({
+      should(response).match({
         documents: [
           { _id: 'id1', _source: '_source1' },
           { _id: 'id2', _source: '_source2' }

--- a/test/api/controller/document.test.js
+++ b/test/api/controller/document.test.js
@@ -747,9 +747,29 @@ describe('DocumentController', () => {
         request,
         [{ _id: 'foobar', _source: '_source' }]);
 
-      should(response).match({
-        _id: 'foobar'
+      should(response).be.eql({ _id: 'foobar' });
+    });
+
+    it('should call publicStorage delete method, notify and retrieve document source', async () => {
+      documentController.publicStorage.get.resolves({
+        _id: 'foobar',
+        _source: '_source'
       });
+      request.input.resource._id = 'foobar';
+      request.input.args.source = true;
+
+      const response = await documentController.delete(request);
+
+      should(documentController.publicStorage.delete).be.calledWith(
+        index,
+        collection,
+        'foobar');
+
+      should(kuzzle.notifier.notifyDocumentMDelete).be.calledWith(
+        request,
+        [{ _id: 'foobar', _source: '_source' }]);
+
+      should(response).be.eql({ _id: 'foobar', _source: '_source'});
     });
   });
 

--- a/test/api/controller/document.test.js
+++ b/test/api/controller/document.test.js
@@ -834,7 +834,7 @@ describe('DocumentController', () => {
     });
   });
 
-  describe.only('#deleteByQuery', () => {
+  describe('#deleteByQuery', () => {
     beforeEach(() => {
       documentController.publicStorage.deleteByQuery.resolves(({
         documents: [

--- a/test/api/controller/document.test.js
+++ b/test/api/controller/document.test.js
@@ -868,6 +868,33 @@ describe('DocumentController', () => {
 
       should(response).be.eql({ ids: ['id1', 'id2'] });
     });
+
+    it('should call publicStorage deleteByQuery method, notify the changes and retrieve all sources', async () => {
+      request.input.body = { query: { foo: 'bar' } };
+      request.input.args.refresh = 'wait_for';
+      request.input.args.source = true;
+
+      const response = await documentController.deleteByQuery(request);
+
+      should(documentController.publicStorage.deleteByQuery).be.calledWith(
+        index,
+        collection,
+        { foo: 'bar' },
+        { refresh: 'wait_for' });
+
+      should(kuzzle.notifier.notifyDocumentMDelete).be.calledWith(
+        request,
+        [
+          { _id: 'id1', _source: '_source1' },
+          { _id: 'id2', _source: '_source2' }
+        ]);
+
+      should(response).be.eql({
+        documents: [
+          { _id: 'id1', _source: '_source1' },
+          { _id: 'id2', _source: '_source2' }
+        ]});
+    });
   });
 
   describe('#validate', () => {


### PR DESCRIPTION
## What does this PR do ?

Prevents the user in some situations from having to get a document before removing it.
Adds support for the optional 'source' argument, returns the already retrieved sources if required.

### Boyscout

- Added a base functional test for the **document:deleteByQuery**
- One-variable-per-declaration on the [document controller](https://github.com/kuzzleio/kuzzle/pull/1632/commits/263d94c00013cd36ba0b0c14b5fced89b557e758)
- Deprecates _array of ids_ in **document:deleteByQuery** response.