### PR TITLE
Add KuzzleContext base class

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,4 +6,5 @@
 index.js
 lib/core/application/backend.js
 lib/util/interfaces.js
+lib/core/application/kuzzleContext.js
 functional-tests-app.js

--- a/.gitignore
+++ b/.gitignore
@@ -81,4 +81,5 @@ upgrade-*.report
 lib/core/application/backend.js
 lib/util/interfaces.js
 features-sdk/support/application/functional-tests-app.js
+lib/core/application/kuzzleContext.js
 index.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,46 +57,70 @@ _doc-deploy: &doc-deploy
 jobs:
   include:
     # ---------------------------------------
-    # Unit Tests & Linters
+    # Stage: Tests
     # ---------------------------------------
-    - stage: Unit Tests & Linters
-      name: Node 12.16.3 - Unit Tests & ESLint
+    - name: ESLint - Node 12.16.3
+      stage: Tests
       os: linux
       language: node_js
       cache: npm
       node_js: 12.16.3
       install:
         - npm ci --silent
+        - npm run build
       script:
         - npm run --silent test:lint
+
+    - name: Unit Tests - Node 12.16.3
+      stage: Tests
+      os: linux
+      language: node_js
+      cache: npm
+      node_js: 12.16.3
+      install:
+        - npm ci --silent
+        - npm run build
+      script:
         - npm run test:unit:coverage
       after_script:
         - npm run codecov
 
-    - stage: Unit Tests & Linters
-      name: Node 12.18.1 - Unit Tests & ESLint
+    - name: ESLint - Node 12.18.1
+      stage: Tests
       os: linux
       language: node_js
       cache: npm
       node_js: 12.18.1
       install:
         - npm ci --silent
+        - npm run build
       script:
         - npm run --silent test:lint
+
+    - name: Unit Tests - Node 12.18.1
+      stage: Tests
+      os: linux
+      language: node_js
+      cache: npm
+      node_js: 12.18.1
+      install:
+        - npm ci --silent
+        - npm run build
+      script:
         - npm run test:unit:coverage
       after_script:
         - npm run codecov
 
-    - stage: Unit Tests & Linters
-      name: SonarCloud
+    - name: SonarCloud
+      stage: Tests
       if: fork != true
       os: linux
       dist: trusty
       script:
         - .ci/sonar.sh
 
-    - stage: Unit Tests & Linters
-      name: Documentation dead links
+    - name: Documentation dead links check
+      stage: Tests
       language: node_js
       node_js: 12
       cache:
@@ -113,8 +137,8 @@ jobs:
         - cd doc/framework/
         - HYDRA_MAX_CONCURRENCY=20 ruby .ci/dead-links.rb -p src/core/2/
 
-    - stage: Unit Tests & Linters
-      name: Error codes check
+    - name: Error codes check
+      stage: Tests
       language: node_js
       node_js: 12
       install:
@@ -122,43 +146,38 @@ jobs:
       script:
         - $TRAVIS_BUILD_DIR/.ci/scripts/check-error-codes-documentation.sh
 
-    # ---------------------------------------
-    # Integration tests
-    # ---------------------------------------
-    - <<: *integration-tests
-      stage: Integration tests
-      name: Node.js 12.16.3 - Functional tests legacy
+    - name: Functional tests legacy - Node.js 12.16.3
+      stage: Tests
+      <<: *integration-tests
       env:
         - KUZZLE_FUNCTIONAL_TESTS=test:functional:legacy
         - NODE_VERSION=12.16.3
         - *integration-tests-env
 
-    - <<: *integration-tests
-      stage: Integration tests
-      name: Node.js 12.16.3 - Functional tests sdk
+    - name: Functional tests sdk - Node.js 12.16.3
+      stage: Tests
+      <<: *integration-tests
       env:
         - KUZZLE_FUNCTIONAL_TESTS=test:functional:sdk
         - NODE_VERSION=12.16.3
         - *integration-tests-env
 
-    - <<: *integration-tests
-      stage: Integration tests
-      name: Node.js 12 - Functional tests legacy
+    - name: Functional tests legacy - Node.js 12.18.1
+      stage: Tests
+      <<: *integration-tests
       env:
         - KUZZLE_FUNCTIONAL_TESTS=test:functional:legacy
         - *integration-tests-env
 
