### PR TITLE
Implement custom redis transaction-like support

### DIFF
--- a/doc/2/api/controllers/memory-storage/mexecute/index.md
+++ b/doc/2/api/controllers/memory-storage/mexecute/index.md
@@ -33,9 +33,9 @@ Body:
 ```js
 {
   "actions": [
-    {"action": "command", "args": ["arg", 42, 42]},
-    {"action": "command", "args": ["arg"]},
-    {"action": "...", "args": [...]}
+    {"action": "command", "args": {"_id": "x", "body": {"value": 1}},
+    {"action": "command", "args": {"_id": "x"}},
+    {"action": "...", "args": {...}}
   ]
 }
 ```
@@ -48,9 +48,9 @@ Body:
   "action": "mexecute",
   "body": {
     "actions": [
-      {"action": "command", "args": ["arg", 42, 42]},
-      {"action": "command", "args": ["arg"]},
-      {"action": "...", "args": [...]}
+        {"action": "command", "args": {"_id": "x", "body": {"value": 1}},
+        {"action": "command", "args": {"_id": "x"}},
+        {"action": "...", "args": {...}}
     ]
   }
 }
@@ -62,7 +62,7 @@ Body:
 
 - `actions`: an array of objects. Each object describes an action to be executed, using the following properties:
   - `action`: action name
-  - `args`: an array of arguments
+  - `args`: an object containing all required arguments
 
 ---
 

