### PR TITLE
New API action: security:searchUsersByCredentials

### DIFF
--- a/doc/2/api/controllers/security/search-users-by-credentials/index.md
+++ b/doc/2/api/controllers/security/search-users-by-credentials/index.md
@@ -16,7 +16,7 @@ If you are using a custom strategy plugin, you must first implement the optional
 :::
 
 ::: warning
-This method is not intended to be exposed to the end user because of sensitive data that represents an exhaustive list of users ids.
+This method is not intended to be exposed to the end user. A full list of users ids should be considered as sensitive data.
 :::
 
 ---

--- a/doc/2/api/controllers/security/search-users-by-credentials/index.md
+++ b/doc/2/api/controllers/security/search-users-by-credentials/index.md
@@ -6,9 +6,18 @@ title: searchUsersByCredentials
 
 # searchUsersByCredentials
 
-Searches users credentials for the specified authentification strategy.
-
 <SinceBadge version="auto-version"/>
+
+Given a credentials related search query, returns matched users' kuid.
+Since credentials depend on the authentification strategy, so do the search query.
+
+::: info
+If you are using a custom strategy plugin, you must first implement the optional search method in order to use this action.
+:::
+
+::: warning
+This method is not intended to be exposed to the end user because of sensitive data that represents an exhaustive list of users ids.
+:::
 
 ---
 
@@ -69,13 +78,18 @@ Body:
 
 ## Body properties
 
-- `query`: documents matching this search query will be deleted. Uses the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-dsl.html) syntax.
+- `query`: Uses the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-dsl.html) syntax. Properties on which the query applies depend entirely on the authentication strategy.
 
 ---
 
 ## Response
 
-Returns a search result containing users data from the authentication strategy and from the core.
+Returns a search result set, with the following properties:
+
+- `hits`: Array of matched users. Each hit has the following properties:
+  - `kuid`: Users unique identifier
+  - `...`: Other properties depend on the authentification strategy
+- `total`: Total of matched users.
 
 ```js
 {
@@ -87,22 +101,9 @@ Returns a search result containing users data from the authentication strategy a
   "result": {
     "hits": [
       {
-        "strategy": {
-          // example with the "local" authentication strategy
-          "local": {
-            "username": "test@example.com"
-          }
-        },
-        "_id": "test",
-        "_source": {
-          "profileIds": [...],
-          "_kuzzle_info": {
-            "author": null,
-            "createdAt": 1620134078450,
-            "updatedAt": null,
-            "updater": null
-          }
-        }
+        kuid: "kuid",
+        // example with the "local" authentication strategy
+        username: "test@example.com"
       }
     ],
     "total": 1

--- a/doc/2/api/controllers/security/search-users-by-credentials/index.md
+++ b/doc/2/api/controllers/security/search-users-by-credentials/index.md
@@ -1,0 +1,113 @@
+---
+code: true
+type: page
+title: searchUsersByCredentials
+---
+
+# searchUsersByCredentials
+
+Searches users credentials for the specified authentification strategy.
+
+<SinceBadge version="auto-version"/>
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/credentials/<strategy>/users/_search
+Method: POST
+Body:
+```
+
+```js
+{
+  "bool": {
+    "must": [
+      {
+        "match": {
+          // example with the "local" authentication strategy
+          "username":  "test@example.com"
+        }
+      }
+    ]
+  }
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "searchUsersByCredentials",
+  "strategy": "<strategy>",
+  "body": {
+    "bool": {
+      "must": [
+        {
+          "match": {
+            // example with the "local" authentication strategy
+            "username":  "test@example.com"
+          }
+        }
+      ]
+    }
+  },
+}
+```
+
+---
+
+## Arguments
+
+- `strategy`: authentication strategy
+
+---
+
+## Body properties
+
+- `query`: documents matching this search query will be deleted. Uses the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-dsl.html) syntax.
+
+---
+
+## Response
+
+Returns a search result containing users data from the authentication strategy and from the core.
+
+```js
+{
+  "action": "searchUsersByCredentials",
+  "controller": "security",
+  "error": null,
+  "node": "knode-smooth-hawking-65812",
+  "requestId": "52772769-2e15-45f6-b27b-a702fec09c18",
+  "result": {
+    "hits": [
+      {
+        "strategy": {
+          // example with the "local" authentication strategy
+          "local": {
+            "username": "test@example.com"
+          }
+        },
+        "_id": "test",
+        "_source": {
+          "profileIds": [...],
+          "_kuzzle_info": {
+            "author": null,
+            "createdAt": 1620134078450,
+            "updatedAt": null,
+            "updater": null
+          }
+        }
+      }
+    ],
+    "total": 1
+  },
+  "status": 200,
+  "volatile": null
+}
+```

