### PR TITLE
Remove since/experimental badges from guides

### DIFF
--- a/doc/2/guides/advanced/configuration/index.md
+++ b/doc/2/guides/advanced/configuration/index.md
@@ -84,7 +84,7 @@ For an exhaustive list of configuration parameters, please refer to the [kuzzler
 <CustomBadge type="error" text="Experimental: non-backward compatible changes or removal may occur in any future release."/>
 
 ::: info
-You can change the configuration only in the `setup` phase, before starting the application.
+You can change the configuration only during the `setup` phase, before starting the application.
 ::: 
 
 The configuration of Kuzzle is also accessible through the [Backend.config](/core/2/framework/classes/backend-config) property.

--- a/doc/2/guides/develop-on-kuzzle/api-controllers/index.md
+++ b/doc/2/guides/develop-on-kuzzle/api-controllers/index.md
@@ -8,9 +8,6 @@ order: 300
 
 # API Controllers
 
-<SinceBadge version="2.8.0" />
-<CustomBadge type="error" text="Experimental: non-backward compatible changes or removal may occur in any future release."/>
-
 Kuzzle allows to extend its existing API using Controllers. Controllers are **logical containers of actions**.  
 
 These actions are then **processed like any other API action** and can be executed through the different mechanisms to secure and normalize requests.

--- a/doc/2/guides/develop-on-kuzzle/customize-api-errors/index.md
+++ b/doc/2/guides/develop-on-kuzzle/customize-api-errors/index.md
@@ -8,9 +8,6 @@ order: 600
 
 # Customize API Errors
 
-<SinceBadge version="2.8.0" />
-<CustomBadge type="error" text="Experimental: non-backward compatible changes or removal may occur in any future release."/>
-
 It is possible to customize the errors that we want to return in case of failure of an API request.
 
 Kuzzle offers a set of standard errors corresponding to specific situations with customizable messages (e.g. `NotFoundError`,` ForbiddenError`, etc.)

--- a/doc/2/guides/develop-on-kuzzle/embedded-sdk/index.md
+++ b/doc/2/guides/develop-on-kuzzle/embedded-sdk/index.md
@@ -8,9 +8,6 @@ order: 200
 
 # Embedded SDK
 
-<SinceBadge version="2.8.0" />
-<CustomBadge type="error" text="Experimental: non-backward compatible changes or removal may occur in any future release."/>
-
 ::: info
 The Embedded SDK is available only during the `runtime` phase, after the application has started.
 ::: 

--- a/doc/2/guides/develop-on-kuzzle/event-system/index.md
+++ b/doc/2/guides/develop-on-kuzzle/event-system/index.md
@@ -8,9 +8,6 @@ order: 300
 
 # Event System
 
-<SinceBadge version="2.8.0" />
-<CustomBadge type="error" text="Experimental: non-backward compatible changes or removal may occur in any future release."/>
-
 Most of the **internal tasks performed by Kuzzle trigger events**.
 
 Kuzzle enables to attach business-logic to these events by defining **hooks** (which allow to perform additional actions when the event triggers) and **pipes** (which change the behavior of the standard logic when the event triggers).

--- a/doc/2/guides/develop-on-kuzzle/external-plugins/index.md
+++ b/doc/2/guides/develop-on-kuzzle/external-plugins/index.md
@@ -8,9 +8,6 @@ order: 500
 
 # External Plugins
 
-<SinceBadge version="2.8.0" />
-<CustomBadge type="error" text="Experimental: non-backward compatible changes or removal may occur in any future release."/>
-
 You can **extend Kuzzle's features** via plugins.
 
 Plugins are **intended to be reused** between several applications by proposing generic features.

--- a/doc/2/guides/getting-started/create-new-controllers/index.md
+++ b/doc/2/guides/getting-started/create-new-controllers/index.md
@@ -8,9 +8,6 @@ order: 700
 
 # Create new Controllers
 
-<SinceBadge version="2.8.0" />
-<CustomBadge type="error" text="Experimental: non-backward compatible changes or removal may occur in any future release."/>
-
 The Kuzzle API is composed of **actions grouped in controllers**.  
 A controller is a **logical container** that groups several actions together.
 

--- a/doc/2/guides/getting-started/customize-api-behavior/index.md
+++ b/doc/2/guides/getting-started/customize-api-behavior/index.md
@@ -8,9 +8,6 @@ order: 800
 
 # Customize the API Behavior
 
-<SinceBadge version="2.8.0" />
-<CustomBadge type="error" text="Experimental: non-backward compatible changes or removal may occur in any future release."/>
-
 <!-- Duplicate with guides/develop-on-kuzzle/event-system -->
 
 Kuzzle allows to modify API actions behavior with a **very precise middleware-like system**.  

--- a/doc/2/guides/getting-started/write-application/index.md
+++ b/doc/2/guides/getting-started/write-application/index.md
@@ -8,9 +8,6 @@ order: 600
 
 # Write an Application
 
-<SinceBadge version="2.8.0" />
-<CustomBadge type="error" text="Experimental: non-backward compatible changes or removal may occur in any future release."/>
-
 Kuzzle is **fully extensible** like any framework. This extensibility is available through the development of an application.
 
 Several classes and methods are available to developers so that they can develop their new business functionalities.


### PR DESCRIPTION
# Description

Remove since/experimental from guide headers, as this can lead to think that an entire feature is only available since kuzzle 2.8.0, and is experimental, when only the feature usage through the new framework is.