### PR TITLE
Fix typo in scroll document page

### DIFF
--- a/doc/2/api/controllers/document/scroll/index.md
+++ b/doc/2/api/controllers/document/scroll/index.md
@@ -13,7 +13,7 @@ A search cursor is created by a [search](/core/2/api/controllers/document/search
 Results returned by a `scroll` request reflect the state of the index at the time of the initial search request, like a fixed snapshot. Subsequent changes to documents do not affect the scroll results.
 
 ::: info
-The maximum value for a scroll session can be configured under the configuration key `services.storage.maxScrollDuration`.
+The maximum value for a scroll session can be configured under the configuration key `services.storageEngine.maxScrollDuration`.
 :::
 
 ---


### PR DESCRIPTION
Fix typo in parameter name for changing the time to live of scroll in kuzzle settings.


## What does this PR do ?

Really short fix of a typo in the documentation, after a try to update the TTL of scroll when you make a search of documents in collection.
I decide to update the documentation for helping people like me who wasn't docker expert and not sure how configurations work. 
I don't arrive to update one value (of course it's little bit more complicated when you don't have the right key 🙃)
So maybe this RP can create a reflexion for improving the kuzzle configuration page or explain how you have the possibility to create settings file for docker image or how to update env variable for docker-compose.yml file.

### How should this be manually tested?

  - Step 1 : I edit the *docker-compose.yml* and adding the `kuzzle_services__storageEngine__maxScrollDuration=5m` in *services.kuzzle.environment* node
  - Step 2 : launch `docker-compose -f docker-compose.yml up -d`
  - Step 3 : curl -H "Content-Type: application/json" -H "Authorization: Bearer <JWT_TOKEN>" -X POST "http://kuzzle-url:7512/index-tests/collection-test/_search?from=0&size=3&scroll=5m" 
  - Step 4 : if you receive an error your parameter is not applied
  ...

### Other changes

No impact on the Kuzzle code, just an help when you want to update the max duration of scroll time to live.

### Boyscout

Typos fixes in documentation for the TTL parameter of scroll
