### PR TITLE
Stick deleteRole/Profile behavior to the documentation

### DIFF
--- a/lib/api/controller/security.js
+++ b/lib/api/controller/security.js
@@ -425,17 +425,20 @@ class SecurityController extends NativeController {
    * @param {Request} request
    * @returns {Promise<Object>}
    */
-  deleteRole(request) {
+  async deleteRole(request) {
     assertHasId(request);
 
     const options = { refresh: getRefresh(request) };
 
-    return this.kuzzle.repositories.role.load(request.input.resource._id)
-      .then(role =>
-      {
-        this.kuzzle.log.info(`[SECURITY] User "${this.getUserId(request)}" applied action "${request.input.action} on role "${role._id}."`);
-        return this.kuzzle.repositories.role.delete(role, options);
-      });
+    const role = await this.kuzzle.repositories.role.load(request.input.resource._id);
+    
+    await this.kuzzle.repositories.role.delete(role, options);
+
+    this.kuzzle.log.info(`[SECURITY] User "${this.getUserId(request)}" applied action "${request.input.action} on role "${role._id}."`);
+
+    return {
+      _id: role._id
+    };
   }
 
   /**
@@ -543,16 +546,19 @@ class SecurityController extends NativeController {
    * @param {Request} request
    * @returns {Promise<Object>}
    */
-  deleteProfile(request) {
+  async deleteProfile(request) {
     assertHasId(request);
 
     const options = { refresh: getRefresh(request) };
 
-    return this.kuzzle.repositories.profile.load(request.input.resource._id)
-      .then(profile => {
-        this.kuzzle.log.info(`[SECURITY] User "${this.getUserId(request)}" applied action "${request.input.action}" on profile "${profile._id}."`);
-        return this.kuzzle.repositories.profile.delete(profile, options);
-      });
+    const profile = await this.kuzzle.repositories.profile.load(request.input.resource._id);
+    
+    await this.kuzzle.repositories.profile.delete(profile, options);
+    
+    this.kuzzle.log.info(`[SECURITY] User "${this.getUserId(request)}" applied action "${request.input.action}" on profile "${profile._id}."`);
+    return {
+      _id: profile._id
+    };
   }
 
   /**

--- a/test/api/controller/security/roles.test.js
+++ b/test/api/controller/security/roles.test.js
@@ -248,16 +248,15 @@ describe('Test: security controller - roles', () => {
   });
 
   describe('#deleteRole', () => {
-    it('should return response with on deleteRole call', done => {
-      const role = {_id: 'role'};
+    it('should return a valid response', () => {
 
-      kuzzle.repositories.role.load.resolves(role);
-      kuzzle.repositories.role.delete.resolves();
+      kuzzle.repositories.role.load.resolves({ _id: 'test' });
+      kuzzle.repositories.role.delete.resolves({ _id: 'test' });
 
-      securityController.deleteRole(new Request({ _id: 'test', body: {} }))
-        .then(() => {
-          should(kuzzle.repositories.role.delete.calledWith(role)).be.true();
-          done();
+      return securityController.deleteRole(new Request({ _id: 'test', body: {} }))
+        .then(response => {
+          should(response).be.instanceOf(Object);
+          should(response._id).be.exactly('test');
         });
     });
 


### PR DESCRIPTION
## What does this PR do ?

`deleteRole` and `deleteProfile` had a different behavior than `deleteUser` : they didnt returned the delete object's `id` while it is documented that way

### Boyscout

Asyncify deleteRole and deleteProfile
Adapt unit test