### PR TITLE
Expose mutex class to plugins

### DIFF
--- a/doc/1/api/essentials/errors/codes/index.md
+++ b/doc/1/api/essentials/errors/codes/index.md
@@ -25,6 +25,7 @@ order: 500
 | core.fatal.service_unavailable<br/><pre>0x00000002</pre> | [ExternalServiceError](/core/1/api/essentials/errors/handling#externalserviceerror) <pre>(500)</pre> | An external service is unavailable |
 | core.fatal.service_timeout<br/><pre>0x00000003</pre> | [InternalError](/core/1/api/essentials/errors/handling#internalerror) <pre>(500)</pre> | Service initialization timeout |
 | core.fatal.unreadable_log_dir<br/><pre>0x00000004</pre> | [InternalError](/core/1/api/essentials/errors/handling#internalerror) <pre>(500)</pre> | Cannot read the content of the log directory |
+| core.fatal.assertion_failed<br/><pre>0x00000005</pre> | [InternalError](/core/1/api/essentials/errors/handling#internalerror) <pre>(500)</pre> | A runtime assertion has failed. Please contact support. |
 
 ---
 

--- a/doc/1/plugins/plugin-context/constructors/mutex/index.md
+++ b/doc/1/plugins/plugin-context/constructors/mutex/index.md
@@ -10,7 +10,7 @@ title: Mutex
 
 Instantiates a new mutex, that can be used to lock a resource. 
 
-Allow to have a process played on only 1 node on a Kuzzle cluster, with the other ones waiting until the lock is freed.
+Allows to have a process played on only 1 node on a Kuzzle cluster, with the other ones waiting until the lock is freed.
 
 Also works within a single node: in that case, it's better if lock attempts from different parts of the code use different Mutex instances (with the same lock ID).
 

--- a/doc/1/plugins/plugin-context/constructors/mutex/index.md
+++ b/doc/1/plugins/plugin-context/constructors/mutex/index.md
@@ -1,0 +1,87 @@
+---
+code: true
+type: page
+title: Mutex
+---
+
+# Mutex
+
+<SinceBadge version="1.12.0" />
+
+Instantiates a new mutex, that can be used to lock a resource. 
+
+Allow to have a process played on only 1 node on a Kuzzle cluster, with the other ones waiting until the lock is freed.
+
+Also works within a single node: in that case, it's better if lock attempts from different parts of the code use different Mutex instances (with the same lock ID).
+
+---
+
+## Constructor
+
+```js
+new context.constructors.Mutex(lockId, [options]);
+```
+
+<br/>
+
+| Arguments           | Type              | Description                                                                                                                     |
+| ------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `lockId`            | <pre>string</pre> | Lock unique id (must be identical across all nodes)  |
+| `options`           | <pre>object</pre> | (optional) Mutex options (see below) |
+
+#### options
+
+The `options` object is used to configure a mutex behavior. The following properties can be provided:
+
+| Option         | Type              | Description                                                                                                      |
+| -------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `attemptDelay` | `Number`          | (default: 200) Delay in milliseconds between lock attempts |
+| `timeout`      | `Number`          | (default: -1) Mutex lock acquisition timeout, in milliseconds. If set to 0, locking will return immediately, whether it can or cannot lock within the 1st attempt. If set to -1, the mutex will try to acquire the resource indefinitely |
+| `ttl`          | `Number`          | (default: 5000) Lock time to live, in milliseconds. Locks will always be freed after that delay has expired. |
+
+---
+
+## lock
+
+Locks the resource.
+
+Returns a promise, resolving to a boolean value.
+
+If a `timeout` (see constructor options) has been set with a number greather than or equal to 0, then you MUST check the boolean result to verify if the lock has been acquired or not.
+
+If the lock timeout was set to `-1`, the promise will only be resolved once the lock was successfully acquired, and the boolean result is always `true`.
+
+
+### Arguments
+
+This function takes no argument.
+
+```js
+lock();
+```
+
+### Return
+
+The `lock` function resolves to a boolean telling whether the lock was acquired or not.
+
+---
+
+## unlock
+
+Frees the locked resource, making it available.
+
+
+### Arguments
+
+This function takes no argument.
+
+```js
+unlock();
+```
+
+
+### Return
+
+Returns a promise, resolved once the mutex has been unlocked.
+
+---

--- a/lib/api/core/plugins/pluginContext.js
+++ b/lib/api/core/plugins/pluginContext.js
@@ -21,21 +21,22 @@
 
 'use strict';
 
-const
-  errorsManager = require('../../../util/errors'),
-  Bluebird = require('bluebird'),
-  Koncorde = require('koncorde'),
-  { Kuzzle: KuzzleSDK } = require('kuzzle-sdk'),
-  FunnelProtocol = require('../sdk/funnelProtocol'),
-  PluginRepository = require('../models/repositories/pluginRepository'),
-  InternalEngine = require('../../../services/internalEngine/index'),
-  PluginInternalEngineBootstrap = require('../../../services/internalEngine/pluginBootstrap'),
-  { deprecateProperties } = require('../../../util/deprecate'),
-  {
-    Request,
-    models: { RequestContext, RequestInput }
-  } = require('kuzzle-common-objects'),
-  { isPlainObject } = require('../../../util/safeObject');
+const Bluebird = require('bluebird');
+const Koncorde = require('koncorde');
+const { Kuzzle: KuzzleSDK } = require('kuzzle-sdk');
+const {
+  Request,
+  models: { RequestContext, RequestInput }
+} = require('kuzzle-common-objects');
+
+const errorsManager = require('../../../util/errors');
+const FunnelProtocol = require('../sdk/funnelProtocol');
+const PluginRepository = require('../models/repositories/pluginRepository');
+const InternalEngine = require('../../../services/internalEngine/index');
+const PluginInternalEngineBootstrap = require('../../../services/internalEngine/pluginBootstrap');
+const { deprecateProperties } = require('../../../util/deprecate');
+const { isPlainObject } = require('../../../util/safeObject');
+const Mutex = require('../../../util/mutex');
 
 const contextError = errorsManager.wrap('plugin', 'context');
 
@@ -65,7 +66,7 @@ class PluginContext {
       Koncorde,
       Dsl: Koncorde, // @deprecated, will be removed in v2
       Request: instantiateRequest,
-      BaseValidationType: require('../validation/baseType')
+      BaseValidationType: require('../validation/baseType'),
     }, {
       Dsl: 'Koncorde'
     });
@@ -221,6 +222,10 @@ class PluginContext {
           replace: pluginRepository.replace.bind(pluginRepository),
           update: pluginRepository.update.bind(pluginRepository)
         };
+      };
+
+      this.constructors.Mutex = function CreateMutex (id, opts) {
+        return new Mutex(kuzzle, id, opts);
       };
     }
   }

