### PR TITLE
Prefix auth user related routes with _me

### DIFF
--- a/doc/2/api/controllers/auth/create-my-credentials/index.md
+++ b/doc/2/api/controllers/auth/create-my-credentials/index.md
@@ -16,12 +16,22 @@ Creates new credentials for the current user.
 
 ### HTTP
 
+<SinceBadge version="auto-version"/>
+```http
+URL: http://kuzzle:7512/_me/credentials/<strategy>/_create
+Method: POST
+Headers: Authorization: "Bearer <authentication token>"
+Body:
+```
+
+<DeprecatedBadge version="auto-version">
 ```http
 URL: http://kuzzle:7512/credentials/<strategy>/_me/_create
 Method: POST
 Headers: Authorization: "Bearer <authentication token>"
 Body:
 ```
+</DeprecatedBadge>
 
 ```js
 {

--- a/doc/2/api/controllers/auth/credentials-exists/index.md
+++ b/doc/2/api/controllers/auth/credentials-exists/index.md
@@ -16,11 +16,20 @@ Checks that the current authenticated user has credentials for the specified aut
 
 ### HTTP
 
+<SinceBadge version="auto-version"/>
+```http
+URL: http://kuzzle:7512/_me/credentials/<strategy>/_exists
+Method: GET
+Headers: Authorization: "Bearer <authentication token>"
+```
+
+<DeprecatedBadge version="auto-version">
 ```http
 URL: http://kuzzle:7512/credentials/<strategy>/_me/_exists
 Method: GET
 Headers: Authorization: "Bearer <authentication token>"
 ```
+</DeprecatedBadge>
 
 ### Other protocols
 

--- a/doc/2/api/controllers/auth/delete-my-credentials/index.md
+++ b/doc/2/api/controllers/auth/delete-my-credentials/index.md
@@ -18,11 +18,20 @@ If the credentials that generated the current JWT are removed, the user will rem
 
 ### HTTP
 
+<SinceBadge version="auto-version"/>
+```http
+URL: http://kuzzle:7512/_me/credentials/<strategy>
+Method: DELETE
+Headers: Authorization: "Bearer <authentication token>"
+```
+
+<DeprecatedBadge version="auto-version">
 ```http
 URL: http://kuzzle:7512/credentials/<strategy>/_me
 Method: DELETE
 Headers: Authorization: "Bearer <authentication token>"
 ```
+</DeprecatedBadge>
 
 ### Other protocols
 

--- a/doc/2/api/controllers/auth/get-current-user/index.md
+++ b/doc/2/api/controllers/auth/get-current-user/index.md
@@ -18,7 +18,7 @@ Returns information about the currently logged in user.
 
 <SinceBadge version="auto-version"/>
 ```http
-URL: http://kuzzle:7512/_me/users
+URL: http://kuzzle:7512/_me
 Method: GET
 Headers: Authorization: "Bearer <authentication token>"
 ```

--- a/doc/2/api/controllers/auth/get-current-user/index.md
+++ b/doc/2/api/controllers/auth/get-current-user/index.md
@@ -16,11 +16,20 @@ Returns information about the currently logged in user.
 
 ### HTTP
 
+<SinceBadge version="auto-version"/>
+```http
+URL: http://kuzzle:7512/_me/users
+Method: GET
+Headers: Authorization: "Bearer <authentication token>"
+```
+
+<DeprecatedBadge version="auto-version">
 ```http
 URL: http://kuzzle:7512/users/_me
 Method: GET
 Headers: Authorization: "Bearer <authentication token>"
 ```
+</DeprecatedBadge>
 
 ### Other protocols
 

--- a/doc/2/api/controllers/auth/get-my-credentials/index.md
+++ b/doc/2/api/controllers/auth/get-my-credentials/index.md
@@ -20,11 +20,20 @@ The result can be an empty object.
 
 ### HTTP
 
+<SinceBadge version="auto-version"/>
+```http
+URL: http://kuzzle:7512/_me/credentials/<strategy>
+Method: GET
+Headers: Authorization: "Bearer <authentication token>"
+```
+
+<DeprecatedBadge version="auto-version">
 ```http
 URL: http://kuzzle:7512/credentials/<strategy>/_me
 Method: GET
 Headers: Authorization: "Bearer <authentication token>"
 ```
+</DeprecatedBadge>
 
 ### Other protocols
 

--- a/doc/2/api/controllers/auth/get-my-rights/index.md
+++ b/doc/2/api/controllers/auth/get-my-rights/index.md
@@ -16,11 +16,20 @@ Returns the exhaustive list of granted or denied rights for the currently logged
 
 ### HTTP
 
+<SinceBadge version="auto-version"/>
+```http
+URL: http://kuzzle:7512/_me/users/_rights
+Method: GET
+Headers: Authorization: "Bearer <authentication token>"
+```
+
+<DeprecatedBadge version="auto-version">
 ```http
 URL: http://kuzzle:7512/users/_me/_rights
 Method: GET
 Headers: Authorization: "Bearer <authentication token>"
 ```
+</DeprecatedBadge>
 
 ### Other protocols
 

--- a/doc/2/api/controllers/auth/get-my-rights/index.md
+++ b/doc/2/api/controllers/auth/get-my-rights/index.md
@@ -18,7 +18,7 @@ Returns the exhaustive list of granted or denied rights for the currently logged
 
 <SinceBadge version="auto-version"/>
 ```http
