### PR TITLE
Fix index:mDelete to make it return the list of deleted indexes

### DIFF
--- a/lib/core/storage/clientAdapter.js
+++ b/lib/core/storage/clientAdapter.js
@@ -100,11 +100,13 @@ class ClientAdapter {
       this.cache.assertIndexExists(index);
     }
 
-    await this.client.deleteIndexes(indexes);
+    const deleted = await this.client.deleteIndexes(indexes);
 
-    for (const index of indexes) {
+    for (const index of deleted) {
       this.cache.removeIndex(index);
     }
+
+    return deleted;
   }
 
   async deleteCollection (index, collection) {

--- a/test/core/storage/clientAdapter.test.js
+++ b/test/core/storage/clientAdapter.test.js
@@ -179,17 +179,22 @@ describe('#core/storage/ClientAdapter', () => {
       }
     });
 
-    describe('#index:mDelete', () => {
+    describe.only('#index:mDelete', () => {
       it('should register an "index:mDelete" event', async () => {
         const indexes = ['foo', 'bar', 'baz'];
 
         for (const adapter of [publicAdapter, privateAdapter]) {
-          await kuzzle.ask(`core:storage:${adapter.scope}:index:mDelete`, indexes);
+          adapter.client.deleteIndexes.resolves(indexes);
+
+          const deleted = await kuzzle.ask(
+            `core:storage:${adapter.scope}:index:mDelete`,
+            indexes);
 
           should(publicAdapter.client.deleteIndexes).calledWith(indexes);
           should(publicAdapter.cache.removeIndex).calledWith('foo');
           should(publicAdapter.cache.removeIndex).calledWith('bar');
           should(publicAdapter.cache.removeIndex).calledWith('baz');
+          should(deleted).eql(indexes);
         }
       });
 

--- a/test/core/storage/clientAdapter.test.js
+++ b/test/core/storage/clientAdapter.test.js
@@ -179,7 +179,7 @@ describe('#core/storage/ClientAdapter', () => {
       }
     });
 
-    describe.only('#index:mDelete', () => {
+    describe('#index:mDelete', () => {
       it('should register an "index:mDelete" event', async () => {
         const indexes = ['foo', 'bar', 'baz'];
 


### PR DESCRIPTION
# Description

As the title says: calling `index:mDelete` resulted in an empty response value, instead of an expected array of deleted indexes.

This bug is live since Kuzzle@2.6.0