### PR TITLE
Allows BackendLogger before startup

### DIFF
--- a/doc/2/framework/classes/internal-logger/debug/index.md
+++ b/doc/2/framework/classes/internal-logger/debug/index.md
@@ -10,7 +10,7 @@ description: InternalLogger.debug method
 Logs a debug message.
 
 ::: info
-This method can only be used after the application started up.
+Before application startup this method will use `console.log` instead of the configured logger.
 :::
 
 ```ts

--- a/doc/2/framework/classes/internal-logger/error/index.md
+++ b/doc/2/framework/classes/internal-logger/error/index.md
@@ -10,7 +10,7 @@ description: InternalLogger.error method
 Logs an error message.
 
 ::: info
-This method can only be used after the application started up.
+Before application startup this method will use `console.log` instead of the configured logger.
 :::
 
 ```ts

--- a/doc/2/framework/classes/internal-logger/info/index.md
+++ b/doc/2/framework/classes/internal-logger/info/index.md
@@ -10,7 +10,7 @@ description: InternalLogger.info method
 Logs an info message.
 
 ::: info
-This method can only be used after the application started up.
+Before application startup this method will use `console.log` instead of the configured logger.
 :::
 
 ```ts

--- a/doc/2/framework/classes/internal-logger/verbose/index.md
+++ b/doc/2/framework/classes/internal-logger/verbose/index.md
@@ -10,7 +10,7 @@ description: InternalLogger.verbose method
 Logs a verbose message.
 
 ::: info
-This method can only be used after the application started up.
+Before application startup this method will use `console.log` instead of the configured logger.
 :::
 
 ```ts

--- a/doc/2/framework/classes/internal-logger/warn/index.md
+++ b/doc/2/framework/classes/internal-logger/warn/index.md
@@ -10,7 +10,7 @@ description: InternalLogger.warn method
 Logs a info message.
 
 ::: info
-This method can only be used after the application started up.
+Before application startup this method will use `console.log` instead of the configured logger.
 :::
 
 ```ts

--- a/docker/scripts/reloader.js
+++ b/docker/scripts/reloader.js
@@ -78,6 +78,17 @@ function startProcess () {
     state = stateEnum.STOPPED;
   });
 
+  // exits child process on termination
+  for (const signal of ['SIGINT', 'SIGTERM']) {
+    process.on(signal, () => {
+      if (childProcess) {
+        childProcess.kill(signal);
+      }
+
+      process.exit();
+    });
+  }
+
   state = stateEnum.RUNNING;
 }
 

--- a/lib/core/application/backend.ts
+++ b/lib/core/application/backend.ts
@@ -385,10 +385,11 @@ class InternalLogger extends ApplicationManager implements InternalLogger {
 
   private _log (level: string, message: any) {
     if (! this._application.started) {
-      throw runtimeError.get('unavailable_before_start', 'log');
+      console.log(util.inspect(message));
     }
-
-    this._kuzzle.log[level](util.inspect(message));
+    else {
+      this._kuzzle.log[level](util.inspect(message));
+    }
   }
 }
 

--- a/lib/core/application/backend.ts
+++ b/lib/core/application/backend.ts
@@ -385,6 +385,7 @@ class InternalLogger extends ApplicationManager implements InternalLogger {
 
   private _log (level: string, message: any) {
     if (! this._application.started) {
+      // eslint-disable-next-line no-console
       console.log(util.inspect(message));
     }
     else {


### PR DESCRIPTION
## What does this PR do ?

Allows to log message before application startup

### Other changes
 
  - terminate the childProcess of the reloaded.js script when the main script is terminated (e.g. CTRL+C)