### PR TITLE
Better stacktrace for sdk

### DIFF
--- a/lib/core/shared/sdk/funnelProtocol.js
+++ b/lib/core/shared/sdk/funnelProtocol.js
@@ -92,13 +92,13 @@ class FunnelProtocol extends KuzzleEventEmitter {
       // enhance and clean stacktrace
       if (process.env.NODE_ENV !== 'production') {
         const lines = stack.split('\n');
-        lines[4] = ' 🡆  ' + lines[4].trimStart();
+        lines[4] = ` 🡆  ${lines[4].trimStart()}`;
         lines[0] = error.stack.split('\n')[0];
         error.stack = lines.join('\n');
       }
       else {
         const lines = error.stack.split('\n');
-        lines[5] = ' 🡆  ' + lines[5].trimStart();
+        lines[5] = ` 🡆  ${lines[5].trimStart()}`;
         error.stack = lines.join('\n');
       }
 

--- a/lib/core/shared/sdk/funnelProtocol.js
+++ b/lib/core/shared/sdk/funnelProtocol.js
@@ -65,6 +65,12 @@ class FunnelProtocol extends KuzzleEventEmitter {
    *  Hydrate the user and execute SDK query
    */
   async query (request) {
+    // Keep a more complete stacktrace in development
+    let stack;
+    if (process.env.NODE_ENV !== 'production') {
+      stack = Error().stack;
+    }
+
     if (! this.requestOptions) {
       this.requestOptions = {
         connection: {
@@ -77,9 +83,27 @@ class FunnelProtocol extends KuzzleEventEmitter {
 
     const kuzzleRequest = new Request(request, this.requestOptions);
 
-    const result = await this.kuzzle.funnel.executePluginRequest(kuzzleRequest);
+    try {
+      const result = await this.kuzzle.funnel.executePluginRequest(kuzzleRequest);
 
-    return { result };
+      return { result };
+    }
+    catch (error) {
+      // enhance and clean stacktrace
+      if (process.env.NODE_ENV !== 'production') {
+        const lines = stack.split('\n');
+        lines[4] = ' 🡆  ' + lines[4].trimStart();
+        lines[0] = error.stack.split('\n')[0];
+        error.stack = lines.join('\n');
+      }
+      else {
+        const lines = error.stack.split('\n');
+        lines[5] = ' 🡆  ' + lines[5].trimStart();
+        error.stack = lines.join('\n');
+      }
+
+      throw error;
+    }
   }
 }
 

--- a/test/core/shared/sdk/funnelProtocol.test.js
+++ b/test/core/shared/sdk/funnelProtocol.test.js
@@ -102,5 +102,46 @@ describe('Test: sdk/funnelProtocol', () => {
           should(response.result.context.user).be.eql(user);
         });
     });
+
+    it('should enhance stacktrace in development', done => {
+      kuzzle.funnel.executePluginRequest = sinon.stub().throws();
+
+      funnelProtocol = new FunnelProtocol(kuzzle);
+
+      funnelProtocol.query(request)
+        .then(() => done(new Error('should throw')))
+        .catch(error => {
+          const stack = error.stack.split('\n');
+
+          should(stack).have.length(17);
+          should(stack[4].startsWith(' 🡆  '));
+
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should enhance stacktrace in production', done => {
+      process.env.NODE_ENV = 'production';
+      kuzzle.funnel.executePluginRequest = sinon.stub().throws();
+
+      funnelProtocol = new FunnelProtocol(kuzzle);
+
+      funnelProtocol.query(request)
+        .then(() => {
+          process.env.NODE_ENV = 'development';
+          done(new Error('should throw'));
+        })
+        .catch(error => {
+          const stack = error.stack.split('\n');
+
+          should(stack).have.length(7);
+          should(stack[5].startsWith(' 🡆  '));
+
+          process.env.NODE_ENV = 'development';
+          done();
+        })
+        .catch(done);
+    });
   });
 });


### PR DESCRIPTION
## What does this PR do ?

Enhance and clean stacktrace when using the embedded SDK in application or plugins.

In development we use a more complete stacktrace and in both environment an arrow is added where the user code start

(I will add unit test if you like the idea)

Before
```
NotFoundError: Controller action "nfo" not found.
[...Kuzzle internal calls deleted...]
    at Funnel.getController (/home/aschen/projets/kuzzleio/kuzzle/lib/api/funnel.js:582:28)
    at Funnel.executePluginRequest (/home/aschen/projets/kuzzleio/kuzzle/lib/api/funnel.js:493:34)
    at FunnelProtocol.query (/home/aschen/projets/kuzzleio/kuzzle/lib/core/shared/sdk/funnelProtocol.js:87:47)
    at Toto.run (/home/aschen/projets/kuzzleio/kuzzle/features-sdk/application/functional-tests-app.ts:61:5)
	status: 404
	id: api.process.action_not_found
```

After: production
```
NotFoundError: Controller action "nfo" not found.
[...Kuzzle internal calls deleted...]
    at Funnel.getController (/home/aschen/projets/kuzzleio/kuzzle/lib/api/funnel.js:582:28)
    at Funnel.executePluginRequest (/home/aschen/projets/kuzzleio/kuzzle/lib/api/funnel.js:493:34)
    at FunnelProtocol.query (/home/aschen/projets/kuzzleio/kuzzle/lib/core/shared/sdk/funnelProtocol.js:86:47)
 🡆  at Toto.run (/home/aschen/projets/kuzzleio/kuzzle/features-sdk/application/functional-tests-app.ts:67:5)
	status: 404
	id: api.process.action_not_found
```

After: development
```
NotFoundError: Controller action "nfo" not found.
    at FunnelProtocol.query (/home/aschen/projets/kuzzleio/kuzzle/lib/core/shared/sdk/funnelProtocol.js:70:15)
    at Proxy.query (/home/aschen/projets/kuzzleio/kuzzle/node_modules/kuzzle-sdk/src/Kuzzle.js:381:30)
    at Proxy.query (/home/aschen/projets/kuzzleio/kuzzle/lib/core/shared/sdk/embeddedSdk.js:92:18)
 🡆  at Toto.run (/home/aschen/projets/kuzzleio/kuzzle/features-sdk/application/functional-tests-app.ts:67:19)
    at runToto (/home/aschen/projets/kuzzleio/kuzzle/features-sdk/application/functional-tests-app.ts:77:15)
    at BaseController.handler [as vault] (/home/aschen/projets/kuzzleio/kuzzle/features-sdk/application/functional-tests-app.ts:111:15)
    at doAction (/home/aschen/projets/kuzzleio/kuzzle/lib/api/funnel.js:748:47)
    at Funnel.processRequest (/home/aschen/projets/kuzzleio/kuzzle/lib/api/funnel.js:414:34)
	status: 404
	id: api.process.action_not_found
```

### How should this be manually tested?

Use this app with kaaf:
```
import { Backend } from './index'

const app = new Backend('stacktrace')

class Toto {
  async run (app: Backend) {
    await app.sdk.query({
      controller: 'server',
      action: 'nfo'
    });
  }
}

const toto = new Toto();

async function runToto () {
  return toto.run(app)
}


app.controller.register('stack', {
  actions: {
    test: {
      handler: async () => {
        await runToto();
      }
    }
  }
});

app.start();
```

Then run ES and Redis in one term: `WITHOUT_KUZZLE=1 docker-compose up`

And run the app `NODE_ENV=development DEBUG=kuzzle:* node -r ts-node/register app.ts`

Finally use Kourou to send a request: `kourou stack:test`

```
[ℹ] Unknown command "stack:test", fallback to API method
 
 🚀 Kourou - Executes an API query.
 
 [ℹ] Connecting to http://localhost:7512 ...
 [X] NotFoundError: Controller action "nfo" not found.
    at FunnelProtocol.query (/home/aschen/projets/kuzzleio/kuzzle/lib/core/shared/sdk/funnelProtocol.js:71:15)
    at Proxy.query (/home/aschen/projets/kuzzleio/kuzzle/node_modules/kuzzle-sdk/src/Kuzzle.js:381:30)
    at Proxy.query (/home/aschen/projets/kuzzleio/kuzzle/lib/core/shared/sdk/embeddedSdk.js:92:18)
 🡆  at Toto.run (/home/aschen/projets/kuzzleio/kuzzle/app.ts:7:19)
    at runToto (/home/aschen/projets/kuzzleio/kuzzle/app.ts:17:15)
    at BaseController.handler [as test] (/home/aschen/projets/kuzzleio/kuzzle/app.ts:25:15)
    at doAction (/home/aschen/projets/kuzzleio/kuzzle/lib/api/funnel.js:748:47)
    at Funnel.processRequest (/home/aschen/projets/kuzzleio/kuzzle/lib/api/funnel.js:414:34)
	status: 404
	id: api.process.action_not_found
```