### PR TITLE
Preserve auth plugin error thrown during user creation

### DIFF
--- a/lib/api/controller/security.js
+++ b/lib/api/controller/security.js
@@ -1178,7 +1178,7 @@ class SecurityController extends NativeController {
     }
 
     if (creationFailure.error instanceof KuzzleError) {
-      throw creationFailure;
+      throw creationFailure.error;
     }
 
     if (creationFailure.validation) {

--- a/test/api/controller/security/users.test.js
+++ b/test/api/controller/security/users.test.js
@@ -191,6 +191,21 @@ describe('Test: security controller - users', () => {
         request.input.resource._id,
         'someStrategy');
     });
+
+    it('should return the plugin error if it threw a KuzzleError error', async () => {
+      const error = new BadRequestError('foo');
+
+      strategyValidateStub.rejects(error);
+
+      await should(securityController._persistUser(request, profileIds, content))
+        .be.rejectedWith(error);
+
+      strategyValidateStub.resolves();
+      strategyCreateStub.rejects(error);
+
+      await should(securityController._persistUser(request, profileIds, content))
+        .be.rejectedWith(error);
+    });
   });
 
   describe('#updateUserMapping', () => {


### PR DESCRIPTION
# Description

During a user creation, if an auth plugin throws a KuzzleError, we expect it to be forwarded to the funnel, and then to the user.

But this was not the case, the error was lost and the returned error message was set to:  `undefined`, due to a non-error object being thrown.

# How to reproduce

Simply create the same user 2 times in a row:

```shell
kourou sdk:query security:createUser --body '{content: { profileIds: ["default"] }, credentials: { local: { username: "foo2", password: "bar" } } }'

kourou sdk:query security:createUser --body '{content: { profileIds: ["default"] }, credentials: { local: { username: "foo2", password: "bar" } } }'
```


Result (dev mode): 

```
 [X] Caught an unexpected plugin error: undefined
This is probably not a Kuzzle error, but a problem with a plugin implementation.
	status: 500
	id: plugin.runtime.unexpected_error
```


Expected output (dev mode):

```
 [X] PreconditionError: Login "foo2" is already used.
    at new PreconditionError (/var/app/node_modules/kuzzle-common-objects/lib/errors/preconditionError.js:5:5)
    at AuthenticationPlugin.validate (/var/app/plugins/available/kuzzle-plugin-auth-passport-local/lib/index.js:143:13)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async methods.<computed> (/var/app/lib/core/plugin/manager.js:503:18)
    at async SecurityController._persistUser (/var/app/lib/api/controller/security.js:1123:9)
    at async Funnel.processRequest (/var/app/lib/api/funnel.js:414:28)
	status: 412
```

