### PR TITLE
Correctly load ES aliases when they point to non-existing Kuzzle indexes

### DIFF
--- a/lib/core/storage/storageEngine.js
+++ b/lib/core/storage/storageEngine.js
@@ -289,6 +289,10 @@ class StorageEngine {
     const aliases = await this._publicClient.listAliases();
 
     for (const { collection, index } of aliases) {
+      if (!this._indexes.has(index)) {
+        this._indexes.set(index, new IndexCache('public'));
+      }
+
       this._indexes.get(index).collections.add(collection);
     }
   }

--- a/test/core/storage/storageEngine.test.js
+++ b/test/core/storage/storageEngine.test.js
@@ -89,6 +89,17 @@ describe('StorageEngine', () => {
       should(storageEngine._indexes.get('barfoo').collections)
         .have.keys('barlection');
     });
+
+    it('should create a new index entry if an alias points to a non-existing index', async () => {
+      storageEngine._publicClient.listAliases.resolves([{
+        name: 'ohnoes', index: 'nope', collection: 'collection'
+      }]);
+
+      await storageEngine.init();
+
+      should(storageEngine._indexes.get('nope').collections)
+        .have.keys('collection');
+    });
   });
 
   describe('#add', () => {


### PR DESCRIPTION
# Description

fix #1721 

Create a new index cache entry when an ES alias points to a non-existing Kuzzle index.