### PR TITLE
Return the right total number of searched documents with non-scroll searches

### DIFF
--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -266,10 +266,9 @@ class ElasticSearch extends Service {
       from,
       index: this._getESIndex(index, collection),
       scroll,
-      size
+      size,
+      trackTotalHits: true,
     };
-
-    debug('Search: %j', esRequest);
 
     if (scroll) {
       const scrollDuration = ms(scroll);
@@ -278,6 +277,8 @@ class ElasticSearch extends Service {
         throw kerror.get('scroll_duration_too_great', scroll);
       }
     }
+
+    debug('Search: %j', esRequest);
 
     try {
       const { body } = await this._client.search(esRequest);
@@ -2026,7 +2027,7 @@ class ElasticSearch extends Service {
             status: result.status
           });
         }
-      } 
+      }
       else {
         successes.push({
           _id: result._id,

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -239,7 +239,7 @@ describe('Test: ElasticSearch service', () => {
       kuzzle.cacheEngine.internal.keys.resolves({ values: [] });
     });
 
-    it('should be able to search documents', () => {
+    it('should be able to search documents', async () => {
       elasticsearch._client.search.resolves({
         body: {
           hits: {
@@ -252,31 +252,29 @@ describe('Test: ElasticSearch service', () => {
         }
       });
 
-      const promise = elasticsearch.search(index, collection, filter);
+      const result = await elasticsearch.search(index, collection, filter);
 
-      return promise
-        .then(result => {
-          should(elasticsearch._client.search.firstCall.args[0]).match({
-            index: esIndexName,
-            body: { query: { match_all: {} } },
-            from: undefined,
-            size: undefined,
-            scroll: undefined
-          });
+      should(elasticsearch._client.search.firstCall.args[0]).match({
+        index: esIndexName,
+        body: { query: { match_all: {} } },
+        from: undefined,
+        size: undefined,
+        scroll: undefined,
+        trackTotalHits: true,
+      });
 
-          should(kuzzle.cacheEngine.internal.psetex.firstCall.args[1])
-            .be.eql(ms(elasticsearch.config.defaults.scrollTTL));
+      should(kuzzle.cacheEngine.internal.psetex.firstCall.args[1])
+        .be.eql(ms(elasticsearch.config.defaults.scrollTTL));
 
-          should(result).match({
-            scrollId: 'i-am-scroll-id',
-            hits: [ { _id: 'liia', _source: { city: 'Kathmandu' }, highlight: 'highlight' } ],
-            total: 1,
-            aggregations: { some: 'aggregs' }
-          });
-        });
+      should(result).match({
+        scrollId: 'i-am-scroll-id',
+        hits: [ { _id: 'liia', _source: { city: 'Kathmandu' }, highlight: 'highlight' } ],
+        total: 1,
+        aggregations: { some: 'aggregs' }
+      });
     });
 
-    it('should be able to search with from/size and scroll arguments', () => {
+    it('should be able to search with from/size and scroll arguments', async () => {
       elasticsearch._client.search.resolves({
         body: {
           hits: { hits: [], total: { value: 0 } },
@@ -284,35 +282,32 @@ describe('Test: ElasticSearch service', () => {
         }
       });
 
-      const promise = elasticsearch.search(
-        index,
-        collection,
-        filter,
-        { from: 0, size: 1, scroll: '30s' });
+      await elasticsearch.search(index, collection, filter, {
+        from: 0,
+        size: 1,
+        scroll: '30s',
+      });
 
-      return promise
-        .then(() => {
-          should(elasticsearch._client.search.firstCall.args[0]).match({
-            index: esIndexName,
-            body: filter,
-            from: 0,
-            size: 1,
-            scroll: '30s'
-          });
-          should(kuzzle.cacheEngine.internal.psetex.firstCall.args[1])
-            .be.eql(ms('30s'));
-        });
+      should(elasticsearch._client.search.firstCall.args[0]).match({
+        index: esIndexName,
+        body: filter,
+        from: 0,
+        size: 1,
+        scroll: '30s',
+        trackTotalHits: true,
+      });
+
+      should(kuzzle.cacheEngine.internal.psetex.firstCall.args[1])
+        .be.eql(ms('30s'));
     });
 
-    it('should return a rejected promise if a search fails', () => {
+    it('should return a rejected promise if a search fails', async () => {
       elasticsearch._client.search.rejects(esClientError);
 
-      const promise = elasticsearch.search(index, collection, filter);
+      await should(elasticsearch.search(index, collection, filter))
+        .be.rejected();
 
-      return should(promise).be.rejected()
-        .then(() => {
-          should(elasticsearch._esWrapper.formatESError).be.calledWith(esClientError);
-        });
+      should(elasticsearch._esWrapper.formatESError).be.calledWith(esClientError);
     });
 
     it('should return a rejected promise if an unhautorized property is in the query', () => {
@@ -321,38 +316,34 @@ describe('Test: ElasticSearch service', () => {
         query : {}
       };
 
-      const promise = elasticsearch.search(index, collection, filter);
-
-      return should(promise)
+      return should(elasticsearch.search(index, collection, filter))
         .be.rejectedWith({ id: 'services.storage.invalid_search_query' });
     });
 
-    it('should not save the scrollId in the cache if not present in response', () => {
+    it('should not save the scrollId in the cache if not present in response', async () => {
       elasticsearch._client.search.resolves({
         body: {
           hits: { hits: [], total: { value: 0 } }
         }
       });
 
-      const promise = elasticsearch.search(index, collection, {});
+      await elasticsearch.search(index, collection, {});
 
-      return promise
-        .then(() => {
-          should(kuzzle.cacheEngine.internal.psetex).not.be.called();
-        });
+      should(kuzzle.cacheEngine.internal.psetex).not.be.called();
     });
 
-    it('should return a rejected promise if the scroll duration is too great', () => {
+    it('should return a rejected promise if the scroll duration is too great', async () => {
       elasticsearch._config.maxScrollDuration = '21m';
 
-      const promise = elasticsearch.search(index, collection, filter, { scroll: '42m' });
+      const promise = elasticsearch.search(index, collection, filter, {
+        scroll: '42m'
+      });
 
-      return should(promise).be.rejectedWith({
+      await should(promise).be.rejectedWith({
         id: 'services.storage.scroll_duration_too_great'
-      })
-        .then(() => {
-          should(elasticsearch._client.search).not.be.called();
-        });
+      });
+
+      should(elasticsearch._client.search).not.be.called();
     });
   });
 


### PR DESCRIPTION
# Description

fix #1723 

Add the `trackTotalHits` option to search queries to force Elasticsearch to return the total number of hits in search results, instead of the _fetchable_ number of documents.
