### PR TITLE
Correctly handles the expiresIn option

### DIFF
--- a/lib/core/security/tokenRepository.js
+++ b/lib/core/security/tokenRepository.js
@@ -50,7 +50,7 @@ class TokenRepository extends Repository {
       this.ttl = opts.ttl;
     }
 
-    this.tokenGracePeriod = this.kuzzle.config.security.jwt.gracePeriod / 1000;
+    this.tokenGracePeriod = Math.floor(this.kuzzle.config.security.jwt.gracePeriod / 1000);
     this.anonymousToken = new Token({userId: '-1'});
   }
 
@@ -198,14 +198,13 @@ class TokenRepository extends Repository {
 
     const signOptions = {algorithm};
 
-    // error parsing expiresIn, let jwt.sign handle the incorrect value
     if (parsedExpiresIn === 0) {
-      signOptions.expiresIn = expiresIn;
+      throw kerror.get('api', 'assert', 'invalid_argument', 'expiresIn', 'a number of milliseconds, or a parsable timespan string');
     }
     // -1 mean infite duration, so we don't pass the expiresIn option to
     // jwt.sign
     else if (parsedExpiresIn !== -1) {
-      signOptions.expiresIn = parsedExpiresIn / 1000;
+      signOptions.expiresIn = Math.floor(parsedExpiresIn / 1000);
     }
 
     let encodedToken;


### PR DESCRIPTION
# Description

Fix #1784 

Correctly submit a rounded number of seconds to `jwt.sign` to prevent rejections when a non exact timespan is provided to the expiresIn option.

# Other changes

Instead of rejecting with a `security.token.generation_failed` error (type: InternalError) when the `expiresIn` option is invalid, Kuzzle will now properly return an `api.assert.invalid_argument` error with an explicit message when the provided expiresIn option is incorrect.