### PR TITLE
Prevent timeouts when refreshing large indexes

### DIFF
--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -1070,13 +1070,17 @@ class ElasticSearch extends Service {
       // @cluster: conflicts when two nodes start at the same time
       conflicts: 'proceed',
       index: this._getESIndex(index, collection),
-      refresh: true
+      refresh: true,
+      // This operation can take some time: this should be an ES
+      // background task. And it's preferable to a request timeout when
+      // processing large indexes.
+      waitForCompletion: false,
     };
 
     debug('UpdateByQuery: %o', esRequest);
 
     try {
-      await this._client.update_by_query(esRequest);
+      await this._client.updateByQuery(esRequest);
     }
     catch (error) {
       throw this._esWrapper.formatESError(error);

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -1906,16 +1906,17 @@ describe('Test: ElasticSearch service', () => {
   });
 
   describe('#updateSearchIndex', () => {
-    it('should call update_by_query', async () => {
-      elasticsearch._client.update_by_query = sinon.stub().resolves();
+    it('should call updateByQuery', async () => {
+      elasticsearch._client.updateByQuery = sinon.stub().resolves();
 
       await elasticsearch.updateSearchIndex(index, collection);
 
-      should(elasticsearch._client.update_by_query).be.calledWithMatch({
+      should(elasticsearch._client.updateByQuery).be.calledWithMatch({
         body: {},
+        conflicts: 'proceed',
         index: '&nyc-open-data.yellow-taxi',
         refresh: true,
-        conflicts: 'proceed'
+        waitForCompletion: false,
       });
     });
   });


### PR DESCRIPTION
# Description

When updating a collection mapping, if a `dynamic` property is set to true or strict, and if it was "false" before, then we trigger an index refresh using [updateByQuery](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-reference.html#_updatebyquery).

When processing large indexes, this refresh can take some time and exceeds the default request timeout.

Rather than extending the timeout with some arbitrary large value, I've opted to ask ES to process this refresh as a background task: this refresh should be rare, and I don't see the value of waiting for it in our request response.