### PR TITLE
Fix the HTTP index:mDelete endpoint

### DIFF
--- a/features/support/api/http.js
+++ b/features/support/api/http.js
@@ -500,7 +500,7 @@ class HttpApi {
 
   deleteIndexes () {
     const options = {
-      url: this.apiPath('_mdelete'),
+      url: this.apiPath('_mDelete'),
       method: 'DELETE'
     };
 

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -46,7 +46,7 @@ const routes = [
   { verb: 'get', path: '/validations/_scroll/:scrollId', controller: 'collection', action: 'scrollSpecifications' },
   { verb: 'get', path: '/:index/_list', controller: 'collection', action: 'list' },
 
-  { verb: 'post', path: '/admin/_resetCache', controller: 'admin', action: 'resetCache' }, 
+  { verb: 'post', path: '/admin/_resetCache', controller: 'admin', action: 'resetCache' },
   { verb: 'post', path: '/admin/_resetSecurity', controller: 'admin', action: 'resetSecurity' },
   { verb: 'post', path: '/admin/_resetDatabase', controller: 'admin', action: 'resetDatabase' },
   { verb: 'post', path: '/admin/_resetKuzzleData', controller: 'admin', action: 'resetKuzzleData' },
@@ -287,6 +287,8 @@ const routes = [
   { verb: 'delete', path: '/:index/:collection/_mDelete', controller: 'document', action: 'mDelete' },
 
   { verb: 'delete', path: '/:index', controller: 'index', action: 'delete' },
+  { verb: 'delete', path: '/_mDelete', controller: 'index', action: 'mDelete' },
+  // @deprecated: has a typo. To be removed in the next major version
   { verb: 'delete', path: '/_mdelete', controller: 'index', action: 'mDelete' },
 
   { verb: 'delete', path: '/:index/:collection', controller: 'collection', action: 'delete' },

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -288,8 +288,7 @@ const routes = [
 
   { verb: 'delete', path: '/:index', controller: 'index', action: 'delete' },
   { verb: 'delete', path: '/_mDelete', controller: 'index', action: 'mDelete' },
-  // @deprecated: has a typo. To be removed in the next major version
-  { verb: 'delete', path: '/_mdelete', controller: 'index', action: 'mDelete' },
+  { verb: 'delete', path: '/_mdelete', controller: 'index', action: 'mDelete', deprecated: { since: '2.4.0', message: 'Use this route instead: http://kuzzle:7512/_mDelete' } }, // @deprecated
 
   { verb: 'delete', path: '/:index/:collection', controller: 'collection', action: 'delete' },
 


### PR DESCRIPTION
# Description

The HTTP API endpoint for `index:mDelete` is currently `http://<host>:<port>/_mdelete` (instead of `_mDelete`), which is inconsistent with the rest of the API.

This PR keeps the old route (it's here since the beta stages of Kuzzle 4 years ago) and deprecates it in favor of a new, fixed route.

The documentation doesn't need to be changed: it already documents the correct version.