### PR TITLE
Prevent a race condition when bootstraping kuzzle indexes at startup

### DIFF
--- a/.ci/test-cluster.yml
+++ b/.ci/test-cluster.yml
@@ -56,33 +56,26 @@ services:
     <<: *kuzzle-config
     container_name: kuzzle_node_1
     ports:
-      - "17510:7512" # Kuzzle API port
-      - "9229:9229" # Debug port
+      - "17510:7512" # Kuzzle API port, used to check if it is up
 
   kuzzle_node_2:
     <<: *kuzzle-config
     container_name: kuzzle_node_2
     ports:
-      - "17511:7512" # Kuzzle API port
-      - "9230:9229" # Debug port
+      - "17511:7512"
 
   kuzzle_node_3:
     <<: *kuzzle-config
     container_name: kuzzle_node_3
     ports:
-      - "17512:7512" # Kuzzle API port
-      - "9231:9229" # Debug port
+      - "17512:7512"
 
   redis:
     image: redis:5
     container_name: kuzzle_redis
-    ports:
-      - "6379:6379"
 
   elasticsearch:
     image: kuzzleio/elasticsearch:7
     container_name: kuzzle_elasticsearch
-    ports:
-      - "9200:9200"
     ulimits:
       nofile: 65536

--- a/lib/core/storage/bootstrap/safeBootstrap.js
+++ b/lib/core/storage/bootstrap/safeBootstrap.js
@@ -77,9 +77,22 @@ class SafeBootstrap {
    *
    * @returns {Promise}
    */
-  async startOrWait () {
-    const bootstrapDone =
-      await this._indexStorage.exists('config', this._BOOTSTRAP_DONE_ID);
+  async startOrWait (attempt = 0) {
+    let bootstrapDone = false;
+
+    try {
+      bootstrapDone = await this._indexStorage
+        .exists('config', this._BOOTSTRAP_DONE_ID);
+    }
+    catch (e) {
+      if (attempt === 3) {
+        throw e;
+      }
+
+      await Bluebird.delay(1000);
+
+      return this.startOrWait(attempt + 1);
+    }
 
     if (bootstrapDone) {
       return null;

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -2424,14 +2424,19 @@ class ElasticSearch extends Service {
 
     while (esState !== esStateEnum.OK) {
       try {
-        // Wait for all shards to be initialized
-        await this._client.cluster.health({
+        // Wait for at least 1 shard to be initialized
+        const health = await this._client.cluster.health({
           waitForNoInitializingShards: true,
         });
 
-        this._kuzzle.log.info('[✔] Elasticsearch is ready');
-
-        esState = esStateEnum.OK;
+        if (health.body.number_of_pending_tasks === 0) {
+          this._kuzzle.log.info('[✔] Elasticsearch is ready');
+          esState = esStateEnum.OK;
+        }
+        else {
+          this._kuzzle.log.info(`Still waiting for Elasticsearch: ${health.body.number_of_pending_tasks} cluster tasks remaining`);
+          await Bluebird.delay(1000);
+        }
       }
       catch (e) {
         await Bluebird.delay(1000);

--- a/test/mocks/service/elasticsearchClient.mock.js
+++ b/test/mocks/service/elasticsearchClient.mock.js
@@ -36,7 +36,11 @@ class ElasticsearchClientMock {
     };
 
     this.cluster = {
-      health: sinon.stub().resolves(),
+      health: sinon.stub().resolves({
+        body: {
+          number_of_pending_tasks: 0,
+        },
+      }),
       stats: sinon.stub().resolves()
     };
 


### PR DESCRIPTION
# Description

When starting a Kuzzle Cluster on a fresh install, it randomly crashes during startup on a `no shards available` exception from Elasticsearch.

This is due to a race condition occuring when building Kuzzle indexes: when trying to test if the lock document exists, if the ES shard is still being built, ES answers with this error. This is why it's random: to occur, this error needs Kuzzle nodes to initialize at roughly the same time on an empty ES environment.

# Changes

* Add an attempt mechanism to the index bootstrap. This is a quick workaround: the real fix has already been put in place in the upcoming "loosely couple the storage module" PR, which uses a new (and much, much more reliable) cluster-friendly mutex system based on Redis

# Other changes

* The Elasticsearch service waiter function now only returns if all ES cluster-related tasks are finished, to prevent sending queries to a still-uninitialized ES cluster

# Boyscout

* Don't expose unnecessary network ports in the docker-compose image used by the CI to test the kuzzle cluster