### PR TITLE
Allow users to disable/configure the Swagger specifications HTTP endpoint

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -19,7 +19,17 @@
     // (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS)
     "accessControlAllowOrigin": "*",
     "accessControlAllowMethods": "GET,POST,PUT,DELETE,OPTIONS,HEAD",
-    "accessControlAllowHeaders": "Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding, Content-Length, X-Kuzzle-Volatile"
+    "accessControlAllowHeaders": "Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding, Content-Length, X-Kuzzle-Volatile",
+    
+    // [Swagger]
+    //   * enabled: 
+    //      enable the Swagger specifications endpoint
+    //   * yamlOutput:
+    //      use YAML format for Swagger specifications output instead of JSON
+    "swagger": {
+      "enabled": true,
+      "yamlOutput": false
+    }
   },
 
   // Kuzzle configured limits

--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -25,7 +25,7 @@
     //   * enabled: 
     //      enable the Swagger specifications endpoint
     //   * yamlOutput:
-    //      use YAML format for Swagger specifications output instead of JSON
+    //      use YAML format to print Swagger specifications instead of JSON
     "swagger": {
       "enabled": true,
       "yamlOutput": false

--- a/lib/config/default.config.js
+++ b/lib/config/default.config.js
@@ -49,7 +49,11 @@ module.exports = {
     routes: require('./httpRoutes'),
     accessControlAllowOrigin: '*',
     accessControlAllowMethods: 'GET,POST,PUT,DELETE,OPTIONS,HEAD',
-    accessControlAllowHeaders: 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding, Content-Length, X-Kuzzle-Volatile'
+    accessControlAllowHeaders: 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding, Content-Length, X-Kuzzle-Volatile',
+    swagger: {
+      enabled: true,
+      yamlOutput: false
+    }
   },
 
   limits: {

--- a/lib/core/network/router.js
+++ b/lib/core/network/router.js
@@ -61,7 +61,7 @@ class Router {
    *
    * @param {RequestContext} requestContext
    */
-  removeConnection (requestContext) {
+  removeConnection(requestContext) {
     const connId = requestContext.connection.id;
 
     if (!connId || !requestContext.connection.protocol) {
@@ -106,7 +106,7 @@ class Router {
   /**
    * Initializes the HTTP routes for the Kuzzle HTTP API.
    */
-  init () {
+  init() {
     // Register API and plugin routes
     const routes = [
       ...this.kuzzle.config.http.routes,
@@ -120,25 +120,11 @@ class Router {
       });
     }
 
-    this.http.get('/swagger.json', (request, cb) => {
-      request.setResult(generateSwagger(this.kuzzle), {
-        headers: {'content-type': 'application/json'},
-        raw: true,
-        status: 200
-      });
-
-      cb(request);
-    });
-
-    this.http.get('/swagger.yml', (request, cb) => {
-      request.setResult(jsonToYaml.stringify(generateSwagger(this.kuzzle)), {
-        headers: {'content-type': 'application/yaml'},
-        raw: true,
-        status: 200
-      });
-
-      cb(request);
-    });
+    if (this.kuzzle.config.http.swagger.enabled) {
+      this._exposeSwaggerSpecifications(
+        generateSwagger(this.kuzzle),
+        this.kuzzle.config.http.swagger.yamlOutput);
+    }
   }
 
   /**
@@ -161,6 +147,35 @@ class Router {
       else {
         this.kuzzle.funnel.execute(mutatedRequest, (err, result) => cb(result));
       }
+    });
+  }
+
+  
+  /**
+   * Expose the Swagger specification as a GET HTTP route and using output format
+   *
+   * @param {object} specifications - contains the OpenAPI JSON object specifications
+   * @param {boolean} yaml - if set to true convert OpenAPI JSON specifications to YAML
+   */
+  _exposeSwaggerSpecifications(specifications, yaml) {
+    const route = yaml
+      ? '/swagger.yml' 
+      : '/swagger.json';
+    const contentType = yaml
+      ? 'application/yaml'
+      : 'application/json';
+    const formatedSpecifications = yaml
+      ? jsonToYaml.stringify(specifications)
+      : specifications;
+
+    this.http.get(route, (request, cb) => {
+      request.setResult(formatedSpecifications, {
+        headers: { 'content-type': contentType },
+        raw: true,
+        status: 200
+      });
+
+      cb(request);
     });
   }
 }

--- a/test/core/network/router/httpRequest.test.js
+++ b/test/core/network/router/httpRequest.test.js
@@ -147,6 +147,12 @@ describe('Test: router.httpRequest', () => {
   });
 
   it('should register the swagger JSON auto-generator route', (done) => {
+    kuzzle.config.http.swagger.enabled = true;
+    kuzzle.config.http.swagger.yamlOutput = false;
+
+    routeController = new Router(kuzzle);
+    routeController.init();
+
     httpRequest.url = '/swagger.json';
     httpRequest.method = 'GET';
 
@@ -164,6 +170,12 @@ describe('Test: router.httpRequest', () => {
   });
 
   it('should register the swagger YAML auto-generator route', (done) => {
+    kuzzle.config.http.swagger.enabled = true;
+    kuzzle.config.http.swagger.yamlOutput = true;
+
+    routeController = new Router(kuzzle);
+    routeController.init();
+
     httpRequest.url = '/swagger.yml';
     httpRequest.method = 'GET';
 
@@ -179,6 +191,35 @@ describe('Test: router.httpRequest', () => {
       }
     });
   });
+
+  it('should not register the swagger JSON or YAML auto-generator route', (done) => {
+    kuzzle.config.http.swagger.enabled = false;
+
+    routeController = new Router(kuzzle);
+    routeController.init();
+
+    const checkResponse = result => {
+      try {
+        should(result.response.status).be.eql(404);
+      }
+      catch (e) {
+        done(e);
+      }
+    };
+
+    httpRequest.url = '/swagger.json';
+    httpRequest.method = 'GET';
+
+    routeController.http.route(httpRequest, checkResponse);
+
+    httpRequest.url = '/swagger.yml';
+    httpRequest.method = 'GET';
+
+    routeController.http.route(httpRequest, checkResponse);
+
+    done();
+  });
+
 
   it('should register plugins HTTP routes', (done) => {
     httpRequest.url = '/foo/bar/baz';


### PR DESCRIPTION
<!--
  This template is optional.
  It simply serves to provide a guide to allow a better review of pull requests.
-->

<!--
  IMPORTANT
  Don't forget to add the corresponding "changelog:xxx" label to your PR.
  This is part of our release process in order to generate the change log.
-->


## What does this PR do ?
<!-- Please fill this section -->

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

Allow users to disable/configure the Swagger specifications HTTP endpoint from the KuzzleRC configuration file.

### How should this be manually tested?

<!--
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration
-->

* Start a Kuzzle stack
* test the two URL `http://localhost:7512/swagger.json` and `http://localhost:7512/swagger.yml` while playing with configuration values in kuzzlerc file or those environment variables in your Docker Compose file:

```shell
    - kuzzle_http__swagger__enabled=false
    - kuzzle_http__swagger__yamlOutput=true
```

### Other changes

<!--
  Please describe here all changes not directly linked to the main issue, but made because of it.
  For instance: issues spotted during this PR and fixed on-the-fly, dependencies update, and so on
-->

* DRY on old Swagger HTTP routes declarations