--- a/doc/2/api/controllers/security/search-users-by-credentials/index.md
+++ b/doc/2/api/controllers/security/search-users-by-credentials/index.md
@@ -74,11 +74,24 @@ Body:
 
 - `strategy`: authentication strategy
 
+### Optional:
+
+- `from`: paginates search results by defining the offset from the first result you want to fetch. Usually used with the `size` argument
+- `size`: set the maximum number of documents returned per result page
+- `lang`: specify the query language to use. By default, it's `elasticsearch` but `koncorde` can also be used.
+
 ---
 
 ## Body properties
 
-- `query`: Uses the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-dsl.html) syntax. Properties on which the query applies depend entirely on the authentication strategy.
+Properties on which the query applies depend entirely on the authentication strategy.
+
+### Optional:
+
+- `query`: the search query itself, using the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-dsl.html) or the [Koncorde Filters DSL](/core/2/api/koncorde-filters-syntax) syntax.
+- `sort`: contains a list of fields, used to [sort search results](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/search-request-sort.html), in order of importance
+
+If the body is left empty, the result will return all available users for this strategy.
 
 ---
 

--- a/doc/2/api/controllers/security/search-users-by-credentials/index.md
+++ b/doc/2/api/controllers/security/search-users-by-credentials/index.md
@@ -9,7 +9,7 @@ title: searchUsersByCredentials
 <SinceBadge version="auto-version"/>
 
 Given a credentials related search query, returns matched users' kuid.
-Since credentials depend on the authentification strategy, so do the search query.
+Since credentials depend on the authentication strategy, so do the search query.
 
 ::: info
 If you are using a custom strategy plugin, you must first implement the optional search method in order to use this action.
@@ -101,7 +101,7 @@ Returns a search result set, with the following properties:
 
 - `hits`: Array of matched users. Each hit has the following properties:
   - `kuid`: Users unique identifier
-  - `...`: Other properties depending on the authentification strategy
+  - `...`: Other properties depending on the authentication strategy
 - `total`: Total of matched users.
 
 ```js

--- a/doc/2/api/controllers/security/search-users-by-credentials/index.md
+++ b/doc/2/api/controllers/security/search-users-by-credentials/index.md
@@ -88,7 +88,7 @@ Returns a search result set, with the following properties:
 
 - `hits`: Array of matched users. Each hit has the following properties:
   - `kuid`: Users unique identifier
-  - `...`: Other properties depend on the authentification strategy
+  - `...`: Other properties depending on the authentification strategy
 - `total`: Total of matched users.
 
 ```js

--- a/doc/2/api/controllers/security/search-users-by-credentials/index.md
+++ b/doc/2/api/controllers/security/search-users-by-credentials/index.md
@@ -80,6 +80,10 @@ Body:
 - `size`: set the maximum number of documents returned per result page
 - `lang`: specify the query language to use. By default, it's `elasticsearch` but `koncorde` can also be used.
 
+::: warning
+There is a limit to how many documents can be returned by a single search query. That limit is by default set at 10000 documents (see `limits.documentsFetchCount`), and you can't get over it even with the `from` and `size` pagination options.
+:::
+
 ---
 
 ## Body properties
@@ -92,6 +96,10 @@ Properties on which the query applies depend entirely on the authentication stra
 - `sort`: contains a list of fields, used to [sort search results](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/search-request-sort.html), in order of importance
 
 If the body is left empty, the result will return all available users for this strategy.
+
+::: warning
+Koncorde `bool` operator and `regexp` clause are not supported for search queries.
+:::
 
 ---
 

