### PR TITLE
Normalize security event names to our latest convention

### DIFF
--- a/lib/api/controller/auth.js
+++ b/lib/api/controller/auth.js
@@ -74,7 +74,7 @@ class AuthController extends NativeController {
    * @returns {Promise}
    */
   async init () {
-    const anonymous = await this.kuzzle.ask('core:security:user:anonymous');
+    const anonymous = await this.kuzzle.ask('core:security:user:anonymous:get');
     this.anonymousId = anonymous._id;
   }
 

--- a/lib/api/controller/security.js
+++ b/lib/api/controller/security.js
@@ -763,7 +763,7 @@ class SecurityController extends NativeController {
    * @returns {Promise<Object>}
    */
   async createFirstAdmin (request) {
-    const adminExists = await this.kuzzle.ask('core:security:admin:exist');
+    const adminExists = await this.kuzzle.ask('core:security:user:admin:exist');
 
     if (adminExists) {
       throw kerror.get('api', 'process', 'admin_exists');

--- a/lib/api/controller/security.js
+++ b/lib/api/controller/security.js
@@ -763,7 +763,7 @@ class SecurityController extends NativeController {
    * @returns {Promise<Object>}
    */
   async createFirstAdmin (request) {
-    const adminExists = await this.kuzzle.ask('core:security:user:adminExists');
+    const adminExists = await this.kuzzle.ask('core:security:admin:exist');
 
     if (adminExists) {
       throw kerror.get('api', 'process', 'admin_exists');

--- a/lib/api/controller/server.js
+++ b/lib/api/controller/server.js
@@ -101,7 +101,7 @@ class ServerController extends NativeController {
    * @returns {Promise<Object>}
    */
   async adminExists () {
-    const exists = await this.kuzzle.ask('core:security:user:adminExists');
+    const exists = await this.kuzzle.ask('core:security:admin:exist');
 
     return { exists };
   }

--- a/lib/api/controller/server.js
+++ b/lib/api/controller/server.js
@@ -101,7 +101,7 @@ class ServerController extends NativeController {
    * @returns {Promise<Object>}
    */
   async adminExists () {
-    const exists = await this.kuzzle.ask('core:security:admin:exist');
+    const exists = await this.kuzzle.ask('core:security:user:admin:exist');
 
     return { exists };
   }

--- a/lib/core/auth/tokenManager.js
+++ b/lib/core/auth/tokenManager.js
@@ -70,7 +70,7 @@ class TokenManager {
   }
 
   async init () {
-    const anonymous = await this.kuzzle.ask('core:security:user:anonymous');
+    const anonymous = await this.kuzzle.ask('core:security:user:anonymous:get');
     this.anonymousUserId = anonymous._id;
   }
 

--- a/lib/core/network/entryPoint.js
+++ b/lib/core/network/entryPoint.js
@@ -140,7 +140,7 @@ class EntryPoint {
 
     await Bluebird.all(initPromises);
 
-    const anonymous = await this.kuzzle.ask('core:security:user:anonymous');
+    const anonymous = await this.kuzzle.ask('core:security:user:anonymous:get');
     this.anonymousUserId = anonymous._id;
 
     await this.loadMoreProtocols();

--- a/lib/core/security/userRepository.js
+++ b/lib/core/security/userRepository.js
@@ -159,7 +159,7 @@ class UserRepository extends Repository {
      * @returns {Boolean}
      */
     this.kuzzle.onAsk(
-      'core:security:admin:exist',
+      'core:security:user:admin:exist',
       () => this.adminExists());
   }
 

--- a/lib/core/security/userRepository.js
+++ b/lib/core/security/userRepository.js
@@ -60,7 +60,7 @@ class UserRepository extends Repository {
      * Gets the standard anonymous User object
      * @returns {User}
      */
-    this.kuzzle.onAsk('core:security:user:anonymous', () => this.anonymousUser);
+    this.kuzzle.onAsk('core:security:user:anonymous:get', () => this.anonymousUser);
 
     /**
      * Creates a new user
@@ -159,7 +159,7 @@ class UserRepository extends Repository {
      * @returns {Boolean}
      */
     this.kuzzle.onAsk(
-      'core:security:user:adminExists',
+      'core:security:admin:exist',
       () => this.adminExists());
   }
 

--- a/test/api/controller/auth.test.js
+++ b/test/api/controller/auth.test.js
@@ -30,7 +30,7 @@ describe('Test the auth controller', () => {
   beforeEach(() => {
     kuzzle = new KuzzleMock();
     kuzzle.config.security.jwt.secret = 'test-secret';
-    kuzzle.ask.withArgs('core:security:user:anonymous').resolves({_id: '-1'});
+    kuzzle.ask.withArgs('core:security:user:anonymous:get').resolves({_id: '-1'});
 
     user = new User();
     kuzzle.passport.authenticate.returns(Bluebird.resolve(user));

--- a/test/api/controller/security/users.test.js
+++ b/test/api/controller/security/users.test.js
@@ -1002,7 +1002,7 @@ describe('Test: security controller - users', () => {
   });
 
   describe('#createFirstAdmin', () => {
-    const adminExistsEvent = 'core:security:admin:exist';
+    const adminExistsEvent = 'core:security:user:admin:exist';
     const createOrReplaceRoleEvent = 'core:security:role:createOrReplace';
     const createOrReplaceProfileEvent = 'core:security:profile:createOrReplace';
     let createOrReplaceRoleStub;

--- a/test/api/controller/security/users.test.js
+++ b/test/api/controller/security/users.test.js
@@ -1002,7 +1002,7 @@ describe('Test: security controller - users', () => {
   });
 
   describe('#createFirstAdmin', () => {
-    const adminExistsEvent = 'core:security:user:adminExists';
+    const adminExistsEvent = 'core:security:admin:exist';
     const createOrReplaceRoleEvent = 'core:security:role:createOrReplace';
     const createOrReplaceProfileEvent = 'core:security:profile:createOrReplace';
     let createOrReplaceRoleStub;

--- a/test/api/controller/server.test.js
+++ b/test/api/controller/server.test.js
@@ -77,9 +77,9 @@ describe('ServerController', () => {
   });
 
   describe('#adminExists', () => {
-    const adminExistsEvent = 'core:security:user:adminExists';
+    const adminExistsEvent = 'core:security:admin:exist';
 
-    it('should calls "core:security:user:adminExists"', async () => {
+    it('should calls "core:security:admin:exist"', async () => {
       kuzzle.ask
         .withArgs(adminExistsEvent)
         .returns(true);

--- a/test/api/controller/server.test.js
+++ b/test/api/controller/server.test.js
@@ -77,9 +77,9 @@ describe('ServerController', () => {
   });
 
   describe('#adminExists', () => {
-    const adminExistsEvent = 'core:security:admin:exist';
+    const adminExistsEvent = 'core:security:user:admin:exist';
 
-    it('should calls "core:security:admin:exist"', async () => {
+    it('should calls "core:security:user:admin:exist"', async () => {
       kuzzle.ask
         .withArgs(adminExistsEvent)
         .returns(true);

--- a/test/api/funnel/execute.test.js
+++ b/test/api/funnel/execute.test.js
@@ -27,7 +27,7 @@ describe('funnelController.execute', () => {
     kuzzle = new KuzzleMock();
 
     kuzzle.config.limits.requestsBufferWarningThreshold = -1;
-    kuzzle.ask.withArgs('core:security:user:anonymous').resolves({_id: '-1'});
+    kuzzle.ask.withArgs('core:security:user:anonymous:get').resolves({_id: '-1'});
 
     request = new Request({
       controller: 'foo',

--- a/test/api/funnel/init.test.js
+++ b/test/api/funnel/init.test.js
@@ -21,7 +21,7 @@ describe('funnel.init', () => {
   it('should initialize API and plugins controller', async () => {
     const kuzzle = new KuzzleMock();
 
-    kuzzle.ask.withArgs('core:security:user:anonymous').resolves({_id: '-1'});
+    kuzzle.ask.withArgs('core:security:user:anonymous:get').resolves({_id: '-1'});
 
     const funnel = new Funnel(kuzzle);
 

--- a/test/core/auth/tokenManager.test.js
+++ b/test/core/auth/tokenManager.test.js
@@ -16,7 +16,7 @@ describe('Test: token manager core component', () => {
     kuzzle = new KuzzleMock();
 
     kuzzle.ask
-      .withArgs('core:security:user:anonymous')
+      .withArgs('core:security:user:anonymous:get')
       .resolves({_id: '-1'});
 
     tokenManager = new TokenManager(kuzzle);

--- a/test/core/network/entryPoint.test.js
+++ b/test/core/network/entryPoint.test.js
@@ -73,7 +73,7 @@ describe('lib/core/core/network/entryPoint', () => {
   beforeEach(() => {
     kuzzle = new KuzzleMock();
 
-    kuzzle.ask.withArgs('core:security:user:anonymous').resolves({_id: '-1'});
+    kuzzle.ask.withArgs('core:security:user:anonymous:get').resolves({_id: '-1'});
 
     HttpMock = FakeHttpProtocol;
     WebSocketMock = FakeWebSocketProtocol;

--- a/test/core/security/userRepository.test.js
+++ b/test/core/security/userRepository.test.js
@@ -48,7 +48,7 @@ describe('Test: security/userRepository', () => {
 
   describe('#anonymous', () => {
     it('should return a valid anonymous user', async () => {
-      const user = await kuzzle.ask('core:security:user:anonymous');
+      const user = await kuzzle.ask('core:security:user:anonymous:get');
       assertIsAnonymous(user);
     });
   });
@@ -171,7 +171,7 @@ describe('Test: security/userRepository', () => {
   });
 
   describe('#adminExists', () => {
-    const adminExistsEvent = 'core:security:user:adminExists';
+    const adminExistsEvent = 'core:security:admin:exist';
 
     it('should register an "adminExists" event', async () => {
       userRepository.adminExists = sinon.stub();

--- a/test/core/security/userRepository.test.js
+++ b/test/core/security/userRepository.test.js
@@ -171,7 +171,7 @@ describe('Test: security/userRepository', () => {
   });
 
   describe('#adminExists', () => {
-    const adminExistsEvent = 'core:security:admin:exist';
+    const adminExistsEvent = 'core:security:user:admin:exist';
 
     it('should register an "adminExists" event', async () => {
       userRepository.adminExists = sinon.stub();


### PR DESCRIPTION
## What does this PR do ?

Rename a couple security events to our latest naming convention.

| Old Name | New Name |
| --- | --- |
| `core:security:user:adminExists` | `core:security:user:admin:exist` |
| `core:security:user:anonymous` | `core:security:user:anonymous:get` |