--- a/doc/2/api/controllers/memory-storage/mexecute/index.md
+++ b/doc/2/api/controllers/memory-storage/mexecute/index.md
@@ -1,0 +1,88 @@
+---
+code: true
+type: page
+title: mexecute
+---
+
+# mexecute
+
+
+
+Allows the execution of multiple commands or 'actions' in a single step.
+
+It creates a redis **transaction** block and **executes** it immediately, all actions will be executed sequentially and as a single atomic and isolated operation.
+
+[[_Redis documentation_]](https://redis.io/topics/transactions)
+
+::: warning
+Only already supported actions can be executed using **mexecute**.
+:::
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/ms/_mexecute
+Method: POST
+Body:
+```
+
+```js
+{
+  "actions": [
+    {"action": "command", "args": ["arg", 42, 42]},
+    {"action": "command", "args": ["arg"]},
+    {"action": "...", "args": [...]}
+  ]
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "ms",
+  "action": "mexecute",
+  "body": {
+    "actions": [
+      {"action": "command", "args": ["arg", 42, 42]},
+      {"action": "command", "args": ["arg"]},
+      {"action": "...", "args": [...]}
+    ]
+  }
+}
+```
+
+---
+
+## Body properties
+
+- `actions`: an array of objects. Each object describes an action to be executed, using the following properties:
+  - `action`: action name
+  - `args`: an array of arguments
+
+---
+
+## Response
+
+Returns an array of error & result pairs for each executed action, in order.
+
+```js
+{
+  "requestId": "<unique request identifier>",
+  "status": 200,
+  "error": null,
+  "controller": "ms",
+  "action": "mexecute",
+  "collection": null,
+  "index": null,
+  "result": [
+      ["err" | null, "result"],
+      [null, "OK"],
+      [null, 1],
+  ]
+}
+```

--- a/features/kuzzle.feature
+++ b/features/kuzzle.feature
@@ -1685,6 +1685,26 @@ Feature: Kuzzle functional tests
       """
     Then The ms result should match the json ["Agrigento", "Palermo"]
 
+  @redis
+  Scenario: memory storage - transactions
+      When I call the mexecute method of the memory storage with arguments
+      """
+      { "body": {
+          "actions": [
+              { "action": "set", "args": ["a", 1] },
+              { "action": "get", "args": ["a"] },
+              { "action": "del", "args": ["a"] }
+          ]
+      }}
+      """
+    Then The ms result should match the json [[null,"OK"],[null,"1"],[null,1]]
+    When I call the mexecute method of the memory storage with arguments
+    """
+    { "body": {
+        "actions": []
+    }}
+    """
+    Then The ms result should match the json []
 
   @validation
   Scenario: Validation - getSpecification & updateSpecification

--- a/features/kuzzle.feature
+++ b/features/kuzzle.feature
@@ -1685,26 +1685,26 @@ Feature: Kuzzle functional tests
       """
     Then The ms result should match the json ["Agrigento", "Palermo"]
 
-  @redis
-  Scenario: memory storage - transactions
-      When I call the mexecute method of the memory storage with arguments
-      """
-      { "body": {
-          "actions": [
-              { "action": "set", "args": ["a", 1] },
-              { "action": "get", "args": ["a"] },
-              { "action": "del", "args": ["a"] }
-          ]
-      }}
-      """
-    Then The ms result should match the json [[null,"OK"],[null,"1"],[null,1]]
+@redis
+Scenario: memory storage - transactions
     When I call the mexecute method of the memory storage with arguments
     """
     { "body": {
-        "actions": []
+        "actions": [
+            { "action": "set", "args": { "_id": "list:a", "body": { "value": 1, "ex": 100, "nx": true } } },
+            { "action": "get", "args": { "_id": "list:a" } },
+            { "action": "del", "args": { "body": { "keys": ["list:a"] } } }
+        ]
     }}
     """
-    Then The ms result should match the json []
+Then The ms result should match the json [[null,"OK"],[null,"1"],[null,1]]
+When I call the mexecute method of the memory storage with arguments
+"""
+{ "body": {
+    "actions": []
+}}
+"""
+Then The ms result should match the json []
 
   @validation
   Scenario: Validation - getSpecification & updateSpecification

--- a/lib/api/controller/memoryStorage.js
+++ b/lib/api/controller/memoryStorage.js
@@ -27,7 +27,7 @@ const
   kerror = require('../../kerror').wrap('api', 'assert'),
   { NativeController } = require('./base'),
   kassert = require('../../util/requestAssertions'),
-  { isPlainObject } = require('../../util/safeObject');
+  { isPlainObject, has } = require('../../util/safeObject');
 
 let mapping;
 
@@ -314,6 +314,9 @@ function initMapping () {
         path: ['args', 'keys']
       }
     },
+    mexecute: {
+      actions: ['body', 'actions']
+    },
     mset: {
       entries: {
         map: (val, request) => {
@@ -594,6 +597,9 @@ function extractArgumentsFromRequest (command, request) {
   if (command === 'zunionstore') {
     return extractArgumentsFromRequestForZInterstore(request);
   }
+  if (command === 'mexecute') {
+    return extractArgumentsFromRequestForMExecute(request);
+  }
 
   if (!mapping[command]) {
     return [];
@@ -741,6 +747,28 @@ function extractArgumentsFromRequestForSort (request) {
   }
 
   return args;
+}
+
+/**
+ * @param {Request} request
+ * @returns {*[]}
+ */
+function extractArgumentsFromRequestForMExecute (request) {
+  kassert.assertHasBody(request);
+  kassert.assertBodyHasAttribute(request, 'actions');
+  kassert.assertBodyAttributeType(request, 'actions', 'array');
+
+  const actions = request.input.body.actions;
+
+  return [actions.map(command => {
+    if (command.action === 'mexecute') {
+      throw kerror.get('forbidden_argument', 'mexecute');
+    }
+    if (!has(mapping, command.action)) {
+      throw kerror.get('forbidden_argument', command.action);
+    }
+    return [command.action, ...command.args];
+  })];
 }
 
 /**

--- a/lib/api/controller/memoryStorage.js
+++ b/lib/api/controller/memoryStorage.js
@@ -27,6 +27,7 @@ const kerror = require('../../kerror').wrap('api', 'assert');
 const { NativeController } = require('./base');
 const kassert = require('../../util/requestAssertions');
 const { isPlainObject, has } = require('../../util/safeObject');
+const { Request } = require('kuzzle-common-objects');
 
 let mapping;
 
@@ -759,13 +760,25 @@ function extractArgumentsFromRequestForMExecute (request) {
   const actions = request.input.body.actions;
 
   return [actions.map(command => {
+    if (!has(command, 'action')) {
+      throw kerror.get('missing_argument', 'action');
+    }
+    if (!has(command, 'args')) {
+      throw kerror.get('missing_argument', 'args');
+    }
+    if (!isPlainObject(command.args)) {
+      throw kerror.get('invalid_type', 'args', 'object');
+    }
     if (command.action === 'mexecute') {
       throw kerror.get('forbidden_argument', 'mexecute');
     }
     if (!has(mapping, command.action)) {
       throw kerror.get('forbidden_argument', command.action);
     }
-    return [command.action, ...command.args];
+    const subRequest = new Request(command.args);
+    const extractedArguments = extractArgumentsFromRequest(command.action, subRequest);
+
+    return [command.action, ...extractedArguments];
   })];
 }
 

--- a/lib/api/controller/memoryStorage.js
+++ b/lib/api/controller/memoryStorage.js
@@ -23,11 +23,10 @@
 
 'use strict';
 
-const
-  kerror = require('../../kerror').wrap('api', 'assert'),
-  { NativeController } = require('./base'),
-  kassert = require('../../util/requestAssertions'),
-  { isPlainObject, has } = require('../../util/safeObject');
+const kerror = require('../../kerror').wrap('api', 'assert');
+const { NativeController } = require('./base');
+const kassert = require('../../util/requestAssertions');
+const { isPlainObject, has } = require('../../util/safeObject');
 
 let mapping;
 
@@ -610,12 +609,11 @@ function extractArgumentsFromRequest (command, request) {
   }
 
   Object.keys(mapping[command]).forEach(key => {
-    const
-      data = mapping[command][key],
-      path = Array.isArray(data) ? data : data.path,
-      toMerge = !Array.isArray(data) && data.merge === true,
-      map = !Array.isArray(data) && data.map,
-      skip = !Array.isArray(data) && data.skip === true;
+    const data = mapping[command][key];
+    const path = Array.isArray(data) ? data : data.path;
+    const toMerge = !Array.isArray(data) && data.merge === true;
+    const map = !Array.isArray(data) && data.map;
+    const skip = !Array.isArray(data) && data.skip === true;
 
     let value = path.reduce(
       (previousValue, currentValue, currentIndex, array) => {

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -231,6 +231,7 @@ module.exports = [
   {verb: 'post', url: '/ms/_lpushx/:_id', controller: 'ms', action: 'lpushx'},
   {verb: 'post', url: '/ms/_lset/:_id', controller: 'ms', action: 'lset'},
   {verb: 'post', url: '/ms/_ltrim/:_id', controller: 'ms', action: 'ltrim'},
+  {verb: 'post', url: '/ms/_mexecute', controller: 'ms', action: 'mexecute'},
   {verb: 'post', url: '/ms/_mset', controller: 'ms', action: 'mset'},
   {verb: 'post', url: '/ms/_msetnx', controller: 'ms', action: 'msetnx'},
   {verb: 'post', url: '/ms/_persist/:_id', controller: 'ms', action: 'persist'},

--- a/lib/service/cache/redis.js
+++ b/lib/service/cache/redis.js
@@ -208,6 +208,19 @@ class Redis extends Service {
     return this._client.mget(_args);
   }
 
+  /**
+   * Executes multiple client commands in a single action
+   *
+   * @returns {Promise}
+   */
+  mexecute (commands) {
+    if (!Array.isArray(commands) || commands.length === 0) {
+      return Bluebird.resolve([]);
+    }
+
+    return this._client.multi(commands).exec();
+  }
+
   _searchNodeKeys (node, pattern) {
     return new Bluebird(resolve => {
       let keys = [];

--- a/lib/service/cache/redis.js
+++ b/lib/service/cache/redis.js
@@ -218,7 +218,10 @@ class Redis extends Service {
       return Bluebird.resolve([]);
     }
 
-    return this._client.multi(commands).exec();
+    return new Bluebird(async (resolve) => {
+      const pipeline = this._client.multi(commands);
+      resolve(pipeline.exec());
+    });
   }
 
   _searchNodeKeys (node, pattern) {

--- a/lib/service/cache/redis.js
+++ b/lib/service/cache/redis.js
@@ -218,10 +218,9 @@ class Redis extends Service {
       return Bluebird.resolve([]);
     }
 
-    return new Bluebird(async (resolve) => {
-      const pipeline = this._client.multi(commands);
-      resolve(pipeline.exec());
-    });
+    return this._client
+      .multi(commands)
+      .exec();
   }
 
   _searchNodeKeys (node, pattern) {

--- a/test/api/controller/memoryStorage.test.js
+++ b/test/api/controller/memoryStorage.test.js
@@ -643,7 +643,9 @@ describe('MemoryStorageController', () => {
 
     it('should be called from extractArgumentsFromRequest when calling "mexecute"', () => {
       request.input.body.actions = [
-        { 'action': 'set', 'args': ['a', 1] }];
+        { 'action': 'set', 'args': { '_id': 'x', 'body': { 'value': 1 } } },
+        { 'action': 'get', 'args': { '_id': 'x' } },
+        { 'action': 'del', 'args': { 'body': { 'keys': ['list:a'] } } }];
       extractArgumentsFromRequest('mexecute', request);
 
       should(called.extractArgumentsFromRequestForMExecute.called).be.true();
@@ -652,11 +654,11 @@ describe('MemoryStorageController', () => {
 
     it('should throw when there is an invalid command', () => {
       request.input.body.actions = [
-        { 'action': 'mexecute', 'args': ['actions', []] }];
+        { 'action': 'set', 'args': {} }];
       should(() => extractArgumentsFromRequestForMExecute(request))
-        .throw(BadRequestError, { id: 'api.assert.forbidden_argument' });
+        .throw(BadRequestError, { id: 'api.assert.missing_argument' });
 
-      request.input.body.actions = [{ 'action': 'exec' }];
+      request.input.body.actions = [{ 'action': 'exec', 'args': {} }];
       should(() => extractArgumentsFromRequestForMExecute(request))
         .throw(BadRequestError, { id: 'api.assert.forbidden_argument' });
     });

--- a/test/service/cache/redis.test.js
+++ b/test/service/cache/redis.test.js
@@ -125,6 +125,34 @@ describe('Redis', () => {
     should(keys).be.eql(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']);
   });
 
+  it('should allow executing multiple commands', async () => {
+    await redis.init();
+
+    const commands = [
+      ['set', 'a', 1],
+      ['get', 'a'],
+      ['del', 'a']];
+    const wanted = [
+      [null,'OK'],
+      [null,'1'],
+      [null,1]];
+
+    sinon.stub(redis._client, 'multi').returns( { exec: () => {
+      return wanted;
+    }});
+
+    const result = await redis.mexecute(commands);
+
+    should(redis._client.multi).be.calledWithMatch(commands);
+    should(result).match(wanted);
+  });
+
+  it('should do nothing when attempting to execute a list of empty commands', () => {
+    const promise = redis.mexecute([]);
+
+    return should(promise).be.fulfilledWith([]);
+  });
+
   it('#set should set a single value', async () => {
     await redis.init();
 


### PR DESCRIPTION
## What does this PR do ?

Implements a memoryStorage.**mexecute** action, that receives multiple commands and executes them _directly_ in one go, using the underlying redis transactional support.

```
{
    "controller": "ms",
    "action": "mexecute",
    "body": {
    "actions": [
        { "action": "del", "args": { "_id": "#list" } },
        { "action": "sadd", "args": { "_id": "#list", "body": { "members": ["a", "b"] } } }
    ]
}
```

- [x] Functional & Unit tests
- [x] Implent mexecute in redis base client wrapper
- [x] Expose mexecute in memoryStorage controller route
- [x] Docs
- [x] Match Kuzzle Lvl API

### Boyscout

- One-variable-per-declaration on the **memoryStorage** controller