-    - <<: *integration-tests
-      stage: Integration tests
-      name: Node.js 12 - Functional tests sdk
+    - name: Functional tests sdk - Node.js 12.18.1
+      stage: Tests
+      <<: *integration-tests
       env:
         - KUZZLE_FUNCTIONAL_TESTS=test:functional:sdk
         - *integration-tests-env
 
-
-
     # ---------------------------------------
-    # Cross-platform tests
+    # Stage: Cross-platform tests
     # ---------------------------------------
     - <<: *integration-tests
       name: Linux ARMHF
@@ -183,27 +202,10 @@ jobs:
         - docker run --rm -it -v "$(pwd)":/mnt kuzzleio/sdk-cross:node8-$ARM ./.ci/scripts/install-$ARM-deps.sh
 
     # ---------------------------------------
-    # Deployments
+    # Stage: Deployments
     # ---------------------------------------
-    - stage: Deployments
-      name: NPM.js
-      if: branch = master
-      os: linux
-      language: node_js
-      node_js: 12
-      script: echo "Deploying Kuzzle to NPM.js"
-      deploy:
-        provider: npm
-        email: support@kuzzle.io
-        api_key:
-          secure: gqLBt1Scnr8wAR0zauW3jI7M576Jr7d+d2C5gvCA+iI1Y6gBWMM04A3w1MHHcPUBNA+xbwNimyoxbrBozq7otiMEDbP5ConS+T3KRWyHYwjdSfmL5KmEoNqwjmo128qJq2uWFxEecBmBk63q9A3gbnhdw3/D+05NKL4B44PpyNDpT6fApsVyDNXQmeib6cYfjwB1rCv8Mcf2sbVE1eqcJuGTwDtxx/860405PqBSg7H8iGGJJr7cymaU8cK4RLre+u8GHRiSDoKeU1UiWIoIoLG0y8TisFllSstZu9kguA6ShPJJA28NLiNyJ7j0KxKW6muvY03AFxa4XQ0sMaxotjQxN3IRUnLdN1mnQydWqMRP2+HWK1uRXCiDoL9ZnSClS1BixSAv15tvhggqE76Rq4uGCcl7hYfagpUzQpsUIV40Wc7CHez/O4ZvvicWIOdo2jmh/6fRYWOFY2+ihzwszaZwAQT1cdTm75JMIqrATyNWEZvwvczQzC85HmJajhf1azyEY08kdIJxwmwh30AMl2Is0vlq9ujCp8XRsanbdj74CcDNf9RSgesiD83McLd/ZJZHSDIe//wNypcTcW4fQbSfGb1oDHWVLQ6L/jr+W3OJUgVBG31mMciGo2jSROOos8n4iHHqs3QbxTwh0B+t+1amvZlpelFUEoicprPCcN8=
-        on:
-          repo: kuzzleio/kuzzle
-          branch: master
-          tags: true
-
-    - stage: Deployments
-      name: Dockerhub
+    - name: Dockerhub
+      stage: Deployments
       os: linux
       language: node_js
       node_js: 12
@@ -214,24 +216,25 @@ jobs:
       script:
         - MODE=production bash docker/build-docker-images.sh
 
-    - <<: *doc-deploy
-      name: Documentation to next-docs.kuzzle.io
+    - name: Documentation to next-docs.kuzzle.io
       if: branch =~ /^[0-9]+-dev$/
+      <<: *doc-deploy
       env:
         - *doc-deploy-env
         - BRANCH=dev
         - S3_BUCKET=docs-next.kuzzle.io
         - CLOUDFRONT_DISTRIBUTION_ID=E2ZCCEK9GRB49U
 
-    - <<: *doc-deploy
-      name: Deploy docs.kuzzle.io
+    - name: Deploy docs.kuzzle.io
       if: branch =~ /^master|[0-9]+-(stable|beta)$/
+      <<: *doc-deploy
       env:
         - *doc-deploy-env
         - S3_BUCKET=docs.kuzzle.io
         - CLOUDFRONT_DISTRIBUTION_ID=E3D6RP0POLCJMM
 
-    - stage: Deploy latest release on NPM
+    - name: Deploy kuzzle package on NPM
+      stage: Deploy latest release on NPM
       if: type = push AND branch =~ /^master|[0-9]+-(stable|beta)$/
       language: node_js
       node_js: 12
@@ -264,10 +267,7 @@ jobs:
 # Stages configuration
 # ------------------------
 stages:
