### PR TITLE
Fix: description should not be required for plugin custom errors

### DIFF
--- a/doc/2/plugins/plugin-context/kerror/index.md
+++ b/doc/2/plugins/plugin-context/kerror/index.md
@@ -20,11 +20,12 @@ Example:
       "code": 1,
       "message": "An error occurred: %s",
       "class": "BadRequestError"
-	},
+	  },
     "some_other_error": {
       "code": 2,
       "message": "An other error occurred: %s",
       "class": "ForbiddenError"
+    }
 	}
 }
 ```

--- a/doc/2/plugins/plugin-context/kerror/index.md
+++ b/doc/2/plugins/plugin-context/kerror/index.md
@@ -20,13 +20,13 @@ Example:
       "code": 1,
       "message": "An error occurred: %s",
       "class": "BadRequestError"
-	  },
+    },
     "some_other_error": {
       "code": 2,
       "message": "An other error occurred: %s",
       "class": "ForbiddenError"
     }
-	}
+  }
 }
 ```
 

--- a/lib/kerror/codes/index.js
+++ b/lib/kerror/codes/index.js
@@ -80,7 +80,7 @@ function checkErrors(subdomain, domain, options) {
       `Error configuration file : Field 'class' must target a known KuzzleError object (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}), '${name.class}' does not exist.`);
 
     // plugin errors aren't required to have descriptions
