### PR TITLE
Allows to not send realtime notification on document controller

### DIFF
--- a/doc/2/api/controllers/document/create-or-replace/index.md
+++ b/doc/2/api/controllers/document/create-or-replace/index.md
@@ -54,7 +54,7 @@ Body:
 ### Optional:
 
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the created/replaced document is indexed
-- `silent`: if set, then Kuzzle will not generate notifications
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
 
 ---
 

--- a/doc/2/api/controllers/document/create-or-replace/index.md
+++ b/doc/2/api/controllers/document/create-or-replace/index.md
@@ -17,7 +17,7 @@ Creates a new document in the persistent data storage, or replaces its content i
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/<index>/<collection>/<documentId>[?refresh=wait_for]
+URL: http://kuzzle:7512/<index>/<collection>/<documentId>[?refresh=wait_for][&silent]
 Method: PUT
 Body:
 ```
@@ -54,6 +54,7 @@ Body:
 ### Optional:
 
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the created/replaced document is indexed
+- `silent`: if set, then Kuzzle will not generate notifications
 
 ---
 

--- a/doc/2/api/controllers/document/create/index.md
+++ b/doc/2/api/controllers/document/create/index.md
@@ -57,7 +57,7 @@ Body:
 
 - `documentId`: set the document unique ID to the provided value, instead of auto-generating a random ID
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the newly created document is indexed
-- `silent`: if set, then Kuzzle will not generate notifications
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
 
 ---
 

--- a/doc/2/api/controllers/document/create/index.md
+++ b/doc/2/api/controllers/document/create/index.md
@@ -19,8 +19,8 @@ Returns an error if the document already exists.
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/<index>/<collection>/_create[?refresh=wait_for]
-URL(2): http://kuzzle:7512/<index>/<collection>/<documentId>/_create[?refresh=wait_for]
+URL: http://kuzzle:7512/<index>/<collection>/_create[?refresh=wait_for][&silent]
+URL(2): http://kuzzle:7512/<index>/<collection>/<documentId>/_create[?refresh=wait_for][&silent]
 Method: POST
 Body:
 ```
@@ -57,6 +57,7 @@ Body:
 
 - `documentId`: set the document unique ID to the provided value, instead of auto-generating a random ID
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the newly created document is indexed
+- `silent`: if set, then Kuzzle will not generate notifications
 
 ---
 

--- a/doc/2/api/controllers/document/delete-by-query/index.md
+++ b/doc/2/api/controllers/document/delete-by-query/index.md
@@ -82,7 +82,7 @@ Body:
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the deleted documents are removed from the search indexes
 - `source`: if set to `true` Kuzzle will return each deleted document body in the response.
 - `lang`: specify the query language to use. By default, it's `elasticsearch` but `koncorde` can also be used. <SinceBadge version="2.8.0"/>
-- `silent`: if set, then Kuzzle will not generate notifications
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
 
 ---
 

