### PR TITLE
Make getRequestSlot accept a function in place of a string

### DIFF
--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -46,13 +46,13 @@ const processError = kerror.wrap('api', 'process');
 
 /**
  * @class PendingRequest
- * @param requestId
- * @param fn
- * @param context
+ * @param {Request} request
+ * @param {Function} fn
+ * @param {Object} context
  */
 class PendingRequest {
-  constructor(requestId, fn, context) {
-    this.requestId = requestId;
+  constructor(request, fn, context) {
+    this.request = request;
     this.fn = fn;
     this.context = context;
   }
@@ -118,12 +118,12 @@ class Funnel {
   }
 
   /**
-   * Asks the overload-protection system for a request slot.
+   * Asks the overload-protection system for an execution slot.
    *
-   * Returns immediately a truthy value if the request can be
+   * Returns immediately true if the request can be
    * executed.
    *
-   * Otherwise, a falsey value is returned, and the caller MUST
+   * Otherwise, false is returned, and the caller MUST
    * stop the request execution.
    * In this case:
    *   - if it can be bufferized, then the request is left untouched
@@ -137,13 +137,12 @@ class Funnel {
    * @param {Function} fn - The function to be executed as soon as the slot is
    *                        available.
    * @param {Object} context - The execution context of the `fn` param.
-   * @param {String} requestId - A unique ID associated with the execution. It
-   *                             handy to use `request.id` since this operation
-   *                             is often performed upon an incoming request.
+   * @param {String} request - The request object that will be passed as
+   *                           argument to `fn`.
    * @returns {Boolean} - A boolean telling whether the request has been
    *                      immediately executed or not.
    */
-  askRequestSlotAnd (fn, context, requestId) {
+  throttle (fn, context, request) {
     if (this.shuttingDown) {
       throw processError.get('shutting_down');
     }
@@ -168,11 +167,11 @@ class Funnel {
     }
 
     if (this.concurrentRequests < this.kuzzle.config.limits.concurrentRequests) {
-      if (this.pendingRequestsById.has(requestId)) {
-        this.pendingRequestsById.delete(requestId);
+      if (this.pendingRequestsById.has(request.id)) {
+        this.pendingRequestsById.delete(request.id);
       }
       // Execute fn immediately, since the slot is available
-      fn.call(context);
+      fn.call(context, request);
       return true;
     }
 
@@ -191,14 +190,15 @@ class Funnel {
       const error = processError.get('overloaded');
       this.kuzzle.emit('log:error', error);
       this.kuzzle.log.error(error);
+      request.setError(error);
       throw error;
     }
 
-    if (!this.pendingRequestsById.has(requestId)) {
+    if (!this.pendingRequestsById.has(request.id)) {
       this.pendingRequestsById.set(
-        requestId,
-        new PendingRequest(requestId, fn, context));
-      this.pendingRequestsQueue.push(requestId);
+        request.id,
+        new PendingRequest(request, fn, context));
+      this.pendingRequestsQueue.push(request.id);
 
       if (!this.overloaded) {
         this.overloaded = true;
@@ -247,29 +247,29 @@ class Funnel {
     }
 
     try {
-      const executing = this.askRequestSlotAnd(() => {
-        if (request.error) {
+      const executing = this.throttle(req => {
+        if (req.error) {
           // "handleErrorDump" shouldn't need to be called for 503 errors
-          callback(request.error, request);
+          callback(req.error, req);
           return 1;
         }
 
         // if the connection is closed there is no need to execute the request
         // => discarding it
-        if (!this.kuzzle.router.isConnectionAlive(request.context)) {
-          debug('Client connection dead: dropping request: %a', request.input);
-          callback(processError.get('connection_dropped'), request);
+        if (!this.kuzzle.router.isConnectionAlive(req.context)) {
+          debug('Client connection dead: dropping request: %a', req.input);
+          callback(processError.get('connection_dropped'), req);
           return 1;
         }
 
-        debug('Starting request %s:%s [%s]: %j', request.input.controller, request.input.action, request.id, request.input);
+        debug('Starting request %s:%s [%s]: %j', req.input.controller, req.input.action, req.id, req.input);
 
         let _request;
 
         this.kuzzle.asyncStore.run(() => {
-          this.kuzzle.asyncStore.set('REQUEST', request);
+          this.kuzzle.asyncStore.set('REQUEST', req);
 
-          this.checkRights(request)
+          this.checkRights(req)
             .then(modifiedRequest => {
               _request = modifiedRequest;
               return this.rateLimiter.isAllowed(_request);
@@ -283,7 +283,7 @@ class Funnel {
             })
             .then(processResult => {
               debug('Request %s successfully executed. Result: %a',
-                request.id,
+                req.id,
                 processResult);
 
               callback(null, processResult);
@@ -293,14 +293,15 @@ class Funnel {
               return null;
             })
             .catch(err => {
-              debug('Error processing request %s: %a', request.id, err);
-              return this._executeError(err, request, true, callback);
+              debug('Error processing request %s: %a', req.id, err);
+              return this._executeError(err, req, true, callback);
             });
         });
-      }, this, request.id);
+      }, this, request);
 
       return executing ? 0 : -1;
     } catch (error) {
+      request.setError(error);
       callback(error, request);
       return 1;
     }
@@ -683,7 +684,7 @@ class Funnel {
           this.pendingRequestsById.get(this.pendingRequestsQueue.peekFront());
 
         try {
-          if (this.askRequestSlotAnd(pendingItem.fn, pendingItem.context, pendingItem.requestId)) {
+          if (this.throttle(pendingItem.fn, pendingItem.context, pendingItem.request)) {
             this.pendingRequestsQueue.shift();
           } else {
             break;

--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -167,8 +167,8 @@ class Funnel {
     }
 
     if (this.concurrentRequests < this.kuzzle.config.limits.concurrentRequests) {
-      if (this.pendingRequestsById.has(request.id)) {
-        this.pendingRequestsById.delete(request.id);
+      if (this.pendingRequestsById.has(request.internalId)) {
+        this.pendingRequestsById.delete(request.internalId);
       }
       // Execute fn immediately, since the slot is available
       fn.call(context, request);
@@ -194,11 +194,11 @@ class Funnel {
       throw error;
     }
 
-    if (!this.pendingRequestsById.has(request.id)) {
+    if (!this.pendingRequestsById.has(request.internalId)) {
       this.pendingRequestsById.set(
-        request.id,
+        request.internalId,
         new PendingRequest(request, fn, context));
-      this.pendingRequestsQueue.push(request.id);
+      this.pendingRequestsQueue.push(request.internalId);
 
       if (!this.overloaded) {
         this.overloaded = true;

--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -45,13 +45,16 @@ const debug = require('../util/debug')('kuzzle:funnel');
 const processError = kerror.wrap('api', 'process');
 
 /**
- * @class CacheItem
+ * @class PendingRequest
+ * @param requestId
+ * @param fn
+ * @param context
  */
-class CacheItem {
-  constructor(executor, request, callback) {
-    this.request = request;
-    this.callback = callback;
-    this.executor = executor;
+class PendingRequest {
+  constructor(requestId, fn, context) {
+    this.requestId = requestId;
+    this.fn = fn;
+    this.context = context;
   }
 }
 
@@ -64,8 +67,8 @@ class Funnel {
     this.overloaded = false;
     this.concurrentRequests = 0;
     this.controllers = new Map();
-    this.requestsCacheQueue = new Deque();
-    this.requestsCacheById = new Map();
+    this.pendingRequestsQueue = new Deque();
+    this.pendingRequestsById = new Map();
     this.lastOverloadTime = 0;
     this.overloadWarned = false;
     this.lastWarningTime = 0;
@@ -131,27 +134,29 @@ class Funnel {
    *     retry submitting the request later, or to abort it and return
    *     the request as it is
    *
-   * @param {String} executor - The name of the function to use to execute the provided
-   *                            request. Must be an exposed function of this object.
-   * @param {Request} request - Can be mutated in case of overload error
-   * @param {Function} executeCallback - the original callback given to `execute`
-   * @returns {boolean}
+   * @param {Function} fn - The function to be executed as soon as the slot is
+   *                        available.
+   * @param {Object} context - The execution context of the `fn` param.
+   * @param {String} requestId - A unique ID associated with the execution. It
+   *                             handy to use `request.id` since this operation
+   *                             is often performed upon an incoming request.
+   * @returns {Boolean} - A boolean telling whether the request has been
+   *                      immediately executed or not.
    */
-  getRequestSlot (executor, request, executeCallback) {
+  askRequestSlotAnd (fn, context, requestId) {
     if (this.shuttingDown) {
-      request.setError(processError.get('shutting_down'));
-      return false;
+      throw processError.get('shutting_down');
     }
 
     if (this.overloaded) {
       const now = Date.now();
 
-      if (this.requestsCacheQueue.length > this.kuzzle.config.limits.requestsBufferWarningThreshold
+      if (this.pendingRequestsQueue.length > this.kuzzle.config.limits.requestsBufferWarningThreshold
         && (this.lastWarningTime === 0 || this.lastWarningTime < now - 500)
       ) {
         const overloadPercentage = Math.round(
           10000 *
-            this.requestsCacheQueue.length /
+            this.pendingRequestsQueue.length /
             this.kuzzle.config.limits.requestsBufferSize) /
             100;
         this.kuzzle.emit('core:overload', overloadPercentage);
@@ -162,11 +167,12 @@ class Funnel {
       }
     }
 
-    // resolves the callback immediately if a slot is available
     if (this.concurrentRequests < this.kuzzle.config.limits.concurrentRequests) {
-      if (this.requestsCacheById.has(request.internalId)) {
-        this.requestsCacheById.delete(request.internalId);
+      if (this.pendingRequestsById.has(requestId)) {
+        this.pendingRequestsById.delete(requestId);
       }
+      // Execute fn immediately, since the slot is available
+      fn.call(context);
       return true;
     }
 
@@ -181,19 +187,18 @@ class Funnel {
      2- the number of cached requests is equal to the requestsBufferSize property.
      The request is then discarded and an error is returned to the sender
      */
-    if (this.requestsCacheQueue.length >= this.kuzzle.config.limits.requestsBufferSize) {
+    if (this.pendingRequestsQueue.length >= this.kuzzle.config.limits.requestsBufferSize) {
       const error = processError.get('overloaded');
       this.kuzzle.emit('log:error', error);
       this.kuzzle.log.error(error);
-      request.setError(error);
-      return false;
+      throw error;
     }
 
-    if (!this.requestsCacheById.has(request.internalId)) {
-      this.requestsCacheById.set(
-        request.internalId,
-        new CacheItem(executor, request, executeCallback));
-      this.requestsCacheQueue.push(request.internalId);
+    if (!this.pendingRequestsById.has(requestId)) {
+      this.pendingRequestsById.set(
+        requestId,
+        new PendingRequest(requestId, fn, context));
+      this.pendingRequestsQueue.push(requestId);
 
       if (!this.overloaded) {
         this.overloaded = true;
@@ -208,7 +213,7 @@ class Funnel {
          even if this means executing this function once for nothing each
          time we start overload mode.
          */
-        this._playCachedRequests();
+        this._playPendingRequests();
       }
     }
 
@@ -241,64 +246,64 @@ class Funnel {
       return 1;
     }
 
-    const processNow = this.getRequestSlot('execute', request, callback);
+    try {
+      const executing = this.askRequestSlotAnd(() => {
+        if (request.error) {
+          // "handleErrorDump" shouldn't need to be called for 503 errors
+          callback(request.error, request);
+          return 1;
+        }
 
-    if (request.error) {
-      // "handleErrorDump" shouldn't need to be called for 503 errors
-      callback(request.error, request);
-      return 1;
-    }
+        // if the connection is closed there is no need to execute the request
+        // => discarding it
+        if (!this.kuzzle.router.isConnectionAlive(request.context)) {
+          debug('Client connection dead: dropping request: %a', request.input);
+          callback(processError.get('connection_dropped'), request);
+          return 1;
+        }
 
-    // request has been cached. Do not process now
-    if (!processNow) {
-      return -1;
-    }
+        debug('Starting request %s:%s [%s]: %j', request.input.controller, request.input.action, request.id, request.input);
 
-    // if the connection is closed there is no need to execute the request
-    // => discarding it
-    if (!this.kuzzle.router.isConnectionAlive(request.context)) {
-      debug('Client connection dead: dropping request: %a', request.input);
-      callback(processError.get('connection_dropped'), request);
-      return 1;
-    }
+        let _request;
 
-    debug('Starting request %s:%s [%s]: %j', request.input.controller, request.input.action, request.id, request.input);
+        this.kuzzle.asyncStore.run(() => {
+          this.kuzzle.asyncStore.set('REQUEST', request);
 
-    let _request;
+          this.checkRights(request)
+            .then(modifiedRequest => {
+              _request = modifiedRequest;
+              return this.rateLimiter.isAllowed(_request);
+            })
+            .then(allowed => {
+              if (!allowed) {
+                throw processError.get('too_many_requests');
+              }
 
-    this.kuzzle.asyncStore.run(() => {
-      this.kuzzle.asyncStore.set('REQUEST', request);
+              return this.processRequest(_request);
+            })
+            .then(processResult => {
+              debug('Request %s successfully executed. Result: %a',
+                request.id,
+                processResult);
 
-      this.checkRights(request)
-        .then(modifiedRequest => {
-          _request = modifiedRequest;
-          return this.rateLimiter.isAllowed(_request);
-        })
-        .then(allowed => {
-          if (!allowed) {
-            throw processError.get('too_many_requests');
-          }
+              callback(null, processResult);
 
-          return this.processRequest(_request);
-        })
-        .then(processResult => {
-          debug('Request %s successfully executed. Result: %a',
-            request.id,
-            processResult);
-
-          callback(null, processResult);
-
-          // disables a bluebird warning in dev. mode triggered when
-          // a promise is created and not returned
-          return null;
-        })
-        .catch(err => {
-          debug('Error processing request %s: %a', request.id, err);
-          return this._executeError(err, request, true, callback);
+              // disables a bluebird warning in dev. mode triggered when
+              // a promise is created and not returned
+              return null;
+            })
+            .catch(err => {
+              debug('Error processing request %s: %a', request.id, err);
+              return this._executeError(err, request, true, callback);
+            });
         });
-    });
+      }, this, request.id);
 
-    return 0;
+      return executing ? 0 : -1;
+    } catch (error) {
+      callback(error, request);
+      return 1;
+    }
   }
 
   /**
@@ -560,7 +565,7 @@ class Funnel {
    * @returns {number}
    */
   get remainingRequests () {
-    return this.concurrentRequests + this.requestsCacheQueue.length;
+    return this.concurrentRequests + this.pendingRequestsQueue.length;
   }
 
   /**
@@ -666,29 +671,31 @@ class Funnel {
    * Background task. Checks if there are any requests in cache, and replay them
    * if Kuzzle is not overloaded anymore,
    */
-  _playCachedRequests () {
+  _playPendingRequests () {
     // If there is room to play bufferized requests, do it now. If not, retry later
     const quantityToInject = Math.min(
-      this.requestsCacheQueue.length,
+      this.pendingRequestsQueue.length,
       this.kuzzle.config.limits.concurrentRequests - this.concurrentRequests);
 
     if (quantityToInject > 0) {
       for (let i = 0; i < quantityToInject; i++) {
-        const cachedItem =
-          this.requestsCacheById.get(this.requestsCacheQueue.peekFront());
+        const pendingItem =
+          this.pendingRequestsById.get(this.pendingRequestsQueue.peekFront());
 
-        if (this[cachedItem.executor](cachedItem.request, cachedItem.callback) === -1) {
-          // no slot found again. We stop here and try next time
+        try {
+          if (this.askRequestSlotAnd(pendingItem.fn, pendingItem.context, pendingItem.requestId)) {
+            this.pendingRequestsQueue.shift();
+          } else {
+            break;
+          }
+        } catch (error) {
           break;
-        }
-        else {
-          this.requestsCacheQueue.shift();
         }
       }
     }
 
-    if (this.requestsCacheQueue.length > 0) {
-      setTimeout(() => this._playCachedRequests(), 0);
+    if (this.pendingRequestsQueue.length > 0) {
+      setTimeout(() => this._playPendingRequests(), 0);
     }
     else {
       const now = Date.now();

--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -251,7 +251,7 @@ class Funnel {
         if (req.error) {
           // "handleErrorDump" shouldn't need to be called for 503 errors
           callback(req.error, req);
-          return 1;
+          return;
         }
 
         // if the connection is closed there is no need to execute the request
@@ -259,7 +259,7 @@ class Funnel {
         if (!this.kuzzle.router.isConnectionAlive(req.context)) {
           debug('Client connection dead: dropping request: %a', req.input);
           callback(processError.get('connection_dropped'), req);
-          return 1;
+          return;
         }
 
         debug('Starting request %s:%s [%s]: %j', req.input.controller, req.input.action, req.id, req.input);

--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -190,7 +190,6 @@ class Funnel {
       const error = processError.get('overloaded');
       this.kuzzle.emit('log:error', error);
       this.kuzzle.log.error(error);
-      request.setError(error);
       throw error;
     }
 
@@ -248,12 +247,6 @@ class Funnel {
 
     try {
       const executing = this.throttle(req => {
-        if (req.error) {
-          // "handleErrorDump" shouldn't need to be called for 503 errors
-          callback(req.error, req);
-          return;
-        }
-
         // if the connection is closed there is no need to execute the request
         // => discarding it
         if (!this.kuzzle.router.isConnectionAlive(req.context)) {


### PR DESCRIPTION
Make the `getRequestSlot` accept a reference to a function in place of a string representing a function name.
The signature of the function changed from this

```javascript
getRequestSlot (executor, request, executeCallback)
```

to this

```javascript
throttle (fn, context, requestId)
```

The previous implementation assumed that `getRequestSlot` could be called only by methods of the Funnel. The `executor` string represented the name of the method. In fact, `getRequestSlot` was kind of aware that `funnel.execute` was the only function that actually called it.

The new implementation takes a reference to a function and its execution context, as well as a unique id that the funnel uses to keep track of it (the name `requestId` is used because, most of the time, these functions are executed to process incoming requests).

### How should this be manually tested?

I use the functional tests to check that everything works like before and also take a tour of the server with the Admin Console.

### Other changes
* `CacheItem` has been renamed to `PendingRequest`
* `requestsCacheQueue` 👉 `pendingRequestsQueue`
* `requestsCacheById` 👉 `pendingRequestsById`

Again, I think these names are more suitable to the purpose of these lists. It's not a cache we can hit or miss, but rather a queue of functions that wait to be executed (thus, _pending_). Since these functions are often associated with incoming requests, I kept the word `Requests`, but it would be more precise to replace it with `Functions` (ore something else).

* `askRequestSlotAnd` now throws an error if the server is overloaded, whereas it returns true or false indicating whether the function has been executed immediately or is pending in a slot.