-URL: http://kuzzle:7512/_me/users/_rights
+URL: http://kuzzle:7512/_me/_rights
 Method: GET
 Headers: Authorization: "Bearer <authentication token>"
 ```

--- a/doc/2/api/controllers/auth/update-my-credentials/index.md
+++ b/doc/2/api/controllers/auth/update-my-credentials/index.md
@@ -16,12 +16,22 @@ Updates the credentials of the currently logged in user.
 
 ### HTTP
 
+<SinceBadge version="auto-version"/>
+```http
+URL: http://kuzzle:7512/_me/credentials/<strategy>/_update
+Method: PUT
+Headers: Authorization: "Bearer <authentication token>"
+Body:
+```
+
+<DeprecatedBadge version="auto-version">
 ```http
 URL: http://kuzzle:7512/credentials/<strategy>/_me/_update
 Method: PUT
 Headers: Authorization: "Bearer <authentication token>"
 Body:
 ```
+</DeprecatedBadge>
 
 ```js
 {

--- a/doc/2/api/controllers/auth/update-self/index.md
+++ b/doc/2/api/controllers/auth/update-self/index.md
@@ -16,12 +16,22 @@ This route cannot update the list of associated security profiles. To change a u
 
 ### HTTP
 
+<SinceBadge version="auto-version"/>
+```http
+URL: http://kuzzle:7512/_me[?refresh=wait_for][?retryOnConflict=10]
+Method: PUT
+Headers: Authorization: "Bearer <authentication token>"
+Body:
+```
+
+<DeprecatedBadge version="auto-version">
 ```http
 URL: http://kuzzle:7512/_updateSelf[?refresh=wait_for][?retryOnConflict=10]
 Method: PUT
 Headers: Authorization: "Bearer <authentication token>"
 Body:
 ```
+</DeprecatedBadge>
 
 ```js
 {

--- a/doc/2/api/controllers/auth/validate-my-credentials/index.md
+++ b/doc/2/api/controllers/auth/validate-my-credentials/index.md
@@ -18,12 +18,22 @@ This route neither creates nor modifies credentials.
 
 ### HTTP
 
+<SinceBadge version="auto-version"/>
+```http
+URL: http://kuzzle:7512/_me/credentials/<strategy>/_validate
+Method: POST
+Headers: Authorization: "Bearer <authentication token>"
+Body:
+```
+
+<DeprecatedBadge version="auto-version">
 ```http
 URL: http://kuzzle:7512/credentials/<strategy>/_me/_validate
 Method: POST
 Headers: Authorization: "Bearer <authentication token>"
 Body:
 ```
+</DeprecatedBadge>
 
 ```js
 {

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -25,7 +25,7 @@
 
 module.exports = [
   // GET (idempotent)
-  {verb: 'get', url: '/_me/users', controller: 'auth', action: 'getCurrentUser'},
+  {verb: 'get', url: '/_me', controller: 'auth', action: 'getCurrentUser'},
   {verb: 'get', url: '/_me/users/_rights', controller: 'auth', action: 'getMyRights'},
   {verb: 'get', url: '/_me/credentials/:strategy', controller: 'auth', action: 'getMyCredentials'},
   {verb: 'get', url: '/_me/credentials/:strategy/_exists', controller: 'auth', action: 'credentialsExist'},

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -25,12 +25,16 @@
 
 module.exports = [
   // GET (idempotent)
-  {verb: 'get', url: '/users/_me', controller: 'auth', action: 'getCurrentUser'},
-  {verb: 'get', url: '/credentials/:strategy/_me', controller: 'auth', action: 'getMyCredentials'},
-  {verb: 'get', url: '/credentials/:strategy/_me/_exists', controller: 'auth', action: 'credentialsExist'},
-  {verb: 'get', url: '/users/_me/_rights', controller: 'auth', action: 'getMyRights'}, // @deprecated
+  {verb: 'get', url: '/_me/users', controller: 'auth', action: 'getCurrentUser'},
   {verb: 'get', url: '/_me/users/_rights', controller: 'auth', action: 'getMyRights'},
+  {verb: 'get', url: '/_me/credentials/:strategy', controller: 'auth', action: 'getMyCredentials'},
+  {verb: 'get', url: '/_me/credentials/:strategy/_exists', controller: 'auth', action: 'credentialsExist'},
   {verb: 'get', url: '/strategies', controller: 'auth', action: 'getStrategies'},
+
+  {verb: 'get', url: '/users/_me', controller: 'auth', action: 'getCurrentUser'}, // @deprecated
+  {verb: 'get', url: '/users/_me/_rights', controller: 'auth', action: 'getMyRights'}, // @deprecated
+  {verb: 'get', url: '/credentials/:strategy/_me', controller: 'auth', action: 'getMyCredentials'}, // @deprecated
+  {verb: 'get', url: '/credentials/:strategy/_me/_exists', controller: 'auth', action: 'credentialsExist'}, // @deprecated
 
   // We need to expose a GET method for "login" action in order to make authentication protocol like Oauth2 or CAS work:
   {verb: 'get', url: '/_login/:strategy', controller: 'auth', action: 'login'},
@@ -155,8 +159,11 @@ module.exports = [
   {verb: 'post', url: '/_logout', controller: 'auth', action: 'logout'},
   {verb: 'post', url: '/_checkToken', controller: 'auth', action: 'checkToken'},
   {verb: 'post', url: '/_refreshToken', controller: 'auth', action: 'refreshToken'},
-  {verb: 'post', url: '/credentials/:strategy/_me/_create', controller: 'auth', action: 'createMyCredentials'},
-  {verb: 'post', url: '/credentials/:strategy/_me/_validate', controller: 'auth', action: 'validateMyCredentials'},
+  {verb: 'post', url: '/_me/credentials/:strategy/_create', controller: 'auth', action: 'createMyCredentials'},
+  {verb: 'post', url: '/_me/credentials/:strategy/_validate', controller: 'auth', action: 'validateMyCredentials'},
+
+  {verb: 'post', url: '/credentials/:strategy/_me/_create', controller: 'auth', action: 'createMyCredentials'}, // @deprecated
+  {verb: 'post', url: '/credentials/:strategy/_me/_validate', controller: 'auth', action: 'validateMyCredentials'}, // @deprecated
 
   {verb: 'post', url: '/:index/:collection/_validateSpecifications', controller: 'collection', action: 'validateSpecifications'},
   {verb: 'post', url: '/validations/_search', controller: 'collection', action: 'searchSpecifications'},
@@ -265,7 +272,9 @@ module.exports = [
 
 
   // DELETE
-  {verb: 'delete', url: '/credentials/:strategy/_me', controller: 'auth', action: 'deleteMyCredentials'},
+  {verb: 'delete', url: '/_me/credentials/:strategy', controller: 'auth', action: 'deleteMyCredentials'},
+
+  {verb: 'delete', url: '/credentials/:strategy/_me', controller: 'auth', action: 'deleteMyCredentials'}, // @deprecated
 
   {verb: 'delete', url: '/:index/:collection/_specifications', controller: 'collection', action: 'deleteSpecifications'},
   {verb: 'delete', url: '/:index/:collection/_truncate', controller: 'collection', action: 'truncate'},
@@ -302,7 +311,9 @@ module.exports = [
 
   // PUT (idempotent)
   {verb: 'put', url: '/_updateSelf', controller: 'auth', action: 'updateSelf'},
-  {verb: 'put', url: '/credentials/:strategy/_me/_update', controller: 'auth', action: 'updateMyCredentials'},
+  {verb: 'put', url: '/_me/credentials/:strategy/_update', controller: 'auth', action: 'updateMyCredentials'},
+
+  {verb: 'put', url: '/credentials/:strategy/_me/_update', controller: 'auth', action: 'updateMyCredentials'}, // @deprecated
 
   {verb: 'put', url: '/:index/:collection', controller: 'collection', action: 'create'},
   {verb: 'post', url: '/:index/:collection', controller: 'collection', action: 'update'},

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -26,7 +26,7 @@
 module.exports = [
   // GET (idempotent)
   {verb: 'get', url: '/_me', controller: 'auth', action: 'getCurrentUser'},
-  {verb: 'get', url: '/_me/users/_rights', controller: 'auth', action: 'getMyRights'},
+  {verb: 'get', url: '/_me/_rights', controller: 'auth', action: 'getMyRights'},
   {verb: 'get', url: '/_me/credentials/:strategy', controller: 'auth', action: 'getMyCredentials'},
   {verb: 'get', url: '/_me/credentials/:strategy/_exists', controller: 'auth', action: 'credentialsExist'},
   {verb: 'get', url: '/strategies', controller: 'auth', action: 'getStrategies'},

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -28,7 +28,8 @@ module.exports = [
   {verb: 'get', url: '/users/_me', controller: 'auth', action: 'getCurrentUser'},
   {verb: 'get', url: '/credentials/:strategy/_me', controller: 'auth', action: 'getMyCredentials'},
   {verb: 'get', url: '/credentials/:strategy/_me/_exists', controller: 'auth', action: 'credentialsExist'},
-  {verb: 'get', url: '/users/_me/_rights', controller: 'auth', action: 'getMyRights'},
+  {verb: 'get', url: '/users/_me/_rights', controller: 'auth', action: 'getMyRights'}, // @deprecated
+  {verb: 'get', url: '/_me/users/_rights', controller: 'auth', action: 'getMyRights'},
   {verb: 'get', url: '/strategies', controller: 'auth', action: 'getStrategies'},
 
   // We need to expose a GET method for "login" action in order to make authentication protocol like Oauth2 or CAS work:

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -310,9 +310,10 @@ module.exports = [
 
 
   // PUT (idempotent)
-  {verb: 'put', url: '/_updateSelf', controller: 'auth', action: 'updateSelf'},
+  {verb: 'put', url: '/_me', controller: 'auth', action: 'updateSelf'},
   {verb: 'put', url: '/_me/credentials/:strategy/_update', controller: 'auth', action: 'updateMyCredentials'},
 
+  {verb: 'put', url: '/_updateSelf', controller: 'auth', action: 'updateSelf'}, // @deprecated
   {verb: 'put', url: '/credentials/:strategy/_me/_update', controller: 'auth', action: 'updateMyCredentials'}, // @deprecated
 
   {verb: 'put', url: '/:index/:collection', controller: 'collection', action: 'create'},


### PR DESCRIPTION
## What does this PR do ?
Normalize all **auth-user** routes with a `_me` prefix AND update all _docs_ accordingly.

It deprecates the following routes and creates new counterparts.

Verb | Deprecated | New Route |
--- | --- | --- |
` GET` | /users/_me | **/_me** |
` GET` | /users/_me/_rights | **/_me/_rights** |
` GET` | /credentials/:strategy/_me | **/_me/credentials/:strategy** |
` GET` | /credentials/:strategy/_me/_exists | **/_me/credentials/:strategy/_exists** |
` POST` | /credentials/:strategy/_me/_create | **/_me/credentials/:strategy/_create** |
` POST` | /credentials/:strategy/_me/_validate | **/_me/credentials/:strategy/_validate** |
` DELETE` | /credentials/:strategy/_me | **/_me/credentials/:strategy** |
` PUT` | /credentials/:strategy/_me/_update | **/_me/credentials/:strategy/_update** |
` PUT` | /_updateSelf | **/_me** |

Docs would look like this:

![image](https://user-images.githubusercontent.com/2495908/87768221-1aa6cd00-c81c-11ea-8e00-ac15417b62d3.png)

Closes #1673 