### PR TITLE
Allow to generate human readable kuid for users

### DIFF
--- a/doc/2/api/controllers/security/create-first-admin/index.md
+++ b/doc/2/api/controllers/security/create-first-admin/index.md
@@ -56,7 +56,8 @@ Body:
   },
   // optional
   "reset": <boolean>,
-  "_id": "<kuid>"
+  "_id": "<kuid>",
+  "kuid": "human"
 }
 ```
 
@@ -68,7 +69,7 @@ Body:
 
 - `_id`: specify the administror [kuid](/core/2/guides/main-concepts/authentication#kuzzle-user-identifier-kuid), instead of letting Kuzzle generate a random identifier.
 - `reset` (boolean): if true, restricted rights are applied to the `anonymous` and `default` roles (by default, these roles don't have any restriction).
-
+- `kuid`: if set to `human`, Kuzzle will generate a human readable id, otherwise if set to `uuid` Kuzzle will generate a standard uuid (default: `"human"`)
 ---
 
 ## Body properties

--- a/doc/2/api/controllers/security/create-restricted-user/index.md
+++ b/doc/2/api/controllers/security/create-restricted-user/index.md
@@ -63,7 +63,8 @@ Body:
 
   // optional arguments
   "_id": "<kuid>",
-  "refresh": "wait_for"
+  "refresh": "wait_for",
+  "kuid": "human"
 }
 ```
 
