### PR TITLE
Avoid useless allocations in plugin context

### DIFF
--- a/lib/core/plugin/pluginContext.js
+++ b/lib/core/plugin/pluginContext.js
@@ -153,15 +153,13 @@ class PluginContext {
       /* context.log ======================================================== */
       Reflect.defineProperty(this, 'log', {
         enumerable: true,
-        get: () => {
-          return {
-            debug: msg => kuzzle.log.debug(`[${pluginName}] ${msg}`),
-            error: msg => kuzzle.log.error(`[${pluginName}] ${msg}`),
-            info: msg => kuzzle.log.info(`[${pluginName}] ${msg}`),
-            silly: msg => kuzzle.log.silly(`[${pluginName}] ${msg}`),
-            verbose: msg => kuzzle.log.verbose(`[${pluginName}] ${msg}`),
-            warn: msg => kuzzle.log.warn(`[${pluginName}] ${msg}`)
-          };
+        value: {
+          debug: msg => kuzzle.log.debug(`[${pluginName}] ${msg}`),
+          error: msg => kuzzle.log.error(`[${pluginName}] ${msg}`),
+          info: msg => kuzzle.log.info(`[${pluginName}] ${msg}`),
+          silly: msg => kuzzle.log.silly(`[${pluginName}] ${msg}`),
+          verbose: msg => kuzzle.log.verbose(`[${pluginName}] ${msg}`),
+          warn: msg => kuzzle.log.warn(`[${pluginName}] ${msg}`)
         }
       });
 
@@ -169,51 +167,45 @@ class PluginContext {
 
       Reflect.defineProperty(this.accessors, 'storage', {
         enumerable: true,
-        get: () => {
-          return {
-            bootstrap: collections => pluginIndexStorage.init(collections),
-            createCollection: (collection, mappings) => (
-              pluginIndexStorage.createCollection(collection, { mappings })
-            )
-          };
+        value: {
+          bootstrap: collections => pluginIndexStorage.init(collections),
+          createCollection: (collection, mappings) => (
+            pluginIndexStorage.createCollection(collection, { mappings })
+          )
         }
       });
 
       Reflect.defineProperty(this.accessors, 'execute', {
         enumerable: true,
-        get: () => (...args) => execute(kuzzle, ...args)
+        value: (...args) => execute(kuzzle, ...args)
       });
 
       Reflect.defineProperty(this.accessors, 'validation', {
         enumerable: true,
-        get: () => {
-          return {
-            addType: kuzzle.validation.addType.bind(kuzzle.validation),
-            validate: kuzzle.validation.validate.bind(kuzzle.validation)
-          };
+        value: {
+          addType: kuzzle.validation.addType.bind(kuzzle.validation),
+          validate: kuzzle.validation.validate.bind(kuzzle.validation)
         }
       });
 
       Reflect.defineProperty(this.accessors, 'strategies', {
         enumerable: true,
-        get: () => {
-          return {
-            add: curryAddStrategy(kuzzle, pluginName),
-            remove: curryRemoveStrategy(kuzzle, pluginName)
-          };
+        value: {
+          add: curryAddStrategy(kuzzle, pluginName),
+          remove: curryRemoveStrategy(kuzzle, pluginName)
         }
       });
 
       Reflect.defineProperty(this.accessors, 'trigger', {
         enumerable: true,
-        get: () => (eventName, payload) => (
+        value: (eventName, payload) => (
           kuzzle.pipe(`plugin-${pluginName}:${eventName}`, payload)
         )
       });
 
       Reflect.defineProperty(this.accessors, 'sdk', {
         enumerable: true,
-        get: () => new EmbeddedSDK(kuzzle)
+        value: new EmbeddedSDK(kuzzle)
       });
     }
   }


### PR DESCRIPTION
## What does this PR do ?

Most of the objects we expose in the plugin context are re-instantiated each time they are accessed.  
This put useless pressure on the GC (particularly with the Embedded SDK).

Objects are now instantiated only once.
