### PR TITLE
Set default log level to info

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -127,7 +127,7 @@
     "kuzzle-plugin-logger": {
       "services": {
         "stdout": {
-          "level": "warning"
+          "level": "info"
         }
       }
     },

--- a/lib/config/default.config.js
+++ b/lib/config/default.config.js
@@ -76,7 +76,7 @@ module.exports = {
     'kuzzle-plugin-logger': {
       services: {
         stdout: {
-          level: 'warning'
+          level: 'info'
         }
       }
     },


### PR DESCRIPTION
## What does this PR do ?

Set default log level to `info` instead of `warn`.  

fix #1797 