### PR TITLE
Log ES request errors

### DIFF
--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -127,7 +127,7 @@ class ElasticSearch extends Service {
    */
   async _initSequence () {
     if (this._client) {
-      return this;
+      return;
     }
 
     if (process.env.NODE_ENV === 'production' && this._config.commonMapping.dynamic === 'true') {

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -64,9 +64,8 @@ class ElasticSearch extends Service {
     // Passed to Elasticsearch's client to make it use
     // Bluebird instead of ES6 promises
     const defer = function defer () {
-      let
-        resolve,
-        reject;
+      let resolve;
+      let reject;
 
       const promise = new Bluebird((res, rej) => {
         resolve = res;
@@ -126,9 +125,9 @@ class ElasticSearch extends Service {
    * @override
    * @returns {Promise}
    */
-  _initSequence () {
+  async _initSequence () {
     if (this._client) {
-      return Bluebird.resolve(this);
+      return this;
     }
 
     if (process.env.NODE_ENV === 'production' && this._config.commonMapping.dynamic === 'true') {
@@ -138,17 +137,17 @@ class ElasticSearch extends Service {
         'See the "services.storageEngine.commonMapping.dynamic" option in the kuzzlerc configuration file to change this value.'
       ].join('\n'));
     }
+
     this._client = ElasticSearch.buildClient(this._config.client);
-    this._esWrapper = new ESWrapper(this._client);
+    this._esWrapper = new ESWrapper(this._client, this._kuzzle);
 
-    return this._client.info()
-      .then(({ body }) => {
-        this._esVersion = body.version;
+    const { body: { version } } = await this._client.info();
 
-        if (this._esVersion && !semver.satisfies(this._esVersion.number, '>= 7.0.0')) {
-          throw kerror.get('version_mismatch', this._esVersion.number);
-        }
-      });
+    if (version && !semver.satisfies(version.number, '>= 7.0.0')) {
+      throw kerror.get('version_mismatch', version.number);
+    }
+
+    this._esVersion = version;
   }
 
   /**

--- a/lib/service/storage/esWrapper.js
+++ b/lib/service/storage/esWrapper.js
@@ -25,10 +25,11 @@
 
 const Bluebird = require('bluebird');
 const _ = require('lodash');
-const debug = require('../../util/debug')('kuzzle:services:storage:ESCommon');
 const es = require('@elastic/elasticsearch');
-const kerror = require('../../kerror').wrap('services', 'storage');
 const { errors: { KuzzleError } } = require('kuzzle-common-objects');
+
+const debug = require('../../util/debug')('kuzzle:services:storage:ESCommon');
+const kerror = require('../../kerror').wrap('services', 'storage');
 
 const errorMessagesMapping = [
   {
@@ -143,8 +144,9 @@ const errorMessagesMapping = [
 
 class ESWrapper {
 
-  constructor(client) {
+  constructor(client, kuzzle) {
     this.client = client;
+    this.kuzzle = kuzzle;
   }
 
   /**
@@ -157,6 +159,13 @@ class ESWrapper {
     if (error instanceof KuzzleError) {
       return error;
     }
+
+    this.kuzzle.log.info({
+      message: `Elasticsearch Client error: ${error.message}`,
+      // /!\ not all ES error classes have a "meta" property
+      meta: error.meta || null,
+      stack: error.stack,
+    });
 
     if (error instanceof es.errors.NoLivingConnectionsError) {
       throw kerror.get('not_connected');

--- a/test/service/storage/esWrapper.test.js
+++ b/test/service/storage/esWrapper.test.js
@@ -71,6 +71,8 @@ describe('Test: ElasticSearch Wrapper', () => {
     });
 
     it('should log the source error for easier support & debugging', () => {
+      kuzzle.log.info.resetHistory();
+
       const error = new Error('test');
       error.meta = {
         statusCode: 420,
@@ -91,6 +93,8 @@ describe('Test: ElasticSearch Wrapper', () => {
     });
 
     it('should be able to log errors without meta', () => {
+      kuzzle.log.info.resetHistory();
+
       const error = new Error('test');
       error.meta = {
         statusCode: 420,

--- a/test/service/storage/esWrapper.test.js
+++ b/test/service/storage/esWrapper.test.js
@@ -87,7 +87,7 @@ describe('Test: ElasticSearch Wrapper', () => {
 
       should(kuzzle.log.info).calledWithMatch({
         message: `Elasticsearch Client error: ${error.message}`,
-        sourceRequest: error.meta.meta.request,
+        meta: error.meta,
         stack: error.stack,
       });
     });
@@ -96,15 +96,12 @@ describe('Test: ElasticSearch Wrapper', () => {
       kuzzle.log.info.resetHistory();
 
       const error = new Error('test');
-      error.meta = {
-        statusCode: 420,
-      };
 
       esWrapper.formatESError(error);
 
       should(kuzzle.log.info).calledWithMatch({
         message: `Elasticsearch Client error: ${error.message}`,
-        sourceRequest: null,
+        meta: null,
         stack: error.stack,
       });
     });

--- a/test/service/storage/esWrapper.test.js
+++ b/test/service/storage/esWrapper.test.js
@@ -2,12 +2,16 @@
 
 const should = require('should');
 const { errors: { ExternalServiceError } } = require('kuzzle-common-objects');
+
 const ESClientMock = require('../../mocks/service/elasticsearchClient.mock');
+const KuzzleMock = require('../../mocks/kuzzle.mock');
+
 const ESWrapper = require('../../../lib/service/storage/esWrapper');
 
 describe('Test: ElasticSearch Wrapper', () => {
+  const kuzzle = new KuzzleMock();
   const client = new ESClientMock();
-  const esWrapper = new ESWrapper(client);
+  const esWrapper = new ESWrapper(client, kuzzle);
 
   describe('#formatESError', () => {
     it('should convert any unknown error to a ExternalServiceError instance', () => {
@@ -63,6 +67,41 @@ describe('Test: ElasticSearch Wrapper', () => {
       should(formatted).be.match({
         message: 'Document "mehry" not found in "nyc-open-data":"yellow-taxi".',
         id: 'services.storage.not_found'
+      });
+    });
+
+    it('should log the source error for easier support & debugging', () => {
+      const error = new Error('test');
+      error.meta = {
+        statusCode: 420,
+        meta: {
+          request: {
+            oh: 'noes',
+          }
+        }
+      };
+
+      esWrapper.formatESError(error);
+
+      should(kuzzle.log.info).calledWithMatch({
+        message: `Elasticsearch Client error: ${error.message}`,
+        sourceRequest: error.meta.meta.request,
+        stack: error.stack,
+      });
+    });
+
+    it('should be able to log errors without meta', () => {
+      const error = new Error('test');
+      error.meta = {
+        statusCode: 420,
+      };
+
+      esWrapper.formatESError(error);
+
+      should(kuzzle.log.info).calledWithMatch({
+        message: `Elasticsearch Client error: ${error.message}`,
+        sourceRequest: null,
+        stack: error.stack,
       });
     });
   });


### PR DESCRIPTION
# Description

ES request errors are currently not logged. Most of the time this is not a problem, but having those request logs can be very handy when investigating Kuzzle issues related to document storage.

The log level chosen for this is `info` so these logs can be easily filtered if they're found to be too verbose on some production environments.