### PR TITLE
Logs why a ws connection is closed

### DIFF
--- a/lib/core/network/protocols/websocket.js
+++ b/lib/core/network/protocols/websocket.js
@@ -133,8 +133,13 @@ class WebSocketProtocol extends Protocol {
     this.entryPoint.newConnection(connection);
     this.connectionPool.set(connection.id, wsConnection);
 
-    socket.on('close', () => {
-      debug('[%s] received a `close` event', connection.id);
+    socket.on('close', (code, reason) => {
+      debug(
+        '[%s] received a `close` event (CODE: %d, REASON: %s)',
+        connection.id,
+        code,
+        reason);
+
       this.onClientDisconnection(connection.id);
     });
 


### PR DESCRIPTION
# Description

Amend the debug output printed when a WebSocket connection closes, to make it print the associated code and reason.