--- a/doc/2/api/controllers/document/delete-by-query/index.md
+++ b/doc/2/api/controllers/document/delete-by-query/index.md
@@ -40,7 +40,7 @@ To remove all documents from a collection, use [collection:truncate](/core/2/api
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/<index>/<collection>/_query[?refresh=wait_for][&source][&lang=<query language>]
+URL: http://kuzzle:7512/<index>/<collection>/_query[?refresh=wait_for][&source][&lang=<query language>][&silent]
 Method: DELETE
 Body:
 ```
@@ -82,6 +82,7 @@ Body:
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the deleted documents are removed from the search indexes
 - `source`: if set to `true` Kuzzle will return each deleted document body in the response.
 - `lang`: specify the query language to use. By default, it's `elasticsearch` but `koncorde` can also be used. <SinceBadge version="2.8.0"/>
+- `silent`: if set, then Kuzzle will not generate notifications
 
 ---
 

--- a/doc/2/api/controllers/document/delete-fields/index.md
+++ b/doc/2/api/controllers/document/delete-fields/index.md
@@ -59,7 +59,7 @@ Body:
 
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the new document content is indexed
 - `source`: if set to `true`, the response will contain the new updated document
-- `silent`: if set, then Kuzzle will not generate notifications
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
 
 ---
 

--- a/doc/2/api/controllers/document/delete-fields/index.md
+++ b/doc/2/api/controllers/document/delete-fields/index.md
@@ -16,7 +16,7 @@ Deletes fields of an existing document.
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/<index>/<collection>/<documentId>/_fields[?refresh=wait_for]
+URL: http://kuzzle:7512/<index>/<collection>/<documentId>/_fields[?refresh=wait_for][&silent]
 Method: DELETE
 Body:
 ```
@@ -59,6 +59,8 @@ Body:
 
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the new document content is indexed
 - `source`: if set to `true`, the response will contain the new updated document
+- `silent`: if set, then Kuzzle will not generate notifications
+
 ---
 
 ## Body properties

--- a/doc/2/api/controllers/document/delete/index.md
+++ b/doc/2/api/controllers/document/delete/index.md
@@ -17,7 +17,7 @@ Deletes a document.
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/<index>/<collection>/<documentId>[?refresh=wait_for][&source]
+URL: http://kuzzle:7512/<index>/<collection>/<documentId>[?refresh=wait_for][&source][&silent]
 Method: DELETE
 ```
 
@@ -45,6 +45,8 @@ Method: DELETE
 
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the deletion has been indexed
 - `source`: if set to `true` Kuzzle will return the deleted document body in the response.
+- `silent`: if set, then Kuzzle will not generate notifications
+
 ---
 
 ## Response

--- a/doc/2/api/controllers/document/delete/index.md
+++ b/doc/2/api/controllers/document/delete/index.md
@@ -45,7 +45,7 @@ Method: DELETE
 
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the deletion has been indexed
 - `source`: if set to `true` Kuzzle will return the deleted document body in the response.
-- `silent`: if set, then Kuzzle will not generate notifications
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
 
 ---
 

--- a/doc/2/api/controllers/document/m-create-or-replace/index.md
+++ b/doc/2/api/controllers/document/m-create-or-replace/index.md
@@ -80,7 +80,7 @@ Body:
 ### Optional:
 
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the created/replaced documents are indexed
-- `silent`: if set, then Kuzzle will not generate notifications
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
 
 ---
 

--- a/doc/2/api/controllers/document/m-create-or-replace/index.md
+++ b/doc/2/api/controllers/document/m-create-or-replace/index.md
@@ -19,7 +19,7 @@ The number of documents that can be created or replaced by a single request is l
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/<index>/<collection>/_mCreateOrReplace[?refresh=wait_for]
+URL: http://kuzzle:7512/<index>/<collection>/_mCreateOrReplace[?refresh=wait_for][&silent]
 Method: PUT
 Body:
 ```
@@ -80,6 +80,7 @@ Body:
 ### Optional:
 
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the created/replaced documents are indexed
+- `silent`: if set, then Kuzzle will not generate notifications
 
 ---
 

--- a/doc/2/api/controllers/document/m-create/index.md
+++ b/doc/2/api/controllers/document/m-create/index.md
@@ -21,7 +21,7 @@ The number of documents that can be created by a single request is limited by th
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/<index>/<collection>/_mCreate[?refresh=wait_for]
+URL: http://kuzzle:7512/<index>/<collection>/_mCreate[?refresh=wait_for][&silent]
 Method: POST
 Body:
 ```
@@ -86,6 +86,7 @@ Body:
 ### Optional:
 
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the newly created documents are indexed
+- `silent`: if set, then Kuzzle will not generate notifications
 
 ---
 

--- a/doc/2/api/controllers/document/m-create/index.md
+++ b/doc/2/api/controllers/document/m-create/index.md
@@ -86,7 +86,7 @@ Body:
 ### Optional:
 
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the newly created documents are indexed
-- `silent`: if set, then Kuzzle will not generate notifications
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
 
 ---
 

--- a/doc/2/api/controllers/document/m-delete/index.md
+++ b/doc/2/api/controllers/document/m-delete/index.md
@@ -19,7 +19,7 @@ The number of documents that can be deleted by a single request is limited by th
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/<index>/<collection>/_mDelete[?refresh=wait_for]
+URL: http://kuzzle:7512/<index>/<collection>/_mDelete[?refresh=wait_for][&silent]
 Method: DELETE
 Body:
 ```
@@ -54,6 +54,7 @@ Body:
 ### Optional:
 
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the deletions are indexed
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
 
 ---
 

--- a/doc/2/api/controllers/document/m-replace/index.md
+++ b/doc/2/api/controllers/document/m-replace/index.md
@@ -76,7 +76,7 @@ Body:
 
 - `collection`: collection name
 - `index`: index name
-- `silent`: if set, then Kuzzle will not generate notifications
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
 
 ### Optional:
 

--- a/doc/2/api/controllers/document/m-replace/index.md
+++ b/doc/2/api/controllers/document/m-replace/index.md
@@ -19,7 +19,7 @@ The number of documents that can be replaced by a single request is limited by t
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/<index>/<collection>/_mReplace[?refresh=wait_for]
+URL: http://kuzzle:7512/<index>/<collection>/_mReplace[?refresh=wait_for][&silent]
 Method: PUT
 Body:
 ```
@@ -76,6 +76,7 @@ Body:
 
 - `collection`: collection name
 - `index`: index name
+- `silent`: if set, then Kuzzle will not generate notifications
 
 ### Optional:
 

--- a/doc/2/api/controllers/document/m-update/index.md
+++ b/doc/2/api/controllers/document/m-update/index.md
@@ -19,7 +19,7 @@ The number of documents that can be updated by a single request is limited by th
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/<index>/<collection>/_mUpdate[?refresh=wait_for][&retryOnConflict=<retries>]
+URL: http://kuzzle:7512/<index>/<collection>/_mUpdate[?refresh=wait_for][&retryOnConflict=<retries>][&silent]
 Method: PUT
 Body:
 ```
@@ -81,6 +81,7 @@ Body:
 
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the updates are indexed
 - `retryOnConflict`: conflicts may occur if the same document gets updated multiple times within a short timespan in a database cluster. You can set the `retryOnConflict` optional argument (with a retry count), to tell Kuzzle to retry the failing updates the specified amount of times before rejecting the request with an error.
+- `silent`: if set, then Kuzzle will not generate notifications
 
 ---
 

--- a/doc/2/api/controllers/document/m-update/index.md
+++ b/doc/2/api/controllers/document/m-update/index.md
@@ -81,7 +81,7 @@ Body:
 
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the updates are indexed
 - `retryOnConflict`: conflicts may occur if the same document gets updated multiple times within a short timespan in a database cluster. You can set the `retryOnConflict` optional argument (with a retry count), to tell Kuzzle to retry the failing updates the specified amount of times before rejecting the request with an error.
-- `silent`: if set, then Kuzzle will not generate notifications
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
 
 ---
 

--- a/doc/2/api/controllers/document/replace/index.md
+++ b/doc/2/api/controllers/document/replace/index.md
@@ -55,7 +55,7 @@ Body:
 ### Optional:
 
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the new document content is indexed
-- `silent`: if set, then Kuzzle will not generate notifications
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
 
 ---
 

--- a/doc/2/api/controllers/document/replace/index.md
+++ b/doc/2/api/controllers/document/replace/index.md
@@ -17,7 +17,7 @@ Replaces the content of an existing document.
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/<index>/<collection>/<documentId>/_replace[?refresh=wait_for]
+URL: http://kuzzle:7512/<index>/<collection>/<documentId>/_replace[?refresh=wait_for][&silent]
 Method: PUT
 Body:
 ```
@@ -55,6 +55,7 @@ Body:
 ### Optional:
 
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the new document content is indexed
+- `silent`: if set, then Kuzzle will not generate notifications
 
 ---
 

--- a/doc/2/api/controllers/document/update-by-query/index.md
+++ b/doc/2/api/controllers/document/update-by-query/index.md
@@ -81,7 +81,7 @@ Body:
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the update is indexed
 - `source`: if set to `true` Kuzzle will return the updated documents body in the response.
 - `lang`: specify the query language to use. By default, it's `elasticsearch` but `koncorde` can also be used. <SinceBadge version="2.8.0"/>
-- `silent`: if set, then Kuzzle will not generate notifications
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
 
 ## Body properties
 

--- a/doc/2/api/controllers/document/update-by-query/index.md
+++ b/doc/2/api/controllers/document/update-by-query/index.md
@@ -32,7 +32,7 @@ To update a greater number of documents, either change the server configuration,
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/<index>/<collection>/_query[?refresh=wait_for][&source][&lang=<query language>]
+URL: http://kuzzle:7512/<index>/<collection>/_query[?refresh=wait_for][&source][&lang=<query language>][&silent]
 Method: PUT
 Body:
 ```
@@ -81,6 +81,7 @@ Body:
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the update is indexed
 - `source`: if set to `true` Kuzzle will return the updated documents body in the response.
 - `lang`: specify the query language to use. By default, it's `elasticsearch` but `koncorde` can also be used. <SinceBadge version="2.8.0"/>
+- `silent`: if set, then Kuzzle will not generate notifications
 
 ## Body properties
 

--- a/doc/2/api/controllers/document/update/index.md
+++ b/doc/2/api/controllers/document/update/index.md
@@ -15,7 +15,7 @@ Applies partial changes to a document. The document must exist in the storage la
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/<index>/<collection>/<_id>/_update[?refresh=wait_for][&retryOnConflict=<int>][&source]
+URL: http://kuzzle:7512/<index>/<collection>/<_id>/_update[?refresh=wait_for][&retryOnConflict=<int>][&source][&silent]
 Method: PUT
 Body:
 ```
@@ -54,6 +54,7 @@ Body:
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the update is indexed
 - `retryOnConflict`: conflicts may occur if the same document gets updated multiple times within a short timespan, in a database cluster. You can set the `retryOnConflict` optional argument (with a retry count), to tell Kuzzle to retry the failing updates the specified amount of times before rejecting the request with an error.
 - `source`: if set to `true` Kuzzle will return the entire updated document body in the response.
+- `silent`: if set, then Kuzzle will not generate notifications
 
 ---
 

--- a/doc/2/api/controllers/document/update/index.md
+++ b/doc/2/api/controllers/document/update/index.md
@@ -54,7 +54,7 @@ Body:
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the update is indexed
 - `retryOnConflict`: conflicts may occur if the same document gets updated multiple times within a short timespan, in a database cluster. You can set the `retryOnConflict` optional argument (with a retry count), to tell Kuzzle to retry the failing updates the specified amount of times before rejecting the request with an error.
 - `source`: if set to `true` Kuzzle will return the entire updated document body in the response.
-- `silent`: if set, then Kuzzle will not generate notifications
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
 
 ---
 

--- a/doc/2/api/controllers/document/upsert/index.md
+++ b/doc/2/api/controllers/document/upsert/index.md
@@ -68,7 +68,7 @@ Body:
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the document is indexed
 - `retryOnConflict`: conflicts may occur if the same document gets updated multiple times within a short timespan, in a database cluster. You can set the `retryOnConflict` optional argument (with a retry count), to tell Kuzzle to retry the failing updates the specified amount of times before rejecting the request with an error.
 - `source`: if set to `true` Kuzzle will return the entire updated document body in the response.
-- `silent`: if set, then Kuzzle will not generate notifications
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
 
 ---
 

--- a/doc/2/api/controllers/document/upsert/index.md
+++ b/doc/2/api/controllers/document/upsert/index.md
@@ -17,7 +17,7 @@ Applies partial changes to a document. If the document doesn't already exist, a 
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/<index>/<collection>/<_id>/_upsert[?refresh=wait_for][&retryOnConflict=<int>][&source]
+URL: http://kuzzle:7512/<index>/<collection>/<_id>/_upsert[?refresh=wait_for][&retryOnConflict=<int>][&source][&silent]
 Method: PUT
 Body:
 ```
@@ -68,6 +68,7 @@ Body:
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the document is indexed
 - `retryOnConflict`: conflicts may occur if the same document gets updated multiple times within a short timespan, in a database cluster. You can set the `retryOnConflict` optional argument (with a retry count), to tell Kuzzle to retry the failing updates the specified amount of times before rejecting the request with an error.
 - `source`: if set to `true` Kuzzle will return the entire updated document body in the response.
+- `silent`: if set, then Kuzzle will not generate notifications
 
 ---
 

--- a/lib/api/controller/document.js
+++ b/lib/api/controller/document.js
@@ -208,6 +208,7 @@ class DocumentController extends NativeController {
     const id = this.getId(request, ifMissingEnum.IGNORE);
     const userId = this.getUserId(request);
     const refresh = this.getRefresh(request);
+    const silent = this.getBoolean(request, 'silent');
     const { index, collection } = this.getIndexAndCollection(request);
 
     const validated = await global.kuzzle.validation.validate(request, false);
@@ -219,11 +220,13 @@ class DocumentController extends NativeController {
       this.getBody(validated),
       { id, refresh, userId });
 
-    await this.ask(
-      'core:realtime:document:notify',
-      validated,
-      actionEnum.CREATE,
-      created);
+    if (! silent) {
+      await this.ask(
+        'core:realtime:document:notify',
+        validated,
+        actionEnum.CREATE,
+        created);
+    }
 
     return created;
   }
@@ -249,6 +252,7 @@ class DocumentController extends NativeController {
     const id = this.getId(request);
     const content = this.getBody(request);
     const userId = this.getUserId(request);
+    const silent = this.getBoolean(request, 'silent');
     const refresh = this.getString(request, 'refresh', 'false');
     const { index, collection } = this.getIndexAndCollection(request);
 
@@ -264,11 +268,13 @@ class DocumentController extends NativeController {
       content,
       { refresh, userId });
 
-    await this.ask(
-      'core:realtime:document:notify',
-      modifiedRequest,
-      actionEnum.WRITE,
-      response);
+    if (! silent) {
+      await this.ask(
+        'core:realtime:document:notify',
+        modifiedRequest,
+        actionEnum.WRITE,
+        response);
+    }
 
     return response;
   }
@@ -294,6 +300,7 @@ class DocumentController extends NativeController {
     const id = this.getId(request);
     const content = this.getBody(request);
     const userId = this.getUserId(request);
+    const silent = this.getBoolean(request, 'silent');
     const refresh = this.getString(request, 'refresh', 'false');
     const retryOnConflict = request.input.args.retryOnConflict;
     const source = this.getBoolean(request, 'source');
@@ -315,15 +322,17 @@ class DocumentController extends NativeController {
       .keys(content)
       .filter(k => k !== '_kuzzle_info');
 
-    await this.ask(
-      'core:realtime:document:notify',
-      modifiedRequest,
-      actionEnum.UPDATE,
-      {
-        _id: updatedDocument._id,
-        _source: updatedDocument._source,
-        _updatedFields,
-      });
+    if (! silent) {
+      await this.ask(
+        'core:realtime:document:notify',
+        modifiedRequest,
+        actionEnum.UPDATE,
+        {
+          _id: updatedDocument._id,
+          _source: updatedDocument._source,
+          _updatedFields,
+        });
+    }
 
     if (source) {
       return updatedDocument;
@@ -349,6 +358,7 @@ class DocumentController extends NativeController {
     const content = this.getBodyObject(request, 'changes');
     const defaultValues = this.getBodyObject(request, 'default', {});
     const userId = this.getUserId(request);
+    const silent = this.getBoolean(request, 'silent');
     const refresh = this.getString(request, 'refresh', 'false');
     const retryOnConflict = request.input.args.retryOnConflict;
     const source = this.getBoolean(request, 'source');
@@ -362,14 +372,14 @@ class DocumentController extends NativeController {
       content,
       { defaultValues, refresh, retryOnConflict, userId });
 
-    if (updatedDocument.created) {
+    if (! silent && updatedDocument.created) {
       await this.ask(
         'core:realtime:document:notify',
         request,
         actionEnum.CREATE,
         updatedDocument._source);
     }
-    else {
+    else if (! silent) {
       const _updatedFields = Object
         .keys(content)
         .filter(k => k !== '_kuzzle_info');
@@ -417,6 +427,7 @@ class DocumentController extends NativeController {
     const id = this.getId(request);
     const content = this.getBody(request);
     const userId = this.getUserId(request);
+    const silent = this.getBoolean(request, 'silent');
     const refresh = this.getString(request, 'refresh', 'false');
     const { index, collection } = this.getIndexAndCollection(request);
 
@@ -432,14 +443,16 @@ class DocumentController extends NativeController {
       content,
       { refresh, userId });
 
-    await this.ask(
-      'core:realtime:document:notify',
-      modifiedRequest,
-      actionEnum.REPLACE,
-      {
-        _id: modifiedRequest.input.resource._id,
-        _source: modifiedRequest.input.body,
-      });
+    if (! silent) {
+      await this.ask(
+        'core:realtime:document:notify',
+        modifiedRequest,
+        actionEnum.REPLACE,
+        {
+          _id: modifiedRequest.input.resource._id,
+          _source: modifiedRequest.input.body,
+        });
+    }
 
     return response;
   }
@@ -463,6 +476,7 @@ class DocumentController extends NativeController {
    */
   async delete (request) {
     const id = this.getId(request);
+    const silent = this.getBoolean(request, 'silent');
     const refresh = this.getString(request, 'refresh', 'false');
     const source = this.getBoolean(request, 'source');
     const { index, collection } = this.getIndexAndCollection(request);
@@ -477,11 +491,13 @@ class DocumentController extends NativeController {
       refresh,
     });
 
-    await this.ask(
-      'core:realtime:document:notify',
-      request,
-      actionEnum.DELETE,
-      document);
+    if (! silent) {
+      await this.ask(
+        'core:realtime:document:notify',
+        request,
+        actionEnum.DELETE,
+        document);
+    }
 
     if (!source) {
       return { _id: document._id };
@@ -499,6 +515,7 @@ class DocumentController extends NativeController {
    */
   async mDelete (request) {
     const ids = this.getBodyArray(request, 'ids');
+    const silent = this.getBoolean(request, 'silent');
     const refresh = this.getString(request, 'refresh', 'false');
     const { index, collection } = this.getIndexAndCollection(request);
 
@@ -509,11 +526,13 @@ class DocumentController extends NativeController {
       ids,
       { refresh });
 
-    await this.ask(
-      'core:realtime:document:mNotify',
-      request,
-      actionEnum.DELETE,
-      documents);
+    if (! silent) {
+      await this.ask(
+        'core:realtime:document:mNotify',
+        request,
+        actionEnum.DELETE,
+        documents);
+    }
 
     return {
       errors,
@@ -529,6 +548,7 @@ class DocumentController extends NativeController {
    */
   async deleteByQuery (request) {
     let query = this.getBodyObject(request, 'query', {});
+    const silent = this.getBoolean(request, 'silent');
     const refresh = this.getString(request, 'refresh', 'false');
     const source = this.getBoolean(request, 'source');
     const { index, collection } = this.getIndexAndCollection(request);
@@ -545,11 +565,13 @@ class DocumentController extends NativeController {
       query,
       { refresh });
 
-    await this.ask(
-      'core:realtime:document:mNotify',
-      request,
-      actionEnum.DELETE,
-      result.documents);
+    if (! silent) {
+      await this.ask(
+        'core:realtime:document:mNotify',
+        request,
+        actionEnum.DELETE,
+        result.documents);
+    }
 
     if (! source) {
       result.documents.forEach(d => (d._source = undefined));
@@ -570,6 +592,7 @@ class DocumentController extends NativeController {
     const id = this.getId(request);
     const fields = this.getBodyArray(request, 'fields');
     const userId = this.getUserId(request);
+    const silent = this.getBoolean(request, 'silent');
     const refresh = this.getString(request, 'refresh', 'false');
     const source = this.getBoolean(request, 'source');
     const { index, collection } = this.getIndexAndCollection(request);
@@ -582,15 +605,17 @@ class DocumentController extends NativeController {
       fields,
       { refresh, userId });
 
-    await this.ask(
-      'core:realtime:document:notify',
-      request,
-      actionEnum.UPDATE,
-      {
-        _id: response._id,
-        _source: response._source,
-      });
-    
+    if (! silent) {
+      await this.ask(
+        'core:realtime:document:notify',
+        request,
+        actionEnum.UPDATE,
+        {
+          _id: response._id,
+          _source: response._source,
+        });
+    }
+
     if (source) {
       return response;
     }
@@ -610,6 +635,7 @@ class DocumentController extends NativeController {
   async updateByQuery (request) {
     let query = this.getBodyObject(request, 'query');
     const changes = this.getBodyObject(request, 'changes');
+    const silent = this.getBoolean(request, 'silent');
     const refresh = this.getString(request, 'refresh', 'false');
     const source = this.getBoolean(request, 'source');
     const { index, collection } = this.getIndexAndCollection(request);
@@ -627,15 +653,17 @@ class DocumentController extends NativeController {
       changes,
       { refresh });
 
-    await this.ask(
-      'core:realtime:document:mNotify',
-      request,
-      actionEnum.UPDATE,
-      result.successes.map(doc => ({
-        _id: doc._id,
-        _source: doc._source,
-        _updatedFields: Object.keys(changes).filter(k => k !== '_kuzzle_info'),
-      })));
+    if (! silent) {
+      await this.ask(
+        'core:realtime:document:mNotify',
+        request,
+        actionEnum.UPDATE,
+        result.successes.map(doc => ({
+          _id: doc._id,
+          _source: doc._source,
+          _updatedFields: Object.keys(changes).filter(k => k !== '_kuzzle_info'),
+        })));
+    }
 
     if (!source) {
       result.successes.forEach(d => (d._source = undefined));
@@ -668,8 +696,9 @@ class DocumentController extends NativeController {
    * @returns {Promise.<Object>} { successes, errors }
    */
   async _mChanges (request, methodName, action) {
-    const refresh = this.getString(request, 'refresh', 'false');
     const userId = this.getUserId(request);
+    const silent = this.getBoolean(request, 'silent');
+    const refresh = this.getString(request, 'refresh', 'false');
     const documents = this.getBodyArray(request, 'documents');
     const { index, collection } = this.getIndexAndCollection(request);
 
@@ -701,11 +730,13 @@ class DocumentController extends NativeController {
       { refresh, userId });
 
     // @todo inject _updatedFields property for mUpdate requests
-    await this.ask(
-      'core:realtime:document:mNotify',
-      request,
-      action,
-      response.items);
+    if (! silent) {
+      await this.ask(
+        'core:realtime:document:mNotify',
+        request,
+        action,
+        response.items);
+    }
 
     return {
       errors: response.errors,

--- a/test/api/controller/document.test.js
+++ b/test/api/controller/document.test.js
@@ -53,7 +53,7 @@ describe('DocumentController', () => {
     });
 
     it('should forward to the store module', async () => {
-      request.input.body = { query: { bar: 'bar '} };
+      request.input.body = { query: { bar: 'bar ' } };
       request.input.args.from = 1;
       request.input.args.size = 3;
       request.input.args.scroll = '10s';
@@ -64,7 +64,7 @@ describe('DocumentController', () => {
         'core:storage:public:document:search',
         index,
         collection,
-        { query: { bar: 'bar '} },
+        { query: { bar: 'bar ' } },
         { from: 1, size: 3, scroll: '10s' });
 
       should(response).match({
@@ -318,6 +318,18 @@ describe('DocumentController', () => {
       });
     });
 
+    it('should not notify with "silent" argument', async () => {
+      request.input.args.silent = true;
+
+      await documentController.create(request);
+
+      should(kuzzle.ask).not.be.calledWithMatch(
+        'core:realtime:document:notify',
+        request,
+        actionEnum.CREATE,
+        { _id: '_id', _source: '_source' });
+    });
+
     it('should forward to the store module and notify', async () => {
       request.input.resource._id = 'foobar';
       request.context.user = { _id: 'aschen' };
@@ -382,6 +394,21 @@ describe('DocumentController', () => {
         items,
         errors: []
       }));
+    });
+
+    it('should not notify with "silent" argument', async () => {
+      request.input.args.silent = true;
+
+      await documentController._mChanges(
+        request,
+        'mCreate',
+        actionEnum.CREATE);
+
+      should(kuzzle.ask).not.be.calledWithMatch(
+        'core:realtime:document:notify',
+        request,
+        actionEnum.CREATE,
+        { _id: '_id', _source: '_source' });
     });
 
     it('should forward to the store module and notify the changes', async () => {
@@ -513,6 +540,18 @@ describe('DocumentController', () => {
       request.input.resource._id = 'foobar';
     });
 
+    it('should not notify with "silent" argument', async () => {
+      request.input.args.silent = true;
+
+      await documentController.createOrReplace(request);
+
+      should(kuzzle.ask).not.be.calledWithMatch(
+        'core:realtime:document:notify',
+        request,
+        actionEnum.CREATE,
+        { _id: '_id', _source: '_source' });
+    });
+
     it('should forward to the store module and notify', async () => {
       request.context.user = { _id: 'aschen' };
       request.input.args.refresh = 'wait_for';
@@ -573,6 +612,18 @@ describe('DocumentController', () => {
       });
 
       request.input.resource._id = 'foobar';
+    });
+
+    it('should not notify with "silent" argument', async () => {
+      request.input.args.silent = true;
+
+      await documentController.update(request);
+
+      should(kuzzle.ask).not.be.calledWithMatch(
+        'core:realtime:document:notify',
+        request,
+        actionEnum.CREATE,
+        { _id: '_id', _source: '_source' });
     });
 
     it('should forward to the store module and notify', async () => {
@@ -650,6 +701,18 @@ describe('DocumentController', () => {
         _source: { ...changes, name: 'gordon' },
         created: false,
       });
+    });
+
+    it('should not notify with "silent" argument', async () => {
+      request.input.args.silent = true;
+
+      await documentController.upsert(request);
+
+      should(kuzzle.ask).not.be.calledWithMatch(
+        'core:realtime:document:notify',
+        request,
+        actionEnum.CREATE,
+        { _id: '_id', _source: '_source' });
     });
 
     it('should forward to the storage module and notify on update', async () => {
@@ -779,6 +842,26 @@ describe('DocumentController', () => {
         .resolves(esResponse);
     });
 
+    it('should not notify with "silent" argument', async () => {
+      request.input.body = {
+        query: {
+          match: { foo: 'bar' }
+        },
+        changes: {
+          bar: 'foo'
+        }
+      };
+      request.input.args.silent = true;
+
+      await documentController.updateByQuery(request);
+
+      should(kuzzle.ask).not.be.calledWithMatch(
+        'core:realtime:document:notify',
+        request,
+        actionEnum.CREATE,
+        { _id: '_id', _source: '_source' });
+    });
+
     it('should forward to the store module and notify the changes', async () => {
       request.input.body = {
         query: {
@@ -798,7 +881,7 @@ describe('DocumentController', () => {
         index,
         collection,
         { match: { foo: 'bar' } },
-        { bar: 'foo'},
+        { bar: 'foo' },
         { refresh: 'wait_for' });
 
       should(kuzzle.ask).be.calledWith(
@@ -808,7 +891,7 @@ describe('DocumentController', () => {
         esResponse.successes.map(doc => ({
           _id: doc._id,
           _source: doc._source,
-          _updatedFields: [ 'bar' ],
+          _updatedFields: ['bar'],
         })));
 
       should(response).be.eql(esResponse);
@@ -843,7 +926,7 @@ describe('DocumentController', () => {
         esResponse.successes.map(doc => ({
           _id: doc._id,
           _source: { foo: 'bar', bar: 'foo' },
-          _updatedFields: [ 'bar' ],
+          _updatedFields: ['bar'],
         })));
 
       should(response).be.eql(esResponse);
@@ -935,6 +1018,18 @@ describe('DocumentController', () => {
       request.input.resource._id = 'foobar';
     });
 
+    it('should not notify with "silent" argument', async () => {
+      request.input.args.silent = true;
+
+      await documentController.replace(request);
+
+      should(kuzzle.ask).not.be.calledWithMatch(
+        'core:realtime:document:notify',
+        request,
+        actionEnum.CREATE,
+        { _id: '_id', _source: '_source' });
+    });
+
     it('should forward to the store module and notify', async () => {
       request.context.user = { _id: 'aschen' };
       request.input.args.refresh = 'wait_for';
@@ -978,13 +1073,29 @@ describe('DocumentController', () => {
   });
 
   describe('#delete', () => {
-    it('should forward to the store module and notify', async () => {
-      request.input.args.refresh = 'wait_for';
+    beforeEach(() => {
+      request.input.resource._id = 'foobar';
+
       kuzzle.ask.withArgs('core:storage:public:document:get').resolves({
         _id: 'foobar',
         _source: '_source'
       });
-      request.input.resource._id = 'foobar';
+    });
+
+    it('should not notify with "silent" argument', async () => {
+      request.input.args.silent = true;
+
+      await documentController.delete(request);
+
+      should(kuzzle.ask).not.be.calledWithMatch(
+        'core:realtime:document:notify',
+        request,
+        actionEnum.CREATE,
+        { _id: '_id', _source: '_source' });
+    });
+
+    it('should forward to the store module and notify', async () => {
+      request.input.args.refresh = 'wait_for';
 
       const response = await documentController.delete(request);
 
@@ -1005,11 +1116,6 @@ describe('DocumentController', () => {
     });
 
     it('should forward to the store module, notify and retrieve document source', async () => {
-      kuzzle.ask.withArgs('core:storage:public:document:get').resolves({
-        _id: 'foobar',
-        _source: '_source'
-      });
-      request.input.resource._id = 'foobar';
       request.input.args.source = true;
 
       const response = await documentController.delete(request);
@@ -1026,7 +1132,7 @@ describe('DocumentController', () => {
         actionEnum.DELETE,
         { _id: 'foobar', _source: '_source' });
 
-      should(response).be.eql({ _id: 'foobar', _source: '_source'});
+      should(response).be.eql({ _id: 'foobar', _source: '_source' });
     });
   });
 
@@ -1049,6 +1155,18 @@ describe('DocumentController', () => {
       request.input.resource._id = 'foobar';
     });
 
+    it('should not notify with "silent" argument', async () => {
+      request.input.args.silent = true;
+
+      await documentController.deleteFields(request);
+
+      should(kuzzle.ask).not.be.calledWithMatch(
+        'core:realtime:document:notify',
+        request,
+        actionEnum.CREATE,
+        { _id: '_id', _source: '_source' });
+    });
+
     it('should forward to the store module and notify', async () => {
       request.context.user = { _id: 'aschen' };
       request.input.args.refresh = 'wait_for';
@@ -1061,7 +1179,7 @@ describe('DocumentController', () => {
         collection,
         'foobar',
         content.fields,
-        { userId: 'aschen', refresh: 'wait_for'});
+        { userId: 'aschen', refresh: 'wait_for' });
 
       should(kuzzle.ask).be.calledWithMatch(
         'core:realtime:document:notify',
@@ -1123,6 +1241,18 @@ describe('DocumentController', () => {
       }));
     });
 
+    it('should not notify with "silent" argument', async () => {
+      request.input.args.silent = true;
+
+      await documentController.mDelete(request);
+
+      should(kuzzle.ask).not.be.calledWithMatch(
+        'core:realtime:document:notify',
+        request,
+        actionEnum.CREATE,
+        { _id: '_id', _source: '_source' });
+    });
+
     it('should forward to the store module and notify the changes', async () => {
       request.input.args.refresh = 'wait_for';
 
@@ -1179,6 +1309,18 @@ describe('DocumentController', () => {
       });
     });
 
+    it('should not notify with "silent" argument', async () => {
+      request.input.args.silent = true;
+
+      await documentController.deleteByQuery(request);
+
+      should(kuzzle.ask).not.be.calledWithMatch(
+        'core:realtime:document:notify',
+        request,
+        actionEnum.CREATE,
+        { _id: '_id', _source: '_source' });
+    });
+
     it('should forward to the store module and notify the changes', async () => {
       request.input.body = { query: { foo: 'bar' } };
       request.input.args.refresh = 'wait_for';
@@ -1205,7 +1347,8 @@ describe('DocumentController', () => {
         documents: [
           { _id: 'id1', _source: undefined },
           { _id: 'id2', _source: undefined }
-        ]});
+        ]
+      });
     });
 
     it('should forward to the store module, notify the changes and retrieve all sources', async () => {
@@ -1235,7 +1378,8 @@ describe('DocumentController', () => {
         documents: [
           { _id: 'id1', _source: '_source1' },
           { _id: 'id2', _source: '_source2' }
-        ]});
+        ]
+      });
     });
 
     it('should reject if the "lang" is not supported', () => {


### PR DESCRIPTION
## What does this PR do ?

Add a `silent` option to the document controller actions.

When set, actions will not generate realtime notifications.

This feature is needed because if you write a document in the callback of a realtime notification, then you can enter an infinite loop.
