### PR TITLE
[Doc > Code-examples > IOT > JS] publish.js snippet fix

### DIFF
--- a/doc/2/guides/code-examples/iot/javascript/snippets/publish.js
+++ b/doc/2/guides/code-examples/iot/javascript/snippets/publish.js
@@ -13,9 +13,12 @@ try {
     body: {
       command: 'battery-report'
     }
-  }));
+  }), err => {
+    if (err) {
+      console.error(err)
+    }
+    client.end()
+  });
 } catch (error) {
   console.log(error.message);
-} finally {
-  client.end();
 }


### PR DESCRIPTION
Fixes the `publish.js` snippet of the IOT code-example in Javascript.
Having the `client.end()` in the `finally` block prevents the `client.publish` to succeed, since `end` and `publish` get called at the same time due to the synchronicity of the MQTT library.

Putting the `client.end()` inside the callback to `publish` allows the connection to be destroyed after the message gets published.