### PR TITLE
Allow the reloader to restart kuzzle upon a kuzzle crash

### DIFF
--- a/docker/scripts/reloader.js
+++ b/docker/scripts/reloader.js
@@ -119,7 +119,7 @@ const watcher = chokidar.watch(script);
 watcher.add(config.watch.map(dir => path.join(config.cwd, dir)));
 
 watcher.on('change', async file => {
-  if (state === stateEnum.RUNNING) {
+  if (state !== stateEnum.STOPPING) {
     console.log(clc.green(`[RELOADER] Change detected on ${path.relative(config.cwd, file)}. Reloading...`));
     await stopProcess();
     startProcess();


### PR DESCRIPTION
# Description

Minor bugfix for the new development kuzzle reloader: when kuzzle crashes, it fails to restart kuzzle upon a file change because of a minor error in the state machine :expressionless: 