### PR TITLE
Update swagger to OpenAPI3

### DIFF
--- a/lib/api/swagger.js
+++ b/lib/api/swagger.js
@@ -66,7 +66,8 @@ module.exports = function generateSwagger (kuzzle) {
       {
         'url': '/'
       }
-    ]
+    ],
+    paths: {}
   };
 
   routes.forEach(route => {

--- a/lib/api/swagger.js
+++ b/lib/api/swagger.js
@@ -93,9 +93,9 @@ module.exports = function generateSwagger (kuzzle) {
         route.infos.description += `\nController: ${route.controller}. Action: ${route.action}.`;
       }
 
-      if (route.infos.produces === undefined) {
-        route.infos.produces = ['applications/json'];
-      }
+      //   if (route.infos.produces === undefined) {
+      //     route.infos.produces = ['applications/json'];
+      //   }
 
       if (route.infos.parameters === undefined) {
         route.infos.parameters = [];

--- a/lib/api/swagger.js
+++ b/lib/api/swagger.js
@@ -19,6 +19,8 @@
  * limitations under the License.
  */
 
+/* eslint sort-keys: 0 */
+
 'use strict';
 
 const _ = require('lodash');

--- a/lib/api/swagger.js
+++ b/lib/api/swagger.js
@@ -45,7 +45,7 @@ module.exports = function generateSwagger (kuzzle) {
   });
 
   const swagger = {
-    openApi: '3.0.1',
+    openapi: '3.0.1',
     info: {
       title: 'Kuzzle API',
       description: 'The Kuzzle HTTP API',

--- a/lib/api/swagger.js
+++ b/lib/api/swagger.js
@@ -38,8 +38,6 @@ module.exports = function generateSwagger (kuzzle) {
 
   kuzzle.config.http.routes.forEach(_route => routes.push(_.assign({}, _route)));
 
-  routes.push({action: 'info', controller: 'server', url: '/_serverInfo', verb: 'get'});
-
   kuzzle.pluginsManager.routes.forEach(_route => {
     const route = _.assign({}, _route);
     route.url = `/_plugin${route.url}`;

--- a/lib/api/swagger.js
+++ b/lib/api/swagger.js
@@ -19,7 +19,7 @@
  * limitations under the License.
  */
 
-/* eslint sort-keys: 0 */
+/* eslint-disable sort-keys */
 
 'use strict';
 

--- a/lib/api/swagger.js
+++ b/lib/api/swagger.js
@@ -69,7 +69,8 @@ module.exports = function generateSwagger (kuzzle) {
         'url': '/'
       }
     ],
-    paths: {}
+    tags: [],
+    paths: {},
   };
 
   routes.forEach(route => {
@@ -84,6 +85,16 @@ module.exports = function generateSwagger (kuzzle) {
 
       if (route.infos === undefined) {
         route.infos = {};
+      }
+
+      if (route.controller !== undefined) {
+        let capitalizedController = route.controller.charAt(0).toUpperCase() + route.controller.slice(1);
+
+        swagger.tags.push({name: route.controller, description: `${capitalizedController} Controller`});
+        if (route.infos.tags === undefined) {
+          route.infos.tags = [];
+        }
+        route.infos.tags.push(route.controller);
       }
 
       if (route.infos.description === undefined) {
@@ -131,5 +142,6 @@ module.exports = function generateSwagger (kuzzle) {
     }
   });
 
+  swagger.tags = _.uniqBy(swagger.tags, 'name');
   return swagger;
 };

--- a/lib/api/swagger.js
+++ b/lib/api/swagger.js
@@ -47,29 +47,26 @@ module.exports = function generateSwagger (kuzzle) {
   });
 
   const swagger = {
-    basePath: '/',
-    consumes: [
-      'application/json'
-    ],
+    openApi: '3.0.1',
     info: {
-      contact: {
-        email: 'hello@kuzzle.io',
-        name: 'Kuzzle team',
-        url: 'http://kuzzle.io'
-      },
+      title: 'Kuzzle API',
       description: 'The Kuzzle HTTP API',
+      contact: {
+        name: 'Kuzzle team',
+        url: 'http://kuzzle.io',
+        email: 'hello@kuzzle.io'
+      },
       license: {
         name: 'Apache 2',
         url: 'http://opensource.org/licenses/apache2.0'
       },
-      title: 'Kuzzle API',
       version: require('../../package').version
     },
-    paths: {},
-    produces: [
-      'application/json'
-    ],
-    swagger: '2.0'
+    servers: [
+      {
+        'url': '/'
+      }
+    ]
   };
 
   routes.forEach(route => {

--- a/lib/api/swagger.js
+++ b/lib/api/swagger.js
@@ -101,7 +101,7 @@ module.exports = function generateSwagger (kuzzle) {
     if (route.controller !== undefined) {
       if (!_.some(swagger.tags, {name: route.controller})) {
         const capitalizedController = route.controller.charAt(0).toUpperCase() + route.controller.slice(1);
-        swagger.tags.push({name: route.controller, description: `${capitalizedController} Controller`});
+        swagger.tags.push({description: `${capitalizedController} Controller`, name: route.controller});
       }
       if (route.info.tags === undefined) {
         route.info.tags = [];
@@ -124,8 +124,8 @@ module.exports = function generateSwagger (kuzzle) {
       while (m !== null) {
         routeUrlMatch.lastIndex++;
         route.info.parameters.push({
-          name: m[1],
           in: 'path',
+          name: m[1],
           required: true,
           schema: {type: 'string'}
         });

--- a/lib/api/swagger.js
+++ b/lib/api/swagger.js
@@ -66,7 +66,17 @@ module.exports = function generateSwagger (kuzzle) {
     },
     servers: [
       {
-        'url': '/'
+        url: 'https://{baseUrl}:{port}',
+        description: 'Kuzzle Base Url',
+        variables: {
+          baseUrl: {
+            default: 'localhost'
+          },
+          port: {
+            default: '7512'
+          }
+        }
+
       }
     ],
     tags: [],
@@ -74,74 +84,70 @@ module.exports = function generateSwagger (kuzzle) {
   };
 
   routes.forEach(route => {
-    // conforms to the swagger format by replacing the parameters notation :parameter by {parameter}
+    // Set :param notation to {param}
     route.url_ = route.url.replace(routeUrlMatch, '{$1}');
 
     if (swagger.paths[route.url_] === undefined) {
       swagger.paths[route.url_] = {};
     }
 
-    if (swagger.paths[route.url_][route.verb] === undefined) {
-
-      if (route.infos === undefined) {
-        route.infos = {};
-      }
-
-      if (route.controller !== undefined) {
-        let capitalizedController = route.controller.charAt(0).toUpperCase() + route.controller.slice(1);
-
-        swagger.tags.push({name: route.controller, description: `${capitalizedController} Controller`});
-        if (route.infos.tags === undefined) {
-          route.infos.tags = [];
-        }
-        route.infos.tags.push(route.controller);
-      }
-
-      if (route.infos.description === undefined) {
-        route.infos.description = `Controller: ${route.controller}. Action: ${route.action}.`;
-      }
-      else {
-        route.infos.description += `\nController: ${route.controller}. Action: ${route.action}.`;
-      }
-
-      //   if (route.infos.produces === undefined) {
-      //     route.infos.produces = ['applications/json'];
-      //   }
-
-      if (route.infos.parameters === undefined) {
-        route.infos.parameters = [];
-
-        let m = routeUrlMatch.exec(route.url);
-        while (m !== null) {
-          routeUrlMatch.lastIndex++;
-          route.infos.parameters.push({
-            description: 'TODO',
-            in: 'path',
-            name: m[1],
-            required: true,
-            type: 'string'
-          });
-
-          m = routeUrlMatch.exec(route.url);
-        }
-      }
-
-      if (route.infos.parameters.length === 0) {
-        route.infos.parameters = undefined;
-      }
-
-      if (route.infos.responses === undefined) {
-        route.infos.responses = {
-          '200': {
-            description: 'OK'
-          }
-        };
-      }
-
-      swagger.paths[route.url_][route.verb] = route.infos;
+    if (swagger.paths[route.url_][route.verb] !== undefined) {
+      return;
     }
+
+    if (route.info === undefined) {
+      route.info = {};
+    }
+    if (route.controller !== undefined) {
+      if (!_.some(swagger.tags, {name: route.controller})) {
+        let capitalizedController = route.controller.charAt(0).toUpperCase() + route.controller.slice(1);
+        swagger.tags.push({name: route.controller, description: `${capitalizedController} Controller`});
+      }
+      if (route.info.tags === undefined) {
+        route.info.tags = [];
+      }
+      if (!route.info.tags.includes(route.controller)) {
+        route.info.tags.push(route.controller);
+      }
+    }
+
+    if (route.info.description === undefined) {
+      route.info.description = `Controller: ${route.controller}.`;
+    }
+    if (route.info.summary === undefined) {
+      route.info.summary = `Action: ${route.action}.`;
+    }
+    if (route.info.parameters === undefined) {
+      route.info.parameters = [];
+
+      let m = routeUrlMatch.exec(route.url);
+      while (m !== null) {
+        routeUrlMatch.lastIndex++;
+        route.info.parameters.push({
+          name: m[1],
+          in: 'path',
+          required: true,
+          schema: {type: 'integer'}
+        });
+
+        m = routeUrlMatch.exec(route.url);
+      }
+    }
+
+    if (route.info.parameters.length === 0) {
+      route.info.parameters = undefined;
+    }
+
+    if (route.info.responses === undefined) {
+      route.info.responses = {
+        '200': {
+          description: 'OK'
+        }
+      };
+    }
+
+    swagger.paths[route.url_][route.verb] = route.info;
   });
 
-  swagger.tags = _.uniqBy(swagger.tags, 'name');
   return swagger;
 };

--- a/lib/api/swagger.js
+++ b/lib/api/swagger.js
@@ -127,7 +127,7 @@ module.exports = function generateSwagger (kuzzle) {
           name: m[1],
           in: 'path',
           required: true,
-          schema: {type: 'integer'}
+          schema: {type: 'string'}
         });
 
         m = routeUrlMatch.exec(route.url);

--- a/lib/api/swagger.js
+++ b/lib/api/swagger.js
@@ -60,6 +60,10 @@ module.exports = function generateSwagger (kuzzle) {
       },
       version: require('../../package').version
     },
+    externalDocs: {
+      description: 'Kuzzle API Documentation',
+      url: 'https://docs.kuzzle.io/core/2/api/'
+    },
     servers: [
       {
         'url': '/'

--- a/lib/api/swagger.js
+++ b/lib/api/swagger.js
@@ -19,8 +19,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable sort-keys */
-
 'use strict';
 
 const _ = require('lodash');
@@ -44,6 +42,7 @@ module.exports = function generateSwagger (kuzzle) {
     routes.push(route);
   });
 
+  /* eslint-disable sort-keys */
   const swagger = {
     openapi: '3.0.1',
     info: {
@@ -82,6 +81,7 @@ module.exports = function generateSwagger (kuzzle) {
     tags: [],
     paths: {},
   };
+  /* eslint-enable sort-keys */
 
   routes.forEach(route => {
     // Set :param notation to {param}

--- a/lib/api/swagger.js
+++ b/lib/api/swagger.js
@@ -100,7 +100,7 @@ module.exports = function generateSwagger (kuzzle) {
     }
     if (route.controller !== undefined) {
       if (!_.some(swagger.tags, {name: route.controller})) {
-        let capitalizedController = route.controller.charAt(0).toUpperCase() + route.controller.slice(1);
+        const capitalizedController = route.controller.charAt(0).toUpperCase() + route.controller.slice(1);
         swagger.tags.push({name: route.controller, description: `${capitalizedController} Controller`});
       }
       if (route.info.tags === undefined) {

--- a/lib/core/network/router.js
+++ b/lib/core/network/router.js
@@ -122,7 +122,7 @@ class Router {
       cb(request);
     });
 
-    this.http.get('/swagger.yml', (request, cb) => {
+    this.http.get('/swagger.yaml', (request, cb) => {
       request.setResult(jsonToYaml.stringify(generateSwagger(this.kuzzle)), {
         headers: {'content-type': 'application/yaml'},
         raw: true,

--- a/lib/core/network/router.js
+++ b/lib/core/network/router.js
@@ -122,7 +122,7 @@ class Router {
       cb(request);
     });
 
-    this.http.get('/swagger.yaml', (request, cb) => {
+    this.http.get('/swagger.yml', (request, cb) => {
       request.setResult(jsonToYaml.stringify(generateSwagger(this.kuzzle)), {
         headers: {'content-type': 'application/yaml'},
         raw: true,


### PR DESCRIPTION
## What does this PR do ?
Updates the old swagger route, to [OpenApi 3.0.1](http://spec.openapis.org/oas/v3.0.1) and a few more tweaks.

![openapi](https://user-images.githubusercontent.com/2495908/84024732-b24a0d80-a98a-11ea-8475-b2f00fc6eaf4.gif)

- Includes a link to Kuzzle Documentation
- Groups routes by controller using tags (Greatly improves readability)
- Includes custom metadata **If** an OpenApi 'info' object is detected in the route object (Set's defaults data if object is incomplete)
- Supports request body definition

## **Route.info** example
```js
  {
    verb: 'get',
    url: '/credentials/:strategy/_me',
    controller: 'auth',
    action: 'getMyCredentials',
    info: {
      description: 'Custom Route description',
      parameters: [{
        name: 'strategy',
        in: 'path',
        required: true,
        description: 'Parameter description',
        schema: {type: 'string'}}
      ]
    }
  }
```
_More info about parameters [here](https://swagger.io/docs/specification/describing-parameters/)._

### How should this be manually tested?
Having Kuzzle running, go to [/swagger.json](http://localhost:7512/swagger.json), then copy/paste into [https://editor.swagger.io/](https://editor.swagger.io/)

### What's next?
Another PR would update **each** Kuzzle's API routes to **fully** support open api