### PR TITLE
Add a HTTP endpoint taking a Kuzzle API request in JSON format

### DIFF
--- a/doc/2/api/essentials/query-syntax/index.md
+++ b/doc/2/api/essentials/query-syntax/index.md
@@ -45,7 +45,7 @@ If the form field holds a file, then the corresponding JSON key will refer to an
 
 Kuzzle also exposes an endpoint to send queries using the standard JSON request format used by other protocols.  
 
-This makes it possible to avoid with the use of HTTP routes and to send queries via the HTTP protocol in the same way as for other protocols.
+This makes it possible to avoid the use of the REST API and to send queries via the HTTP protocol the same way as for any other protocols.
 
 This endpoint is accessible on the route `POST http://<host>:<port>/_query`:
 

--- a/doc/2/api/essentials/query-syntax/index.md
+++ b/doc/2/api/essentials/query-syntax/index.md
@@ -41,6 +41,27 @@ If the form field holds a file, then the corresponding JSON key will refer to an
 - `mimetype`: MIME type
 - `file`: file content, encoded in base64
 
+### JSON query endpoint
+
+Kuzzle also exposes an endpoint to send queries using the standard JSON request format used by other protocols.  
+
+This makes it possible to avoid with the use of HTTP routes and to send queries via the HTTP protocol in the same way as for other protocols.
+
+This endpoint is accessible on the route `POST http://<host>:<port>/_query`:
+
+```bash
+$ curl -X POST -H  "Content-Type: application/json" "http://localhost:7512/_query" --data '{
+  "controller":"server", 
+  "action":"now" 
+}'
+```
+
+The body of the query will be processed by Kuzzle as a standard query.
+
+::: warning
+This endpoint does not allow to benefit from the advantages of the cache system integrated to HTTP via URLS.
+:::
+
 ---
 
 ## Other protocols

--- a/doc/2/api/essentials/query-syntax/index.md
+++ b/doc/2/api/essentials/query-syntax/index.md
@@ -59,7 +59,7 @@ $ curl -X POST -H  "Content-Type: application/json" "http://localhost:7512/_quer
 The body of the query will be processed by Kuzzle as a standard query.
 
 ::: warning
-This endpoint does not allow to benefit from the advantages of the cache system integrated to HTTP via URLS.
+This endpoint does not allow to benefit from the advantages of the cache system integrated to HTTP via URLs.
 :::
 
 ---

--- a/features-sdk/Api.feature
+++ b/features-sdk/Api.feature
@@ -1,0 +1,15 @@
+Feature: API
+
+  @mappings
+  Scenario: Send Request to the HTTP JSON endpoint
+    Given an existing collection "nyc-open-data":"yellow-taxi"
+    When I send a HTTP "post" request with:
+      | controller | "document"                      |
+      | action     | "create"                        |
+      | index      | "nyc-open-data"                 |
+      | collection | "yellow-taxi"                   |
+      | _id        | "foobar-1"                      |
+      | body       | { "name": "Aschen", "age": 27 } |
+    And The document "foobar-1" content match:
+      | name | "Aschen" |
+      | age  | 27       |

--- a/features-sdk/step_definitions/controllers-steps.js
+++ b/features-sdk/step_definitions/controllers-steps.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert');
 
+const requestPromise = require('request-promise');
 const _ = require('lodash');
 const should = require('should');
 const { Then } = require('cucumber');
@@ -164,4 +165,19 @@ Then('I got an error with id {string}', function (id) {
   assert(this.props.error !== null, 'Expected the previous step to return an error');
 
   assert(this.props.error.id === id, `Expected error to have id "${id}", but got "${this.props.error.id}"`);
+});
+
+Then('I send a HTTP {string} request with:', async function (method, dataTable) {
+  const body = this.parseObject(dataTable);
+
+  const options = {
+    url: `http://${this._host}:${this._port}/_query`,
+    json: true,
+    method,
+    body,
+  };
+
+  const response = await requestPromise(options);
+
+  this.props.result = response.result;
 });