-    if (options.plugin) {
+    if (!options.plugin) {
       assert(
         typeof error.description === 'string' && error.description.length > 0,
         `Error configuration file : Field 'description' must be a non-empty string (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}).`);
@@ -121,7 +121,7 @@ function checkSubdomains(domain, options) {
       `Error configuration file : code ${subdomain.code} for subdomain '${subdomainName}' is not unique (domain: ${domain.code}).`);
 
     // We don't allow duplicates, except for defaulted plugin subdomain codes
-    if (options.plugin || subdomain.code > 0) {
+    if (!options.plugin || subdomain.code > 0) {
       subdomainCodes.add(subdomain.code);
     }
 

--- a/lib/kerror/codes/index.js
+++ b/lib/kerror/codes/index.js
@@ -21,9 +21,11 @@
 
 'use strict';
 
-const { errors } = require('kuzzle-common-objects');
-const _ = require('lodash');
 const assert = require('assert');
+
+const { errors } = require('kuzzle-common-objects');
+
+const { has, isPlainObject } = require('../../util/safeObject');
 
 // codes
 const domains = {
@@ -46,43 +48,48 @@ function checkErrors(subdomain, domain) {
 
   for (const [name, error] of Object.entries(subdomain.errors)) {
     assert(
-      !codes.has(error.code),
-      `Error configuration file : code ${error.code} for error '${name}' is not unique (domain: ${domain.code}, subdomain: ${subdomain.code}).`);
-
-    codes.add(error.code);
-
-    assert(
-      Boolean(error.message),
-      `Error configuration file : Missing required 'message' field (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}).`);
-    assert(
-      typeof error.message === 'string',
-      `Error configuration file : Field 'message' must be a string (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}).`);
-    assert(
-      Boolean(error.class),
-      `Error configuration file : Missing required 'class' field (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}).`);
-    assert(
-      typeof error.class === 'string',
-      `Error configuration file : Field 'class' must be a string (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}).`);
-    assert(
-      Boolean(errors[error.class]),
-      `Error configuration file : Invalid field 'class' (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}), '${name.class}' does not exist.`);
-    assert(
-      Boolean(error.code),
+      has(error, 'code'),
       `Error configuration file : Missing required 'code' field (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}).`);
     assert(
       Number.isInteger(error.code),
       `Error configuration file : Field 'code' must be an integer (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}).`);
     assert(
       error.code > 0x0000 && error.code <= 0xFFFF,
-      `Error configuration file : Field 'code' must be between 0 and 65535 (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}).`);
+      `Error configuration file : Field 'code' must be between 1 and 65535 (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}).`);
     assert(
-      typeof error.description === 'string' && error.description.length > 0,
-      `Error configuration file : Field 'description' is required and must be a string (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}).`);
+      !codes.has(error.code),
+      `Error configuration file : code ${error.code} for error '${name}' is not unique (domain: ${domain.code}, subdomain: ${subdomain.code}).`);
+
+    codes.add(error.code);
+
+    assert(
+      has(error, 'message'),
+      `Error configuration file : Missing required 'message' field (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}).`);
+    assert(
+      typeof error.message === 'string',
+      `Error configuration file : Field 'message' must be a string (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}).`);
+
+    assert(
+      has(error, 'class'),
+      `Error configuration file : Missing required 'class' field (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}).`);
+    assert(
+      typeof error.class === 'string',
+      `Error configuration file : Field 'class' must be a string (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}).`);
+    assert(
+      has(errors, error.class),
+      `Error configuration file : Invalid field 'class' (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}), '${name.class}' does not exist.`);
+
+    // plugin errors aren't required to have descriptions
+    if (domain.code !== domains.plugin.code) {
+      assert(
+        typeof error.description === 'string' && error.description.length > 0,
+        `Error configuration file : Field 'description' is required and must be a string (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}).`);
+    }
 
     if (error.deprecated) {
       assert(
         typeof error.deprecated === 'string',
-        'Error configuration file : Field \'code\' must be a string');
+        `Error configuration file : Field 'deprecated' must be a string  (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}).`);
     }
   }
 }
@@ -93,29 +100,37 @@ function checkSubdomains(domain) {
   for (const subdomainName of Object.keys(domain.subdomains)) {
     const subdomain = domain.subdomains[subdomainName];
 
-    assert(
-      !subdomainCodes.has(subdomain.code),
-      `Error configuration file : code ${subdomain.code} for subdomain '${subdomainName}' is not unique (domain: ${domain.code}).`);
-
-    if (subdomain.code !== 0x00) {
-      subdomainCodes.add(subdomain.code);
+    // Subdomain code for plugins is not required and is automatically set to 0
+    if (domain.code !== domains.plugin.code) {
+      assert(
+        has(subdomain, 'code'),
+        `Error configuration file : Missing required 'code' field (domain: ${domain.code}, subdomain: ${subdomainName}).`);
+    }
+    else if (!has(subdomain, 'code')) {
+      subdomain.code = 0;
     }
 
-    assert(
-      Boolean(subdomain.errors),
-      `Error configuration file : Missing required 'errors' field (domain: ${domain.code}, subdomain: ${subdomainName}).`);
-    assert(
-      _.isPlainObject(subdomain.errors),
-      `Error configuration file : Field 'subdomains' must be an object (domain: ${domain.code}, subdomain: ${subdomainName}).`);
-    assert(
-      _.has(subdomain, 'code'),
-      `Error configuration file : Missing required 'code' field (domain: ${domain.code}, subdomain: ${subdomainName}).`);
     assert(
       Number.isInteger(subdomain.code),
       `Error configuration file : Field 'code' must be an integer (domain: ${domain.code}, subdomain: ${subdomainName}).`);
     assert(
       subdomain.code >= 0x00 && subdomain.code <= 0xFF,
       `Error configuration file : Field 'code' must be between 0 and 255 (domain: ${domain.code}, subdomain: ${subdomainName}).`);
+    assert(
+      !subdomainCodes.has(subdomain.code),
+      `Error configuration file : code ${subdomain.code} for subdomain '${subdomainName}' is not unique (domain: ${domain.code}).`);
+
+    // We don't allow duplicates, except for defaulted plugin subdomain codes
+    if (domain.code !== domains.plugin.code || subdomain.code > 0) {
+      subdomainCodes.add(subdomain.code);
+    }
+
+    assert(
+      has(subdomain, 'errors'),
+      `Error configuration file : Missing required 'errors' field (domain: ${domain.code}, subdomain: ${subdomainName}).`);
+    assert(
+      isPlainObject(subdomain.errors),
+      `Error configuration file : Field 'errors' must be an object (domain: ${domain.code}, subdomain: ${subdomainName}).`);
 
     checkErrors(subdomain, domain);
   }
@@ -128,19 +143,7 @@ function checkDomains(errorCodesFiles) {
     const domain = errorCodesFiles[domainName];
 
     assert(
-      !domainCodes.has(domain.code),
-      `Error configuration file : code ${domain.code} for domain ${domainName} is not unique.`);
-
-    domainCodes.add(domain.code);
-
-    assert(
-      Boolean(domain.subdomains),
-      `Error configuration file : Missing required 'subdomains' field. (domain: '${domainName}').`);
-    assert(
-      _.isPlainObject(domain.subdomains),
-      `Error configuration file : Field 'subdomains' must be an object. (domain: '${domainName}').`);
-    assert(
-      _.has(domain, 'code'),
+      has(domain, 'code'),
       `Error configuration file : Missing required 'code' field. (domain: '${domainName}').`);
     assert(
       Number.isInteger(domain.code),
@@ -148,12 +151,27 @@ function checkDomains(errorCodesFiles) {
     assert(
       domain.code >= 0x00 && domain.code <= 0xFF,
       `Error configuration file : Field 'code' must be between 0 and 255. (domain: '${domainName}').`);
+    assert(
+      !domainCodes.has(domain.code),
+      `Error configuration file : code ${domain.code} for domain ${domainName} is not unique.`);
+
+    domainCodes.add(domain.code);
+
+    assert(
+      has(domain, 'subdomains'),
+      `Error configuration file : Missing required 'subdomains' field. (domain: '${domainName}').`);
+    assert(
+      isPlainObject(domain.subdomains),
+      `Error configuration file : Field 'subdomains' must be an object. (domain: '${domainName}').`);
 
     checkSubdomains(domain);
   }
 }
 
 function loadPluginsErrors(pluginManifest, pluginCode) {
+  // @todo (breaking change) this is unacceptable as it allows plugins to
+  // overwrite existing native errors.
+  // A new, dedicated domain should be created, with a dedicated domain code.
   domains.plugin.subdomains[pluginManifest.name] = {
     code: pluginCode,
     errors: pluginManifest.errors
@@ -164,6 +182,7 @@ function loadPluginsErrors(pluginManifest, pluginCode) {
 checkDomains(domains);
 
 module.exports = {
+  checkDomains,
   domains,
-  loadPluginsErrors
+  loadPluginsErrors,
 };

--- a/lib/kerror/codes/index.js
+++ b/lib/kerror/codes/index.js
@@ -43,7 +43,7 @@ const domains = {
  *  @param {object} - error config file domain
  */
 
-function checkErrors(subdomain, domain) {
+function checkErrors(subdomain, domain, options) {
   const codes = new Set();
 
   for (const [name, error] of Object.entries(subdomain.errors)) {
@@ -66,8 +66,8 @@ function checkErrors(subdomain, domain) {
       has(error, 'message'),
       `Error configuration file : Missing required 'message' field (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}).`);
     assert(
-      typeof error.message === 'string',
-      `Error configuration file : Field 'message' must be a string (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}).`);
+      typeof error.message === 'string' && error.message.length > 0,
+      `Error configuration file : Field 'message' must be a non-empty string (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}).`);
 
     assert(
       has(error, 'class'),
@@ -77,31 +77,31 @@ function checkErrors(subdomain, domain) {
       `Error configuration file : Field 'class' must be a string (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}).`);
     assert(
       has(errors, error.class),
-      `Error configuration file : Invalid field 'class' (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}), '${name.class}' does not exist.`);
+      `Error configuration file : Field 'class' must target a known KuzzleError object (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}), '${name.class}' does not exist.`);
 
     // plugin errors aren't required to have descriptions
-    if (domain.code !== domains.plugin.code) {
+    if (options.plugin) {
       assert(
         typeof error.description === 'string' && error.description.length > 0,
-        `Error configuration file : Field 'description' is required and must be a string (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}).`);
+        `Error configuration file : Field 'description' must be a non-empty string (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}).`);
     }
 
-    if (error.deprecated) {
+    if (error.deprecated !== undefined && error.deprecated !== null) {
       assert(
-        typeof error.deprecated === 'string',
-        `Error configuration file : Field 'deprecated' must be a string  (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}).`);
+        typeof error.deprecated === 'string' && error.deprecated.length > 0,
+        `Error configuration file : Field 'deprecated' must be a non-empty string (domain: ${domain.code}, subdomain: ${subdomain.code}, error: ${name}).`);
     }
   }
 }
 
-function checkSubdomains(domain) {
+function checkSubdomains(domain, options) {
   const subdomainCodes = new Set();
 
   for (const subdomainName of Object.keys(domain.subdomains)) {
     const subdomain = domain.subdomains[subdomainName];
 
     // Subdomain code for plugins is not required and is automatically set to 0
-    if (domain.code !== domains.plugin.code) {
+    if (!options.plugin) {
       assert(
         has(subdomain, 'code'),
         `Error configuration file : Missing required 'code' field (domain: ${domain.code}, subdomain: ${subdomainName}).`);
@@ -121,7 +121,7 @@ function checkSubdomains(domain) {
       `Error configuration file : code ${subdomain.code} for subdomain '${subdomainName}' is not unique (domain: ${domain.code}).`);
 
     // We don't allow duplicates, except for defaulted plugin subdomain codes
-    if (domain.code !== domains.plugin.code || subdomain.code > 0) {
+    if (options.plugin || subdomain.code > 0) {
       subdomainCodes.add(subdomain.code);
     }
 
@@ -132,11 +132,11 @@ function checkSubdomains(domain) {
       isPlainObject(subdomain.errors),
       `Error configuration file : Field 'errors' must be an object (domain: ${domain.code}, subdomain: ${subdomainName}).`);
 
-    checkErrors(subdomain, domain);
+    checkErrors(subdomain, domain, options);
   }
 }
 
-function checkDomains(errorCodesFiles) {
+function checkDomains(errorCodesFiles, options = {plugin: false}) {
   const domainCodes = new Set();
 
   for (const domainName of Object.keys(errorCodesFiles)) {
@@ -164,19 +164,17 @@ function checkDomains(errorCodesFiles) {
       isPlainObject(domain.subdomains),
       `Error configuration file : Field 'subdomains' must be an object. (domain: '${domainName}').`);
 
-    checkSubdomains(domain);
+    checkSubdomains(domain, options);
   }
 }
 
 function loadPluginsErrors(pluginManifest, pluginCode) {
-  // @todo (breaking change) this is unacceptable as it allows plugins to
-  // overwrite existing native errors.
-  // A new, dedicated domain should be created, with a dedicated domain code.
+  // @todo this should be in its own, independant domain
   domains.plugin.subdomains[pluginManifest.name] = {
     code: pluginCode,
     errors: pluginManifest.errors
   };
-  checkDomains({ plugin: domains.plugin });
+  checkDomains({ plugin: domains.plugin }, { plugin: true });
 }
 
 checkDomains(domains);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2385,6 +2385,23 @@
         "once": "^1.4.0"
       }
     },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
+      },
+      "dependencies": {
+        "ansi-colors": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+          "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+          "dev": true
+        }
+      }
+    },
     "env-paths": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
@@ -2531,22 +2548,23 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
-      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.3.1.tgz",
+      "integrity": "sha512-cQC/xj9bhWUcyi/RuMbRtC3I0eW8MH0jhRELSvpKYkWep3C6YZ2OkvcvJVUeO6gcunABmzptbXBuDoXsjHmfTA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
-        "chalk": "^2.1.0",
-        "cross-spawn": "^6.0.5",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
-        "eslint-scope": "^5.0.0",
-        "eslint-utils": "^1.4.3",
-        "eslint-visitor-keys": "^1.1.0",
-        "espree": "^6.1.2",
-        "esquery": "^1.0.1",
+        "enquirer": "^2.3.5",
+        "eslint-scope": "^5.1.0",
+        "eslint-utils": "^2.0.0",
+        "eslint-visitor-keys": "^1.2.0",
+        "espree": "^7.1.0",
+        "esquery": "^1.2.0",
         "esutils": "^2.0.2",
         "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
@@ -2555,72 +2573,50 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^7.0.0",
         "is-glob": "^4.0.0",
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
+        "levn": "^0.4.1",
         "lodash": "^4.17.14",
         "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.8.3",
+        "optionator": "^0.9.1",
         "progress": "^2.0.0",
-        "regexpp": "^2.0.1",
-        "semver": "^6.1.2",
-        "strip-ansi": "^5.2.0",
-        "strip-json-comments": "^3.0.1",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
         "table": "^5.2.3",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
         "acorn": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
-          "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+          "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
           "dev": true
-        },
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
         },
         "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
           }
         },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "dev": true,
           "requires": {
-            "color-name": "1.1.3"
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
           }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
         },
         "eslint-scope": {
           "version": "5.1.0",
@@ -2632,15 +2628,24 @@
             "estraverse": "^4.1.1"
           }
         },
-        "espree": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
-          "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+        "eslint-utils": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
           "dev": true,
           "requires": {
-            "acorn": "^7.1.1",
-            "acorn-jsx": "^5.2.0",
             "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "espree": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-7.1.0.tgz",
+          "integrity": "sha512-dcorZSyfmm4WTuTnE5Y7MEN1DyoPYy1ZR783QW1FJoenn7RailyWFsq/UL6ZAAA7uXurN9FIpYyUs3OfiIW+Qw==",
+          "dev": true,
+          "requires": {
+            "acorn": "^7.2.0",
+            "acorn-jsx": "^5.2.0",
+            "eslint-visitor-keys": "^1.2.0"
           }
         },
         "globals": {
@@ -2652,34 +2657,70 @@
             "type-fest": "^0.8.1"
           }
         },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+        "levn": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+          "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "prelude-ls": "^1.2.1",
+            "type-check": "~0.4.0"
           }
         },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+        "optionator": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+          "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "deep-is": "^0.1.3",
