### PR TITLE
Fix the "total" property returned by security:searchUsers

### DIFF
--- a/features-sdk/SecurityController.feature
+++ b/features-sdk/SecurityController.feature
@@ -80,7 +80,7 @@ Feature: Security Controller
   # security:deleteApiKey =======================================================
 
   @security
-  Scenario: Delete a API key for a user
+  Scenario: Delete an API key for a user
     Given I successfully call the route "security":"createApiKey" with args:
       | userId    | "test-admin"                     |
       | _id       | "SGN-HCM"                        |

--- a/features-sdk/SecurityController.feature
+++ b/features-sdk/SecurityController.feature
@@ -253,6 +253,7 @@ Feature: Security Controller
     And The property "_source.controllers.functional-test-plugin/non-existing-controller.actions" of the result should match:
       | manage | false |
 
+  @security
   Scenario: Get multiple users
     Given I create a user "test-user" with content:
       | profileIds | ["default"] |
@@ -271,16 +272,24 @@ Feature: Security Controller
       | "test-user"  |
       | "test-user2" |
 
+  @security
   Scenario: Search users
     Given I create a user "test-user" with content:
       | profileIds | ["default"] |
     And I create a user "test-user2" with content:
       | profileIds | ["admin"] |
     When I successfully call the route "security":"searchUsers" with args:
-      | body | {"query": {"match": {"_id": "test-user"} } } |
+      | body | {"query": {"terms": {"_id": ["test-user", "test-user2"]} } } |
     Then I should receive a "hits" array of objects matching:
       | _id          |
       | "test-user"  |
       | "test-user2" |
+    And I should receive a result matching:
+      | total | 2 |
+    When I successfully call the route "security":"searchUsers" with args:
+      | body | {"query": {"terms": {"_id": ["test-user", "test-user2"]} } } |
+      | from | 2                                                            |
+      | size | 10                                                           |
+    Then I should receive a empty "hits" array
     And I should receive a result matching:
       | total | 2 |

--- a/features-sdk/SecurityController.feature
+++ b/features-sdk/SecurityController.feature
@@ -25,7 +25,7 @@ Feature: Security Controller
   # security:createApiKey ======================================================
 
   @security @login
-  Scenario: Create an API key for an user
+  Scenario: Create an API key for a user
     Given I create a user "My" with content:
       | profileIds | ["default"] |
     When I successfully call the route "security":"createApiKey" with args:
@@ -49,7 +49,7 @@ Feature: Security Controller
   # security:searchApiKeys =====================================================
 
   @security
-  Scenario: Search for an user API keys
+  Scenario: Search for a user API keys
     Given I create a user "My" with content:
       | profileIds | ["default"] |
     And I successfully call the route "security":"createApiKey" with args:
@@ -80,7 +80,7 @@ Feature: Security Controller
   # security:deleteApiKey =======================================================
 
   @security
-  Scenario: Delete an API key for an user
+  Scenario: Delete a API key for a user
     Given I successfully call the route "security":"createApiKey" with args:
       | userId    | "test-admin"                     |
       | _id       | "SGN-HCM"                        |
@@ -271,3 +271,16 @@ Feature: Security Controller
       | "test-user"  |
       | "test-user2" |
 
+  Scenario: Search users
+    Given I create a user "test-user" with content:
+      | profileIds | ["default"] |
+    And I create a user "test-user2" with content:
+      | profileIds | ["admin"] |
+    When I successfully call the route "security":"searchUsers" with args:
+      | body | {"query": {"match": {"_id": "test-user"} } } |
+    Then I should receive a "hits" array of objects matching:
+      | _id          |
+      | "test-user"  |
+      | "test-user2" |
+    And I should receive a result matching:
+      | total | 2 |

