### PR TITLE
Fix missing curl in Docker images

### DIFF
--- a/bin/wait-elasticsearch
+++ b/bin/wait-elasticsearch
@@ -28,6 +28,8 @@ const { Client: ESClient } = require('@elastic/elasticsearch');
 
 const Kuzzle = require('../lib/kuzzle');
 
+const sleep = seconds => new Promise(resolve => setTimeout(() => resolve(), seconds * 1000))
+
 async function waitForEs (maxSeconds = 120) {
   const kuzzle = new Kuzzle();
   const esConfig = kuzzle.config.services.storageEngine;
@@ -47,14 +49,15 @@ async function waitForEs (maxSeconds = 120) {
 
       return;
     }
-    catch (error) {}
+    catch (e) {}
 
     process.stdout.write(`[${spinner.charAt(i)}] Still trying to connect to Elasticsearch (${seconds}s)...`);
     process.stdout.write('\r');
 
     i = i === 3 ? 0 : i + 1;
     seconds++;
-    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    await sleep(1);
   }
 
   throw new Error(`Timeout after ${seconds}s: cannot connect to Elasticsearch at "${esConfig.node}"`);

--- a/bin/wait-kuzzle
+++ b/bin/wait-kuzzle
@@ -35,7 +35,7 @@ function tryConnect (host, port) {
   return new Promise(resolve => {
     const client = new net.Socket();
 
-    client.on('error', error => resolve(false));
+    client.on('error', () => resolve(false));
 
     client.connect(port, host, () => resolve(true));
   });
@@ -70,8 +70,18 @@ async function waitKuzzle (host, port, maxTries) {
   process.exit(1);
 }
 
+const run = async () => {
+  try {
+    await waitKuzzle(kuzzleHost, kuzzlePort, maxTries);
+  }
+  catch (error) {
+    console.error(`[x] ${error.message}`);
+    process.exit(1);
+  }
+};
+
 if (require.main === module) {
-  waitKuzzle(kuzzleHost, kuzzlePort, maxTries);
+  run();
 }
 
 module.exports = waitKuzzle;

--- a/docker/images/kuzzle.alpine/Dockerfile
+++ b/docker/images/kuzzle.alpine/Dockerfile
@@ -53,7 +53,7 @@ RUN  set -x \
 ################################################################################
 # Production image
 ################################################################################
-FROM node:12.18.1-alpine3.11 as kuzzle
+FROM node:12.18.1-alpine3.11
 
 LABEL io.kuzzle.vendor="Kuzzle <support@kuzzle.io>"
 LABEL description="Run your Kuzzle backend in production mode with alpine"
@@ -64,6 +64,10 @@ ADD ./docker/scripts/entrypoint.sh /bin/entrypoint
 ADD ./docker/scripts/run-prod.sh /bin/kuzzle
 
 COPY --from=builder /app /var/app
+
+WORKDIR /var/app
+
+ENV PATH=$PATH:/var/app/bin
 
 ENTRYPOINT ["/bin/entrypoint"]
 

--- a/docker/images/kuzzle.scratch/Dockerfile
+++ b/docker/images/kuzzle.scratch/Dockerfile
@@ -90,7 +90,7 @@ RUN tar czf /app.tar.gz /var/app
 ################################################################################
 # Production image
 ################################################################################
-FROM scratch as kuzzle
+FROM scratch
 
 LABEL io.kuzzle.vendor="Kuzzle <support@kuzzle.io>"
 LABEL description="Run your Kuzzle backend in production mode with scratch image"
@@ -107,6 +107,10 @@ COPY --from=minifier /app.tar.gz /app.tar.gz
 COPY --from=minifier /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
 
 RUN ln -s /lib/ld-musl-x86_64.so.1 /lib/libc.musl-x86_64.so.1
+
+WORKDIR /var/app
+
+ENV PATH=$PATH:/var/app/bin
 
 ENTRYPOINT ["/bin/entrypoint"]
 

--- a/docker/images/kuzzle/Dockerfile
+++ b/docker/images/kuzzle/Dockerfile
@@ -60,7 +60,10 @@ ENV NODE_ENV=production
 COPY --from=builder /app /app
 
 RUN  set -x \
-  && apt-get update && apt-get install -y xz-utils binutils \
+  && apt-get update && apt-get install -y
+    xz-utils \
+    binutils \
+    curl \
   && strip /usr/local/bin/node \
   && apt-get remove -y binutils xz-utils \
   && apt-get clean autoclean \
@@ -70,7 +73,7 @@ RUN  set -x \
 ################################################################################
 # Production image
 ################################################################################
-FROM bitnami/minideb:stretch as kuzzle
+FROM bitnami/minideb:stretch
 
 LABEL io.kuzzle.vendor="Kuzzle <support@kuzzle.io>"
 LABEL description="Run your Kuzzle backend in production mode"
@@ -84,9 +87,13 @@ ENV NODE_ENV=production
 ADD ./docker/scripts/entrypoint.sh /bin/entrypoint
 ADD ./docker/scripts/run-prod.sh /bin/kuzzle
 
-ENTRYPOINT ["/bin/entrypoint"]
-
 RUN ln -s /var/app /app
+
+WORKDIR /var/app
+
+ENV PATH=$PATH:/var/app/bin
+
+ENTRYPOINT ["/bin/entrypoint"]
 
 CMD ["kuzzle", "start"]
 

--- a/docker/images/kuzzle/Dockerfile
+++ b/docker/images/kuzzle/Dockerfile
@@ -61,14 +61,9 @@ COPY --from=builder /app /app
 
 RUN  set -x \
   && apt-get update && apt-get install -y
-    xz-utils \
-    binutils \
     curl \
-  && strip /usr/local/bin/node \
-  && apt-get remove -y binutils xz-utils \
   && apt-get clean autoclean \
-  && apt-get autoremove --yes \
-  && rm -rf /var/lib/{apt,dpkg,cache,log}/
+  && apt-get autoremove --yes
 
 ################################################################################
 # Production image

--- a/docker/images/plugin-dev/Dockerfile
+++ b/docker/images/plugin-dev/Dockerfile
@@ -52,7 +52,7 @@ RUN  set -x \
 ################################################################################
 # Plugin development image
 ################################################################################
-FROM debian:stretch-slim as plugin-dev
+FROM debian:stretch-slim
 
 LABEL io.kuzzle.vendor="Kuzzle <support@kuzzle.io>"
 LABEL description="Develop new plugin or protocol for Kuzzle with ease"
@@ -70,6 +70,10 @@ RUN  set -x \
   && rm /bin/sh \
   && ln -s /bin/bash /bin/sh \
   && ln -s /var/app /app
+
+WORKDIR /var/app
+
+ENV PATH=$PATH:/var/app/bin
 
 ENTRYPOINT ["/bin/entrypoint"]
 


### PR DESCRIPTION
## What does this PR do ?

`curl` was missing from new images because it's not necessary anymore thanks to `wait-elasticsearch` and `wait-kuzzle` Node.js scripts.

But some other projects may still rely on bash script using `curl` to determine ES or Kuzzle availability (eg: Kourou ci)

This PR adds `curl` to the `kuzzleio/kuzzle` `2-*` tags.

### Other changes

 - do not strip node binaries for `2-*` and `2-alpine*` tags because some observability tools may rely on it
 - fix the `WORKDIR`
 - add `/var/app/bin` to `PATH`