--- a/doc/2/api/errors/error-codes/plugin/index.md
+++ b/doc/2/api/errors/error-codes/plugin/index.md
@@ -74,6 +74,7 @@ description: Error codes definitions
 | plugin.strategy.unauthorized_removal<br/><pre>0x04030012</pre>  | [PluginImplementationError](/core/2/api/errors/error-codes#pluginimplementationerror) <pre>(500)</pre> | Cannot remove strategy %s: owned by another plugin. | Tried to remove a strategy owned by another plugin |
 | plugin.strategy.strategy_not_found<br/><pre>0x04030013</pre>  | [NotFoundError](/core/2/api/errors/error-codes#notfounderror) <pre>(404)</pre> | Cannot remove strategy %s: strategy does not exist. | Attempted to remove a non-existent authentication strategy |
 | plugin.strategy.missing_user<br/><pre>0x04030014</pre>  | [UnauthorizedError](/core/2/api/errors/error-codes#unauthorizederror) <pre>(401)</pre> | %s | A strategy plugin approved credentials without providing a user object to Kuzzle |
+| plugin.strategy.missing_optional_method<br/><pre>0x04030015</pre>  | [NotFoundError](/core/2/api/errors/error-codes#notfounderror) <pre>(404)</pre> | %s method is optional. The %s strategy did not implement it yet. | An optional method has not been implemented for this strategy |
 
 ---
 

--- a/doc/2/api/errors/error-codes/plugin/index.md
+++ b/doc/2/api/errors/error-codes/plugin/index.md
@@ -74,7 +74,7 @@ description: Error codes definitions
 | plugin.strategy.unauthorized_removal<br/><pre>0x04030012</pre>  | [PluginImplementationError](/core/2/api/errors/error-codes#pluginimplementationerror) <pre>(500)</pre> | Cannot remove strategy %s: owned by another plugin. | Tried to remove a strategy owned by another plugin |
 | plugin.strategy.strategy_not_found<br/><pre>0x04030013</pre>  | [NotFoundError](/core/2/api/errors/error-codes#notfounderror) <pre>(404)</pre> | Cannot remove strategy %s: strategy does not exist. | Attempted to remove a non-existent authentication strategy |
 | plugin.strategy.missing_user<br/><pre>0x04030014</pre>  | [UnauthorizedError](/core/2/api/errors/error-codes#unauthorizederror) <pre>(401)</pre> | %s | A strategy plugin approved credentials without providing a user object to Kuzzle |
-| plugin.strategy.missing_optional_method<br/><pre>0x04030015</pre>  | [NotFoundError](/core/2/api/errors/error-codes#notfounderror) <pre>(404)</pre> | %s method is optional. The %s strategy did not implement it yet. | An optional method has not been implemented for this strategy |
+| plugin.strategy.missing_optional_method<br/><pre>0x04030015</pre>  | [PluginImplementationError](/core/2/api/errors/error-codes#pluginimplementationerror) <pre>(500)</pre> | "%s" method is optional. The %s strategy plugin has not yet implemented it. | An optional method has not been implemented for this strategy |
 
 ---
 

--- a/doc/2/framework/classes/plugin-storage/bootstrap/index.md
+++ b/doc/2/framework/classes/plugin-storage/bootstrap/index.md
@@ -9,7 +9,7 @@ description: PluginStorage class bootstrap() method
 
 Initializes the plugin private storage.
 
-Can be called ad much as needed as long as identical mappings are provided.
+Can be called as much as needed as long as identical mappings are provided.
 
 
 ## Arguments

--- a/doc/2/framework/classes/plugin-strategy/add/index.md
+++ b/doc/2/framework/classes/plugin-strategy/add/index.md
@@ -52,6 +52,7 @@ const strategy = {
     create: 'create',
     delete: 'delete',
     exists: 'exists',
+    search: 'search',
     update: 'update',
     validate: 'validate',
     verify: 'verify'

--- a/doc/2/guides/write-plugins/integrate-authentication-strategy/index.md
+++ b/doc/2/guides/write-plugins/integrate-authentication-strategy/index.md
@@ -403,14 +403,15 @@ Beware of which properties are searchable. It would be unsafe to let the passwor
 ### Arguments
 
 ```js
-search(query);
+search(searchBody, options);
 ```
 
 <br/>
 
-| Arguments | Type                                                                                                  | Description                           |
-| --------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------- |
-| `query`   | [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/query-dsl.html) | A query concerning the authentification strategy credentials |
+| Arguments    | Type                                                                                                  | Description                                                  |
+| ------------ | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `searchBody` | [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/query-dsl.html) | A query concerning the authentification strategy credentials |
+| `options`    | `{ from?: number, size?: number }`                                                                    | Search options useful for paginations                        |
 
 ### Returned value
 

--- a/doc/2/guides/write-plugins/integrate-authentication-strategy/index.md
+++ b/doc/2/guides/write-plugins/integrate-authentication-strategy/index.md
@@ -79,6 +79,7 @@ this.strategies = {
       exists: 'exists',
       getById: 'getById',
       getInfo: 'getInfo',
+      search: 'search',
       update: 'update',
       validate: 'validate',
       verify: 'verify'
@@ -109,17 +110,18 @@ The `config` part of the `strategies` object can contain the following propertie
 
 The `methods` part of the `strategies` object can contain the following properties:
 
-| Arguments       | Type              | Description                                                                                                                        |
-| --------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `create`        | <pre>string</pre> | The name of the exposed [create](#create) function                                   |
-| `delete`        | <pre>string</pre> | The name of the exposed [delete](#delete) function                                   |
-| `exists`        | <pre>string</pre> | The name of the exposed [exists](#exists) function                                   |
-| `update`        | <pre>string</pre> | The name of the exposed [update](#update) function                                   |
-| `validate`      | <pre>string</pre> | The name of the exposed [validate](#update) function                                 |
-| `verify`        | <pre>string</pre> | The name of the exposed [verify](#verify) function                                   |
+| Arguments       | Type              | Description                                                              |
+| --------------- | ----------------- | ------------------------------------------------------------------------ |
+| `create`        | <pre>string</pre> | The name of the exposed [create](#create) function                       |
+| `delete`        | <pre>string</pre> | The name of the exposed [delete](#delete) function                       |
+| `exists`        | <pre>string</pre> | The name of the exposed [exists](#exists) function                       |
+| `update`        | <pre>string</pre> | The name of the exposed [update](#update) function                       |
+| `validate`      | <pre>string</pre> | The name of the exposed [validate](#update) function                     |
+| `verify`        | <pre>string</pre> | The name of the exposed [verify](#verify) function                       |
 | `afterRegister` | <pre>string</pre> | (optional) The name of the exposed [afterRegister](#optional-afterregister) function |
-| `getById`       | <pre>string</pre> | (optional) The name of the exposed [getById](#optional-getbyid) function             |
-| `getInfo`       | <pre>string</pre> | (optional) The name of the exposed [getInfo](#optional-getinfo) function             |
+| `getById`       | <pre>string</pre> | (optional) The name of the exposed [getById](#optional-getbyid) function |
+| `getInfo`       | <pre>string</pre> | (optional) The name of the exposed [getInfo](#optional-getinfo) function |
+| `search`        | <pre>string</pre> | (optional) The name of the exposed [search](#optional-search) function   |
 
 Even though each strategy must declare its own set of properties, the same strategy method can be used by multiple strategies.
 
@@ -385,6 +387,43 @@ getInfo(request, kuid, strategy);
 ### Returned value
 
 The `getInfo` function must return a promise, resolving to an object containing credentials information. It can be left empty.
+
+---
+
+## (optional) search
+
+Given a credentials related search query, returns matched users' kuid.
+
+If this function is not implemented, a `missing_optional_method` error occurs.
+
+### Arguments
+
+```js
+search(query);
+```
+
+<br/>
+
+| Arguments | Type                                                                                                  | Description                           |
+| --------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| `query`   | [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/query-dsl.html) | A query concerning the authentification strategy credentials |
+
+:::warning
+Beware of which properties are searchable. It would be unsafe to let the password be a search criteria, isn't it?
+:::
+
+### Returned value
+
+The `search` function must return a promise, resolving to an search result with the following properties:
+
+- `hits`: Array of matched users. Each hit has the following properties:
+  - `kuid`: Users unique identifier
+  - `...`: __Non sensitive__ credentials specific to this authentification strategy
+- `total`: Total of matched users.
+
+:::warning
+The object resolved by the promise is directly forwarded to the originating user. For security reasons, it must only contain *non sensitive* information.
+:::
 
 ---
 

--- a/doc/2/guides/write-plugins/integrate-authentication-strategy/index.md
+++ b/doc/2/guides/write-plugins/integrate-authentication-strategy/index.md
@@ -410,7 +410,7 @@ search(searchBody, options);
 
 | Arguments    | Type                                                                                                  | Description                                                  |
 | ------------ | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| `searchBody` | [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/query-dsl.html) | A query concerning the authentification strategy credentials |
+| `searchBody` | [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/query-dsl.html) | A query concerning the authentication strategy credentials |
 | `options`    | `{ from?: number, size?: number }`                                                                    | Search options useful for paginations                        |
 
 ### Returned value
@@ -419,7 +419,7 @@ The `search` function must return a promise, resolving to an search result with 
 
 - `hits`: Array of matched users. Each hit has the following properties:
   - `kuid`: Users unique identifier
-  - `...`: __Non sensitive__ credentials specific to this authentification strategy
+  - `...`: __Non sensitive__ credentials specific to this authentication strategy
 - `total`: Total of matched users.
 
 :::warning

--- a/doc/2/guides/write-plugins/integrate-authentication-strategy/index.md
+++ b/doc/2/guides/write-plugins/integrate-authentication-strategy/index.md
@@ -396,6 +396,10 @@ Given a credentials related search query, returns matched users' kuid.
 
 If this function is not implemented, a `missing_optional_method` error occurs.
 
+:::warning
+Beware of which properties are searchable. It would be unsafe to let the password be a search criteria, isn't it?
+:::
+
 ### Arguments
 
 ```js
@@ -407,10 +411,6 @@ search(query);
 | Arguments | Type                                                                                                  | Description                           |
 | --------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------- |
 | `query`   | [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/query-dsl.html) | A query concerning the authentification strategy credentials |
-
-:::warning
-Beware of which properties are searchable. It would be unsafe to let the password be a search criteria, isn't it?
-:::
 
 ### Returned value
 

--- a/lib/api/controllers/baseController.js
+++ b/lib/api/controllers/baseController.js
@@ -151,8 +151,8 @@ class NativeController extends BaseController {
   /**
    * Throws if page size exceeed Kuzzle limits
    *
-   * @param {String} index
-   * @param {String} collection
+   * @param {Number} asked
+   * @throws
    */
   assertNotExceedMaxFetch (asked) {
     const limit = global.kuzzle.config.limits.documentsFetchCount;

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -688,13 +688,30 @@ class SecurityController extends NativeController {
    * @returns {Promise<Object>}
    */
   async searchUsersByCredentials(request) {
-    const strategy = this.getString(request, 'strategy');
+    const strategy = request.getString('strategy');
 
     this.assertIsStrategyRegistered(strategy);
 
     const searchMethod = this.getStrategyMethod(strategy, 'search');
 
-    return searchMethod(request, this.getBody(request));
+    const searchResult = await searchMethod(request);
+
+    // Strategy method 'search' must return 'kuid' property in order to get user data
+    let promises = [];
+    for (const hit of searchResult.hits) {
+      promises.push(this.ask('core:security:user:get', hit.kuid));
+    }
+
+    const usersResult = await Promise.all(promises);
+
+    searchResult.hits = searchResult.hits.map((credentials, index) => {
+      delete credentials.kuid;
+      return Object.assign(
+        { strategy: { [strategy]: credentials } },
+        formatProcessing.serializeUser(usersResult[index]));
+    });
+
+    return searchResult;
   }
 
   /**

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -698,7 +698,7 @@ class SecurityController extends NativeController {
       throw kerror.get('plugin', 'strategy', 'missing_optional_method', 'search', strategy);
     }
 
-    return searchMethod(query);
+    return searchMethod({ query });
   }
 
   /**

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -84,6 +84,7 @@ class SecurityController extends NativeController {
       'searchProfiles',
       'searchRoles',
       'searchUsers',
+      'searchUsersByCredentials',
       'updateCredentials',
       'updateProfile',
       'updateProfileMapping',
@@ -677,6 +678,23 @@ class SecurityController extends NativeController {
       scrollId: response.scrollId,
       total: response.total,
     };
+  }
+
+  /**
+   * Returns the User objects matching the given query
+   *
+   * @param {Request} request
+   * @param {Request} request
+   * @returns {Promise<Object>}
+   */
+  async searchUsersByCredentials(request) {
+    const strategy = this.getString(request, 'strategy');
+
+    this.assertIsStrategyRegistered(strategy);
+
+    const searchMethod = this.getStrategyMethod(strategy, 'search');
+
+    return searchMethod(request, this.getBody(request));
   }
 
   /**

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -688,7 +688,8 @@ class SecurityController extends NativeController {
    */
   async searchUsersByCredentials (request) {
     const strategy = request.getString('strategy');
-    const query = request.getBodyObject('query');
+    const lang = request.getLangParam();
+    const { from, size, searchBody } = request.getSearchParams();
 
     this.assertIsStrategyRegistered(strategy);
 
@@ -698,7 +699,13 @@ class SecurityController extends NativeController {
       throw kerror.get('plugin', 'strategy', 'missing_optional_method', 'search', strategy);
     }
 
-    return searchMethod({ query });
+    if (lang === 'koncorde') {
+      searchBody.query = await this.translateKoncorde(searchBody.query || {});
+    }
+
+    this.assertNotExceedMaxFetch(size - from);
+
+    return searchMethod(searchBody, { from, size });
   }
 
   /**

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -681,9 +681,9 @@ class SecurityController extends NativeController {
   }
 
   /**
-   * Returns the User objects matching the given query
+   * Given a search query, return matched users.
+   * Each result contains user data from the authentication strategy plugin and from the core.
    *
-   * @param {Request} request
    * @param {Request} request
    * @returns {Promise<Object>}
    */

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -681,37 +681,32 @@ class SecurityController extends NativeController {
   }
 
   /**
-   * Given a search query, return matched users.
-   * Each result contains user data from the authentication strategy plugin and from the core.
+   * Given a search query, return matched users kuid.
    *
    * @param {Request} request
    * @returns {Promise<Object>}
    */
   async searchUsersByCredentials(request) {
     const strategy = request.getString('strategy');
+    const query = request.getString('query');
 
     this.assertIsStrategyRegistered(strategy);
 
     const searchMethod = this.getStrategyMethod(strategy, 'search');
 
-    const searchResult = await searchMethod(request);
-
-    // Strategy method 'search' must return 'kuid' property in order to get user data
-    const promises = [];
-    for (const hit of searchResult.hits) {
-      promises.push(this.ask('core:security:user:get', hit.kuid));
+    if ( !searchMethod ) {
+      throw kerror.get('security', 'credentials', 'missing_optional_method', 'search', strategy);
     }
 
-    const usersResult = await Promise.all(promises);
+    const sanitizedQuery =
+      global.app.storage.storageClient()._sanitizeSearchBody(query);
 
-    searchResult.hits = searchResult.hits.map((credentials, index) => {
-      delete credentials.kuid;
-      return Object.assign(
-        { strategy: { [strategy]: credentials } },
-        formatProcessing.serializeUser(usersResult[index]));
-    });
+    const searchResult = await searchMethod(sanitizedQuery);
 
-    return searchResult;
+    return {
+      hits: searchResult.hits.map((hit) => ({ kuid: hit.kuid })),
+      total: searchResult.total
+    };
   }
 
   /**

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -694,7 +694,7 @@ class SecurityController extends NativeController {
 
     const searchMethod = this.getStrategyMethod(strategy, 'search');
 
-    if ( !searchMethod ) {
+    if (! searchMethod) {
       throw kerror.get('plugin', 'strategy', 'missing_optional_method', 'search', strategy);
     }
 

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -686,7 +686,7 @@ class SecurityController extends NativeController {
    * @param {Request} request
    * @returns {Promise<Object>}
    */
-  async searchUsersByCredentials(request) {
+  async searchUsersByCredentials (request) {
     const strategy = request.getString('strategy');
     const query = request.getBodyObject('query');
 

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -681,32 +681,24 @@ class SecurityController extends NativeController {
   }
 
   /**
-   * Given a search query, return matched users kuid.
+   * Given a credentials related search query, returns matched users' kuid.
    *
    * @param {Request} request
    * @returns {Promise<Object>}
    */
   async searchUsersByCredentials(request) {
     const strategy = request.getString('strategy');
-    const query = request.getString('query');
+    const query = request.getBodyObject('query');
 
     this.assertIsStrategyRegistered(strategy);
 
     const searchMethod = this.getStrategyMethod(strategy, 'search');
 
     if ( !searchMethod ) {
-      throw kerror.get('security', 'credentials', 'missing_optional_method', 'search', strategy);
+      throw kerror.get('plugin', 'strategy', 'missing_optional_method', 'search', strategy);
     }
 
-    const sanitizedQuery =
-      global.app.storage.storageClient()._sanitizeSearchBody(query);
-
-    const searchResult = await searchMethod(sanitizedQuery);
-
-    return {
-      hits: searchResult.hits.map((hit) => ({ kuid: hit.kuid })),
-      total: searchResult.total
-    };
+    return searchMethod(query);
   }
 
   /**

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -697,7 +697,7 @@ class SecurityController extends NativeController {
     const searchResult = await searchMethod(request);
 
     // Strategy method 'search' must return 'kuid' property in order to get user data
-    let promises = [];
+    const promises = [];
     for (const hit of searchResult.hits) {
       promises.push(this.ask('core:security:user:get', hit.kuid));
     }

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -212,6 +212,7 @@ const routes = [
   { verb: 'post', path: '/profiles/_search', controller: 'security', action: 'searchProfiles' },
   { verb: 'post', path: '/roles/_search', controller: 'security', action: 'searchRoles' },
   { verb: 'post', path: '/users/_search', controller: 'security', action: 'searchUsers' },
+  { verb: 'post', path: '/credentials/:strategy/users/_search', controller: 'security', action: 'searchUsersByCredentials' },
   { verb: 'post', path: '/credentials/:strategy/:_id/_validate', controller: 'security', action: 'validateCredentials' },
   { verb: 'post', path: '/_checkRights', controller: 'auth', action: 'checkRights' },
   { verb: 'post', path: '/_checkRights/:userId', controller: 'security', action: 'checkRights' },

--- a/lib/kerror/codes/4-plugin.json
+++ b/lib/kerror/codes/4-plugin.json
@@ -266,6 +266,12 @@
           "code": 20,
           "message": "%s",
           "class": "UnauthorizedError"
+        },
+        "missing_optional_method": {
+          "description": "An optional method has not been implemented for this strategy",
+          "code": 21,
+          "message": "%s method is optional. The %s strategy did not implement it yet.",
+          "class": "NotFoundError"
         }
       }
     },

--- a/lib/kerror/codes/4-plugin.json
+++ b/lib/kerror/codes/4-plugin.json
@@ -270,8 +270,8 @@
         "missing_optional_method": {
           "description": "An optional method has not been implemented for this strategy",
           "code": 21,
-          "message": "%s method is optional. The %s strategy did not implement it yet.",
-          "class": "NotFoundError"
+          "message": "\"%s\" method is optional. The %s strategy plugin has not yet implemented it.",
+          "class": "PluginImplementationError"
         }
       }
     },

--- a/lib/types/StrategyDefinition.ts
+++ b/lib/types/StrategyDefinition.ts
@@ -50,6 +50,7 @@ export type StrategyDefinition = {
       exists: string,
       getById?: string,
       getInfo?: string,
+      search?: string,
       update: string,
       validate: string,
       verify: string,


### PR DESCRIPTION
## What does this PR do ?

Thanks to this feature, Kuzzle users will be able to retreive users kuid by credentials. Credentials depend on the chosen authentification strategy, its the username in local strategy for example.

Data that can be searched into as much as information that is retreive are __critical__ :warning:, so this action must be implemented and used with caution.

#### Detailed changes
- New `security:searchUsersByCredentials` action which relies on `search` method implementation in strategy plugins
- Documentation for `security:searchUsersByCredentials` and generic `search`
- `search` method can now be optionally implemented for strategy plugins (avoid breaking changes)
- New `missing_optional_method` error for strategy plugins
- Unit tests for `security:searchUsersByCredentials`

### Other changes
`search` method has been implemented in our local authentication strategy plugin in this [PR](https://github.com/kuzzleio/kuzzle-plugin-auth-passport-local/pull/76)

### Example

**POST** `http://localhost:7512/credentials/local/users/_search`

#### Request
```json
{
  "query": {
    "bool": {
      "must": [
        {
          "match": {
            "username":  "test@test.com" // example with the local authentication strategy
          }
        }
      ]
    }
  }
}
```

#### Response
```json
{
  "action": "searchUsersByCredentials",
  "controller": "security",
  "error": null,
  "node": "knode-smooth-hawking-65812",
  "requestId": "52772769-2e15-45f6-b27b-a702fec09c18",
  "result": {
    "hits": [
      {
        "kuid": "kuid",
        "username": "test@test.com" // example with the local authentication strategy
      }
    ],
    "total": 1
  },
  "status": 200,
  "volatile": null
}
```

### How should this be manually tested?

1. Clone + Run
2. [Live Test Here](https://hoppscotch.io/?method=POST&url=http://localhost:7512&path=/credentials/local/users/_search&contentType=application/json&rawParams=%7B%0A%20%20%20%20%0A%20%20%22bool%22:%20%7B%0A%20%20%20%20%22must%22:%20%5B%0A%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%22match%22:%20%7B%0A%20%20%20%20%20%20%20%20%20%20%22username%22:%20%20%22test@test.com%22%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%5D%0A%20%20%7D%0A%7D)

Closes #1676 