+            "fast-levenshtein": "^2.0.6",
+            "levn": "^0.4.1",
+            "prelude-ls": "^1.2.1",
+            "type-check": "^0.4.0",
+            "word-wrap": "^1.2.3"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "prelude-ls": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+          "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+          "dev": true
+        },
+        "regexpp": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+          "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "type-check": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+          "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1"
           }
         },
         "type-fest": {
@@ -2687,6 +2728,15 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
           "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
           "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
         }
       }
     },
@@ -6606,6 +6656,166 @@
       "dev": true,
       "requires": {
         "eslint": "^6.8.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+          "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "eslint": {
+          "version": "6.8.0",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+          "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "ajv": "^6.10.0",
+            "chalk": "^2.1.0",
+            "cross-spawn": "^6.0.5",
+            "debug": "^4.0.1",
+            "doctrine": "^3.0.0",
+            "eslint-scope": "^5.0.0",
+            "eslint-utils": "^1.4.3",
+            "eslint-visitor-keys": "^1.1.0",
+            "espree": "^6.1.2",
+            "esquery": "^1.0.1",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^5.0.1",
+            "functional-red-black-tree": "^1.0.1",
+            "glob-parent": "^5.0.0",
+            "globals": "^12.1.0",
+            "ignore": "^4.0.6",
+            "import-fresh": "^3.0.0",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^7.0.0",
+            "is-glob": "^4.0.0",
+            "js-yaml": "^3.13.1",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.14",
+            "minimatch": "^3.0.4",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.3",
+            "progress": "^2.0.0",
+            "regexpp": "^2.0.1",
+            "semver": "^6.1.2",
+            "strip-ansi": "^5.2.0",
+            "strip-json-comments": "^3.0.1",
+            "table": "^5.2.3",
+            "text-table": "^0.2.0",
+            "v8-compile-cache": "^2.0.3"
+          }
+        },
+        "eslint-scope": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+          "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "espree": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+          "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+          "dev": true,
+          "requires": {
+            "acorn": "^7.1.1",
+            "acorn-jsx": "^5.2.0",
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
       }
     },
     "rimraf": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "async": "^3.2.0",
     "codecov": "^3.7.0",
     "cucumber": "^6.0.5",
