### PR TITLE
Add missing version tag

### DIFF
--- a/doc/2/plugins/plugin-context/accessors/subscription/index.md
+++ b/doc/2/plugins/plugin-context/accessors/subscription/index.md
@@ -6,6 +6,8 @@ title: subscription
 
 # `subscription`
 
+<SinceBadge version="2.7.0"/>
+
 Adds or removes [real-time subscriptions](/core/2/guides/essentials/real-time) from the backend.
 
 ## `register`


### PR DESCRIPTION
# Description

The new `pluginContext.accessors.subscription` documentation is missing its version tag.