--- a/features-sdk/support/world.js
+++ b/features-sdk/support/world.js
@@ -43,20 +43,14 @@ class KuzzleWorld {
   }
 
   parseObject(dataTable) {
-    const rawContent = dataTable.rowsHash();
-    const content = {};
+    if (typeof dataTable.rowsHash !== 'function') {
+      throw new Error('Argument is not a datatTable');
+    }
 
-    for (const [path, value] of Object.entries(rawContent)) {
-      if (value.includes('_AGO_')) {
-        // format: "_5m_AGO_"
-        const timeAgo = ms(value.split('_')[1]);
+    const content = dataTable.rowsHash();
 
-        _.set(content, path, this.props.now - timeAgo);
-      }
-      else {
-        console.log({ path, v: eval(`var o = ${value}; o`)})
-        _.set(content, path, eval(`var o = ${value}; o`)); // eslint-disable-line no-eval
-      }
+    for (const key of Object.keys(content)) {
+      content[key] = JSON.parse(content[key]);
     }
 
     return content;

--- a/features-sdk/support/world.js
+++ b/features-sdk/support/world.js
@@ -3,6 +3,7 @@
 const { setWorldConstructor } = require('cucumber');
 const { Kuzzle, WebSocket, Http } = require('kuzzle-sdk');
 const _ = require('lodash');
+const ms = require('ms');
 
 const config = require('../../lib/config');
 
@@ -53,7 +54,7 @@ class KuzzleWorld {
         _.set(content, path, this.props.now - timeAgo);
       }
       else {
-        _.set(content, path, eval(`var o = ${value}; o`));
+        _.set(content, path, eval(`var o = ${value}; o`)); // eslint-disable-line no-eval
       }
     }
 

--- a/features-sdk/support/world.js
+++ b/features-sdk/support/world.js
@@ -2,8 +2,6 @@
 
 const { setWorldConstructor } = require('cucumber');
 const { Kuzzle, WebSocket, Http } = require('kuzzle-sdk');
-const _ = require('lodash');
-const ms = require('ms');
 
 const config = require('../../lib/config');
 

--- a/features-sdk/support/world.js
+++ b/features-sdk/support/world.js
@@ -54,6 +54,7 @@ class KuzzleWorld {
         _.set(content, path, this.props.now - timeAgo);
       }
       else {
+        console.log({ path, v: eval(`var o = ${value}; o`)})
         _.set(content, path, eval(`var o = ${value}; o`)); // eslint-disable-line no-eval
       }
     }

--- a/lib/core/network/router.js
+++ b/lib/core/network/router.js
@@ -21,6 +21,8 @@
 
 'use strict';
 
+const { Request } = require('kuzzle-common-objects');
+
 const kerror = require('../../kerror');
 const HttpRouter = require('./httpRouter');
 
@@ -111,10 +113,24 @@ class Router {
       ...this.kuzzle.pluginsManager.routes
     ];
 
+    this.http.post('_query', (request, cb) => {
+      // We need to build a new request from the body
+      // and we also need to keep the original request context
+      const apiRequest = new Request(
+        request.input.body,
+        request.serialize().options);
+
+      this._executeFromHttp('post', apiRequest, cb);
+    });
+
     for (const route of routes) {
       const verb = route.verb.toLowerCase();
-      this.http[verb](route.path, (data, cb) => {
-        this._executeFromHttp(route, data, cb);
+
+      this.http[verb](route.path, (request, cb) => {
+        request.input.controller = route.controller;
+        request.input.action = route.action;
+
+        this._executeFromHttp(route.verb, request, cb);
       });
     }
   }
@@ -123,15 +139,12 @@ class Router {
    * Transmit HTTP requests to the funnel controller and forward its response
    * back to the client
    *
-   * @param {object} route contains the request action, controller and verb
+   * @param {String} verb
    * @param {Request} request - includes URL and POST query data
    * @param {function} cb - callback to invoke with the result
    */
-  _executeFromHttp (route, request, cb) {
-    request.input.controller = route.controller;
-    request.input.action = route.action;
-
-    this.kuzzle.pipe(`http:${route.verb}`, request, (error, mutatedRequest) => {
+  _executeFromHttp (verb, request, cb) {
+    this.kuzzle.pipe(`http:${verb}`, request, (error, mutatedRequest) => {
       if (error) {
         request.setError(error);
         cb(request);

--- a/plugins/available/functional-test-plugin/functionalTestPlugin.js
+++ b/plugins/available/functional-test-plugin/functionalTestPlugin.js
@@ -175,12 +175,10 @@ class FunctionalTestPlugin {
     }
 
     for (const document of documents) {
-      console.log(document)
       for (const [field, value] of Object.entries(pipe.payload)) {
         /* eslint-disable-next-line no-eval */
         _.set(document, field, eval(value));
       }
-      console.log(document)
     }
 
     return documents;

--- a/plugins/available/functional-test-plugin/functionalTestPlugin.js
+++ b/plugins/available/functional-test-plugin/functionalTestPlugin.js
@@ -175,10 +175,12 @@ class FunctionalTestPlugin {
     }
 
     for (const document of documents) {
+      console.log(document)
       for (const [field, value] of Object.entries(pipe.payload)) {
         /* eslint-disable-next-line no-eval */
         _.set(document, field, eval(value));
       }
+      console.log(document)
     }
 
     return documents;


### PR DESCRIPTION
## What does this PR do ?

Add a HTTP route `/_query` that takes a Kuzzle API request in the JSON body and then execute it.

Fix #1774

### How should this be manually tested?

```bash
$ curl -X POST -H  "Content-Type: application/json" "localhost:7512/_query" --data '{ "controller":"server", "action":"now" }'
```