--- a/features-sdk/step_definitions/controllers-steps.js
+++ b/features-sdk/step_definitions/controllers-steps.js
@@ -56,6 +56,7 @@ Then(/I (successfully )?call the route "(.*?)":"(.*?)"$/, async function (expect
 Then(/I should receive a ("(.*?)" )?array (of objects )?matching:/, function (name, objects, dataTable) {
   const expected = objects ? this.parseObjectArray(dataTable) : _.flatten(dataTable.rawTable).map(JSON.parse);
   const result = name ? this.props.result[name] : this.props.result;
+
   should(result.length).be.eql(
     expected.length,
     `Array are not the same size: expected ${expected.length} got ${result.length}`);

--- a/features-sdk/step_definitions/security-steps.js
+++ b/features-sdk/step_definitions/security-steps.js
@@ -53,6 +53,9 @@ Then('I am able to find {int} roles by searching controller:', async function (c
   const controller = this.parseObject(dataTable);
 
   const result = await this.sdk.security.searchRoles(controller);
+
+  should(result.total).eql(count);
+
   this.props.result = result;
 });
 
@@ -188,4 +191,11 @@ Then(/The user "(.*?)"( should not)? exists/, async function (userId, shouldNot)
 Then('I am able to mGet users with the following ids:', async function (dataTable) {
   const userIds = _.flatten(dataTable.rawTable).map(JSON.parse);
   this.props.result = await this.sdk.security.mGetUsers(userIds);
+});
+
+Then('I am able to find {int} total users :', async function (count, dataTable) {
+  const controller = this.parseObject(dataTable);
+
+  const result = await this.sdk.security.searchRoles(controller);
+  this.props.result = result;
 });

--- a/features-sdk/step_definitions/security-steps.js
+++ b/features-sdk/step_definitions/security-steps.js
@@ -54,8 +54,6 @@ Then('I am able to find {int} roles by searching controller:', async function (c
 
   const result = await this.sdk.security.searchRoles(controller);
 
-  should(result.total).eql(count);
-
   this.props.result = result;
 });
 

--- a/features-sdk/step_definitions/security-steps.js
+++ b/features-sdk/step_definitions/security-steps.js
@@ -190,10 +190,3 @@ Then('I am able to mGet users with the following ids:', async function (dataTabl
   const userIds = _.flatten(dataTable.rawTable).map(JSON.parse);
   this.props.result = await this.sdk.security.mGetUsers(userIds);
 });
-
-Then('I am able to find {int} total users :', async function (count, dataTable) {
-  const controller = this.parseObject(dataTable);
-
-  const result = await this.sdk.security.searchRoles(controller);
-  this.props.result = result;
-});

--- a/lib/core/shared/repository.js
+++ b/lib/core/shared/repository.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const Bluebird = require('bluebird');
+
 const IndexStorage = require('../storage/indexStorage');
 const kerror = require('../../kerror');
 
@@ -141,9 +142,13 @@ class Repository {
    * @param {object} [options] - optional search arguments (from, size, scroll)
    * @returns {Promise}
    */
-  search (query, options = {}) {
-    return this.indexStorage.search(this.collection, query, options)
-      .then(response => this._formatSearchResults(response));
+  async search (query, options = {}) {
+    const response = await this.indexStorage.search(
+      this.collection,
+      query,
+      options);
+
+    return this._formatSearchResults(response);
   }
 
   /**
@@ -493,31 +498,21 @@ class Repository {
    * @returns {Promise<object>}
    * @private
    */
-  _formatSearchResults (raw) {
+  async _formatSearchResults (raw) {
     const result = {
+      aggregations: raw.aggregations,
       hits: [],
-      total: 0
+      scrollId: raw.scrollId,
+      total: raw.total,
     };
 
-    for (const arg of ['aggregations', 'scrollId']) {
-      if (raw[arg]) {
-        result[arg] = raw[arg];
-      }
-    }
-
     if (raw.hits && raw.hits.length > 0) {
-      result.total = raw.total;
-
-      return Bluebird
-        .map(raw.hits, doc => this.fromDTO(
-          Object.assign({}, doc._source, { _id: doc._id })))
-        .then(hits => {
-          result.hits = hits;
-          return result;
-        });
+      result.hits = await Bluebird.map(raw.hits, doc => {
+        return this.fromDTO(Object.assign({}, doc._source, { _id: doc._id }));
+      });
     }
 
-    return Bluebird.resolve(result);
+    return result;
   }
 }
 


### PR DESCRIPTION
# Description

The `total` property returned in the `security:searchUsers` response was incorrectly set to `0` if no hits were returned.

Fix #1709 
