### PR TITLE
Configure codecov to better match our needs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,12 +1,17 @@
 coverage:
   range: "80...100"
-
   status:
     project:
       default:
-        threshold: 1
-
-    patch:
-      default:
-        branches:
-          - master
+        threshold: 1%
+    patch: off
+github_checks:
+  annotations: false
+ignore:
+  - "features"
+  - "features-legacy"
+  - "bin"
+  - "test"
+  - ".ci"
+  - "doc"
+  - "docker"


### PR DESCRIPTION
# Description

Better configure codecov to suit our needs:

* do not compare to the `master` branch anymore
* disable `patch` checks, as they rarely are interesting
* disable github annotations: this heavily clutters the github files interface, and this can make a PR hard to review
* ignore test directories (I don't think this does anything, since we don't produce coverage data on them)