### PR TITLE
Fix HTTP multipart crash

### DIFF
--- a/features/fixtures/bad-multipart.req
+++ b/features/fixtures/bad-multipart.req
@@ -1,0 +1,17 @@
+PUT /t/t/t HTTP/1.1
+Host: localhost:7512
+User-Agent: curl/7.70.0
+Accept: */*
+Content-Length: 280
+Content-Type: multipart/form-data; boundary=------------------------59cfb325b8d638cf
+
+--------------------------59cfb325b8d638cf
+Content-Disposition: form-data; name="t"
+
+1
+--------------------------59cfb325b8d638cf
+Content-Disposition: form-data; name="f"; filename="empty"
+Content-Type: application/octet-stream
+
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/features/kuzzle.feature
+++ b/features/kuzzle.feature
@@ -1,5 +1,9 @@
 Feature: Kuzzle functional tests
 
+  Scenario: Http server does not crash on crafted request
+    When I send the crafted HTTP multipart request
+    Then Kuzzle is still up
+
   Scenario: API method server:publicApi
     When I get the public API
     Then I have the definition of kuzzle and plugins controllers

--- a/features/step_definitions/http.js
+++ b/features/step_definitions/http.js
@@ -1,11 +1,21 @@
 'use strict';
 
-const { execSync } = require('child_process');
+const net = require('net');
+const fs = require('fs');
 
 const { Then } = require('cucumber');
 
-Then('I send the crafted HTTP multipart request', function () {
-  return execSync('cat features/fixtures/bad-multipart.req | nc localhost 7512');
+Then('I send the crafted HTTP multipart request', function (done) {
+  const socket = net.createConnection(7512, () => {
+    const rq = fs.readFileSync('./features/fixtures/bad-multipart.req');
+
+    socket.write(rq.toString(), error => {
+      socket.end();
+      done(error);
+    });
+  });
+
+  socket.on('error', done);
 });
 
 Then('Kuzzle is still up', function () {

--- a/features/step_definitions/http.js
+++ b/features/step_definitions/http.js
@@ -1,0 +1,11 @@
+const { execSync } = require('child_process');
+
+const { Then } = require('cucumber');
+
+Then('I send the crafted HTTP multipart request', async function () {
+  execSync('cat features/fixtures/bad-multipart.req | nc localhost 7512');
+});
+
+Then('Kuzzle is still up', async function () {
+  await this.api.serverPublicApi();
+});

--- a/features/step_definitions/http.js
+++ b/features/step_definitions/http.js
@@ -1,11 +1,13 @@
+'use strict';
+
 const { execSync } = require('child_process');
 
 const { Then } = require('cucumber');
 
-Then('I send the crafted HTTP multipart request', async function () {
-  execSync('cat features/fixtures/bad-multipart.req | nc localhost 7512');
+Then('I send the crafted HTTP multipart request', function () {
+  return execSync('cat features/fixtures/bad-multipart.req | nc localhost 7512');
 });
 
-Then('Kuzzle is still up', async function () {
-  await this.api.serverPublicApi();
+Then('Kuzzle is still up', function () {
+  return this.api.serverPublicApi();
 });

--- a/lib/api/core/entrypoints/embedded/service/httpFormDataStream.js
+++ b/lib/api/core/entrypoints/embedded/service/httpFormDataStream.js
@@ -76,6 +76,10 @@ class HttpFormDataStream extends Busboy {
       payload.json[fieldname] = val;
     });
 
+    this.on('error', error => {
+      request.emit('error', errorsManager.get('unexpected_error', error.message));
+    });
+
     return this;
   }
 }


### PR DESCRIPTION
## What does this PR do ?

Fix a crash occuring when a crafted HTTP multipart request is submitted to Kuzzle.

### How should this be manually tested?

Copy this content to a text file:
```
PUT /t/t/t HTTP/1.1
Host: localhost:7512
User-Agent: curl/7.70.0
Accept: */*
Content-Length: 280
Content-Type: multipart/form-data; boundary=------------------------59cfb325b8d638cf

--------------------------59cfb325b8d638cf
Content-Disposition: form-data; name="t"

1
--------------------------59cfb325b8d638cf
Content-Disposition: form-data; name="f"; filename="empty"
Content-Type: application/octet-stream

aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
```

Use it with nc: `cat req | nc localhost 7512`
(only works with a naked kuzzle or with haproxy or traefik: most other load balancers prevent this: nginx, aws' ALB, azure, ...)