### PR TITLE
Make the list of embedded plugins configurable

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -99,9 +99,13 @@
   // (see https://docs.kuzzle.io/core/2/guides/write-plugins)
   "plugins": {
     // [Common]
-    //  * bootstrapLockTimeout
+    //   * bootstrapLockTimeout
     //        Maximum amount of time (in milliseconds)
     //        to wait for a concurrent plugin bootstrap
+    //   * include
+    //        List of Kuzzle's embedded plugins to be activated.
+    //        Edit this list to deactivate one or more of those plugins.
+    //        NOTE: this list does not control plugins installed manually.
     //   * pipeWarnTime:
     //        Warning time threshold (in milliseconds)
     //        on a pipe plugin action
@@ -125,7 +129,11 @@
       "pipeWarnTime": 40,
       "initTimeout": 2000,
       "maxConcurrentPipes": 50,
-      "pipesBufferSize": 50000
+      "pipesBufferSize": 50000,
+      "include": [
+        "kuzzle-plugin-logger",
+        "kuzzle-plugin-auth-passport-local"
+      ]
     },
 
     // plugin logger configuration.

--- a/lib/config/default.config.js
+++ b/lib/config/default.config.js
@@ -73,7 +73,11 @@ module.exports = {
       pipeWarnTime: 500,
       initTimeout: 10000,
       maxConcurrentPipes: 50,
-      pipesBufferSize: 50000
+      pipesBufferSize: 50000,
+      include: [
+        'kuzzle-plugin-logger',
+        'kuzzle-plugin-auth-passport-local',
+      ]
     },
     'kuzzle-plugin-logger': {
       services: {

--- a/lib/core/application/backend.ts
+++ b/lib/core/application/backend.ts
@@ -24,8 +24,6 @@ import util from 'util';
 import fs from 'fs';
 import _ from 'lodash';
 import { Client } from '@elastic/elasticsearch';
-import PluginPassportAuthLocal from 'kuzzle-plugin-auth-passport-local';
-import PluginLogger from 'kuzzle-plugin-logger';
 
 import Kuzzle from '../../kuzzle';
 import PluginObject from '../plugin/plugin';
@@ -607,12 +605,13 @@ export class Backend {
     this._kuzzle = new Kuzzle(this.config.content);
 
     // we need to load the default plugins
-    this.plugin.use(
-      new PluginPassportAuthLocal(),
-      { deprecationWarning: false, name: 'kuzzle-plugin-auth-passport-local' });
-    this.plugin.use(
-      new PluginLogger(),
-      { deprecationWarning: false, name: 'kuzzle-plugin-logger' });
+    for (const plugin of this.config.content.plugins.common.include) {
+      const { default: PluginClass } = await import(plugin);
+      this.plugin.use(new PluginClass(), {
+        deprecationWarning: false,
+        name: plugin,
+      });
+    }
 
     const application = new PluginObject(
       this._instanceProxy,

--- a/test/core/application/Backend.test.js
+++ b/test/core/application/Backend.test.js
@@ -95,6 +95,23 @@ describe('Backend', () => {
       should(options.fixtures).be.eql(application._support.fixtures);
       should(options.securities).be.eql(application._support.securities);
     });
+
+    it('should only submit the configured embedded plugins', async () => {
+      application.config.content.plugins.common.include = ['foo'];
+
+      await should(application.start()).rejectedWith(/Cannot find module 'foo'.*/);
+
+      application.config.content.plugins.common.include = ['kuzzle-plugin-logger'];
+
+      await application.start();
+
+      should(global.kuzzle.start).be.calledOnce();
+
+      const [, options] = global.kuzzle.start.getCall(0).args;
+
+      should(options.plugins).have.keys('kuzzle-plugin-logger');
+      should(options.plugins).not.have.keys('kuzzle-plugin-auth-passport-local');
+    });
   });
 
   describe('PipeManager#register', () => {


### PR DESCRIPTION
# Description

Kuzzle has a couple embedded plugins that are automatically loaded at startup, namely the logger and the `local` authentication strategy.

There are a few use cases where those embedded plugins are not wanted. So this PR makes this list configurable via the kuzzlerc file.