### PR TITLE
Updates search index only when dynamic changes from false to true

### DIFF
--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -1034,7 +1034,7 @@ class ElasticSearch extends Service {
 
         await this.updateMapping(index, collection, mappings);
 
-        if (JSON.stringify(previousMappings).includes('"dynamic":"false"')) {
+        if (this._dynamicChanges(previousMappings, mappings)) {
           await this.updateSearchIndex(index, collection);
         }
       }
@@ -2362,9 +2362,48 @@ class ElasticSearch extends Service {
 
     return parsedValue;
   }
+
+  /**
+   * Returns true if one of the mappings dynamic property changes value from
+   * false to true
+   */
+  _dynamicChanges (previousMappings, newMappings) {
+    const previousValues = findDynamic(previousMappings);
+
+    for (const [path, previousValue] of Object.entries(previousValues)) {
+      if (previousValue.toString() !== 'false') {
+        continue;
+      }
+
+      const newValue = _.get(newMappings, path);
+
+      if (newValue && newValue.toString() === 'true') {
+        return true;
+      }
+    }
+
+    return false;
+  }
 }
 
 module.exports = ElasticSearch;
+
+/**
+ * Finds paths and values of mappings dynamic properties
+ */
+function findDynamic (mappings, path = [], results = {}) {
+  if (mappings.dynamic !== undefined) {
+    results[path.concat('dynamic').join('.')] = mappings.dynamic;
+  }
+
+  for (const [key, value] of Object.entries(mappings)) {
+    if (_.isPlainObject(value)) {
+      findDynamic(value, path.concat(key), results);
+    }
+  }
+
+  return results;
+}
 
 /**
  * Forbids the use of the _routing ES option

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -2377,7 +2377,7 @@ class ElasticSearch extends Service {
 
       const newValue = _.get(newMappings, path);
 
-      if (newValue && newValue.toString() === 'true') {
+      if (newValue && newValue.toString() !== 'false') {
         return true;
       }
     }
@@ -2397,7 +2397,7 @@ function findDynamic (mappings, path = [], results = {}) {
   }
 
   for (const [key, value] of Object.entries(mappings)) {
-    if (_.isPlainObject(value)) {
+    if (isPlainObject(value)) {
       findDynamic(value, path.concat(key), results);
     }
   }

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -1636,7 +1636,7 @@ describe('Test: ElasticSearch service', () => {
     });
   });
 
-  describe('#updateCollection', () => {
+  describe.only('#updateCollection', () => {
     let
       oldSettings,
       settings,
@@ -1666,26 +1666,16 @@ describe('Test: ElasticSearch service', () => {
       elasticsearch.updateSettings = sinon.stub().resolves();
       elasticsearch.updateSearchIndex = sinon.stub().resolves();
     });
-    it('should call updateSettings, updateMapping and updateSearchIndex', async () => {
+    it('should call updateSettings, updateMapping', async () => {
       elasticsearch.getMapping = sinon.stub().resolves({dynamic: 'true', properties: { city: { type: 'keyword' }, dynamic: 'false' } });
       await elasticsearch.updateCollection(index, collection, { mappings, settings });
 
       should(elasticsearch.updateSettings).be.calledWith(index, collection, settings);
       should(elasticsearch.updateMapping).be.calledWith(index, collection, mappings);
-      should(elasticsearch.updateSearchIndex).be.calledWith(index, collection);
-    });
-
-    it('should call updateSettings, updateMapping and updateSearchIndex', async () => {
-      elasticsearch.getMapping = sinon.stub().resolves({ dynamic: 'false', properties: { city: { type: 'keyword' } } });
-      await elasticsearch.updateCollection(index, collection, { mappings, settings });
-
-      should(elasticsearch.updateSettings).be.calledWith(index, collection, settings);
-      should(elasticsearch.updateMapping).be.calledWith(index, collection, mappings);
-      should(elasticsearch.updateSearchIndex).be.calledWith(index, collection);
     });
 
     it('should call updateSettings and updateMapping', async () => {
-      elasticsearch.getMapping = sinon.stub().resolves({ dynamic: 'true', properties: { city: { type: 'keyword' } } });
+      elasticsearch.getMapping = sinon.stub().resolves({ dynamic: 'false', properties: { city: { type: 'keyword' } } });
       await elasticsearch.updateCollection(index, collection, { mappings, settings });
 
       should(elasticsearch.updateSettings).be.calledWith(index, collection, settings);
@@ -1709,6 +1699,27 @@ describe('Test: ElasticSearch service', () => {
           should(elasticsearch.updateSettings.getCall(1).args)
             .be.eql([index, collection, { index: { blocks: { write: false } } }]);
         });
+    });
+
+    it('should calls updateSearchIndex if dynamic change from false to true', async () => {
+      elasticsearch.getMapping = sinon.stub().resolves({
+        properties: {
+          content: {
+            dynamic: 'false'
+          }
+        }
+      });
+      const newMappings = {
+        properties: {
+          content: {
+            dynamic: true
+          }
+        }
+      };
+
+      await elasticsearch.updateCollection(index, collection, { mappings: newMappings });
+
+      should(elasticsearch.updateSearchIndex).be.calledOnce();
     });
   });
 

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -1636,7 +1636,7 @@ describe('Test: ElasticSearch service', () => {
     });
   });
 
-  describe.only('#updateCollection', () => {
+  describe('#updateCollection', () => {
     let
       oldSettings,
       settings,


### PR DESCRIPTION
## What does this PR do ?

Force the search index update only if at least one dynamic field value went from `false` to `true`