-    "eslint": "^6.8.0",
+    "eslint": "^7.3.1",
     "kuzdoc": "^1.2.2",
     "minimist": "^1.2.5",
     "mocha": "^7.2.0",

--- a/test/kerror/codes.test.js
+++ b/test/kerror/codes.test.js
@@ -1,0 +1,250 @@
+'use strict';
+
+const should = require('should');
+
+const { checkDomains, loadPluginsErrors } = require('../../lib/kerror/codes');
+const pluginDomain = require('../../lib/kerror/codes/plugin.json');
+
+describe.only('kerror: error codes loader', () => {
+  let domains;
+
+  beforeEach(() => {
+    domains = {
+      foo: {
+        code: 111,
+        subdomains: {
+          sub1: {
+            code: 234,
+            errors: {
+              err1: {
+                code: 13,
+                class: 'InternalError',
+                description: 'description',
+                message: 'message',
+              },
+              err2: {
+                code: 42,
+                class: 'InternalError',
+                description: 'description',
+                message: 'message',
+              },
+            },
+          },
+          sub2: {
+            code: 235,
+            errors: {
+              err1: {
+                code: 42,
+                class: 'InternalError',
+                description: 'description',
+                message: 'message',
+              },
+            },
+          },
+        },
+      },
+      bar: {
+        code: 222,
+        subdomains: {
+          sub1: {
+            code: 234,
+            errors: {
+              err1: {
+                code: 42,
+                class: 'InternalError',
+                description: 'description',
+                message: 'message',
+              },
+            },
+          },
+        },
+      },
+    };
+  });
+
+  describe('#checkDomains', () => {
+    it('should throw if a domain is missing a code', () => {
+      delete domains.foo.code;
+      should(() => checkDomains(domains)).throw(/missing required 'code' field/i);
+    });
+
+    it('should throw if the domain code is not an integer', () => {
+      for (const code of [null, undefined, [], {}, 3.14, 'foo', false, true]) {
+        domains.foo.code = code;
+
+        /* eslint-disable-next-line no-loop-func -- false positive */
+        should(() => checkDomains(domains)).throw(/field 'code' must be an integer/i);
+      }
+    });
+
+    it('should throw if the domain code is already used', () => {
+      domains.bar.code = domains.foo.code;
+      should(() => checkDomains(domains)).throw(/code .* is not unique/i);
+    });
+
+    it('should throw if the domain code exceeds the allowed range', () => {
+      for (const code of [-1, 256]) {
+        domains.foo.code = code;
+
+        /* eslint-disable-next-line no-loop-func -- false positive */
+        should(() => checkDomains(domains)).throw(/field 'code' must be between 0 and 255/i);
+      }
+
+      // prevent domain code conflict
+      delete domains.bar;
+
+      for (let code = 0; code <= 0xff; code++) {
+        domains.foo.code = code;
+        /* eslint-disable-next-line no-loop-func -- false positive */
+        should(() => checkDomains(domains)).not.throw();
+      }
+    });
+
+    it('should throw if no subdomains are defined', () => {
+      delete domains.foo.subdomains;
+      should(() => checkDomains(domains)).throw(/missing required 'subdomains' field/i);
+    });
+
+    it('should throw if the subdomains property is not an object', () => {
+      for (const subdomains of [null, undefined, [], 3.14, 'foo', false, true]) {
+        domains.foo.subdomains = subdomains;
+
+        /* eslint-disable-next-line no-loop-func -- false positive */
+        should(() => checkDomains(domains)).throw(/field 'subdomains' must be an object/i);
+      }
+    });
+
+    it('should throw if a non-plugin subdomain is missing a code', () => {
+      delete domains.bar.subdomains.sub1.code;
+      should(() => checkDomains(domains)).throw(/missing required 'code' field/i);
+    });
+
+    it('should default plugin subdomains code to 0 if not set', () => {
+      domains.bar.code = pluginDomain.code;
+      delete domains.bar.subdomains.sub1.code;
+      should(() => checkDomains(domains)).not.throw();
+      should(domains.bar.subdomains.sub1.code).eql(0);
+    });
+
+    it('should throw if a subdomain code is not an integer', () => {
+      for (const code of [null, undefined, [], {}, 3.14, 'foo', false, true]) {
+        domains.foo.subdomains.sub2.code = code;
+
+        /* eslint-disable-next-line no-loop-func -- false positive */
+        should(() => checkDomains(domains)).throw(/field 'code' must be an integer/i);
+      }
+    });
+
+    it('should throw if a subdomain code is already used', () => {
+      domains.foo.subdomains.sub1.code = 0;
+      domains.foo.subdomains.sub2.code = 0;
+      should(() => checkDomains(domains)).throw(/code .* is not unique/i);
+    });
+
+    it('should not throw if a plugin subdomain contains multiple defaulted codes', () => {
+      delete domains.foo.subdomains.sub1;
+      delete domains.foo.subdomains.sub2;
+      domains.foo.code = pluginDomain.code;
+      should(() => checkDomains(domains)).not.throw();
+    });
+
+    it('should throw if a plugin subdomain contain duplicates, non-default, codes', () => {
+      domains.foo.subdomains.sub1.code = 42;
+      domains.foo.subdomains.sub2.code = 42;
+      domains.foo.code = pluginDomain.code;
+      should(() => checkDomains(domains)).throw(/code .* is not unique/i);
+    });
+
+    it('should throw if a subdomain code exceeds the allowed range', () => {
+      for (const code of [-1, 256]) {
+        domains.foo.subdomains.sub2.code = code;
+        /* eslint-disable-next-line no-loop-func -- false positive */
+        should(() => checkDomains(domains)).throw(/field 'code' must be between 0 and 255/i);
+      }
+
+      // prevent subdomain code conflict
+      delete domains.foo.subdomains.sub2;
+
+      for (let code = 0; code <= 0xff; code++) {
+        domains.foo.subdomains.sub1.code = code;
+
+        /* eslint-disable-next-line no-loop-func -- false positive */
+        should(() => checkDomains(domains)).not.throw();
+      }
+    });
+
+    it('should throw if a subdomain is missing an errors object', () => {
+      delete domains.foo.subdomains.sub2.errors;
+      should(() => checkDomains(domains)).throw(/missing required 'errors' field/i);
+    });
+
+    it('should throw if a subdomain has a non-object errors property', () => {
+      for (const errors of [null, undefined, [], 3.14, 'foo', false, true]) {
+        domains.foo.subdomains.sub2.errors = errors;
+
+        /* eslint-disable-next-line no-loop-func -- false positive */
+        should(() => checkDomains(domains)).throw(/field 'errors' must be an object/i);
+      }
+    });
+
+    it('should throw if an error is missing a code', () => {
+      delete domains.foo.subdomains.sub1.errors.err1.code;
+      should(() => checkDomains(domains)).throw(/missing required 'code' field/i);
+    });
+
+    it('should throw if an error code is not an integer', () => {
+      for (const code of [null, undefined, [], {}, 3.14, 'foo', false, true]) {
+        domains.foo.subdomains.sub2.errors.err1.code = code;
+
+        /* eslint-disable-next-line no-loop-func -- false positive */
+        should(() => checkDomains(domains)).throw(/field 'code' must be an integer/i);
+      }
+    });
+
+    it('should throw if an error code is outside its allowing range', () => {
+      for (const code of [-1, 0, 65536]) {
+        domains.foo.subdomains.sub2.errors.err1.code = code;
+
+        /* eslint-disable-next-line no-loop-func -- false positive */
+        should(() => checkDomains(domains)).throw(/field 'code' must be between 1 and 65535/i);
+      }
+
+      for (let code = 1; code <= 0xffff; code++) {
+        domains.foo.subdomains.sub2.errors.err1.code = code;
+
+        /* eslint-disable-next-line no-loop-func -- false positive */
+        should(() => checkDomains(domains)).not.throw();
+      }
+    });
+
+    it('should throw if an error is missing a message', () => {
+      delete domains.foo.subdomains.sub1.errors.err1.message;
+
+      should(() => checkDomains(domains)).throw(/missing required 'message' field/i);
+    });
+
+    it('should throw if an error message is not a string', () => {
+      for (const message of [null, undefined, [], {}, 3.14, false, true]) {
+        domains.foo.subdomains.sub2.errors.err1.message = message;
+
+        /* eslint-disable-next-line no-loop-func -- false positive */
+        should(() => checkDomains(domains)).throw(/field 'message' must be a string/i);
+      }
+    });
+
+    it('should throw if an error is missing an error class', () => {
+      delete domains.foo.subdomains.sub1.errors.err1.class;
+
+      should(() => checkDomains(domains)).throw(/missing required 'class' field/i);
+    });
+
+    it('should throw if an error class is not a string', () => {
+      for (const className of [null, undefined, [], {}, 3.14, false, true]) {
+        domains.foo.subdomains.sub2.errors.err1.class = className;
+
+        /* eslint-disable-next-line no-loop-func -- false positive */
+        should(() => checkDomains(domains)).throw(/field 'class' must be a string/i);
+      }
+    });
+  });
+});


### PR DESCRIPTION
# Description

Fix #1603:

The error loader now makes the difference between native and plugin errors, and applies fewer checks to the latter.

# Changes

* add unit tests to the errors loader
* enforce non-empty strings, when applicable
* fix a few error messages
* check property types correctly (e.g. does not handle false booleans or nul numbers as non-existing properties)
* does not allow subdomain codes to be equal to 0, except for plugin errors (0 is the default plugin subdomain, if none is set)

# Other changes

* update eslint to v7 to allow comments when disabling rules