### PR TITLE
Allows to load rights for non-existent API actions at startup

### DIFF
--- a/lib/core/security/roleRepository.js
+++ b/lib/core/security/roleRepository.js
@@ -358,7 +358,7 @@ class RoleRepository extends Repository {
     });
 
     this.checkRoleNativeRights(role);
-    await this.checkRolePluginsRights(role, options);
+    this.checkRolePluginsRights(role, options);
     await this.persistToDatabase(role, options);
 
     const updatedRole = await this.loadOneFromDatabase(role._id);
@@ -411,7 +411,7 @@ class RoleRepository extends Repository {
    * @param {Role} role
    * @param {Force} force
    */
-  async checkRolePluginsRights (role, { force=false, forceWarn=false } = {}) {
+  checkRolePluginsRights (role, { force=false, forceWarn=false } = {}) {
     const plugins = this.kuzzle.pluginsManager;
 
     for (const roleController of Object.keys(role.controllers)) {
@@ -472,7 +472,7 @@ class RoleRepository extends Repository {
     const roles = await this.search({}, {});
 
     for (const role of roles.hits) {
-      await this.checkRolePluginsRights(role, { force: true, forceWarn: true });
+      this.checkRolePluginsRights(role, { force: true, forceWarn: true });
     }
   }
 

--- a/lib/core/security/roleRepository.js
+++ b/lib/core/security/roleRepository.js
@@ -414,8 +414,6 @@ class RoleRepository extends Repository {
   async checkRolePluginsRights (role, { force=false, forceWarn=false } = {}) {
     const plugins = this.kuzzle.pluginsManager;
 
-    const kuzzleStarted = await this.kuzzle.ask('kuzzle:started:get');
-
     for (const roleController of Object.keys(role.controllers)) {
       if ( roleController === '*'
         || this.kuzzle.funnel.isNativeController(roleController)
@@ -437,7 +435,7 @@ class RoleRepository extends Repository {
         // because plugins controllers are loaded after default roles
         // then we need to display non-existing controllers with the sanity check
         // made after plugins controllers loading.
-        if (kuzzleStarted || forceWarn) {
+        if (this.kuzzle.running || forceWarn) {
           this.kuzzle.log.warn(`The role "${role._id}" gives access to the non-existing controller "${roleController}".`);
         }
 
@@ -457,7 +455,7 @@ class RoleRepository extends Repository {
           }
 
           // see the other comment
-          if (kuzzleStarted || forceWarn) {
+          if (this.kuzzle.running || forceWarn) {
             this.kuzzle.log.warn(`The role "${role._id}" gives access to the non-existing action "${action}" for the controller "${roleController}".`);
           }
         }

--- a/lib/core/security/roleRepository.js
+++ b/lib/core/security/roleRepository.js
@@ -358,7 +358,7 @@ class RoleRepository extends Repository {
     });
 
     this.checkRoleNativeRights(role);
-    this.checkRolePluginsRights(role, options);
+    await this.checkRolePluginsRights(role, options);
     await this.persistToDatabase(role, options);
 
     const updatedRole = await this.loadOneFromDatabase(role._id);
@@ -411,10 +411,12 @@ class RoleRepository extends Repository {
    * @param {Role} role
    * @param {Force} force
    */
-  checkRolePluginsRights (role, { force=false } = {}) {
+  async checkRolePluginsRights (role, { force=false, forceWarn=false } = {}) {
     const plugins = this.kuzzle.pluginsManager;
 
-    Object.keys(role.controllers).forEach(roleController => {
+    const kuzzleStarted = await this.kuzzle.ask('kuzzle:started:get');
+
+    for (const roleController of Object.keys(role.controllers)) {
       if ( roleController === '*'
         || this.kuzzle.funnel.isNativeController(roleController)
       ) {
@@ -430,13 +432,20 @@ class RoleRepository extends Repository {
             didYouMean(roleController, plugins.getControllerNames()));
         }
 
-        this.kuzzle.log.warn(`The role "${role._id}" gives access to the non-existing controller "${roleController}".`);
+        // Do not print any warning if Kuzzle is not started or if warn is not forced.
+        // We need this to load rights without displaying warning at startup
+        // because plugins controllers are loaded after default roles
+        // then we need to display non-existing controllers with the sanity check
+        // made after plugins controllers loading.
+        if (kuzzleStarted || forceWarn) {
+          this.kuzzle.log.warn(`The role "${role._id}" gives access to the non-existing controller "${roleController}".`);
+        }
 
         return;
       }
 
       const roleActions = Object.keys(role.controllers[roleController].actions);
-      roleActions.forEach(action => {
+      for (const action of roleActions) {
         if (action !== '*' && !plugins.isAction(roleController, action)) {
           if (!force) {
             throw roleRightsError.get(
@@ -447,10 +456,13 @@ class RoleRepository extends Repository {
               didYouMean(action, plugins.getActions(roleController)));
           }
 
-          this.kuzzle.log.warn(`The role "${role._id}" gives access to the non-existing action "${action}" for the controller "${roleController}".`);
+          // see the other comment
+          if (kuzzleStarted || forceWarn) {
+            this.kuzzle.log.warn(`The role "${role._id}" gives access to the non-existing action "${action}" for the controller "${roleController}".`);
+          }
         }
-      });
-    });
+      }
+    }
   }
 
   /**
@@ -461,9 +473,9 @@ class RoleRepository extends Repository {
   async sanityCheck () {
     const roles = await this.search({}, {});
 
-    roles.hits.forEach(role => {
-      this.checkRolePluginsRights(role, { force: true });
-    });
+    for (const role of roles.hits) {
+      await this.checkRolePluginsRights(role, { force: true, forceWarn: true });
+    }
   }
 
   /**

--- a/lib/core/shared/sdk/embeddedSdk.ts
+++ b/lib/core/shared/sdk/embeddedSdk.ts
@@ -83,7 +83,7 @@ export class EmbeddedSDK extends Kuzzle {
         ? false
         : options.propagate;
 
-      if (this.kuzzle.started && process.env.NODE_ENV !== 'production') {
+      if (this.kuzzle.running && process.env.NODE_ENV !== 'production') {
         this.kuzzle.log.warn('A realtime subscription has been made at runtime.\nRealtime subscriptions should only be made during Kuzzle initialization to ensure correct cluster replication.\nSee https://docs.kuzzle.io/core/2/plugins/plugin-context/accessors/sdk/#realtime-notifications for more information.');
       }
     }

--- a/lib/kuzzle/kuzzle.js
+++ b/lib/kuzzle/kuzzle.js
@@ -57,7 +57,8 @@ class Kuzzle extends KuzzleEventEmitter {
       config.plugins.common.maxConcurrentPipes,
       config.plugins.common.pipesBufferSize);
 
-    this.started = false;
+    this.state = Kuzzle.states.STARTING;
+
     this.config = config;
 
     this.log = new Logger(this);
@@ -107,11 +108,6 @@ class Kuzzle extends KuzzleEventEmitter {
 
     // Kuzzle version
     this.version = require('../../package.json').version;
-
-    /**
-     * Returns true if Kuzzle has started and is ready to handle requests
-     */
-    this.onAsk('kuzzle:started:get', () => this.started);
   }
 
   /**
@@ -193,7 +189,7 @@ class Kuzzle extends KuzzleEventEmitter {
       // @deprecated
       this.emit('core:kuzzleStart', 'Kuzzle is ready to accept requests');
 
-      this.started = true;
+      this.state = Kuzzle.states.RUNNING;
     }
     catch(error) {
       this.log.error(`[X] Cannot start Kuzzle ${this.version}: ${error.message}`);
@@ -204,6 +200,8 @@ class Kuzzle extends KuzzleEventEmitter {
   }
 
   shutdown () {
+    this.state = Kuzzle.states.SHUTTING_DOWN;
+
     shutdown(this);
   }
 
@@ -226,6 +224,24 @@ class Kuzzle extends KuzzleEventEmitter {
 
     return murmur(Buffer.from(inString), 'hex', this.config.internal.hash.seed);
   }
+
+  get starting () {
+    return this.state === Kuzzle.states.STARTING;
+  }
+
+  get running () {
+    return this.state === Kuzzle.states.RUNNING;
+  }
+
+  get shuttingDown () {
+    return this.state === Kuzzle.states.SHUTTING_DOWN;
+  }
 }
+
+Kuzzle.states = {
+  RUNNING: 2,
+  SHUTTING_DOWN: 3,
+  STARTING: 1,
+};
 
 module.exports = Kuzzle;

--- a/lib/kuzzle/kuzzle.js
+++ b/lib/kuzzle/kuzzle.js
@@ -107,6 +107,11 @@ class Kuzzle extends KuzzleEventEmitter {
 
     // Kuzzle version
     this.version = require('../../package.json').version;
+
+    /**
+     * Returns true if Kuzzle has started and is ready to handle requests
+     */
+    this.onAsk('kuzzle:started:get', () => this.started);
   }
 
   /**
@@ -157,12 +162,9 @@ class Kuzzle extends KuzzleEventEmitter {
 
       if (options.securities) {
         console.log('[ℹ] Loading default rights... This can take some time.');
-        await this.ask('core:security:load', options.securities);
+        await this.ask('core:security:load', options.securities, { force: true });
         console.log('[✔] Default rights loaded');
       }
-
-      await this.ask('core:security:verify');
-
       // must be initialized before plugins to allow API requests from plugins
       // before opening connections to external users
       await this.entryPoint.init();
@@ -170,6 +172,8 @@ class Kuzzle extends KuzzleEventEmitter {
       this.pluginsManager.application = application;
       await this.pluginsManager.init(options.plugins);
       console.log(`[✔] Successfully loaded ${this.pluginsManager.plugins.length} plugins: ${this.pluginsManager.plugins.map(p => p.name).join(', ')}`);
+
+      await this.ask('core:security:verify');
 
       this.router.init();
 

--- a/test/core/security/roleRepository.test.js
+++ b/test/core/security/roleRepository.test.js
@@ -594,22 +594,22 @@ describe('Test: security/roleRepository', () => {
       kuzzle.pluginsManager.plugins = { plugin_test };
     });
 
-    it('should skip non-plugins or wildcarded controllers', async () => {
+    it('should skip non-plugins or wildcarded controllers', () => {
       kuzzle.pluginsManager.isController.returns(false);
 
       const role = new Role();
       role.controllers = { '*': 123 };
 
       kuzzle.funnel.isNativeController.returns(false);
-      await roleRepository.checkRolePluginsRights(role);
+      roleRepository.checkRolePluginsRights(role);
 
       role.controllers = { 'foo': 0 };
 
       kuzzle.funnel.isNativeController.returns(true);
-      await roleRepository.checkRolePluginsRights(role);
+      roleRepository.checkRolePluginsRights(role);
     });
 
-    it('should warn if we force a role having an invalid plugin controller.', async () => {
+    it('should warn if we force a role having an invalid plugin controller.', () => {
       kuzzle.pluginsManager.isController.returns(false);
       const role = new Role();
 
@@ -622,12 +622,12 @@ describe('Test: security/roleRepository', () => {
         }
       };
 
-      await roleRepository.checkRolePluginsRights(role, {force: true});
+      roleRepository.checkRolePluginsRights(role, {force: true});
 
       should(kuzzle.log.warn).be.calledWith('The role "test" gives access to the non-existing controller "invalid_controller".');
     });
 
-    it('should warn if kuzzle is not started and forceWarn is set', async () => {
+    it('should warn if kuzzle is not started and forceWarn is set', () => {
       kuzzle.state = KuzzleMock.states.STARTING;
       kuzzle.pluginsManager.isController.returns(false);
       const role = new Role();
@@ -641,7 +641,7 @@ describe('Test: security/roleRepository', () => {
         }
       };
 
-      await roleRepository.checkRolePluginsRights(
+      roleRepository.checkRolePluginsRights(
         role,
         { force: true, forceWarn: true });
 
@@ -668,7 +668,7 @@ describe('Test: security/roleRepository', () => {
       });
     });
 
-    it('should warn if we force a role having an invalid plugin action.', async () => {
+    it('should warn if we force a role having an invalid plugin action.', () => {
       kuzzle.pluginsManager.isController = sinon.stub().returns(true);
       kuzzle.pluginsManager.isAction = sinon.stub().returns(false);
       const controllers = {
@@ -682,7 +682,7 @@ describe('Test: security/roleRepository', () => {
       role._id = 'test';
       role.controllers = controllers;
 
-      await roleRepository.checkRolePluginsRights(role, {force: true});
+      roleRepository.checkRolePluginsRights(role, {force: true});
 
       should(kuzzle.log.warn).be.calledWith('The role "test" gives access to the non-existing action "iDontExist" for the controller "foobar".');
     });
@@ -706,7 +706,7 @@ describe('Test: security/roleRepository', () => {
       });
     });
 
-    it('should not warn nor throw when a role contains valid controller and action.', async () => {
+    it('should not warn nor throw when a role contains valid controller and action.', () => {
       kuzzle.pluginsManager.isController.returns(true);
       kuzzle.pluginsManager.isAction.returns(true);
 
@@ -721,7 +721,7 @@ describe('Test: security/roleRepository', () => {
         }
       };
 
-      await roleRepository.checkRolePluginsRights(role);
+      roleRepository.checkRolePluginsRights(role);
 
       should(kuzzle.log.warn).be.not.called();
     });

--- a/test/core/security/roleRepository.test.js
+++ b/test/core/security/roleRepository.test.js
@@ -663,7 +663,7 @@ describe('Test: security/roleRepository', () => {
         }
       };
 
-      return should(roleRepository.checkRolePluginsRights(role)).be.rejectedWith({
+      return should(() => roleRepository.checkRolePluginsRights(role)).throw({
         id: 'security.role.unknown_controller'
       });
     });
@@ -701,7 +701,7 @@ describe('Test: security/roleRepository', () => {
         }
       };
 
-      return should(roleRepository.checkRolePluginsRights(role)).be.rejectedWith({
+      return should(() => roleRepository.checkRolePluginsRights(role)).throw({
         id: 'security.role.unknown_action'
       });
     });

--- a/test/core/security/roleRepository.test.js
+++ b/test/core/security/roleRepository.test.js
@@ -488,8 +488,7 @@ describe('Test: security/roleRepository', () => {
     const { NativeController } = require('../../../lib/api/controller/base');
 
     beforeEach(() => {
-      kuzzle.ask = sinon.stub();
-      kuzzle.ask.withArgs('kuzzle:started:get').resolves(true);
+      kuzzle.state = KuzzleMock.states.RUNNING;
       kuzzle.funnel.controllers.set('document', new NativeController(kuzzle, [
         'create',
         'delete'
@@ -582,8 +581,8 @@ describe('Test: security/roleRepository', () => {
     let plugin_test;
 
     beforeEach(() => {
-      kuzzle.ask = sinon.stub();
-      kuzzle.ask.withArgs('kuzzle:started:get').resolves(true);
+      kuzzle.state = KuzzleMock.states.RUNNING;
+
       plugin_test = {
         object: {
           controllers: {
@@ -602,12 +601,12 @@ describe('Test: security/roleRepository', () => {
       role.controllers = { '*': 123 };
 
       kuzzle.funnel.isNativeController.returns(false);
-      await should(async () => await roleRepository.checkRolePluginsRights(role)).not.throw();
+      await roleRepository.checkRolePluginsRights(role);
 
       role.controllers = { 'foo': 0 };
 
       kuzzle.funnel.isNativeController.returns(true);
-      await should(async () => await roleRepository.checkRolePluginsRights(role)).not.throw();
+      await roleRepository.checkRolePluginsRights(role);
     });
 
     it('should warn if we force a role having an invalid plugin controller.', async () => {
@@ -629,7 +628,7 @@ describe('Test: security/roleRepository', () => {
     });
 
     it('should warn if kuzzle is not started and forceWarn is set', async () => {
-      kuzzle.ask.withArgs('kuzzle:started:get').resolves(false);
+      kuzzle.state = KuzzleMock.states.STARTING;
       kuzzle.pluginsManager.isController.returns(false);
       const role = new Role();
 
@@ -707,7 +706,7 @@ describe('Test: security/roleRepository', () => {
       });
     });
 
-    it('should not warn nor throw when a role contains valid controller and action.', () => {
+    it('should not warn nor throw when a role contains valid controller and action.', async () => {
       kuzzle.pluginsManager.isController.returns(true);
       kuzzle.pluginsManager.isAction.returns(true);
 
@@ -722,7 +721,7 @@ describe('Test: security/roleRepository', () => {
         }
       };
 
-      should(async () => await roleRepository.checkRolePluginsRights(role)).not.throw();
+      await roleRepository.checkRolePluginsRights(role);
 
       should(kuzzle.log.warn).be.not.called();
     });

--- a/test/core/shared/sdk/embeddedSdk.test.js
+++ b/test/core/shared/sdk/embeddedSdk.test.js
@@ -12,7 +12,7 @@ describe('EmbeddedSDK', () => {
 
   beforeEach(() => {
     kuzzle = new KuzzleMock();
-    kuzzle.started = true;
+    kuzzle.state = KuzzleMock.states.RUNNING;
 
     embeddedSdk = new EmbeddedSDK(kuzzle);
   });

--- a/test/kuzzle/kuzzle.test.js
+++ b/test/kuzzle/kuzzle.test.js
@@ -76,6 +76,14 @@ describe('/lib/kuzzle/kuzzle.js', () => {
     kuzzle.emit('event');
   });
 
+  it('should register a kuzzle:started:get event', async () => {
+    const kuzzleBis = new Kuzzle(config);
+
+    kuzzleBis.started = true;
+
+    should(await kuzzleBis.ask('kuzzle:started:get')).be.True();
+  });
+
   describe('#start', () => {
     it('should init the components in proper order', async () => {
       const options = {
@@ -100,9 +108,9 @@ describe('/lib/kuzzle/kuzzle.js', () => {
         kuzzle.storageEngine.public.loadMappings,
         kuzzle.storageEngine.public.loadFixtures,
         kuzzle.ask.withArgs('core:security:load', sinon.match.object),
-        kuzzle.ask.withArgs('core:security:verify'),
         kuzzle.entryPoint.init,
         kuzzle.pluginsManager.init,
+        kuzzle.ask.withArgs('core:security:verify'),
         kuzzle.router.init,
         kuzzle.pipe.withArgs('kuzzle:start'),
         kuzzle.pipe.withArgs('kuzzle:state:live'),

--- a/test/kuzzle/kuzzle.test.js
+++ b/test/kuzzle/kuzzle.test.js
@@ -76,14 +76,6 @@ describe('/lib/kuzzle/kuzzle.js', () => {
     kuzzle.emit('event');
   });
 
-  it('should register a kuzzle:started:get event', async () => {
-    const kuzzleBis = new Kuzzle(config);
-
-    kuzzleBis.started = true;
-
-    should(await kuzzleBis.ask('kuzzle:started:get')).be.True();
-  });
-
   describe('#start', () => {
     it('should init the components in proper order', async () => {
       const options = {
@@ -92,7 +84,7 @@ describe('/lib/kuzzle/kuzzle.js', () => {
         securities: {}
       };
 
-      should(kuzzle.started).be.false();
+      should(kuzzle.state).be.eql(Kuzzle.states.STARTING);
 
       await kuzzle.start(application, options);
 
@@ -119,7 +111,7 @@ describe('/lib/kuzzle/kuzzle.js', () => {
         kuzzle.emit.withArgs('core:kuzzleStart')
       );
 
-      should(kuzzle.started).be.true();
+      should(kuzzle.state).be.eql(Kuzzle.states.RUNNING);
     });
 
     // @deprecated

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -218,7 +218,7 @@ class KuzzleMock extends Kuzzle {
       const kuzzleProto = Object.getPrototypeOf(mockProto);
 
       for (const name of Object.getOwnPropertyNames(kuzzleProto)) {
-        if (['constructor', 'hash'].includes(name)) {
+        if (['constructor', 'hash', 'starting', 'running', 'shuttingDown'].includes(name)) {
           continue;
         }
 


### PR DESCRIPTION
## What does this PR do ?

A regression prevent to set rights for API action if those actions does not exists.  

It's problematic because application and plugins can declare new API actions and the only way to prevent unauthorized usage of those action after startup is to set the rights with the `--securities <securities file>` flag with the command line.

Now only a warning will be printed.

Fix #1771 