--- a/lib/api/kuzzle.js
+++ b/lib/api/kuzzle.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const
+  { randomBytes } = require('crypto'),
   EventEmitter = require('eventemitter3'),
   config = require('../config'),
   path = require('path'),
@@ -92,6 +93,7 @@ class Kuzzle extends EventEmitter {
   constructor() {
     super();
 
+    this.id = randomBytes(8);
     this.config = config;
     this.log = new Logger(this);
 

--- a/lib/config/error-codes/core.json
+++ b/lib/config/error-codes/core.json
@@ -27,8 +27,13 @@
           "code": 4,
           "message": "Cannot read log directory '%s' : %s.",
           "class": "InternalError"
+        },
+        "assertion_failed": {
+          "description": "A runtime assertion has failed. Please contact support.",
+          "code": 5,
+          "message": "Runtime assertion failed: %s",
+          "class": "InternalError"
         }
-
       }
     },
     "realtime": {

--- a/lib/util/mutex.js
+++ b/lib/util/mutex.js
@@ -1,0 +1,165 @@
+/*
+ * Kuzzle, a backend software, self-hostable and ready to use
+ * to power modern apps
+ *
+ * Copyright 2015-2020 Kuzzle
+ * mailto: support AT kuzzle.io
+ * website: http://kuzzle.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const { randomBytes } = require('crypto');
+
+const Bluebird = require('bluebird');
+
+const kerror = require('./errors');
+const debug = require('../kuzzleDebug')('kuzzle:mutex');
+
+const fatal = kerror.wrap('core', 'fatal');
+
+// LUA script for Redis: we want our mutexes to only delete the lock they
+// acquired. Prevents removing locks acquired by other processes if unlocking
+// occurs after the lock expires
+const delIfValueEqualLua = `
+if redis.call("get",KEYS[1]) == ARGV[1]
+then
+  return redis.call("del",KEYS[1])
+else
+  return 0
+end
+`;
+
+// Global: we need to register the LUA script only once. This variable is used
+// to keep track of whether the script was already registered or not
+let delScriptRegistered = false;
+
+/**
+ * Mutex meant to work across a kuzzle cluster.
+ *
+ * Allow to have a process played on only 1 node, with the other ones waiting
+ * until the lock is freed.
+ * Also works within a single node: in that case, it's better
+ * if lock attempts from different parts of the code use different Mutex
+ * instances: each mutex will lock using a unique ID, and the lock can only
+ * be freed by that mutex instance, and it alone.
+ *
+ * /!\ Meant to be used only with 1 independant redis client (single node or
+ * cluster). Which is what Kuzzle supports today.
+ * If, in the future, Kuzzle is able to support multiple independant
+ * Redis servers, then this class needs to implement redlock to properly handle
+ * synchronization between servers (see https://redis.io/topics/distlock)
+ */
+class Mutex {
+  /**
+   * @param {Kuzzle} kuzzle
+   * @param {string} id - lock unique id (must be identical across all nodes)
+   * @param {Object} [options] - mutex options
+   * @param {Number} [options.attemptDelay] - delay between 2 lock attempts
+   * @param {Number} [options.timeout] - mutex lock acquisition timeout in
+   *                                  milliseconds
+   *                                 if 0, locking will fail immediately if it
+   *                                 cannot lock with its 1st attempt
+   *                                 (default) if -1, will try to acquire the
+   *                                 lock indefinitely
+   * @param {Number} [options.ttl] - lock TTL in milliseconds (default: 5000)
+   */
+  constructor (kuzzle, id, { attemptDelay = 200, timeout = -1, ttl = 5000 } = {}) {
+    this.kuzzle = kuzzle;
+    this.lockId = id;
+    this.mutexId = `${kuzzle.id}/${randomBytes(16).toString('hex')}`;
+    this.locked = false;
+    this.attemptDelay = attemptDelay;
+    this.timeout = timeout;
+    this.ttl = ttl;
+
+    this._lockCoroutine = Bluebird.coroutine(function * lockfn () {
+      let duration = 0;
+
+      do {
+        this.locked = yield this.kuzzle.services.list.internalCache.set(
+          this.lockId,
+          this.mutexId,
+          'NX',
+          'PX',
+          this.ttl);
+
+        duration += this.attemptDelay;
+
+        if (!this.locked && (this.timeout === -1 || duration <= this.timeout)) {
+          yield Bluebird.delay(this.attemptDelay);
+        }
+      }
+      while (!this.locked && (this.timeout === -1 || duration <= this.timeout));
+    }.bind(this));
+  }
+
+  /**
+   * Locks the resource.
+   * Resolves to a boolean telling whether the lock could be acquired before
+   * the timeout or not.
+   *
+   * @return {Promise.<boolean>}
+   */
+  lock () {
+    if (this.locked) {
+      return fatal.reject('assertion_failed', `resource "${this.lockId}" already locked by this mutex (id: ${this.mutexId})`);
+    }
+
+    return this._lockCoroutine()
+      .then(() => {
+        if (!this.locked) {
+          debug('Failed to lock %s (mutex id: %s)', this.lockId, this.mutexId);
+          return false;
+        }
+
+        debug('Resource %s locked (mutex id: %s)', this.lockId, this.mutexId);
+
+        return true;
+      });
+  }
+
+  /**
+   * Unlock the mutex
+   *
+   * @return {Promise}
+   */
+  unlock () {
+    if (!this.locked) {
+      return fatal.reject('assertion_failed', `tried to unlock the resource "${this.lockId}", which is not locked (mutex id: ${this.mutexId})`);
+    }
+
+    if (!delScriptRegistered) {
+      this.kuzzle.services.list.internalCache._client.defineCommand(
+        'delIfValueEqual',
+        {
+          numberOfKeys: 1,
+          lua: delIfValueEqualLua,
+        });
+      delScriptRegistered = true;
+    }
+
+    return this.kuzzle.services.list.internalCache._client
+      .delIfValueEqual(this.lockId, this.mutexId)
+      .then(() => {
+        this.locked = false;
+        debug('Resource %s freed (mutex id: %s)', this.lockId, this.mutexId);
+
+        return null;
+      });
+  }
+}
+
+module.exports = Mutex;

--- a/lib/util/mutex.js
+++ b/lib/util/mutex.js
@@ -58,7 +58,7 @@ let delScriptRegistered = false;
  *
  * /!\ Meant to be used only with 1 independant redis client (single node or
  * cluster). Which is what Kuzzle supports today.
- * If, in the future, Kuzzle is able to support multiple independant
+ * If, in the future, Kuzzle is able to support multiple independent
  * Redis servers, then this class needs to implement redlock to properly handle
  * synchronization between servers (see https://redis.io/topics/distlock)
  */

--- a/test/api/controllers/funnelController/execute.test.js
+++ b/test/api/controllers/funnelController/execute.test.js
@@ -115,8 +115,9 @@ describe('funnelController.execute', () => {
       setTimeout(() => funnel.execute(request, () => {}), 499);
       clock.tick(510);
 
-      should(kuzzle.emit)
-        .have.callCount(0);
+      should(kuzzle.emit).have.callCount(0);
+
+      clock.restore();
     });
   });
 

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -289,6 +289,9 @@ class KuzzleMock extends Kuzzle {
           run: this.sandbox.stub().resolves({ids: []})
         },
         internalCache: {
+          _client: {
+            defineCommand: this.sandbox.stub().resolves(),
+          },
           get: this.sandbox.stub().resolves(null),
           del: this.sandbox.stub().resolves(),
           exists: this.sandbox.stub().resolves(),

--- a/test/services/internalEngine/bootstrap.test.js
+++ b/test/services/internalEngine/bootstrap.test.js
@@ -397,7 +397,7 @@ describe('services/internalEngine/bootstrap.js', () => {
   describe('#_waitTillUnlocked', () => {
     it('should throw if locked for too long', () => {
       bootstrap.db.exists.returns(Bluebird.resolve(true));
-      mockrequire('bluebird', Object.assign(require('bluebird'), {delay: () => Bluebird.resolve()}));
+      mockrequire('bluebird', Object.assign({}, require('bluebird'), {delay: () => Bluebird.resolve()}));
       mockrequire.reRequire('../../../lib/services/internalEngine/bootstrap');
 
       return bootstrap._waitTillUnlocked()

--- a/test/services/internalEngine/pluginBootstrap.test.js
+++ b/test/services/internalEngine/pluginBootstrap.test.js
@@ -60,7 +60,7 @@ describe('services/internalEngine/pluginBootstrap.js', () => {
     });
 
     it('should throw if locked for too long', () => {
-      mockrequire('bluebird', Object.assign(Bluebird, {delay: sinon.stub().returns(Bluebird.resolve())}));
+      mockrequire('bluebird', Object.assign({}, Bluebird, {delay: sinon.stub().returns(Bluebird.resolve())}));
       mockrequire.reRequire('../../../lib/services/internalEngine/pluginBootstrap');
 
       bootstrap.lock = sinon.stub().returns(Bluebird.resolve(true));

--- a/test/util/mutex.test.js
+++ b/test/util/mutex.test.js
@@ -1,0 +1,186 @@
+'use strict';
+
+const should = require('should');
+const sinon = require('sinon');
+const Bluebird = require('bluebird');
+const mockRequire = require('mock-require');
+const {
+  errors: {
+    InternalError: KuzzleInternalError
+  }
+} = require('kuzzle-common-objects');
+
+const KuzzleMock = require('../mocks/kuzzle.mock');
+
+describe('#mutex', () => {
+  let Mutex = require('../../lib/util/mutex');
+  let kuzzle;
+
+  beforeEach(() => {
+    kuzzle = new KuzzleMock();
+  });
+
+  describe('#lock', () => {
+    it('should be able to lock a ressource', () => {
+      kuzzle.services.list.internalCache.set.resolves(true);
+
+      const mutex = new Mutex(kuzzle, 'foo', { timeout: 0, ttl: 123 });
+
+      return mutex.lock()
+        .then(result => {
+          should(result).be.true();
+          should(kuzzle.services.list.internalCache.set).calledWith(
+            'foo',
+            sinon.match.string,
+            'NX',
+            'PX',
+            123);
+        });
+    });
+
+    it('should use random values for different mutex instances', () => {
+      const mutex1 = new Mutex(kuzzle, 'foo');
+      const mutex2 = new Mutex(kuzzle, 'foo');
+
+      should(mutex1.mutexId).not.eql(mutex2.mutexId);
+    });
+
+    it('should reject if already locking/locked', () => {
+      const mutex = new Mutex(kuzzle, 'foo', { timeout: 0 });
+
+      kuzzle.services.list.internalCache.set.resolves(true);
+
+      return mutex.lock()
+        .then(() => should(mutex.lock()).rejectedWith(KuzzleInternalError, {
+          id: 'core.fatal.assertion_failed',
+        }));
+    });
+
+    it('should return immediately if failing to acquire a lock (timeout = 0)', () => {
+      kuzzle.services.list.internalCache.set.resolves(false);
+
+      const mutex = new Mutex(kuzzle, 'foo', { timeout: 0, ttl: 123 });
+
+      return mutex.lock()
+        .then(result => {
+          should(result).be.false();
+
+          should(kuzzle.services.list.internalCache.set).calledWith(
+            'foo',
+            sinon.match.string,
+            'NX',
+            'PX',
+            123);
+        });
+    });
+
+    it('should wait until timeout if failing to acquire a lock (timeout > 0)', () => {
+      kuzzle.services.list.internalCache.set.resolves(false);
+      const start = Date.now();
+      const mutex = new Mutex(kuzzle, 'foo', { timeout: 1000 });
+
+      return mutex.lock()
+        .then(result => {
+          should(result).be.false();
+          should(Date.now() - start).approximately(1000, 200);
+        });
+    });
+
+    it('should successfully acquire a lock if it becomes available (timeout > 0)', () => {
+      kuzzle.services.list.internalCache.set.resolves(false);
+
+      const mutex = new Mutex(kuzzle, 'foo', { timeout: 1000 });
+      const start = Date.now();
+
+      return mutex.lock()
+        .then(result => {
+          should(result).be.false();
+          should(Date.now() - start).approximately(1000, 200);
+          kuzzle.services.list.internalCache.set.resolves(true);
+          return mutex.lock();
+        })
+        .then(result => {
+          should(result).be.true();
+        });
+    });
+
+    it('should wait indefinitely until a lock becomes available (timeout = -1)', () => {
+      kuzzle.services.list.internalCache.set.resolves(false);
+
+      const mutex = new Mutex(kuzzle, 'foo', { timeout: -1 });
+
+      const mutexPromise = mutex.lock();
+      const start = Date.now();
+
+      return Bluebird.delay(2000)
+        .then(() => {
+          should(mutex.locked).be.false();
+          kuzzle.services.list.internalCache.set.resolves(true);
+          return mutexPromise;
+        })
+        .then(result => {
+          should(mutex.locked).be.true();
+          should(result).be.true();
+          should(Date.now() - start).approximately(2000, 200);
+        });
+    });
+  });
+
+  describe('#unlock', () => {
+    beforeEach(() => {
+      kuzzle.services.list.internalCache.set.resolves(true);
+      kuzzle.services.list.internalCache._client.delIfValueEqual = sinon.stub().resolves();
+    });
+
+    it('should unlock an acquired lock', () => {
+      const mutex = new Mutex(kuzzle, 'foo', { timeout: 0 });
+
+      return mutex.lock()
+        .then(() => {
+          should(mutex.locked).be.true();
+          return mutex.unlock();
+        })
+        .then(() => {
+          should(mutex.locked).be.false();
+          should(kuzzle.services.list.internalCache._client.delIfValueEqual)
+            .calledWith('foo', mutex.mutexId);
+        });
+    });
+
+    it('should reject if trying to unlock a non-locked ressource', () => {
+      const mutex = new Mutex(kuzzle, 'foo', { timeout: 0 });
+
+      return should(mutex.unlock()).rejectedWith(KuzzleInternalError, {
+        id: 'core.fatal.assertion_failed',
+      });
+    });
+
+    it('should register a dedicated script the 1st time a mutex is unlocked', () => {
+      // clear cached dependency
+      Mutex = mockRequire.reRequire('../../lib/util/mutex');
+
+      const mutex = new Mutex(kuzzle, 'foo', { timeout: 0 });
+      let anotherMutex;
+
+      return mutex.lock()
+        .then(() => mutex.unlock())
+        .then(() => {
+          should(kuzzle.services.list.internalCache._client.defineCommand)
+            .calledWith('delIfValueEqual', {
+              numberOfKeys: 1,
+              lua: sinon.match.string
+            });
+
+          kuzzle.services.list.internalCache._client.defineCommand.resetHistory();
+          anotherMutex = new Mutex(kuzzle, 'bar', { timeout: 0 });
+
+          return anotherMutex.lock();
+        })
+        .then(() => anotherMutex.unlock())
+        .then(() => {
+          should(kuzzle.services.list.internalCache._client.defineCommand)
+            .not.called();
+        });
+    });
+  });
+});


### PR DESCRIPTION
# Description

Backports the `Mutex` class from Kuzzle v2 and exposes it to plugins, allowing them to safely lock resources and prevents concurrent accesses in cluster environments.

