### PR TITLE
Add a "remaining" property to scroll search results

### DIFF
--- a/doc/2/api/controllers/document/scroll/index.md
+++ b/doc/2/api/controllers/document/scroll/index.md
@@ -60,6 +60,7 @@ Returns a paginated search result set, with the following properties:
   - `_id`: document unique identifier
   - `_score`: [relevance score](https://www.elastic.co/guide/en/elasticsearch/guide/current/relevance-intro.html)
   - `_source`: new document content
+- `remaining`: remaining documents that can be fetched
 - `scrollId`: identifier to the next page of result. Can be different than the previous one(s)
 - `total`: total number of found documents. Usually greater than the number of documents in a result page
 

--- a/doc/2/api/controllers/document/scroll/index.md
+++ b/doc/2/api/controllers/document/scroll/index.md
@@ -60,11 +60,9 @@ Returns a paginated search result set, with the following properties:
   - `_id`: document unique identifier
   - `_score`: [relevance score](https://www.elastic.co/guide/en/elasticsearch/guide/current/relevance-intro.html)
   - `_source`: new document content
+- `remaining`: remaining documents that can be fetched <SinceBadge version="auto-version"/>
 - `scrollId`: identifier to the next page of result. Can be different than the previous one(s)
 - `total`: total number of found documents. Usually greater than the number of documents in a result page
-
-<SinceBadge version="auto-version"/>
-- `remaining`: remaining documents that can be fetched
 
 ```js
 {

--- a/doc/2/api/controllers/document/scroll/index.md
+++ b/doc/2/api/controllers/document/scroll/index.md
@@ -60,9 +60,11 @@ Returns a paginated search result set, with the following properties:
   - `_id`: document unique identifier
   - `_score`: [relevance score](https://www.elastic.co/guide/en/elasticsearch/guide/current/relevance-intro.html)
   - `_source`: new document content
-- `remaining`: remaining documents that can be fetched
 - `scrollId`: identifier to the next page of result. Can be different than the previous one(s)
 - `total`: total number of found documents. Usually greater than the number of documents in a result page
+
+<SinceBadge version="auto-version"/>
+- `remaining`: remaining documents that can be fetched
 
 ```js
 {

--- a/doc/2/api/controllers/document/search/index.md
+++ b/doc/2/api/controllers/document/search/index.md
@@ -126,11 +126,9 @@ Returns a paginated search result set, with the following properties:
   - `_score`: [relevance score](https://www.elastic.co/guide/en/elasticsearch/guide/current/relevance-intro.html)
   - `_source`: new document content
   - `highlight`: optional result from [highlight API](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/search-request-body.html#request-body-search-highlighting)
+- `remaining`: remaining documents that can be fetched. Present only if the `scroll` argument has been supplied <SinceBadge version="auto-version"/>
 - `scrollId`: identifier to the next page of result. Present only if the `scroll` argument has been supplied
 - `total`: total number of found documents. Can be greater than the number of documents in a result page, meaning that other matches than the one retrieved are available
-
-<SinceBadge version="auto-version"/>
-- `remaining`: remaining documents that can be fetched. Present only if the `scroll` argument has been supplied
 
 ```js
 {

--- a/doc/2/api/controllers/document/search/index.md
+++ b/doc/2/api/controllers/document/search/index.md
@@ -126,9 +126,11 @@ Returns a paginated search result set, with the following properties:
   - `_score`: [relevance score](https://www.elastic.co/guide/en/elasticsearch/guide/current/relevance-intro.html)
   - `_source`: new document content
   - `highlight`: optional result from [highlight API](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/search-request-body.html#request-body-search-highlighting)
-- `remaining`: remaining documents that can be fetched. Present only if the `scroll` argument has been supplied
 - `scrollId`: identifier to the next page of result. Present only if the `scroll` argument has been supplied
 - `total`: total number of found documents. Can be greater than the number of documents in a result page, meaning that other matches than the one retrieved are available
+
+<SinceBadge version="auto-version"/>
+- `remaining`: remaining documents that can be fetched. Present only if the `scroll` argument has been supplied
 
 ```js
 {

--- a/doc/2/api/controllers/document/search/index.md
+++ b/doc/2/api/controllers/document/search/index.md
@@ -126,7 +126,8 @@ Returns a paginated search result set, with the following properties:
   - `_score`: [relevance score](https://www.elastic.co/guide/en/elasticsearch/guide/current/relevance-intro.html)
   - `_source`: new document content
   - `highlight`: optional result from [highlight API](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/search-request-body.html#request-body-search-highlighting)
-- `scrollId`: identifier to the next page of result. Present only if the `scroll` argument has been set
+- `remaining`: remaining documents that can be fetched. Present only if the `scroll` argument has been supplied
+- `scrollId`: identifier to the next page of result. Present only if the `scroll` argument has been supplied
 - `total`: total number of found documents. Can be greater than the number of documents in a result page, meaning that other matches than the one retrieved are available
 
 ```js

--- a/features-sdk/DocumentController.feature
+++ b/features-sdk/DocumentController.feature
@@ -93,6 +93,43 @@ Feature: Document Controller
       | _id          |
       | "document-3" |
 
+  @mappings
+  Scenario: Search with scroll
+    Given an existing collection "nyc-open-data":"yellow-taxi"
+    And I "create" the following documents:
+      | _id          | body                    |
+      | "document-1" | { "name": "document1" } |
+      | "document-2" | { "name": "document2" } |
+      | "document-3" | { "name": "document3" } |
+    And I refresh the collection
+    When I search documents with the following query:
+      """
+      {}
+      """
+    And with the following search options:
+      """
+      {
+        "scroll": "30s",
+        "size": 1
+      }
+      """
+    And I execute the search query
+    Then I should receive a result matching:
+      | remaining | 2 |
+      | total     | 3 |
+    And I should receive a "hits" array containing 1 elements
+    When I scroll to the next page
+    Then I should receive a result matching:
+      | remaining | 1 |
+      | total     | 3 |
+    And I should receive a "hits" array containing 1 elements
+    When I scroll to the next page
+    Then I should receive a result matching:
+      | remaining | 0 |
+      | total     | 3 |
+    And I should receive a "hits" array containing 1 elements
+
+
   # document:exists ============================================================
 
   @mappings

--- a/features-sdk/run.sh
+++ b/features-sdk/run.sh
@@ -8,5 +8,5 @@ export SCOPE=${1:-features-sdk}
 
 for protocol in websocket http; do
   # profiles are defined in the cucumber.js file at the root of this project
-  KUZZLE_PROTOCOL=$protocol ./node_modules/.bin/cucumber-js --profile $protocol $SCOPE
+  KUZZLE_PROTOCOL=$protocol npx cucumber-js --profile $protocol $SCOPE
 done

--- a/features-sdk/step_definitions/documents-steps.js
+++ b/features-sdk/step_definitions/documents-steps.js
@@ -148,11 +148,42 @@ Then('with the following highlights:', function (highlightsRaw) {
   this.props.searchBody.highlight = highlights;
 });
 
+Then('with the following search options:', function (optionsRaw) {
+  const options = JSON.parse(optionsRaw);
+
+  this.props.searchOptions = options;
+});
+
 Then('I execute the search query', async function () {
-  this.props.result = await this.sdk.document.search(
-    this.props.index,
-    this.props.collection,
-    this.props.searchBody);
+  // temporary use of sdk.query until we add the new "remaining" property
+  // in the SDK's SearchResults class
+  const response = await this.sdk.query({
+    action: 'search',
+    body: this.props.searchBody,
+    collection: this.props.collection,
+    controller: 'document',
+    index: this.props.index,
+    ...this.props.searchOptions,
+  });
+
+  this.props.result = response.result;
+});
+
+Then('I scroll to the next page', async function () {
+  // temporary use of raw results, until the "remaining" propery is made
+  // available to the SearchResults SDK class
+  if (!this.props.result.scrollId) {
+    throw new Error('No scroll ID found');
+  }
+
+  const response = await this.sdk.query({
+    action: 'scroll',
+    controller: 'document',
+    scroll: '30s',
+    scrollId: this.props.result.scrollId,
+  });
+
+  this.props.result = response.result;
 });
 
 Then('I execute the search query with verb "GET"', async function () {
@@ -163,7 +194,7 @@ Then('I execute the search query with verb "GET"', async function () {
     collection: this.props.collection,
   };
   const options = {};
-  
+
   if (this.kuzzleConfig.PROTOCOL === 'http') {
     request.searchBody = JSON.stringify(this.props.searchBody);
     options.verb = 'GET';

--- a/lib/api/controller/document.js
+++ b/lib/api/controller/document.js
@@ -61,51 +61,51 @@ class DocumentController extends NativeController {
    * @param {Request} request
    * @returns {Promise<Object>}
    */
-  search (request) {
+  async search (request) {
     const { from, size, scrollTTL, searchBody } = this.getSearchParams(request);
     const { index, collection } = this.getIndexAndCollection(request);
 
-    if ( [',', '*', '+'].some(searchValue => index.indexOf(searchValue) !== -1)
-      || index === '_all'
-    ) {
+    if (hasMultiTargets(index)) {
       throw kerror.get('services', 'storage', 'no_multi_indexes');
     }
-    if ( [',', '*', '+'].some(searchValue => collection.indexOf(searchValue) !== -1)
-      || collection === '_all'
-    ) {
+
+    if (hasMultiTargets(collection)) {
       throw kerror.get('services', 'storage', 'no_multi_collections');
     }
 
     this.assertNotExceedMaxFetch(size - from);
 
-    return this.publicStorage.search(
+    const result = await this.publicStorage.search(
       index,
       collection,
       searchBody,
-      { from, scroll: scrollTTL, size }
-    )
-      .then(({ scrollId, hits, aggregations, total }) => ({
-        aggregations,
-        hits,
-        scrollId,
-        total
-      }));
+      { from, scroll: scrollTTL, size });
+
+    return {
+      aggregations: result.aggregations,
+      hits: result.hits,
+      remaining: result.remaining,
+      scrollId: result.scrollId,
+      total: result.total,
+    };
   }
 
   /**
    * @param {Request} request
    * @returns {Promise<Object>}
    */
-  scroll (request) {
+  async scroll (request) {
     const scrollTTL = this.getScrollTTLParam(request);
     const _scrollId = this.getString(request, 'scrollId');
 
-    return this.publicStorage.scroll(_scrollId, { scrollTTL })
-      .then(({ scrollId, hits, total }) => ({
-        hits,
-        scrollId,
-        total
-      }));
+    const result = await this.publicStorage.scroll(_scrollId, { scrollTTL });
+
+    return {
+      hits: result.hits,
+      remaining: result.remaining,
+      scrollId: result.scrollId,
+      total: result.total,
+    };
   }
 
   /**
@@ -527,6 +527,10 @@ class DocumentController extends NativeController {
       successes: response.items
     };
   }
+}
+
+function hasMultiTargets (str) {
+  return [',', '*', '+'].some(chr => str.includes(chr)) || str === '_all';
 }
 
 module.exports = DocumentController;

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -197,11 +197,11 @@ class ElasticSearch extends Service {
     const _scrollTTL = scrollTTL || this._config.defaults.scrollTTL;
     const esRequest = {
       scroll: _scrollTTL,
-      scrollId
+      scrollId,
     };
 
-    const cacheKey = SCROLL_CACHE_PREFIX + this._kuzzle.constructor.hash(
-      esRequest.scrollId);
+    const cacheKey = SCROLL_CACHE_PREFIX
+      + this._kuzzle.constructor.hash(esRequest.scrollId);
 
     debug('Scroll: %o', esRequest);
 
@@ -237,6 +237,8 @@ class ElasticSearch extends Service {
           ms(_scrollTTL) || this.scrollTTL,
           fetched);
       }
+
+      body.remaining = body.hits.total.value - fetched;
 
       return this._formatSearchResult(body);
     }
@@ -291,6 +293,8 @@ class ElasticSearch extends Service {
           SCROLL_CACHE_PREFIX + this._kuzzle.constructor.hash(body._scroll_id),
           ttl,
           body.hits.hits.length);
+
+        body.remaining = body.hits.total.value - body.hits.hits.length;
       }
 
       return this._formatSearchResult(body);
@@ -301,24 +305,19 @@ class ElasticSearch extends Service {
   }
 
   _formatSearchResult (body) {
-    const hits = [];
-
-    for (let i = 0; i < body.hits.hits.length; i++) {
-      const hit = body.hits.hits[i];
-
-      hits.push({
-        _id: hit._id,
-        _score: hit._score,
-        _source: hit._source,
-        highlight: hit.highlight
-      });
-    }
+    const hits = body.hits.hits.map(hit => ({
+      _id: hit._id,
+      _score: hit._score,
+      _source: hit._source,
+      highlight: hit.highlight,
+    }));
 
     return {
       aggregations: body.aggregations,
       hits,
+      remaining: body.remaining,
       scrollId: body._scroll_id,
-      total: body.hits.total.value
+      total: body.hits.total.value,
     };
   }
 


### PR DESCRIPTION
# Description

Add a new `remaining` property to scroll search results, showing the number of remaining documents that can still be fetched.

This should make easier for our API clients to know when they have fetched the last page of scroll searches without having to track  it using the number of documents already retrieved, and comparing that to the total number of hits.

# Other changes

* fix a couple unit tests about `document:updateByQuery` that were erroneously successful