@@ -75,6 +76,7 @@ Body:
 
 - `_id`: user [kuid](/core/2/guides/main-concepts/authentication#kuzzle-user-identifier-kuid). An error is returned if the provided identifier already exists. If not provided, a random kuid is automatically generated.
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the newly created user is indexed (default: `"wait_for"`)
+- `kuid`: if set to `human`, Kuzzle will generate a human readable id, otherwise if set to `uuid` Kuzzle will generate a standard uuid (default: `"human"`)
 
 ---
 

--- a/doc/2/api/controllers/security/create-user/index.md
+++ b/doc/2/api/controllers/security/create-user/index.md
@@ -69,7 +69,8 @@ Body:
 
   // optional arguments
   "_id": "<kuid>",
-  "refresh": "wait_for"
+  "refresh": "wait_for",
+  "kuid": "human"
 }
 ```
 
@@ -81,7 +82,7 @@ Body:
 
 - `_id`: user [kuid](/core/2/guides/main-concepts/authentication#kuzzle-user-identifier-kuid). An error is returned if the provided identifier already exists. If not provided, a random kuid is automatically generated.
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the newly created user is indexed (default: `"wait_for"`)
-
+- `kuid`: if set to `human`, Kuzzle will generate a human readable id, otherwise if set to `uuid` Kuzzle will generate a standard uuid (default: `"human"`)
 ---
 
 ## Body properties

--- a/lib/api/controller/base.js
+++ b/lib/api/controller/base.js
@@ -631,12 +631,12 @@ class NativeController extends BaseController {
    * @throws
    * @returns {String}
    */
-  getId (request, ifMissing = ifMissingEnum.ERROR) {
+  getId (request, ifMissing = ifMissingEnum.ERROR, generator = uuidv4) {
     const id = request.input.resource._id;
 
     if (! id) {
       if (ifMissing === ifMissingEnum.GENERATE) {
-        return uuidv4();
+        return generator();
       }
 
       if (ifMissing === ifMissingEnum.IGNORE) {

--- a/lib/api/controller/security.js
+++ b/lib/api/controller/security.js
@@ -31,6 +31,9 @@ const formatProcessing = require('../../core/auth/formatProcessing');
 const ApiKey = require('../../model/storage/apiKey');
 const kerror = require('../../kerror');
 const { has, get } = require('../../util/safeObject');
+const nameGenerator = require('../../util/name-generator');
+const { v4: uuidv4 } = require('uuid');
+const { until } = require('async');
 
 /**
  * @class SecurityController
@@ -1160,31 +1163,51 @@ class SecurityController extends NativeController {
    * @private
    */
   async _persistUser(request, profileIds, content) {
-    const id = this.getId(request, ifMissingEnum.GENERATE);
+    const humanReadable = this.getBodyString(request, 'kuid', 'human') !== 'uuid';
+    const generator = humanReadable ? nameGenerator : uuidv4;
     const credentials = this.getBodyObject(request, 'credentials', {});
     const strategies = Object.keys(credentials);
-
+    
+    let id = null;
+    let generated = null;
+    let alreadExists = false
     // Early checks before the user is created
-    if (id) {
-      for (const strategy of strategies) {
-        if (!global.kuzzle.pluginsManager.listStrategies().includes(strategy)) {
-          throw kerror.get(
-            'security',
-            'credentials',
-            'unknown_strategy',
-            strategy);
+    do {
+      id = this.getId(
+        request,
+        ifMissingEnum.GENERATE,
+        () => {
+          generated = true;
+          return `kuid-${generator()}`
         }
+      );
 
-        const exists = this.getStrategyMethod(strategy, 'exists');
-        if (await exists(request, id, strategy)) {
-          throw kerror.get(
-            'security',
-            'credentials',
-            'database_inconsistency',
-            id);
+      if (id) {
+        for (const strategy of strategies) {
+          if (!global.kuzzle.pluginsManager.listStrategies().includes(strategy)) {
+            throw kerror.get(
+              'security',
+              'credentials',
+              'unknown_strategy',
+              strategy);
+          }
+
+          const exists = this.getStrategyMethod(strategy, 'exists');
+          alreadExists = await exists(request, id, strategy)
+          if (alreadExists) {
+            if (generated) {
+              break; // exit for loop, to regenerate an id
+            }
+
+            throw kerror.get(
+              'security',
+              'credentials',
+              'database_inconsistency',
+              id);
+          }
         }
       }
-    }
+    } while (alreadExists)
 
     const user = await this.ask(
       'core:security:user:create',

--- a/lib/api/controller/security.js
+++ b/lib/api/controller/security.js
@@ -1168,16 +1168,16 @@ class SecurityController extends NativeController {
     const strategies = Object.keys(credentials);
     
     let id = null;
-    let generated = null;
-    let alreadExists = false
+    let alreadExists = false;
     // Early checks before the user is created
     do {
+      let generated = false;
       id = this.getId(
         request,
         ifMissingEnum.GENERATE,
         () => {
           generated = true;
-          return `kuid-${generator()}`
+          return `kuid-${generator()}`;
         }
       );
 
@@ -1192,7 +1192,7 @@ class SecurityController extends NativeController {
           }
 
           const exists = this.getStrategyMethod(strategy, 'exists');
-          alreadExists = await exists(request, id, strategy)
+          alreadExists = await exists(request, id, strategy);
           if (alreadExists) {
             if (generated) {
               break; // exit for loop, to regenerate an id
@@ -1206,7 +1206,7 @@ class SecurityController extends NativeController {
           }
         }
       }
-    } while (alreadExists)
+    } while (alreadExists);
 
     const user = await this.ask(
       'core:security:user:create',

--- a/lib/api/controller/security.js
+++ b/lib/api/controller/security.js
@@ -705,7 +705,7 @@ class SecurityController extends NativeController {
   async createUser(request) {
     const content = this.getBodyObject(request, 'content');
     const profileIds = get(content, 'profileIds');
-    const humanReadable = this.getBodyString(request, 'kuid', 'human') !== 'uuid';
+    const humanReadableId = this.getBodyString(request, 'kuid', 'human') !== 'uuid';
 
     if (profileIds === undefined) {
       throw kerror.get('api', 'assert', 'missing_argument', 'body.content.profileIds');
@@ -715,7 +715,7 @@ class SecurityController extends NativeController {
       throw kerror.get('api', 'assert', 'invalid_type', 'body.content.profileIds', 'array');
     }
 
-    return this._persistUser(request, profileIds, content, humanReadable);
+    return this._persistUser(request, profileIds, content, humanReadableId);
   }
 
   /**
@@ -726,7 +726,7 @@ class SecurityController extends NativeController {
    */
   async createRestrictedUser(request) {
     const content = this.getBodyObject(request, 'content', {});
-    const humanReadable = this.getBodyString(request, 'kuid', 'human') !== 'uuid';
+    const humanReadableId = this.getBodyString(request, 'kuid', 'human') !== 'uuid';
 
     if (has(content, 'profileIds')) {
       throw kerror.get('api', 'assert', 'forbidden_argument', 'body.content.profileIds');
@@ -736,7 +736,7 @@ class SecurityController extends NativeController {
       request,
       global.kuzzle.config.security.restrictedProfileIds,
       content,
-      humanReadable);
+      humanReadableId);
   }
 
   /**
@@ -854,13 +854,13 @@ class SecurityController extends NativeController {
     const userId = this.getUserId(request);
     const content = this.getBodyObject(request, 'content', {});
     const reset = this.getBoolean(request, 'reset');
-    const humanReadable = this.getBodyString(request, 'kuid', 'human') !== 'uuid';
+    const humanReadableId = this.getBodyString(request, 'kuid', 'human') !== 'uuid';
 
     if (has(content, 'profileIds')) {
       throw kerror.get('api', 'assert', 'forbidden_argument', 'body.content.profileIds');
     }
 
-    const user = await this._persistUser(request, [ 'admin' ], content, humanReadable);
+    const user = await this._persistUser(request, [ 'admin' ], content, humanReadableId);
 
     if (reset) {
       for (const type of ['role', 'profile']) {
@@ -1165,8 +1165,8 @@ class SecurityController extends NativeController {
    * @returns {Promise}
    * @private
    */
-  async _persistUser(request, profileIds, content, humanReadable=true) {
-    const generator = humanReadable ? nameGenerator : uuidv4;
+  async _persistUser(request, profileIds, content, humanReadableId=true) {
+    const generator = humanReadableId ? nameGenerator : uuidv4;
     const credentials = this.getBodyObject(request, 'credentials', {});
     const strategies = Object.keys(credentials);
     

--- a/lib/api/controller/security.js
+++ b/lib/api/controller/security.js
@@ -33,7 +33,6 @@ const kerror = require('../../kerror');
 const { has, get } = require('../../util/safeObject');
 const nameGenerator = require('../../util/name-generator');
 const { v4: uuidv4 } = require('uuid');
-const { until } = require('async');
 
 /**
  * @class SecurityController

--- a/lib/api/controller/security.js
+++ b/lib/api/controller/security.js
@@ -715,7 +715,7 @@ class SecurityController extends NativeController {
       throw kerror.get('api', 'assert', 'invalid_type', 'body.content.profileIds', 'array');
     }
 
-    return this._persistUser(request, profileIds, content, humanReadableId);
+    return this._persistUser(request, profileIds, content, { humanReadableId });
   }
 
   /**
@@ -736,7 +736,7 @@ class SecurityController extends NativeController {
       request,
       global.kuzzle.config.security.restrictedProfileIds,
       content,
-      humanReadableId);
+      { humanReadableId });
   }
 
   /**
@@ -860,7 +860,7 @@ class SecurityController extends NativeController {
       throw kerror.get('api', 'assert', 'forbidden_argument', 'body.content.profileIds');
     }
 
-    const user = await this._persistUser(request, [ 'admin' ], content, humanReadableId);
+    const user = await this._persistUser(request, [ 'admin' ], content, { humanReadableId });
 
     if (reset) {
       for (const type of ['role', 'profile']) {
@@ -1165,12 +1165,12 @@ class SecurityController extends NativeController {
    * @returns {Promise}
    * @private
    */
-  async _persistUser(request, profileIds, content, humanReadableId=true) {
+  async _persistUser(request, profileIds, content, { humanReadableId=true } = {}) {
     const generator = humanReadableId ? nameGenerator : uuidv4;
     const credentials = this.getBodyObject(request, 'credentials', {});
     const strategies = Object.keys(credentials);
     
-    let id = null;
+    let id = '';
     let alreadyExists = false;
     // Early checks before the user is created
     do {

--- a/lib/api/controller/security.js
+++ b/lib/api/controller/security.js
@@ -705,7 +705,7 @@ class SecurityController extends NativeController {
   async createUser(request) {
     const content = this.getBodyObject(request, 'content');
     const profileIds = get(content, 'profileIds');
-    const humanReadableId = this.getBodyString(request, 'kuid', 'human') !== 'uuid';
+    const humanReadableId = this.getString(request, 'kuid', 'human') !== 'uuid';
 
     if (profileIds === undefined) {
       throw kerror.get('api', 'assert', 'missing_argument', 'body.content.profileIds');
@@ -726,7 +726,7 @@ class SecurityController extends NativeController {
    */
   async createRestrictedUser(request) {
     const content = this.getBodyObject(request, 'content', {});
-    const humanReadableId = this.getBodyString(request, 'kuid', 'human') !== 'uuid';
+    const humanReadableId = this.getString(request, 'kuid', 'human') !== 'uuid';
 
     if (has(content, 'profileIds')) {
       throw kerror.get('api', 'assert', 'forbidden_argument', 'body.content.profileIds');
@@ -854,7 +854,7 @@ class SecurityController extends NativeController {
     const userId = this.getUserId(request);
     const content = this.getBodyObject(request, 'content', {});
     const reset = this.getBoolean(request, 'reset');
-    const humanReadableId = this.getBodyString(request, 'kuid', 'human') !== 'uuid';
+    const humanReadableId = this.getString(request, 'kuid', 'human') !== 'uuid';
 
     if (has(content, 'profileIds')) {
       throw kerror.get('api', 'assert', 'forbidden_argument', 'body.content.profileIds');
@@ -1171,7 +1171,7 @@ class SecurityController extends NativeController {
     const strategies = Object.keys(credentials);
     
     let id = null;
-    let alreadExists = false;
+    let alreadyExists = false;
     // Early checks before the user is created
     do {
       let generated = false;
@@ -1195,8 +1195,8 @@ class SecurityController extends NativeController {
           }
 
           const exists = this.getStrategyMethod(strategy, 'exists');
-          alreadExists = await exists(request, id, strategy);
-          if (alreadExists) {
+          alreadyExists = await exists(request, id, strategy);
+          if (alreadyExists) {
             if (generated) {
               break; // exit for loop, to regenerate an id
             }
@@ -1209,7 +1209,7 @@ class SecurityController extends NativeController {
           }
         }
       }
-    } while (alreadExists);
+    } while (alreadyExists);
 
     const user = await this.ask(
       'core:security:user:create',

--- a/lib/api/controller/security.js
+++ b/lib/api/controller/security.js
@@ -705,6 +705,7 @@ class SecurityController extends NativeController {
   async createUser(request) {
     const content = this.getBodyObject(request, 'content');
     const profileIds = get(content, 'profileIds');
+    const humanReadable = this.getBodyString(request, 'kuid', 'human') !== 'uuid';
 
     if (profileIds === undefined) {
       throw kerror.get('api', 'assert', 'missing_argument', 'body.content.profileIds');
@@ -714,7 +715,7 @@ class SecurityController extends NativeController {
       throw kerror.get('api', 'assert', 'invalid_type', 'body.content.profileIds', 'array');
     }
 
-    return this._persistUser(request, profileIds, content);
+    return this._persistUser(request, profileIds, content, humanReadable);
   }
 
   /**
@@ -725,6 +726,7 @@ class SecurityController extends NativeController {
    */
   async createRestrictedUser(request) {
     const content = this.getBodyObject(request, 'content', {});
+    const humanReadable = this.getBodyString(request, 'kuid', 'human') !== 'uuid';
 
     if (has(content, 'profileIds')) {
       throw kerror.get('api', 'assert', 'forbidden_argument', 'body.content.profileIds');
@@ -733,7 +735,8 @@ class SecurityController extends NativeController {
     return this._persistUser(
       request,
       global.kuzzle.config.security.restrictedProfileIds,
-      content);
+      content,
+      humanReadable);
   }
 
   /**
@@ -851,12 +854,13 @@ class SecurityController extends NativeController {
     const userId = this.getUserId(request);
     const content = this.getBodyObject(request, 'content', {});
     const reset = this.getBoolean(request, 'reset');
+    const humanReadable = this.getBodyString(request, 'kuid', 'human') !== 'uuid';
 
     if (has(content, 'profileIds')) {
       throw kerror.get('api', 'assert', 'forbidden_argument', 'body.content.profileIds');
     }
 
-    const user = await this._persistUser(request, [ 'admin' ], content);
+    const user = await this._persistUser(request, [ 'admin' ], content, humanReadable);
 
     if (reset) {
       for (const type of ['role', 'profile']) {
@@ -1161,8 +1165,7 @@ class SecurityController extends NativeController {
    * @returns {Promise}
    * @private
    */
-  async _persistUser(request, profileIds, content) {
-    const humanReadable = this.getBodyString(request, 'kuid', 'human') !== 'uuid';
+  async _persistUser(request, profileIds, content, humanReadable=true) {
     const generator = humanReadable ? nameGenerator : uuidv4;
     const credentials = this.getBodyObject(request, 'credentials', {});
     const strategies = Object.keys(credentials);

--- a/lib/api/controller/security.js
+++ b/lib/api/controller/security.js
@@ -1183,32 +1183,31 @@ class SecurityController extends NativeController {
           return `kuid-${generator()}`;
         }
       );
+      
+      for (const strategy of strategies) {
+        if (!global.kuzzle.pluginsManager.listStrategies().includes(strategy)) {
+          throw kerror.get(
+            'security',
+            'credentials',
+            'unknown_strategy',
+            strategy);
+        }
 
-      if (id) {
-        for (const strategy of strategies) {
-          if (!global.kuzzle.pluginsManager.listStrategies().includes(strategy)) {
-            throw kerror.get(
-              'security',
-              'credentials',
-              'unknown_strategy',
-              strategy);
+        const exists = this.getStrategyMethod(strategy, 'exists');
+        alreadyExists = await exists(request, id, strategy);
+        if (alreadyExists) {
+          if (generated) {
+            break; // exit for loop, to regenerate an id
           }
 
-          const exists = this.getStrategyMethod(strategy, 'exists');
-          alreadyExists = await exists(request, id, strategy);
-          if (alreadyExists) {
-            if (generated) {
-              break; // exit for loop, to regenerate an id
-            }
-
-            throw kerror.get(
-              'security',
-              'credentials',
-              'database_inconsistency',
-              id);
-          }
+          throw kerror.get(
+            'security',
+            'credentials',
+            'database_inconsistency',
+            id);
         }
       }
+      
     } while (alreadyExists);
 
     const user = await this.ask(


### PR DESCRIPTION
This PR changes the way kuids are generated when creating a new user:
-  Now we are generating human readable kuid by default
- It is possible to choose between human readable kuid or standard uuid thanks to the request optional parameter `kuid` that can be either set to `human` or `uuid`