### PR TITLE
Replace nodemon with a custom reloader

### DIFF
--- a/docker/scripts/reloader.js
+++ b/docker/scripts/reloader.js
@@ -35,7 +35,7 @@ const config = {
     'lib',
     'plugins',
     'node_modules',
-    'index.js',
+    'index.*s',
     'docker/scripts/*.ts',
   ],
 };

--- a/docker/scripts/reloader.js
+++ b/docker/scripts/reloader.js
@@ -79,16 +79,13 @@ function startProcess () {
 
     console.log(clc.red(`[RELOADER] Process exited with ${msg}. Waiting for a file change to restart it.`));
     childProcess = null;
+    state = stateEnum.STOPPED;
   });
 
   state = stateEnum.RUNNING;
 }
 
 async function stopProcess () {
-  if (childProcess === null) {
-    state = stateEnum.STOPPED;
-  }
-
   if (state !== stateEnum.RUNNING) {
     return;
   }

--- a/docker/scripts/reloader.js
+++ b/docker/scripts/reloader.js
@@ -1,0 +1,137 @@
+/*
+ * For development purposes only: this script is meant to be run on top
+ * of a Kuzzle starter script. It watches source files (json, ts, js) from
+ * Kuzzle core, plugins, configuration files.
+ * When a file changes, it automatically shuts the current process down, WAIT
+ * until it has correctly been stopped (or kills it after some delay), and only
+ * then restarts it.
+ *
+ * This script is meant to replace solutions like nodemon, which have a few
+ * cumbersome caveats.
+ *
+ * Usage: node reloader.js <config file> <node args> <starter script> <args>
+ *
+ * With:
+ *   - <config file>: this script configuration file
+ *   - <node args>: arguments to pass to the node interpreter
+ *   - <starter script>: the script to execute using node
+ *   - <args>: script arguments
+ */
+
+/* eslint-disable no-console */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { fork } = require('child_process');
+
+const chokidar = require('chokidar');
+const jsonStrip = require('strip-json-comments');
+const clc = require('cli-color');
+
+const stateEnum = Object.freeze({
+  RUNNING: 1,
+  STOPPED: 2,
+  STOPPING: 3,
+});
+
+const config = loadConfig();
+const { nodeArgs, script, scriptArgs } = parseArgs();
+
+let childProcess;
+let state = stateEnum.STOPPED;
+
+function parseArgs () {
+  const args = process.argv.slice(3);
+  const idx = args.findIndex(arg => arg.endsWith('.js') || arg.endsWith('.ts'));
+
+  return {
+    nodeArgs: args.slice(0, idx),
+    script: args[idx],
+    scriptArgs: args.slice(idx + 1),
+  };
+}
+
+function loadConfig () {
+  const cfg = JSON.parse(jsonStrip(fs.readFileSync(process.argv[2]).toString()));
+
+  return Object.assign(
+    {
+      cwd: '.',
+      directories: [],
+      files: [],
+      waitExit: 5000,
+    },
+    cfg);
+}
+
+function startProcess () {
+  childProcess = fork(script, scriptArgs, {
+    detached: true,
+    execArgv: nodeArgs,
+  });
+
+  childProcess.on('exit', (code, signal) => {
+    const msg = code !== null
+      ? `code ${code}`
+      : `signal ${signal}`;
+
+    console.log(clc.red(`[RELOADER] Process exited with ${msg}. Waiting for a file change to restart it.`));
+    childProcess = null;
+  });
+
+  state = stateEnum.RUNNING;
+}
+
+async function stopProcess () {
+  if (childProcess === null) {
+    state = stateEnum.STOPPED;
+  }
+
+  if (state !== stateEnum.RUNNING) {
+    return;
+  }
+
+  state = stateEnum.STOPPING;
+
+  childProcess.removeAllListeners();
+
+  let exited = false;
+
+  childProcess.on('exit', () => {
+    exited = true;
+  });
+
+  childProcess.kill();
+
+  // Wait for config.waitExit for the process to stop itself, after that: kill it
+  const now = Date.now();
+  let forced = false;
+
+  while (!exited) {
+    await new Promise(resolve => setTimeout(resolve, 200));
+
+    if (!forced && (Date.now() - now) > config.waitExit) {
+      console.log(clc.red(`[RELOADER] Process still here after ${config.waitExit}ms. Sending a SIGKILL signal`));
+      childProcess.kill('SIGKILL');
+      forced = true;
+    }
+  }
+
+  state = stateEnum.STOPPED;
+}
+
+const watcher = chokidar.watch(script);
+watcher.add(config.directories.map(dir => path.join(config.cwd, dir)));
+watcher.add(config.files.map(file => path.join(config.cwd, file)));
+
+watcher.on('change', async file => {
+  if (state === stateEnum.RUNNING) {
+    console.log(clc.green(`[RELOADER] Change detected on ${path.relative(config.cwd, file)}. Reloading...`));
+    await stopProcess();
+    startProcess();
+  }
+});
+
+startProcess();

--- a/docker/scripts/reloader.js
+++ b/docker/scripts/reloader.js
@@ -61,7 +61,7 @@ function loadConfig () {
       cwd: '.',
       directories: [],
       files: [],
-      waitExit: 5000,
+      killDelay: 5000,
     },
     cfg);
 }
