### PR TITLE
Fix document:mCreate documentation

### DIFF
--- a/doc/2/api/controllers/document/m-create/index.md
+++ b/doc/2/api/controllers/document/m-create/index.md
@@ -130,26 +130,46 @@ Each errored document is an object of the `errors` array with the following prop
       {
         "_id": "<documentId>",
         "_source": {
+          // kuzzle metadata
+          "_kuzzle_info": {
+            "author": "<user kuid>",
+            "createdAt": <creation timestamp>,
+            "updatedAt": null,
+            "updater": null
+          },
           // document content
         },
-        "_version": 1,
-        "created": true
+        "result": "created",
+        "status": 201,
+        "_version": 1
       },
       {
         "_id": "<anotherDocumentId>",
         "_source": {
-          "// document content
-        "_version": 1,
-        "created": true
+          // kuzzle metadata
+          "_kuzzle_info": {
+            "author": "<user kuid>",
+            "createdAt": <creation timestamp>,
+            "updatedAt": null,
+            "updater": null
+          },
+          // document content
+        },
+        "result": "created",
+        "status": 201,
+        "_version": 1
       }
     ],
     "errors": [
       {
         "document": {
-          // document content
+          "_id": "<document id>",
+          "body": {
+            // document content
+          }
         },
-        "status": 400,
-        "reason": "Document already exists"
+        "reason": "document already exists",
+        "status": 400
       }
     ]
   }


### PR DESCRIPTION
# Description

The example for the `document:mCreate` response appears to be outdated. 