### PR TITLE
Extract and export HttpRoute from ControllerDefinition

### DIFF
--- a/features/support/assertions.js
+++ b/features/support/assertions.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const _ = require('lodash');
 const should = require('should');
 

--- a/features/support/assertions.js
+++ b/features/support/assertions.js
@@ -1,8 +1,5 @@
-'use strict';
-
-const
-  _ = require('lodash'),
-  should = require('should');
+const _ = require('lodash');
+const should = require('should');
 
 should.Assertion.add(
   'matchObject',
@@ -27,10 +24,28 @@ should.Assertion.add(
       else if (expectedValue === '_UNDEFINED_') {
         should(objectValue).be.undefined();
       }
+      else if (expectedValue === '_DATE_NOW_') {
+        should(objectValue).be.approximately(Date.now(), 1000);
+      }
+      else if (expectedValue === '_DATE_NOW_SEC_') {
+        should(objectValue).be.approximately(Date.now() / 1000, 1000);
+      }
+      else if (_.isPlainObject(objectValue)) {
+        should(objectValue).matchObject(
+          expectedValue,
+          `"${keyPath}" does not match. Expected "${JSON.stringify(expectedValue)}" have "${JSON.stringify(objectValue)}"`);
+      }
+      else if (_.isArray(objectValue)) {
+        for (let i = 0; i < objectValue.length; i++) {
+          should(objectValue[i]).matchObject(
+            expectedValue[i],
+            `"${keyPath}[${i}]" does not match. Expected "${JSON.stringify(expectedValue[i])}" have "${JSON.stringify(objectValue[i])}"`);
+        }
+      }
       else {
         should(objectValue).match(
           expectedValue,
-          `${keyPath} does not match. Expected "${JSON.stringify(expectedValue)}" have "${JSON.stringify(objectValue)}"`);
+          `"${keyPath}" does not match. Expected "${JSON.stringify(expectedValue)}" have "${JSON.stringify(objectValue)}"`);
       }
     }
   },

--- a/lib/types/ControllerDefinition.ts
+++ b/lib/types/ControllerDefinition.ts
@@ -59,20 +59,24 @@ export type ControllerDefinition = {
        * Declare HTTP routes (optional).
        * Http routes will be auto-generated unless at least one is provided
        * or an empty array is provided.
-       *
        */
-      http?: Array<{
-        /**
-         * HTTP verb.
-         */
-        verb: 'get' | 'post' | 'put' | 'delete' | 'head',
-        /**
-         * Route path.
-         * A route starting with `/` will be prefixed by `/_` otherwise the route
-         * will be prefixed by `/_/<application-name>/`.
-         */
-        path: string
-      }>
+      http?: HttpRoute[]
     }
   }
-}
+};
+
+/**
+ * Http route definition
+ */
+export type HttpRoute = {
+  /**
+   * HTTP verb.
+   */
+  verb: 'get' | 'post' | 'put' | 'delete' | 'head',
+  /**
+   * Route path.
+   * A route starting with `/` will be prefixed by `/_` otherwise the route
+   * will be prefixed by `/_/<application-name>/`.
+   */
+  path: string
+};


### PR DESCRIPTION
## What does this PR do ?

Extract and export `HttpRoute` definition

```js
/**
 * Http route definition
 */
export type HttpRoute = {
  /**
   * HTTP verb.
   */
  verb: 'get' | 'post' | 'put' | 'delete' | 'head',
  /**
   * Route path.
   * A route starting with `/` will be prefixed by `/_` otherwise the route
   * will be prefixed by `/_/<application-name>/`.
   */
  path: string
};
```

### Other changes

 - update cucumber framework `should.matchObject` assertion