### PR TITLE
Deprecate misc.url for misc.path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
     # Unit Tests & Linters
     # ---------------------------------------
     - stage: Unit Tests & Linters
-      name: Node 12.16.3 - Unit Tests & ESLint
+      name: Node 12.16.3 - Unit Tests
       os: linux
       language: node_js
       cache: npm
@@ -66,13 +66,25 @@ jobs:
       install:
         - npm ci --silent
       script:
-        - npm run --silent test:lint
         - npm run test:unit:coverage
       after_script:
         - npm run codecov
 
     - stage: Unit Tests & Linters
-      name: Node 12.18.1 - Unit Tests & ESLint
+      name: Node 12.18.1 - Unit Tests
+      os: linux
+      language: node_js
+      cache: npm
+      node_js: 12.18.1
+      install:
+        - npm ci --silent
+      script:
+        - npm run test:unit:coverage
+      after_script:
+        - npm run codecov
+
+    - stage: Unit Tests & Linters
+      name: Node 12.18.1 - ESLint
       os: linux
       language: node_js
       cache: npm
@@ -81,9 +93,6 @@ jobs:
         - npm ci --silent
       script:
         - npm run --silent test:lint
-        - npm run test:unit:coverage
-      after_script:
-        - npm run codecov
 
     - stage: Unit Tests & Linters
       name: SonarCloud

--- a/lib/core/network/httpRouter/routeHandler.js
+++ b/lib/core/network/httpRouter/routeHandler.js
@@ -55,7 +55,9 @@ class RouteHandler {
         id: message.connection.id,
         ips: message.ips,
         protocol: 'http',
+        // @deprecated use "path" instead
         url: message.url,
+        path: message.path,
         verb: message.method
       }
     };

--- a/lib/core/network/httpRouter/routeHandler.js
+++ b/lib/core/network/httpRouter/routeHandler.js
@@ -54,10 +54,10 @@ class RouteHandler {
         headers: message.headers,
         id: message.connection.id,
         ips: message.ips,
+        path: message.path,
         protocol: 'http',
         // @deprecated use "path" instead
         url: message.url,
-        path: message.path,
         verb: message.method
       }
     };

--- a/lib/core/network/protocols/http.js
+++ b/lib/core/network/protocols/http.js
@@ -71,7 +71,9 @@ class HttpMessage {
     this.json = null;
     this.ips = connection.ips;
     this.requestId = connection.id;
+    // @deprecated use "path" instead
     this.url = request.url;
+    this.path = request.url;
     this.method = request.method;
     this.headers = Object.assign({}, request.headers);
   }

--- a/test/core/network/protocols/http.test.js
+++ b/test/core/network/protocols/http.test.js
@@ -203,7 +203,7 @@ describe('/lib/core/network/protocols/http', () => {
         should(protocol._replyWithError)
           .be.calledOnce()
           .be.calledWithMatch(
-            { url: request.url, method: request.method },
+            { path: request.url, url: request.url, method: request.method },
             response,
             {message: 'Maximum HTTP request size exceeded.'});
       });
@@ -260,7 +260,7 @@ describe('/lib/core/network/protocols/http', () => {
         should(protocol._replyWithError)
           .be.calledOnce()
           .be.calledWithMatch(
-            { url: request.url, method: request.method },
+            { path: request.url, url: request.url, method: request.method },
             response,
             {message: 'Too many encodings.'});
       });
@@ -273,7 +273,7 @@ describe('/lib/core/network/protocols/http', () => {
         should(protocol._replyWithError)
           .be.calledOnce()
           .be.calledWithMatch(
-            { url: request.url, method: request.method },
+            { path: request.url, url: request.url, method: request.method },
             response,
             {message: 'Unsupported compression algorithm "foobar".'});
       });
@@ -394,7 +394,7 @@ describe('/lib/core/network/protocols/http', () => {
 
             should(protocol._replyWithError)
               .be.calledWithMatch(
-                { url: request.url, method: request.method },
+                { path: request.url, url: request.url, method: request.method },
                 response,
                 { message: 'Maximum HTTP request size exceeded.' });
             done();
@@ -415,7 +415,7 @@ describe('/lib/core/network/protocols/http', () => {
         should(protocol._replyWithError)
           .be.calledOnce()
           .be.calledWithMatch(
-            { url: request.url, method: request.method },
+            { path: request.url, url: request.url, method: request.method },
             response,
             {
               id: 'network.http.unexpected_error',


### PR DESCRIPTION
## What does this PR do ?

Since we use the path property to define HTTP routes in Kuzzle we should be consistent in the connection information.

This PR deprecate the usage of `request.context.connection.misc.url` for `request.context.connection.misc.path`

Linked with https://github.com/kuzzleio/kuzzle-common-objects/pull/103