### PR TITLE
Fix error thrown when trying to submit an empty document:mUpdate request

### DIFF
--- a/lib/api/controller/document.js
+++ b/lib/api/controller/document.js
@@ -552,6 +552,13 @@ class DocumentController extends NativeController {
 
     this.assertNotExceedMaxWrite(documents.length);
 
+    if (documents.length === 0) {
+      return {
+        errors: [],
+        successes: [],
+      };
+    }
+
     for (let i = 0; i < documents.length; i++) {
       if (documents[i]._source) {
         throw kerror.get(

--- a/lib/core/cache/cacheEngine.js
+++ b/lib/core/cache/cacheEngine.js
@@ -101,7 +101,14 @@ class CacheEngine {
      */
     this.kuzzle.onAsk(
       'core:cache:internal:mget',
-      keys => this.internal.commands.mget(keys));
+      keys => {
+        // redis throws an error if trying to mget without arguments
+        if (keys.length === 0) {
+          return [];
+        }
+
+        return this.internal.commands.mget(keys);
+      });
 
     /**
      * Makes a key persistent (disable its expiration delay, if there is one)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "bin": {
     "kuzzle": "./bin/start-kuzzle-server"

--- a/test/api/controller/document.test.js
+++ b/test/api/controller/document.test.js
@@ -438,6 +438,25 @@ describe('DocumentController', () => {
           SizeLimitError,
           { id: 'services.storage.write_limit_exceeded' });
     });
+
+    it('should return immediately if the provided payload is empty', async () => {
+      request.input.body.documents = [];
+
+      const response = await documentController._mChanges(
+        request,
+        'mCreate',
+        actionEnum.CREATE);
+
+      should(response).match({
+        errors: [],
+        successes: [],
+      });
+
+      should(kuzzle.ask.withArgs('core:storage:public:document:mCreate'))
+        .not.called();
+      should(kuzzle.ask.withArgs('core:realtime:document:mNotify'))
+        .not.called();
+    });
   });
 
   describe('#createOrReplace', () => {

--- a/test/core/cache/cacheEngine.test.js
+++ b/test/core/cache/cacheEngine.test.js
@@ -113,4 +113,20 @@ describe('CacheEngine', () => {
       should(cacheEngine.public.store).calledWith('key', 'value', 'ttl');
     });
   });
+
+  describe('#internal events', () => {
+    beforeEach(() => {
+      kuzzle.ask.restore();
+      return cacheEngine.init();
+    });
+
+    describe('#mget', () => {
+      it('should not invoke ioredis if an empty keys list is provided', async () => {
+        const result = await kuzzle.ask('core:cache:internal:mget', []);
+
+        should(cacheEngine.internal.commands.mget).not.called();
+        should(result).be.an.Array().and.be.empty();
+      });
+    });
+  });
 });


### PR DESCRIPTION
# Description

When submitting an empty `document:mUpdate` request, Kuzzle returns the following error:
`Error: Caught an unexpected plugin error: ERR wrong number of arguments for 'mget' command`

This is caused by the realtime notification module, which tries to get the stored Redis keys for the updated documents. This sends an `core:internal:cache:mget` event with an empty keys list payload, which is then forwarded by the cache adapter to Redis which, in turn, returns that error.

This PR solves this problem in two ways:
* `document:m*` API actions now do nothing with empty payloads, they simply return an empty response. Kuzzle doesn't have to work if there is nothing to do.
* The event `core:internal:cache:mget` now returns an empty value list without asking Redis, when an empty payload is submitted

# Why is this a hotfix?

This issue is a show stopper for one of our clients.

# How to reproduce

```
kourou collection:create foo bar
kourou document:mUpdate foo bar '{ documents: [] }'
```
