### PR TITLE
Fix: load manifest configuration correctly

### DIFF
--- a/lib/core/network/entryPoint.js
+++ b/lib/core/network/entryPoint.js
@@ -193,25 +193,27 @@ class EntryPoint {
   /**
    * Loads installed protocols in memory
    */
-  loadMoreProtocols () {
+  async loadMoreProtocols () {
     const dir = path.join(__dirname, '../../../protocols/enabled');
-
     let dirs;
+
     try {
       dirs = fs.readdirSync(dir);
     }
     catch (e) {
-      return Bluebird.resolve();
+      // ignore if there is no protocols directory
+      return;
     }
 
     dirs = dirs
       .map(d => path.join(dir, d))
       .filter(d => fs.statSync(d).isDirectory());
 
-    return Bluebird.map(dirs, protoDir => {
-      const
-        protocol = new (require(protoDir))(),
-        manifest = new Manifest(this.kuzzle, protoDir, protocol);
+    await Bluebird.map(dirs, protoDir => {
+      const protocol = new (require(protoDir))();
+      const manifest = new Manifest(this.kuzzle, protoDir, protocol);
+
+      manifest.load();
 
       const initTimeout = this.kuzzle.config.services.common.defaultInitTimeout;
 

--- a/lib/core/network/protocolManifest.js
+++ b/lib/core/network/protocolManifest.js
@@ -28,8 +28,6 @@ class ProtocolManifest extends AbstractManifest {
     super(kuzzle, protocolPath);
 
     this.protocol = protocol;
-
-    this.loadFromDisk();
   }
 }
 

--- a/lib/core/plugin/plugin.js
+++ b/lib/core/plugin/plugin.js
@@ -186,8 +186,11 @@ class Plugin {
 
       throw runtimeError.getFrom(error, 'unexpected_error', error.message);
     }
+
     // load manifest
     plugin.manifest = new Manifest(kuzzle, pluginPath);
+    plugin.manifest.load();
+
     plugin.name = plugin.manifest.name;
 
     // load plugin version if exists

--- a/lib/core/plugin/pluginManifest.js
+++ b/lib/core/plugin/pluginManifest.js
@@ -30,24 +30,23 @@ class PluginManifest extends AbstractManifest {
   constructor(kuzzle, pluginPath) {
     super(kuzzle, pluginPath);
     this.privileged = false;
-
-    this.loadFromDisk();
   }
 
   load () {
+    super.load();
+
     // Ensure ES will accept the plugin name as index
     if (!/^[\w-]+$/.test(this.name)) {
       throw kerror.get('invalid_name', this.path);
     }
 
-    if (!_.isNil(this.raw.privileged)) {
+    if (!_.isNil(this.raw) && !_.isNil(this.raw.privileged)) {
       if (typeof this.raw.privileged !== 'boolean') {
         throw kerror.get(
           'invalid_privileged',
           this.path,
           typeof this.raw.privileged);
       }
-
       this.privileged = this.raw.privileged;
     }
   }

--- a/lib/core/shared/abstractManifest.js
+++ b/lib/core/shared/abstractManifest.js
@@ -47,7 +47,7 @@ class AbstractManifest {
     this.raw = null;
   }
 
-  loadFromDisk () {
+  load () {
     try {
       this.raw = require(this.manifestPath);
     }

--- a/test/core/plugin/pluginManifest.test.js
+++ b/test/core/plugin/pluginManifest.test.js
@@ -1,13 +1,19 @@
 'use strict';
 
 const should = require('should');
-const KuzzleMock = require('../../mocks/kuzzle.mock');
 const mockrequire = require('mock-require');
+const {
+  errors: {
+    PluginImplementationError,
+  }
+} = require('kuzzle-common-objects');
+
+const KuzzleMock = require('../../mocks/kuzzle.mock');
+
 const AbstractManifest = require('../../../lib/core/shared/abstractManifest');
-const { errors: { PluginImplementationError } } = require('kuzzle-common-objects');
 
 class AbstractManifestStub extends AbstractManifest {
-  loadFromDisk() {}
+  load() {}
 }
 
 describe('Plugins manifest class', () => {
@@ -32,10 +38,9 @@ describe('Plugins manifest class', () => {
       manifest.name = name;
 
       /* eslint-disable-next-line no-loop-func */
-      should(() => manifest.load())
-        .throw(PluginImplementationError, {
-          id: 'plugin.manifest.invalid_name'
-        });
+      should(() => manifest.load()).throw(PluginImplementationError, {
+        id: 'plugin.manifest.invalid_name'
+      });
     }
   });
 

--- a/test/core/shared/abstractManifest.test.js
+++ b/test/core/shared/abstractManifest.test.js
@@ -1,17 +1,17 @@
 'use strict';
 
 const should = require('should');
-const KuzzleMock = require('../../mocks/kuzzle.mock');
 const rewire = require('rewire');
 const {
   errors: { PluginImplementationError }
 } = require('kuzzle-common-objects');
 
+const KuzzleMock = require('../../mocks/kuzzle.mock');
+
 describe('AbstractManifest class', () => {
-  const
-    kuzzle = new KuzzleMock(),
-    defaultKuzzleVersion = '>=2.0.0 <3.0.0',
-    pluginPath = 'foo/bar';
+  const kuzzle = new KuzzleMock();
+  const defaultKuzzleVersion = '>=2.0.0 <3.0.0';
+  const pluginPath = 'foo/bar';
 
   let Manifest;
 
@@ -31,7 +31,7 @@ describe('AbstractManifest class', () => {
   it('should throw if no manifest.json is found', () => {
     const manifest = new Manifest(kuzzle, pluginPath);
 
-    should(() => manifest.loadFromDisk()).throw(PluginImplementationError, {
+    should(() => manifest.load()).throw(PluginImplementationError, {
       id: 'plugin.manifest.cannot_load'
     });
   });
@@ -40,28 +40,26 @@ describe('AbstractManifest class', () => {
     const manifest = new Manifest(kuzzle, pluginPath);
 
     mockRequireManifest({ name: 'foobar', kuzzleVersion: 123 })(() => {
-      should(() => manifest.loadFromDisk())
+      should(() => manifest.load())
         .throw(PluginImplementationError, { id: 'plugin.manifest.version_mismatch' });
     });
   });
 
   it('should throw if kuzzleVersion is not present', () => {
-    const
-      manifest = new Manifest(kuzzle, pluginPath);
+    const manifest = new Manifest(kuzzle, pluginPath);
 
     mockRequireManifest({ name: 'foobar' })(() => {
-      should(() => manifest.loadFromDisk())
+      should(() => manifest.load())
         .throw(PluginImplementationError, { id: 'plugin.manifest.missing_version' });
     });
   });
 
   it('should set the provided kuzzleVersion value', () => {
-    const
-      kuzzleVersion = '>1.0.0 <=99.99.99',
-      manifest = new Manifest(kuzzle, pluginPath);
+    const kuzzleVersion = '>1.0.0 <=99.99.99';
+    const manifest = new Manifest(kuzzle, pluginPath);
 
     mockRequireManifest({ name: 'foobar', kuzzleVersion })(() => {
-      manifest.loadFromDisk();
+      manifest.load();
       should(manifest).match({ name: 'foobar', kuzzleVersion });
     });
   });
@@ -71,7 +69,7 @@ describe('AbstractManifest class', () => {
 
     [123, false, ''].forEach(name => {
       mockRequireManifest({ name, kuzzleVersion: defaultKuzzleVersion })(() => {
-        should(() => manifest.loadFromDisk()).throw(PluginImplementationError, {
+        should(() => manifest.load()).throw(PluginImplementationError, {
           id: 'plugin.manifest.invalid_name_type'
         });
       });
@@ -83,7 +81,7 @@ describe('AbstractManifest class', () => {
 
     [undefined, null].forEach(name => {
       mockRequireManifest({ name, kuzzleVersion: defaultKuzzleVersion })(() => {
-        should(() => manifest.loadFromDisk()).throw(PluginImplementationError, {
+        should(() => manifest.load()).throw(PluginImplementationError, {
           id: 'plugin.manifest.missing_name'
         });
       });
@@ -91,12 +89,11 @@ describe('AbstractManifest class', () => {
   });
 
   it('should throw if kuzzleVersion does not match the current Kuzzle version', () => {
-    const
-      kuzzleVersion = '>0.4.2 <1.0.0',
-      manifest = new Manifest(kuzzle, pluginPath);
+    const kuzzleVersion = '>0.4.2 <1.0.0';
+    const manifest = new Manifest(kuzzle, pluginPath);
 
     mockRequireManifest({ name: 'foobar', kuzzleVersion })(() => {
-      should(() => manifest.loadFromDisk()).throw(PluginImplementationError, {
+      should(() => manifest.load()).throw(PluginImplementationError, {
         id: 'plugin.manifest.version_mismatch'
       });
     });
@@ -105,8 +102,11 @@ describe('AbstractManifest class', () => {
   it('should serialize only the necessary properties', () => {
     const manifest = new Manifest(kuzzle, pluginPath);
 
-    mockRequireManifest({ name: 'foobar', kuzzleVersion: defaultKuzzleVersion })(() => {
-      manifest.loadFromDisk();
+    mockRequireManifest({
+      kuzzleVersion: defaultKuzzleVersion ,
+      name: 'foobar',
+    })(() => {
+      manifest.load();
 
       const serialized = JSON.parse(JSON.stringify(manifest));
 


### PR DESCRIPTION
# Description

Plugin manifests were not correctly loaded because of a coding error pushed on the 2-dev branch: the plugin manifest constructor calls `loadFromDisk` but its overload is named `load`

Fix:
* rename `loadFromDisk` back to `load` in the parent class
* do not call `load` directly from the constructor: it's generally a bad practice to perform I/Os in the constructor. Plus, it's more difficult to test

