### PR TITLE
Fix bug that limits the number of document deleted by bulk:deleteByQuery

### DIFF
--- a/lib/api/controller/bulk.js
+++ b/lib/api/controller/bulk.js
@@ -148,7 +148,7 @@ class BulkController extends NativeController {
       index,
       collection,
       query,
-      { fetch: false, refresh });
+      { fetch: false, refresh, size: -1 });
 
     return { deleted };
   }

--- a/test/api/controller/bulk.test.js
+++ b/test/api/controller/bulk.test.js
@@ -234,14 +234,14 @@ describe('Test the bulk controller', () => {
       });
     });
 
-    it('should call deleteByQuery with fetch=false', async () => {
+    it('should call deleteByQuery with fetch=false and size=-1', async () => {
       const response = await controller.deleteByQuery(request);
 
       should(controller.publicStorage.deleteByQuery).be.calledWith(
         index,
         collection,
         query,
-        { refresh: 'wait_for', fetch: false });
+        { refresh: 'wait_for', fetch: false, size: -1 });
 
       should(response.deleted).be.eql(2);
     });


### PR DESCRIPTION
## What does this PR do ?

This PR allows to delete any number of documents with `bulk:deleteByQuery` instead of the actual limit who was 1000