### PR TITLE
Fix stacktrace cleaning

### DIFF
--- a/lib/kerror/index.js
+++ b/lib/kerror/index.js
@@ -60,6 +60,21 @@ const errors = {
 };
 
 /**
+ * Gets this file name in the exact same format than the one printed in the
+ * stacktraces (used to clean kerror lines from stacktraces)
+ */
+let _currentFileName = null;
+function _getCurrentFileName () {
+  if (_currentFileName !== null) {
+    return _currentFileName;
+  }
+
+  _currentFileName = module.filename.substr(process.cwd().length + 1);
+
+  return _currentFileName;
+}
+
+/**
  * Construct and return the corresponding error
  *
  * @param  {string} domain - Domain (eg: 'external')
@@ -103,39 +118,44 @@ function get (domain, subdomain, error, ...placeholders) {
   }
 
   if (error.name !== 'InternalError') {
-    cleanStackTrace(kerror, 3);
+    cleanStackTrace(kerror);
   }
 
   return kerror;
 }
 
 /**
- * Removes the n first lines of the stacktrace because they are related
+ * Removes the first lines of the stacktrace because they are related
  * to internal mechanisms.
  *
- * Eg:
+ * e.g.
  *  at new PluginImplementationError (
- *  at get (kuzzle/lib/kerror/index.js:70:14)
- *  at Object.get (kuzzle/lib/kerror/index.js:146:38)
+ *  at get (lib/kerror/index.js:70:14)
+ *  at Object.get (lib/kerror/index.js:146:38) // only for wrapped kerror objects
  *  // Line that triggered the error =>
  *  at ControllerManager.add (kuzzle/lib/core/application/backend.ts:226:34)
  */
-function cleanStackTrace (error, depth) {
-  // Keep the original error message (2 lines for PluginImplementationError)
-  let errorMessage = '';
-  let i = error.name === 'PluginImplementationError' ? 2 : 1;
-  while (i--) {
-    const idx = error.stack.indexOf('\n') + 1;
-    errorMessage += error.stack.slice(0, idx);
-    error.stack = error.stack.slice(idx);
-  }
+function cleanStackTrace (error) {
+  // Keep the original error message
+  let messageLength = error.message.split('\n').length;
+  const currentFileName = _getCurrentFileName();
 
-  // Remove the first 3 lines of the stacktrace
-  while (depth--) {
-    const idx = error.stack.indexOf('\n') + 1;
-    error.stack = error.stack.slice(idx);
-  }
-  error.stack = errorMessage + '[...Kuzzle internal calls deleted...]\n' + error.stack;
+  // we keep the new error instantiation line ("new ...Error (") on purpose:
+  // this will allow us to replace it without inserting a new line in the array,
+  // saving us from building a new array
+  const newStack = error.stack.split('\n').filter((line, index) => {
+    if (index < messageLength) {
+      return true;
+    }
+
+    // filter all lines related to the kerror object
+    return !line.includes(currentFileName);
+  });
+
+  // insert a deletion message in place of the new error instantiation line
+  newStack[messageLength] = '    [...Kuzzle internal calls deleted...]';
+
+  error.stack = newStack.join('\n');
 }
 
 /**


### PR DESCRIPTION
# Description

The current stacktrace cleaning code statically removes the first 3 lines of the stack : 
* the `new ...Error(...)` instantiation line
* 2 lines from `kerror`: one for the error builder function (get or getFrom), and one for the wrapper function

When kerror is invoked without a wrapper, one important line gets removed from the stacktrace: the one that has actually triggered the error. This makes debugging a tad difficult.

I have implemented a new, more dynamic way of cleaning up stacktraces, which removes any number of stracktrace lines coming from the kerror object itself.

Another related change: while I was at it, I replaced the code keeping the first line (error message), and sometimes 2 when the error was a PluginImplementationError one. Instead, the stacktrace cleaner now keeps the same number of lines than the one in the `error.message` property.
