### PR TITLE
Hotfix: Restore API keys when the cache is wiped clean

### DIFF
--- a/lib/core/security/tokenRepository.js
+++ b/lib/core/security/tokenRepository.js
@@ -26,12 +26,17 @@ const jwt = require('jsonwebtoken');
 const ms = require('ms');
 const Bluebird = require('bluebird');
 
+const ApiKey = require('../../model/storage/apiKey');
 const { UnauthorizedError } = require('../../kerror/errors');
 const Token = require('../../model/security/token');
 const Repository = require('../shared/repository');
 const kerror = require('../../kerror');
+const debug = require('../../util/debug')('kuzzle:bootstrap:tokens');
+const { Mutex } = require('../../util/mutex');
 
 const securityError = kerror.wrap('security', 'token');
+
+const BOOTSTRAP_DONE_KEY = 'token/bootstrap';
 
 /**
  * @class TokenRepository
@@ -53,6 +58,8 @@ class TokenRepository extends Repository {
   }
 
   async init() {
+    await this._loadApiKeys();
+
     /**
      * Assign an existing token to a user. Stores the token in Kuzzle's cache.
      * @param  {String} hash - JWT
@@ -358,6 +365,51 @@ class TokenRepository extends Repository {
         await this.expire(cacheToken);
       }
     });
+  }
+
+  /**
+   * Loads authentication token from API key into Redis
+   *
+   * @returns {Promise}
+   */
+  async _loadApiKeys () {
+    const mutex = new Mutex('ApiKeysBootstrap', {
+      timeout: -1,
+      ttl: 30000,
+    });
+
+    await mutex.lock();
+
+    try {
+      const bootstrapped = await global.kuzzle.ask(
+        'core:cache:internal:get',
+        BOOTSTRAP_DONE_KEY);
+
+      if (bootstrapped) {
+        debug('API keys already in cache. Skip.');
+        return;
+      }
+
+      debug('Loading API keys into Redis');
+
+      const promises = [];
+      const createToken = async ({token, ttl, userId }) => {
+        return await this.persistForUser(token, userId, ttl);
+      };
+
+      await ApiKey.batchExecute({ match_all: {} }, apiKeys => {
+        for (const { _source } of apiKeys) {
+          promises.push(createToken(_source));
+        }
+      });
+
+      await Bluebird.all(promises);
+
+      await global.kuzzle.ask('core:cache:internal:store', BOOTSTRAP_DONE_KEY, 1);
+    }
+    finally {
+      mutex.unlock();
+    }
   }
 
   /**

--- a/lib/kuzzle/internalIndexHandler.js
+++ b/lib/kuzzle/internalIndexHandler.js
@@ -28,7 +28,6 @@ const Bluebird = require('bluebird');
 const debug = require('../util/debug')('kuzzle:bootstrap:internalIndex');
 const Store = require('../core/shared/store');
 const { Mutex } = require('../util/mutex');
-const ApiKey = require('../model/storage/apiKey');
 const scopeEnum = require('../core/storage/storeScopeEnum');
 const kerror = require('../kerror');
 
@@ -144,9 +143,6 @@ class InternalIndexHandler extends Store {
     debug('Bootstrapping JWT secret');
     await this._persistSecret();
 
-    debug('Loading API keys into Redis');
-    await this._loadApiKeys();
-
     // Create datamodel version
     await this.create('config', { version: dataModelVersion }, {
       id: this._DATAMODEL_VERSION_ID,
@@ -203,28 +199,6 @@ class InternalIndexHandler extends Store {
     await this.create('config', { seed }, {
       id: this._JWT_SECRET_ID,
     });
-  }
-
-  /**
-   * Loads authentication token from API key into Redis
-   *
-   * @returns {Promise}
-   */
-  async _loadApiKeys () {
-    const promises = [];
-    const createToken = obj => global.kuzzle.ask(
-      'core:security:token:assign',
-      obj.token,
-      obj.userId,
-      obj.ttl);
-
-    await ApiKey.batchExecute({ match_all: {} }, apiKeys => {
-      for (const { _source } of apiKeys) {
-        promises.push(createToken(_source));
-      }
-    });
-
-    return Bluebird.all(promises);
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "bin": {
     "kuzzle": "./bin/start-kuzzle-server"

--- a/test/core/security/tokenRepository.test.js
+++ b/test/core/security/tokenRepository.test.js
@@ -20,7 +20,7 @@ const User = require('../../../lib/model/security/user');
 const Repository = require('../../../lib/core/shared/repository');
 const ApiKey = require('../../../lib/model/storage/apiKey');
 
-describe.only('Test: security/tokenRepository', () => {
+describe('Test: security/tokenRepository', () => {
   let kuzzle;
   let TokenRepository;
   let tokenRepository;

--- a/test/kuzzle/internalIndexHandler.test.js
+++ b/test/kuzzle/internalIndexHandler.test.js
@@ -9,8 +9,6 @@ const { InternalError: KuzzleInternalError } = require('../../index');
 const KuzzleMock = require('../mocks/kuzzle.mock');
 const MutexMock = require('../mocks/mutex.mock');
 
-const ApiKey = require('../../lib/model/storage/apiKey');
-
 describe('#kuzzle/InternalIndexHandler', () => {
   let InternalIndexHandler;
   let internalIndexHandler;
@@ -20,13 +18,8 @@ describe('#kuzzle/InternalIndexHandler', () => {
   beforeEach(() => {
     kuzzle = new KuzzleMock();
     internalIndexHandler = new InternalIndexHandler();
-    sinon.stub(ApiKey, 'batchExecute');
 
     internalIndexName = kuzzle.config.services.storageEngine.internalIndex.name;
-  });
-
-  afterEach(() => {
-    ApiKey.batchExecute.restore();
   });
 
   describe('#init', () => {
@@ -164,14 +157,12 @@ describe('#kuzzle/InternalIndexHandler', () => {
       sinon.stub(internalIndexHandler, 'createInitialSecurities');
       sinon.stub(internalIndexHandler, 'createInitialValidations');
       sinon.stub(internalIndexHandler, '_persistSecret');
-      sinon.stub(internalIndexHandler, '_loadApiKeys');
 
       await internalIndexHandler._bootstrapSequence();
 
       should(internalIndexHandler.createInitialSecurities).called();
       should(internalIndexHandler.createInitialValidations).called();
       should(internalIndexHandler._persistSecret).called();
-      should(internalIndexHandler._loadApiKeys).called();
 
       should(kuzzle.ask).calledWith(
         'core:storage:private:document:create',
@@ -363,25 +354,6 @@ describe('#kuzzle/InternalIndexHandler', () => {
         internalIndexName,
         'config',
         internalIndexHandler._JWT_SECRET_ID);
-    });
-  });
-
-  describe('#_loadApiKeys', () => {
-    it('should load API key tokens to Redis cache', async () => {
-      ApiKey.batchExecute.callsArgWith(1, [
-        { _source: { token: 'encoded-token-1', userId: 'user-id-1', ttl: 42 } },
-        { _source: { token: 'encoded-token-2', userId: 'user-id-2', ttl: -1 } },
-      ]);
-
-      await internalIndexHandler._loadApiKeys();
-
-      should(ApiKey.batchExecute).be.calledWith({ match_all: {} });
-
-      const tokenAssignEvent = 'core:security:token:assign';
-
-      should(kuzzle.ask)
-        .be.calledWith(tokenAssignEvent, 'encoded-token-1', 'user-id-1', 42)
-        .be.calledWith(tokenAssignEvent, 'encoded-token-2', 'user-id-2', -1);
     });
   });
 });


### PR DESCRIPTION
# Description

This PR solves 2 problems.

First, API keys are stored in Elasticsearch, and synchronized in Redis. They are supposed to be loaded into Redis during the bootstrap of the internal indexes, which are run only once during the lifetime of Kuzzle: when it's started for the first time. 
If the Redis cache is wiped, or when Kuzzle is started for the first time with an ES storage restored from a snapshot, Kuzzle skips the internal index bootstrap, and API keys aren't synchronized in Redis, making them unusable.

Second, loading API keys in the internal index bootstrapper doesn't work. This wasn't visible because the bootstrap only occured when Kuzzle is started for the first time, on a blank ES storage. But the API key loader uses the Token Repository, which isn't initialized until after the internal indexes are bootstrapped.

# Solution

The API keys synchronization is now the responsibility of the Token Repository, and a different bootstrap key is used. Contrary to the one used by the internal index bootstrap, this bootstrap key is stored in Redis.
This way, if the cache is wiped, or if Kuzzle is started from a restored ES storage, the Token Repository correctly restores the API keys in the cache, and this is done only once, whatever the number of Kuzzle nodes in a cluster environment.

# Why is this a hotfix?

Because one of our clients is currently experiencing this issue, and it's a blocking one.