### PR TITLE
Fix url generation for kaaf

### DIFF
--- a/doc/2/api/essentials/error-codes/plugin/index.md
+++ b/doc/2/api/essentials/error-codes/plugin/index.md
@@ -29,6 +29,7 @@ description: Error codes definitions
 | plugin.assert.no_name_provided<br/><pre>0x0401000b</pre>  | [PluginImplementationError](/core/2/api/essentials/error-handling#pluginimplementationerror) <pre>(500)</pre> | Cannot infer plugin name. No constructor method and no name provided | The plugin does not have a constructor method and no name has been provided. |
 | plugin.assert.invalid_controller_definition<br/><pre>0x0401000c</pre>  | [PluginImplementationError](/core/2/api/essentials/error-handling#pluginimplementationerror) <pre>(500)</pre> | Incorrect "%s" controller definition: %s | The controller definition is incorrect. |
 | plugin.assert.invalid_application_name<br/><pre>0x0401000d</pre>  | [PluginImplementationError](/core/2/api/essentials/error-handling#pluginimplementationerror) <pre>(500)</pre> | Application name "%s" is invalid. Application names must be in kebab-case. | The application name is invalid. Application names can only contain lowercase letters and dashes. |
+| plugin.assert.duplicated_api_definition<br/><pre>0x0401000e</pre>  | [PluginImplementationError](/core/2/api/essentials/error-handling#pluginimplementationerror) <pre>(500)</pre> | Cannot define new controllers in the "api" and the "controllers" objects at the same time | You cannot use the "api" and the "controllers" objects at the same time. Use the "api" object to define controllers. |
 
 ---
 

--- a/docker/scripts/start-kuzzle-dev.ts
+++ b/docker/scripts/start-kuzzle-dev.ts
@@ -112,7 +112,7 @@ app.controller.register('tests', {
       handler: async (request: Request) => {
         return { greeting: `Hello, ${request.input.args.name}` };
       },
-      http: [{ verb: 'POST', path: '/hello/:name' }]
+      http: [{ verb: 'post', path: '/hello/:name' }]
     },
 
     // Trigger custom event
@@ -148,7 +148,7 @@ app.controller.register('tests', {
         return response.body;
       },
       http: [
-        { verb: 'POST', path: '/tests/storage-client/:index' }
+        { verb: 'post', path: '/tests/storage-client/:index' }
       ]
     }
   }

--- a/lib/core/application/backend.ts
+++ b/lib/core/application/backend.ts
@@ -394,7 +394,12 @@ class Logger extends ApplicationManager {
       throw runtimeError.get('unavailable_before_start', 'log');
     }
 
-    this._kuzzle.log[level](`[${this._application.name}]: ${message}`);
+    if (typeof message === 'object') {
+      this._kuzzle.log[level](JSON.stringify(message));
+    }
+    else {
+      this._kuzzle.log[level](message);
+    }
   }
 }
 

--- a/lib/core/application/backend.ts
+++ b/lib/core/application/backend.ts
@@ -19,6 +19,7 @@
  * limitations under the License.
  */
 
+import util from 'util';
 
 import fs from 'fs';
 import _ from 'lodash';
@@ -164,7 +165,7 @@ class ControllerManager extends ApplicationManager {
    *   actions: {
    *     sayHello: {
    *       handler: async request => `Hello, ${request.input.args.name}`,
-   *       http: [{ verb: 'POST', path: '/greeting/hello/:name' }]
+   *       http: [{ verb: 'post', path: 'greeting/hello/:name' }]
    *     }
    *   }
    * })
@@ -264,7 +265,7 @@ class ControllerManager extends ApplicationManager {
     for (const [action, definition] of Object.entries(controllerDefinition.actions)) {
       if (! definition.http) {
         // eslint-disable-next-line sort-keys
-        definition.http = [{ verb: 'GET', path: `/${kebabCase(controllerName)}/${kebabCase(action)}` }];
+        definition.http = [{ verb: 'get', path: `${kebabCase(controllerName)}/${kebabCase(action)}` }];
       }
     }
   }
@@ -394,12 +395,7 @@ class Logger extends ApplicationManager {
       throw runtimeError.get('unavailable_before_start', 'log');
     }
 
-    if (typeof message === 'object') {
-      this._kuzzle.log[level](JSON.stringify(message));
-    }
-    else {
-      this._kuzzle.log[level](message);
-    }
+    this._kuzzle.log[level](util.inspect(message));
   }
 }
 