-  - name: Unit Tests & Linters
-    if: type =~ /(cron|pull_request)/ OR (type = push AND branch =~ /^master|[0-9]+-(dev|stable)$/)
-  - name: Integration tests
-    # if: type = cron
+  - name: Tests
     if: type =~ /(cron|pull_request)/ OR (type = push AND branch =~ /^master|[0-9]+-(dev|stable)$/)
   - name: Cross-platform tests
     if: type = cron

--- a/doc/2/api/essentials/error-codes/plugin/index.md
+++ b/doc/2/api/essentials/error-codes/plugin/index.md
@@ -43,6 +43,8 @@ description: Error codes definitions
 | plugin.runtime.too_many_pipes<br/><pre>0x04020004</pre>  | [ServiceUnavailableError](/core/2/api/essentials/error-handling#serviceunavailableerror) <pre>(503)</pre> | Request discarded: maximum number of executing pipe functions reached. | The number of running pipes exceeds the configured capacity (see configuration files). This may be caused by pipes being too slow, or by an insufficient number of Kuzzle nodes. |
 | plugin.runtime.already_started<br/><pre>0x04020005</pre>  | [PluginImplementationError](/core/2/api/essentials/error-handling#pluginimplementationerror) <pre>(500)</pre> | Cannot use Backend.%s when application is already running | Features definition cannot be changed after startup. |
 | plugin.runtime.unavailable_before_start<br/><pre>0x04020006</pre>  | [PluginImplementationError](/core/2/api/essentials/error-handling#pluginimplementationerror) <pre>(500)</pre> | Cannot use property "%s" before application startup | The property is only accessible after application startup. |
+| plugin.runtime.unavailable_before_app_creation<br/><pre>0x04020007</pre>  | [PluginImplementationError](/core/2/api/essentials/error-handling#pluginimplementationerror) <pre>(500)</pre> | Cannot use the application context before instantiation. | The KuzzleContext.app property is only available after Backend instantiation. |
+| plugin.runtime.app_already_instantiated<br/><pre>0x04020008</pre>  | [PluginImplementationError](/core/2/api/essentials/error-handling#pluginimplementationerror) <pre>(500)</pre> | A Backend has already been instantiated.  | Only one Backend can be instantiated by process. |
 
 ---
 

--- a/lib/core/application/backend.ts
+++ b/lib/core/application/backend.ts
@@ -534,6 +534,7 @@ export class Backend {
       // Silent if no version can be found
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { KuzzleContext } = require('./kuzzleContext');
     KuzzleContext._app = this;
   }

--- a/lib/core/application/kuzzleContext.ts
+++ b/lib/core/application/kuzzleContext.ts
@@ -1,0 +1,45 @@
+/*
+ * Kuzzle, a backend software, self-hostable and ready to use
+ * to power modern apps
+ *
+ * Copyright 2015-2020 Kuzzle
+ * mailto: support AT kuzzle.io
+ * website: http://kuzzle.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Backend } from './backend'
+import kerror from '../../kerror';
+
+const runtimeError = kerror.wrap('plugin', 'runtime');
+
+/**
+ * Base class to access the application context
+ */
+export class KuzzleContext {
+
+  private static _app: Backend;
+
+  constructor () {}
+
+  get app (): Backend {
+    if (! KuzzleContext._app) {
+      throw runtimeError.get('unavailable_before_app_creation');
+    }
+
+    return KuzzleContext._app;
+  }
+}
+
+module.exports = { KuzzleContext };

--- a/lib/core/application/kuzzleContext.ts
+++ b/lib/core/application/kuzzleContext.ts
@@ -19,7 +19,7 @@
  * limitations under the License.
  */
 
-import { Backend } from './backend'
+import { Backend } from './backend';
 import kerror from '../../kerror';
 
 const runtimeError = kerror.wrap('plugin', 'runtime');
@@ -31,8 +31,9 @@ export class KuzzleContext {
 
   private static _app: Backend;
 
-  constructor () {}
-
+  /**
+   * Accessor to the application context
+   */
   get app (): Backend {
     if (! KuzzleContext._app) {
       throw runtimeError.get('unavailable_before_app_creation');

--- a/lib/kerror/codes/4-plugin.json
+++ b/lib/kerror/codes/4-plugin.json
@@ -123,6 +123,18 @@
           "code": 6,
           "message": "Cannot use property \"%s\" before application startup",
           "class": "PluginImplementationError"
+        },
+        "unavailable_before_app_creation": {
+          "description": "The KuzzleContext.app property is only available after Backend instantiation.",
+          "code": 7,
+          "message": "Cannot use the application context before instantiation.",
+          "class": "PluginImplementationError"
+        },
+        "app_already_instantiated": {
+          "description": "Only one Backend can be instantiated by process.",
+          "code": 8,
+          "message": "A Backend has already been instantiated. ",
+          "class": "PluginImplementationError"
         }
       }
     },

--- a/test/core/application/Backend.test.js
+++ b/test/core/application/Backend.test.js
@@ -6,6 +6,7 @@ const sinon = require('sinon');
 const { Client: ElasticsearchClient } = require('@elastic/elasticsearch');
 
 const { Backend } = require('../../../lib/core/application/backend.ts');
+const { KuzzleContext } = require('../../../lib/core/application/kuzzleContext.ts');
 const EmbeddedSDK = require('../../../lib/core/shared/sdk/embeddedSdk');
 const Kuzzle = require('../../../lib/kuzzle/kuzzle');
 
@@ -13,7 +14,20 @@ describe('Backend', () => {
   let application;
 
   beforeEach(() => {
+    Backend._instantiated = false;
     application = new Backend('black-mesa');
+  });
+
+  describe('#constructor', () => {
+    it('should set the KuzzleContext.app property', () => {
+      should(KuzzleContext._app).be.eql(application);
+    });
+
+    it('should throw an error if a Backend has already been instantiated', () => {
+      should(() => {
+        new Backend('city-17');
+      }).throwError({ id: 'plugin.runtime.app_already_instantiated' });
+    });
   });
 
   describe('#_instanceProxy', () => {

--- a/test/core/application/Backend.test.js
+++ b/test/core/application/Backend.test.js
@@ -5,8 +5,8 @@ const should = require('should');
 const sinon = require('sinon');
 const { Client: ElasticsearchClient } = require('@elastic/elasticsearch');
 
-const { Backend } = require('../../../lib/core/application/backend.ts');
-const { KuzzleContext } = require('../../../lib/core/application/kuzzleContext.ts');
+const { Backend } = require('../../../lib/core/application/backend');
+const { KuzzleContext } = require('../../../lib/core/application/kuzzleContext');
 const EmbeddedSDK = require('../../../lib/core/shared/sdk/embeddedSdk');
 const Kuzzle = require('../../../lib/kuzzle/kuzzle');
 

--- a/test/core/application/KuzzleContext.test.js
+++ b/test/core/application/KuzzleContext.test.js
@@ -2,8 +2,8 @@
 
 const should = require('should');
 
-const { Backend } = require('../../../lib/core/application/backend.ts');
-const { KuzzleContext } = require('../../../lib/core/application/kuzzleContext.ts');
+const { Backend } = require('../../../lib/core/application/backend');
+const { KuzzleContext } = require('../../../lib/core/application/kuzzleContext');
 
 class Service extends KuzzleContext {}
 

--- a/test/core/application/KuzzleContext.test.js
+++ b/test/core/application/KuzzleContext.test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const should = require('should');
+
+const { Backend } = require('../../../lib/core/application/backend.ts');
+const { KuzzleContext } = require('../../../lib/core/application/kuzzleContext.ts');
+
+class Service extends KuzzleContext {}
+
+describe('KuzzleContext', () => {
+  let application;
+  let service;
+
+  beforeEach(() => {
+    service = new Service();
+    Backend._instantiated = false;
+    application = new Backend('black-mesa');
+  });
+
+  describe('#app', () => {
+    it('should expose the application instance', () => {
+      should(service.app).be.eql(application);
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do ?

Add a `KuzzleContext` class meant to be extended by users custom classes (services, models, etc.).

This class contain a reference to the instantiated `Backend` so users can access the application context

### How should this be manually tested?

```
import { Backend, KuzzleContext } from 'kuzzle';

class Service extends KuzzleContext {
  // user defined class
}

const service = new Service();

// here service.app property is not available since the Backend is not instantiated

const app = new Backend('black-mesa');

app.start()
  .then(async () => {
    console.log(await service.app.sdk.server.info())
  })
  .catch(error => {
    console.error(error);
    process.exitCode = 1;
  });
```

### Other changes

  - ensure only one `Backend` can be instantiated 
  - clean travis.ci: parallelize unit tests and linters, play functional tests at the first stage