@@ -102,15 +102,15 @@ async function stopProcess () {
 
   childProcess.kill();
 
-  // Wait for config.waitExit for the process to stop itself, after that: kill it
+  // Wait for config.killDelay for the process to stop itself, after that: kill it
   const now = Date.now();
   let forced = false;
 
   while (!exited) {
     await new Promise(resolve => setTimeout(resolve, 200));
 
-    if (!forced && (Date.now() - now) > config.waitExit) {
-      console.log(clc.red(`[RELOADER] Process still here after ${config.waitExit}ms. Sending a SIGKILL signal`));
+    if (!forced && (Date.now() - now) > config.killDelay) {
+      console.log(clc.red(`[RELOADER] Process still here after ${config.killDelay}ms. Sending a SIGKILL signal`));
       childProcess.kill('SIGKILL');
       forced = true;
     }

--- a/docker/scripts/reloader.json
+++ b/docker/scripts/reloader.json
@@ -1,0 +1,8 @@
+{
+  "cwd": "/var/app",
+  "directories": [ "lib", "plugins", "node_modules" ],
+  "files": [
+    "index.js"
+  ],
+  "waitExit": 5000
+}

--- a/docker/scripts/reloader.json
+++ b/docker/scripts/reloader.json
@@ -1,8 +1,0 @@
-{
-  "cwd": "/var/app",
-  "directories": [ "lib", "plugins", "node_modules" ],
-  "files": [
-    "index.js"
-  ],
-  "killDelay": 5000
-}

--- a/docker/scripts/reloader.json
+++ b/docker/scripts/reloader.json
@@ -4,5 +4,5 @@
   "files": [
     "index.js"
   ],
-  "waitExit": 5000
+  "killDelay": 5000
 }

--- a/docker/scripts/run-dev.sh
+++ b/docker/scripts/run-dev.sh
@@ -26,10 +26,10 @@ else
   ENABLED_PLUGINS=functional-test-plugin
 fi
 
-nodemon \
-    --ext 'js,json,ts' \
+node docker/scripts/reloader.js \
+    docker/scripts/reloader.json \
     --inspect=0.0.0.0:9229 \
-    --exec node -r ts-node/register docker/scripts/start-kuzzle-dev.ts \
+    -r ts-node/register docker/scripts/start-kuzzle-dev.ts \
     --mappings /fixtures/mappings.json \
     --fixtures /fixtures/fixtures.json \
     --securities /fixtures/securities.json \

--- a/docker/scripts/run-dev.sh
+++ b/docker/scripts/run-dev.sh
@@ -27,7 +27,6 @@ else
 fi
 
 node docker/scripts/reloader.js \
-    docker/scripts/reloader.json \
     --inspect=0.0.0.0:9229 \
     -r ts-node/register docker/scripts/start-kuzzle-dev.ts \
     --mappings /fixtures/mappings.json \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1658,9 +1658,9 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
     "chokidar": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
-      "integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
+      "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.1",
@@ -1670,7 +1670,7 @@
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.3.0"
+        "readdirp": "~3.4.0"
       }
     },
     "chownr": {
@@ -5628,6 +5628,22 @@
             }
           }
         },
+        "chokidar": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
+          "integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
+          "dev": true,
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.1.2",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.3.0"
+          }
+        },
         "cliui": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -5724,6 +5740,15 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
+        },
+        "readdirp": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
+          "integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
+          "dev": true,
+          "requires": {
+            "picomatch": "^2.0.7"
+          }
         },
         "string-width": {
           "version": "3.1.0",
@@ -6796,12 +6821,12 @@
       }
     },
     "readdirp": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
-      "integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+      "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
       "dev": true,
       "requires": {
-        "picomatch": "^2.0.7"
+        "picomatch": "^2.2.1"
       }
     },
     "redeyed": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@typescript-eslint/eslint-plugin": "^3.9.0",
     "@typescript-eslint/parser": "^3.9.0",
     "async": "^3.2.0",
+    "chokidar": "^3.4.2",
     "codecov": "^3.7.2",
     "cucumber": "^6.0.5",
     "eslint": "^7.6.0",


### PR DESCRIPTION
# Description

We currently use [nodemon](https://www.npmjs.com/package/nodemon) to force Kuzzle instances to restart whenever a file is changed, during development.

But nodemon has one infuriating caveat: it doesn't check if the spawned process is down before restarting another one. Which leads to constant errors due to the node debug port being still used when restarting a new instance, mainly because of Kuzzle's graceful shutdown (it doesn't stop immediately, it first processes remaining requests before shutting down):

![Screenshot from 2020-10-14 15-23-50](https://user-images.githubusercontent.com/12997967/95995108-5b20e180-0e31-11eb-9798-6e080f76f113.png)


I browsed NPM for another module, didn't find one that satisfied me, so... I wrote a tiny one, fit for our needs. It doesn't do much: it monitors files, and if one changes, it stops Kuzzle. If Kuzzle doesn't stop before a reasonable delay, it kills it. And once the process is really down, it restarts a new one. Simple.

# About nodemon in docker images

Don't remove nodemon from docker images just yet. I made several tests using this custom reloader, and it seems to work just fine in various situations. But there might be issues I didn't foresee on various environments, or various situations, so we should keep nodemon in the docker images for now, just in case, until we're all satisfied with it.
