### PR TITLE
Allow "inner_hits" key in ES search body whitelist

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -468,7 +468,7 @@
     //       Maximum amount of time (in milliseconds)
     //       to wait for a concurrent database bootstrap
     "internalIndex": {
-      "bootstrapLockTimeout": 5000
+      "bootstrapLockTimeout": 60000
     },
 
     // [internalCache]

--- a/doc/2/guides/main-concepts/querying/index.md
+++ b/doc/2/guides/main-concepts/querying/index.md
@@ -21,6 +21,7 @@ Elasticsearch supports many keywords in a search query root level. For security 
   - `explain`
   - `from`
   - `highlight`
+  - `inner_hits`
   - `query`
   - `search_after`
   - `search_timeout`

--- a/lib/config/default.config.js
+++ b/lib/config/default.config.js
@@ -250,7 +250,7 @@ module.exports = {
       }
     },
     internalIndex: {
-      bootstrapLockTimeout: 5000
+      bootstrapLockTimeout: 60000
     },
     storageEngine: {
       aliases: ['storageEngine'],

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -110,6 +110,7 @@ class ElasticSearch extends Service {
       'explain',
       'from',
       'highlight',
+      'inner_hits',
       'query',
       'search_after',
       'search_timeout',


### PR DESCRIPTION
Closes #1956

## What does this PR do ?
Adding compatibility with inner_hits [see here](https://discord.com/channels/306054601436561410/694124702053957720/806623592246804531)

