### PR TITLE
Forbid overriding of native controller in applications

### DIFF
--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -84,6 +84,17 @@ class Funnel {
   init () {
     this.kuzzle.on('kuzzle:shutdown', () => ( this.shuttingDown = true ));
 
+    /**
+     * Returns true if the controller is one of Kuzzle native's one
+     *
+     * @param {String} name
+     *
+     * @returns {Boolean}
+     */
+    this.kuzzle.onAsk(
+      'kuzzle:api:funnel:controller:isNative',
+      name => this.isNativeController(name));
+
     this.rateLimiter.init();
 
     this.controllers.set('auth', new AuthController(this.kuzzle));

--- a/lib/core/plugin/plugin.js
+++ b/lib/core/plugin/plugin.js
@@ -253,7 +253,7 @@ class Plugin {
       throw assertionError.get(
         'invalid_controller_definition',
         name,
-        'definition must be an object');
+        'Controller definition must be an object');
     }
 
     for (const [action, actionDefinition] of Object.entries(definition.actions)) {

--- a/lib/core/plugin/pluginsManager.js
+++ b/lib/core/plugin/pluginsManager.js
@@ -636,7 +636,7 @@ class PluginsManager {
         throw assertionError.get(
           'invalid_controller_definition',
           controller,
-          'Native controllers can not be overriden');
+          'Native controllers cannot be overriden');
       }
 
       Plugin.checkControllerDefinition(controller, definition);

--- a/lib/core/plugin/pluginsManager.js
+++ b/lib/core/plugin/pluginsManager.js
@@ -218,7 +218,7 @@ class PluginsManager {
           }
         })())
         .timeout(initTimeout, `${plugin.logPrefix} Initialization timed out after ${initTimeout}ms. Try to increase the configuration "plugins.common.initTimeout".`)
-        .then(() => {
+        .then(async () => {
           plugin.initCalled = true;
 
           if ( ! _.isEmpty(plugin.instance.controllers)
@@ -232,7 +232,7 @@ class PluginsManager {
           }
 
           if (! _.isEmpty(plugin.instance.api)) {
-            this._initApi(plugin);
+            await this._initApi(plugin);
           }
 
           if (! _.isEmpty(plugin.instance.authenticators)) {
@@ -625,12 +625,19 @@ class PluginsManager {
     }
   }
 
-  _initApi (plugin) {
+  async _initApi (plugin) {
     for (const [controller, definition] of Object.entries(plugin.instance.api)) {
       debug(
         '[%s][%s] starting api controller registration',
         plugin.name,
         controller);
+
+      if (await this.kuzzle.ask('kuzzle:api:funnel:controller:isNative', controller)) {
+        throw assertionError.get(
+          'invalid_controller_definition',
+          controller,
+          'Native controllers can not be overriden');
+      }
 
       Plugin.checkControllerDefinition(controller, definition);
 


### PR DESCRIPTION
## What does this PR do ?

Checks if the controller name is the same as a native one and throw an error to avoid overriding Kuzzle native controllers.