--- a/lib/core/plugin/pluginsManager.js
+++ b/lib/core/plugin/pluginsManager.js
@@ -221,6 +221,12 @@ class PluginsManager {
         .then(() => {
           plugin.initCalled = true;
 
+          if ( ! _.isEmpty(plugin.instance.controllers)
+            && ! _.isEmpty(plugin.instance.api))
+          {
+            throw runtimeError.get('duplicated_api_definition')
+          }
+
           if (! _.isEmpty(plugin.instance.controllers)) {
             this._initControllers(plugin);
           }

--- a/lib/core/plugin/pluginsManager.js
+++ b/lib/core/plugin/pluginsManager.js
@@ -224,7 +224,7 @@ class PluginsManager {
           if ( ! _.isEmpty(plugin.instance.controllers)
             && ! _.isEmpty(plugin.instance.api))
           {
-            throw runtimeError.get('duplicated_api_definition')
+            throw runtimeError.get('duplicated_api_definition');
           }
 
           if (! _.isEmpty(plugin.instance.controllers)) {

--- a/lib/core/plugin/pluginsManager.js
+++ b/lib/core/plugin/pluginsManager.js
@@ -646,10 +646,14 @@ class PluginsManager {
               httpRoute.path,
               controller);
 
+            const routePath = httpRoute.path.charAt(0) === '/'
+              ? httpRoute.path
+              : `/_/${httpRoute.path}`;
+
             this.routes.push({
               action,
               controller,
-              path: `/_${httpRoute.path}`,
+              path: routePath,
               verb: httpRoute.verb
             });
           }

--- a/lib/kerror/codes/4-plugin.json
+++ b/lib/kerror/codes/4-plugin.json
@@ -81,6 +81,12 @@
           "code": 13,
           "message": "Application name \"%s\" is invalid. Application names must be in kebab-case.",
           "class": "PluginImplementationError"
+        },
+        "duplicated_api_definition": {
+          "description": "You cannot use the \"api\" and the \"controllers\" objects at the same time. Use the \"api\" object to define controllers.",
+          "code": 14,
+          "message": "Cannot define new controllers in the \"api\" and the \"controllers\" objects at the same time",
+          "class": "PluginImplementationError"
         }
       }
     },

--- a/lib/util/interfaces.ts
+++ b/lib/util/interfaces.ts
@@ -62,7 +62,7 @@ export interface ControllerDefinition {
         /**
          * HTTP verb.
          */
-        verb: string,
+        verb: 'get' | 'post' | 'put' | 'delete' | 'head',
         /**
          * Route path.
          * A route starting with `/` will be prefixed by `/_` otherwise the route

--- a/test/core/application/Backend.test.js
+++ b/test/core/application/Backend.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const util = require('util');
+
 const _ = require('lodash');
 const should = require('should');
 const sinon = require('sinon');
@@ -249,7 +251,7 @@ describe('Backend', () => {
       should(application._controllers.greeting).not.be.undefined();
       should(application._controllers.greeting.actions.sayBye.http)
         .be.eql([
-          { verb: 'GET', path: '/greeting/say-bye' }
+          { verb: 'get', path: 'greeting/say-bye' }
         ]);
     });
   });
@@ -376,11 +378,11 @@ describe('Backend', () => {
         application.log.error('error');
         application.log.verbose({ info: 'verbose' });
 
-        should(application._kuzzle.log.debug).be.calledWith('debug');
-        should(application._kuzzle.log.info).be.calledWith('info');
-        should(application._kuzzle.log.warn).be.calledWith('warn');
-        should(application._kuzzle.log.error).be.calledWith('error');
-        should(application._kuzzle.log.verbose).be.calledWith(JSON.stringify({ info: 'verbose' }));
+        should(application._kuzzle.log.debug).be.calledWith(util.inspect('debug'));
+        should(application._kuzzle.log.info).be.calledWith(util.inspect('info'));
+        should(application._kuzzle.log.warn).be.calledWith(util.inspect('warn'));
+        should(application._kuzzle.log.error).be.calledWith(util.inspect('error'));
+        should(application._kuzzle.log.verbose).be.calledWith(util.inspect({ info: 'verbose' }));
       });
     });
   });

--- a/test/core/application/Backend.test.js
+++ b/test/core/application/Backend.test.js
@@ -374,13 +374,13 @@ describe('Backend', () => {
         application.log.info('info');
         application.log.warn('warn');
         application.log.error('error');
-        application.log.verbose('verbose');
+        application.log.verbose({ info: 'verbose' });
 
-        should(application._kuzzle.log.debug).be.calledWith('[black-mesa]: debug');
-        should(application._kuzzle.log.info).be.calledWith('[black-mesa]: info');
-        should(application._kuzzle.log.warn).be.calledWith('[black-mesa]: warn');
-        should(application._kuzzle.log.error).be.calledWith('[black-mesa]: error');
-        should(application._kuzzle.log.verbose).be.calledWith('[black-mesa]: verbose');
+        should(application._kuzzle.log.debug).be.calledWith('debug');
+        should(application._kuzzle.log.info).be.calledWith('info');
+        should(application._kuzzle.log.warn).be.calledWith('warn');
+        should(application._kuzzle.log.error).be.calledWith('error');
+        should(application._kuzzle.log.verbose).be.calledWith(JSON.stringify({ info: 'verbose' }));
       });
     });
   });

--- a/test/core/plugin/pluginsManager.test.js
+++ b/test/core/plugin/pluginsManager.test.js
@@ -240,7 +240,8 @@ describe('Plugin', () => {
         }
       };
 
-      should(() => pluginsManager._initApi(plugin)).throwError({ id: 'plugin.assert.invalid_controller_definition' })
+      should(() => pluginsManager._initApi(plugin))
+        .throwError({ id: 'plugin.assert.invalid_controller_definition' });
     });
   });
 

--- a/test/core/plugin/pluginsManager.test.js
+++ b/test/core/plugin/pluginsManager.test.js
@@ -183,8 +183,64 @@ describe('Plugin', () => {
   });
 
   describe('#_initApi', () => {
-    it('', () => {
+    beforeEach(() => {
+      plugin.instance.api = {
+        email: {
+          actions: {
+            send: {
+              handler: sinon.stub().resolves()
+            },
+            receive: {
+              handler: sinon.stub().resolves(),
+              http: [
+                { verb: 'get', path: '/path-from-root' },
+                { verb: 'post', path: 'path-with-leading-underscore' }
+              ]
+            }
+          }
+        }
+      };
+    });
 
+    it('should create a BaseController and add corresponding actions', () => {
+      pluginsManager._initApi(plugin);
+
+      const emailController = pluginsManager.controllers.get('email');
+      should(emailController).be.instanceOf(BaseController);
+      should(emailController.__actions).be.eql(new Set(['send', 'receive']));
+      should(emailController.send).be.a.Function();
+      should(emailController.receive).be.a.Function();
+    });
+
+    it('should add http routes', () => {
+      pluginsManager._initApi(plugin);
+
+      should(pluginsManager.routes).match([
+        {
+          action: 'receive',
+          controller: 'email',
+          path: '/path-from-root',
+          verb: 'get'
+        },
+        {
+          action: 'receive',
+          controller: 'email',
+          path: '/_/path-with-leading-underscore',
+          verb: 'post'
+        }
+      ]);
+    });
+
+    it('should throw an error if the controller definition is invalid', () => {
+      plugin.instance.api = {
+        email: {
+          actions: {
+            handelr: sinon.stub().resolves()
+          }
+        }
+      };
+
+      should(() => pluginsManager._initApi(plugin)).throwError({ id: 'plugin.assert.invalid_controller_definition' })
     });
   });
 


### PR DESCRIPTION
## What does this PR do ?

When defining a controller action HTTP route path there is 2 options:
 - starts the path with a leading `/` (e.g. `/path/from/root` will give the url `http://kuzzle/path/from/root`)
 - starts the path without leading `/` (e.g `path/classic` will give the url `http://kuzzle/_/path/classic`)

This PR fix the generation for the 2nd usecase. It was `http://kuzzle/_path/classic` instead of `http://kuzzle/_/path/classic`

### Other changes

  - allows to display any kind of object in Kaaf log methods
  - use a restricted union type for http verbs
