### PR TITLE
Qualiy of life: faster/better unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ jobs:
         - npm ci --silent
       script:
         - npm run --silent test:lint
-        - npm run test:unit
+        - npm run test:unit:coverage
       after_script:
         - npm run codecov
 

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "kuzzle": "./bin/start-kuzzle-server"
   },
   "scripts": {
-    "test": "npm run --silent test:lint && npm run test:unit && npm run test:functional",
-    "test:unit": "DEBUG= nyc --reporter=text-summary --reporter=lcov mocha",
+    "test": "npm run --silent test:lint && npm run test:unit:coverage && npm run test:functional",
+    "test:unit": "DEBUG= npx --node-arg=--trace-warnings mocha",
+    "test:unit:coverage": "DEBUG= nyc --reporter=text-summary --reporter=lcov mocha",
     "test:functional": "npm run test:functional:legacy && npm run test:functional:sdk",
     "test:functional:legacy": "bash features/run.sh",
     "test:functional:sdk": "bash features-sdk/run.sh",


### PR DESCRIPTION
# Description

This is a simple, quality-of-life PR for core developpers, in order to (massively) gain time when executing unit tests manually (i.e. when executing `npm run test:unit`)

## don't use `nyc` when testing manually

`nyc` is a great tool... for measuring test coverage. It works well when used in a CI tool, but it has two shortcomings when used during development:

1. it rewrites the code: it's a necessary step to measure code coverage, in order to add beacons allowing nyc to know if tests enter functions or branches. This also means that when errors occur, stack traces don't show the correct line numbers, and it often takes time to understand exactly where the error is
2. rewriting the entire code base takes time. Everytime you start unit tests, you have to wait several seconds for the first tests to show up.

This PR:
* adds a new `test:unit:coverage` command, launched by the CI or when executing the full test suite (`npm test`), which executes unit tests with `nyc` as it was done before.
* changes the `test:unit` command to execute `mocha` directly, without `nyc`. This makes unit tests waaaaaaay faster

## traces warnings

Sometimes, there are unhandled promise rejections detected in unit tests. These usually look like this (real example):

```
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․(node:7029) Warning: a promise was created in a handler at internal/timers.js:456:21 but was not returned from it, see http://goo.gl/rRqMUw
    at Function.Promise.cast (/var/app/node_modules/bluebird/js/release/promise.js:225:13)
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․ (etc)
```

Problem is... no stacktrace. And you'll have to play detective to find the culprit. 
Not anymore: unit tests are now launched with the `--trace-warnings` node options, allowing to have a full stack trace on warnings. Now, the new `npm run test:unit` command shows this:

```
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․(node:7029) Warning: a promise was created in a handler at internal/timers.js:456:21 but was not returned from it, see http://goo.gl/rRqMUw
    at Function.Promise.cast (/var/app/node_modules/bluebird/js/release/promise.js:225:13)
    at Object.invoke (/var/app/node_modules/sinon/lib/sinon/behavior.js:170:53)
    at functionStub (/var/app/node_modules/sinon/lib/sinon/stub.js:39:43)
    at Function.invoke (/var/app/node_modules/sinon/lib/sinon/proxy-invoke.js:47:47)
    at stub (/var/app/node_modules/sinon/lib/sinon/proxy.js:215:26)
    at Array.wrapper (/var/app/lib/core/plugin/manager.js:432:26)
    at WaterfallContext.next (/var/app/lib/kuzzle/event/waterfall.js:58:44)
    at waterfallNext (/var/app/lib/kuzzle/event/waterfall.js:90:9)
    at WaterfallContext.waterfallCB (/var/app/lib/kuzzle/event/waterfall.js:78:5)
    at cb (/var/app/lib/core/plugin/manager.js:426:9)
    at /var/app/lib/core/plugin/manager.js:440:29
    at processImmediate (internal/timers.js:456:21)
From previous event:
    at Array.wrapper (/var/app/lib/core/plugin/manager.js:440:14)
    at WaterfallContext.next (/var/app/lib/kuzzle/event/waterfall.js:58:44)
    at waterfallNext (/var/app/lib/kuzzle/event/waterfall.js:90:9)
    at waterfall (/var/app/lib/kuzzle/event/waterfall.js:100:3)
    at PipeRunner.run (/var/app/lib/kuzzle/event/pipeRunner.js:127:5)
    at KuzzleMock.pipe (/var/app/lib/kuzzle/event/kuzzleEventEmitter.js:151:23)
    at Context.<anonymous> (/var/app/test/core/plugin/manager/run.test.js:245:20)
․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
```

Combined with real stacktraces since unit tests are not launched with `nyc` anymore, you can get to the non-returned promise in a heartbeat.