### PR TITLE
Fix: handling of Elasticsearch aliases

### DIFF
--- a/lib/core/storage/storageEngine.js
+++ b/lib/core/storage/storageEngine.js
@@ -21,11 +21,12 @@
 
 'use strict';
 
+const Bluebird = require('bluebird');
+
 const Elasticsearch = require('../../service/storage/elasticsearch');
 const kerror = require('../../kerror').wrap('services', 'storage');
 const ClientAdapter = require('./clientAdapter');
 const BaseModel = require('../../model/storage/baseModel');
-const Bluebird = require('bluebird');
 
 class IndexCache {
   constructor (scope) {
@@ -210,10 +211,8 @@ class StorageEngine {
    * @returns {Promise}
    */
   async _populateIndexCache () {
-    let
-      publicIndexes,
-      internalIndexes;
-
+    let publicIndexes;
+    let internalIndexes;
     const promises = [];
 
     promises.push(
@@ -266,11 +265,10 @@ class StorageEngine {
    * @returns {Promise}
    */
   _addCollections (indexes, scope) {
-    const
-      storageClient = scope === 'public'
-        ? this._publicClient
-        : this._internalClient,
-      promises = [];
+    const storageClient = scope === 'public'
+      ? this._publicClient
+      : this._internalClient;
+    const promises = [];
 
     for (const index of indexes) {
       this._indexes.set(index, new IndexCache(scope));
@@ -290,8 +288,8 @@ class StorageEngine {
   async _addCollectionsAliases () {
     const aliases = await this._publicClient.listAliases();
 
-    for (const { name, index } of aliases) {
-      this._indexes.get(index).collections.add(name);
+    for (const { collection, index } of aliases) {
+      this._indexes.get(index).collections.add(collection);
     }
   }
 }

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -1337,14 +1337,19 @@ class ElasticSearch extends Service {
    *
    * @returns {Promise.<Array>} Collection names
    */
-  listCollections (index) {
-    return this._client.cat.indices({ format: 'json' })
-      .then(({ body }) => {
-        const esIndexes = body.map(({ index: esIndex }) => esIndex);
+  async listCollections (index) {
+    let body;
 
-        return this._extractCollections(esIndexes, index);
-      })
-      .catch(error => this._esWrapper.reject(error));
+    try {
+      ({ body } = await this._client.cat.indices({ format: 'json' }));
+    }
+    catch (error) {
+      throw this._esWrapper.formatESError(error);
+    }
+
+    const esIndexes = body.map(({ index: esIndex }) => esIndex);
+
+    return this._extractCollections(esIndexes, index);
   }
 
   /**
@@ -1352,14 +1357,19 @@ class ElasticSearch extends Service {
    *
    * @returns {Promise.<Array>} Index names
    */
-  listIndexes () {
-    return this._client.cat.indices({ format: 'json' })
-      .then(({ body }) => {
-        const esIndexes = body.map(({ index }) => index);
+  async listIndexes () {
+    let body;
 
-        return this._extractIndexes(esIndexes);
-      })
-      .catch(error => this._esWrapper.reject(error));
+    try {
+      ({ body } = await this._client.cat.indices({ format: 'json' }));
+    }
+    catch(error) {
+      throw this._esWrapper.formatESError(error);
+    }
+
+    const esIndexes = body.map(({ index }) => index);
+
+    return this._extractIndexes(esIndexes);
   }
 
   /**
@@ -1367,24 +1377,28 @@ class ElasticSearch extends Service {
    *
    * @returns {Promise.<Object[]>} [ { name, index, collection } ]
    */
-  listAliases () {
-    return this._client.cat.aliases({ format: 'json' })
-      .then(({ body }) => {
-        const aliases = [];
+  async listAliases () {
+    let body;
 
-        for (const { alias, index: esIndex } of body) {
-          if (esIndex[0] === this._indexPrefix) {
-            aliases.push({
-              collection: this._extractCollection(esIndex),
-              index: this._extractIndex(esIndex),
-              name: alias
-            });
-          }
-        }
+    try {
+      ({ body } = await this._client.cat.aliases({ format: 'json' }));
+    }
+    catch (error) {
+      throw this._esWrapper.formatESError(error);
+    }
 
-        return aliases;
-      })
-      .catch(error => this._esWrapper.reject(error));
+    const aliases = [];
+
+    for (const { alias, index: esIndex } of body) {
+      if (alias[0] === this._indexPrefix) {
+        aliases.push({
+          collection: this._extractCollection(alias),
+          index: this._extractIndex(alias),
+          name: esIndex,
+        });
+      }
+    }
+    return aliases;
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "main": "./lib/kuzzle",
   "bin": {

--- a/test/core/storage/storageEngine.test.js
+++ b/test/core/storage/storageEngine.test.js
@@ -3,9 +3,11 @@
 const sinon = require('sinon');
 const should = require('should');
 const mockrequire = require('mock-require');
+
 const KuzzleMock = require('../../mocks/kuzzle.mock');
-const BaseModel = require('../../../lib/model/storage/baseModel');
 const ClientAdapterMock = require('../../mocks/clientAdapter.mock');
+
+const BaseModel = require('../../../lib/model/storage/baseModel');
 
 describe('StorageEngine', () => {
   let StorageEngine;
@@ -85,7 +87,7 @@ describe('StorageEngine', () => {
       await storageEngine.init();
 
       should(storageEngine._indexes.get('barfoo').collections)
-        .have.keys('barlection', 'barlection-alias');
+        .have.keys('barlection');
     });
   });
 

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -3,9 +3,6 @@
 const should = require('should');
 const sinon = require('sinon');
 const ms = require('ms');
-const KuzzleMock = require('../../mocks/kuzzle.mock');
-const ESClientMock = require('../../mocks/service/elasticsearchClient.mock');
-const ES = require('../../../lib/service/storage/elasticsearch');
 const {
   errors: {
     BadRequestError,
@@ -13,6 +10,11 @@ const {
     SizeLimitError,
   }
 } = require('kuzzle-common-objects');
+
+const KuzzleMock = require('../../mocks/kuzzle.mock');
+const ESClientMock = require('../../mocks/service/elasticsearchClient.mock');
+
+const ES = require('../../../lib/service/storage/elasticsearch');
 
 describe('Test: ElasticSearch service', () => {
   let kuzzle;
@@ -2182,15 +2184,12 @@ describe('Test: ElasticSearch service', () => {
         });
     });
 
-    it('should return a rejected promise if client fails', () => {
+    it('should return a rejected promise if client fails', async () => {
       elasticsearch._client.cat.indices.rejects(esClientError);
 
-      const promise = elasticsearch.listCollections(index);
+      await should(elasticsearch.listCollections(index)).be.rejected();
 
-      return should(promise).be.rejected()
-        .then(() => {
-          should(elasticsearch._esWrapper.reject).be.calledWith(esClientError);
-        });
+      should(elasticsearch._esWrapper.formatESError).be.calledWith(esClientError);
     });
   });
 
@@ -2236,15 +2235,12 @@ describe('Test: ElasticSearch service', () => {
         });
     });
 
-    it('should return a rejected promise if client fails', () => {
+    it('should return a rejected promise if client fails', async () => {
       elasticsearch._client.cat.indices.rejects(esClientError);
 
-      const promise = elasticsearch.listIndexes();
+      await should(elasticsearch.listIndexes()).be.rejected();
 
-      return should(promise).be.rejected()
-        .then(() => {
-          should(elasticsearch._esWrapper.reject).be.calledWith(esClientError);
-        });
+      should(elasticsearch._esWrapper.formatESError).be.calledWith(esClientError);
     });
   });
 
@@ -2252,59 +2248,50 @@ describe('Test: ElasticSearch service', () => {
     beforeEach(() => {
       elasticsearch._client.cat.aliases.resolves({
         body: [
-          { alias: 'alias-mehry', index: '&nepali.mehry' },
-          { alias: 'alias-liia', index: '&nepali.liia' },
-          { alias: 'alias-taxi', index: '&nyc-open-data.taxi' }
+          { index: 'mehry', alias: '&nepali.mehry' },
+          { index: 'liia', alias: '&nepali.liia' },
+          { index: 'taxi', alias: '&nyc-open-data.taxi' }
         ]
       });
     });
 
-    it('should allow listing all available aliases', () => {
-      const promise = elasticsearch.listAliases();
+    it('should allow listing all available aliases', async () => {
+      const result = await elasticsearch.listAliases();
 
-      return promise
-        .then(result => {
-          should(elasticsearch._client.cat.aliases).be.calledWithMatch({
-            format: 'json'
-          });
+      should(elasticsearch._client.cat.aliases).be.calledWithMatch({
+        format: 'json'
+      });
 
-          should(result).match([
-            { name: 'alias-mehry', index: 'nepali', collection: 'mehry' },
-            { name: 'alias-liia', index: 'nepali', collection: 'liia' },
-            { name: 'alias-taxi', index: 'nyc-open-data', collection: 'taxi' },
-          ]);
-        });
+      should(result).match([
+        { name: 'mehry', index: 'nepali', collection: 'mehry' },
+        { name: 'liia', index: 'nepali', collection: 'liia' },
+        { name: 'taxi', index: 'nyc-open-data', collection: 'taxi' },
+      ]);
     });
 
-    it('should not list unauthorized aliases', () => {
+    it('should not list unauthorized aliases', async () => {
       elasticsearch._client.cat.aliases.resolves({
         body: [
-          { alias: 'alias-mehry', index: '%nepali.mehry' },
-          { alias: 'alias-liia', index: '%nepali.liia' },
-          { alias: 'alias-taxi', index: '%nyc-open-data.taxi' },
-          { alias: 'alias-lfiduras', index: '&vietnam.lfiduras' }
+          { index: 'alias-mehry', alias: '%nepali.mehry' },
+          { index: 'alias-liia', alias: '%nepali.liia' },
+          { index: 'alias-taxi', alias: '%nyc-open-data.taxi' },
+          { index: 'alias-lfiduras', alias: '&vietnam.lfiduras' }
         ]
       });
 
-      const promise = elasticsearch.listAliases();
+      const result = await elasticsearch.listAliases();
 
-      return promise
-        .then(result => {
-          should(result).match([
-            { name: 'alias-lfiduras', index: 'vietnam', collection: 'lfiduras' },
-          ]);
-        });
+      should(result).match([
+        { name: 'alias-lfiduras', index: 'vietnam', collection: 'lfiduras' },
+      ]);
     });
 
-    it('should return a rejected promise if client fails', () => {
+    it('should return a rejected promise if client fails', async () => {
       elasticsearch._client.cat.aliases.rejects(esClientError);
 
-      const promise = elasticsearch.listAliases();
+      await should(elasticsearch.listAliases()).be.rejected();
 
-      return should(promise).be.rejected()
-        .then(() => {
-          should(elasticsearch._esWrapper.reject).be.calledWith(esClientError);
-        });
+      should(elasticsearch._esWrapper.formatESError).be.calledWith(esClientError);
     });
   });
 
@@ -2312,59 +2299,51 @@ describe('Test: ElasticSearch service', () => {
     beforeEach(() => {
       elasticsearch._client.cat.aliases.resolves({
         body: [
-          { alias: 'alias-mehry', index: '&nepali.mehry' },
-          { alias: 'alias-liia', index: '&nepali.liia' },
-          { alias: 'alias-taxi', index: '&nyc-open-data.taxi' }
+          { index: 'mehry', alias: '&nepali.mehry' },
+          { index: 'liia', alias: '&nepali.liia' },
+          { index: 'taxi', alias: '&nyc-open-data.taxi' }
         ]
       });
     });
 
-    it('should allow listing all available aliases', () => {
-      const promise = elasticsearch.listAliases();
+    it('should allow listing all available aliases', async () => {
+      const result = await elasticsearch.listAliases();
 
-      return promise
-        .then(result => {
-          should(elasticsearch._client.cat.aliases).be.calledWithMatch({
-            format: 'json'
-          });
+      should(elasticsearch._client.cat.aliases).be.calledWithMatch({
+        format: 'json'
+      });
 
-          should(result).match([
-            { name: 'alias-mehry', index: 'nepali', collection: 'mehry' },
-            { name: 'alias-liia', index: 'nepali', collection: 'liia' },
-            { name: 'alias-taxi', index: 'nyc-open-data', collection: 'taxi' },
-          ]);
-        });
+      should(result).match([
+        { name: 'mehry', index: 'nepali', collection: 'mehry' },
+        { name: 'liia', index: 'nepali', collection: 'liia' },
+        { name: 'taxi', index: 'nyc-open-data', collection: 'taxi' },
+      ]);
     });
 
-    it('should not list unauthorized aliases', () => {
+    it('should not list unauthorized aliases', async () => {
       elasticsearch._client.cat.aliases.resolves({
         body: [
-          { alias: 'alias-mehry', index: '%nepali.mehry' },
-          { alias: 'alias-liia', index: '%nepali.liia' },
-          { alias: 'alias-taxi', index: '%nyc-open-data.taxi' },
-          { alias: 'alias-lfiduras', index: '&vietnam.lfiduras' }
+          { index: 'mehry', alias: '%nepali.mehry' },
+          { index: 'liia', alias: '%nepali.liia' },
+          { index: 'taxi', alias: '%nyc-open-data.taxi' },
+          { index: 'lfiduras', alias: '&vietnam.lfiduras' }
         ]
       });
 
-      const promise = elasticsearch.listAliases();
+      const result = await elasticsearch.listAliases();
 
-      return promise
-        .then(result => {
-          should(result).match([
-            { name: 'alias-lfiduras', index: 'vietnam', collection: 'lfiduras' },
-          ]);
-        });
+      should(result).match([
+        { name: 'lfiduras', index: 'vietnam', collection: 'lfiduras' },
+      ]);
     });
 
-    it('should return a rejected promise if client fails', () => {
+    it('should return a rejected promise if client fails', async () => {
       elasticsearch._client.cat.aliases.rejects(esClientError);
 
       const promise = elasticsearch.listAliases();
 
-      return should(promise).be.rejected()
-        .then(() => {
-          should(elasticsearch._esWrapper.reject).be.calledWith(esClientError);
-        });
+      await should(promise).be.rejected();
+      should(elasticsearch._esWrapper.formatESError).be.calledWith(esClientError);
     });
   });
 
@@ -2415,15 +2394,11 @@ describe('Test: ElasticSearch service', () => {
         });
     });
 
-    it('should return a rejected promise if client fails', () => {
+    it('should return a rejected promise if client fails', async () => {
       elasticsearch._client.cat.indices.rejects(esClientError);
 
-      const promise = elasticsearch.listIndexes();
-
-      return should(promise).be.rejected()
-        .then(() => {
-          should(elasticsearch._esWrapper.reject).be.calledWith(esClientError);
-        });
+      await should(elasticsearch.listIndexes()).be.rejected();
+      should(elasticsearch._esWrapper.formatESError).be.calledWith(esClientError);
     });
   });
 


### PR DESCRIPTION
# Description

Kuzzle should be able to handle index aliases using its formalism and pointing to another place.

Example/How to reproduce the bug:
* create an index named `foobar`
* alias it to `&foo.bar` 

Expected result: Kuzzle should correctly map the alias to `{ index: 'foo', collection: 'bar'}` and use it as any other non-alias indexes

Without this patch, Kuzzle incorrectly maps the alias to: `{ index: 'foo', collection: '&foo.bar'}`

# Changes

The `listAliases` method in the `elasticsearch` service now returns the following array of objects: 
```js
[ 
  {name: '<origin ES index>', index: '<inferred index name>', collection: '<inferred index collection>'},
  {name: '<origin ES index>', index: '<inferred index name>', collection: '<inferred index collection>'},
  // ...
]
```

The `name` property is not currently used, but I found it interesting to keep it for later uses.

Kuzzle's index cache bootstrap now correctly uses that `listAliases` method to get non-listed indexes by `cat.indices` and complete its cache with its results.