### PR TITLE
[HOTFIX] Propagate metadata for document:updateByQuery

### DIFF
--- a/doc/2/api/controllers/document/create-or-replace/index.md
+++ b/doc/2/api/controllers/document/create-or-replace/index.md
@@ -54,7 +54,7 @@ Body:
 ### Optional:
 
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the created/replaced document is indexed
-- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="2.9.2" />
 
 ---
 

--- a/doc/2/api/controllers/document/create/index.md
+++ b/doc/2/api/controllers/document/create/index.md
@@ -57,7 +57,7 @@ Body:
 
 - `documentId`: set the document unique ID to the provided value, instead of auto-generating a random ID
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the newly created document is indexed
-- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="2.9.2" />
 
 ---
 

--- a/doc/2/api/controllers/document/delete-by-query/index.md
+++ b/doc/2/api/controllers/document/delete-by-query/index.md
@@ -82,7 +82,7 @@ Body:
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the deleted documents are removed from the search indexes
 - `source`: if set to `true` Kuzzle will return each deleted document body in the response.
 - `lang`: specify the query language to use. By default, it's `elasticsearch` but `koncorde` can also be used. <SinceBadge version="2.8.0"/>
-- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="2.9.2" />
 
 ---
 

--- a/doc/2/api/controllers/document/delete-fields/index.md
+++ b/doc/2/api/controllers/document/delete-fields/index.md
@@ -59,7 +59,7 @@ Body:
 
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the new document content is indexed
 - `source`: if set to `true`, the response will contain the new updated document
-- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="2.9.2" />
 
 ---
 

--- a/doc/2/api/controllers/document/delete/index.md
+++ b/doc/2/api/controllers/document/delete/index.md
@@ -45,7 +45,7 @@ Method: DELETE
 
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the deletion has been indexed
 - `source`: if set to `true` Kuzzle will return the deleted document body in the response.
-- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="2.9.2" />
 
 ---
 

--- a/doc/2/api/controllers/document/m-create-or-replace/index.md
+++ b/doc/2/api/controllers/document/m-create-or-replace/index.md
@@ -80,7 +80,7 @@ Body:
 ### Optional:
 
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the created/replaced documents are indexed
-- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="2.9.2" />
 
 ---
 

--- a/doc/2/api/controllers/document/m-create/index.md
+++ b/doc/2/api/controllers/document/m-create/index.md
@@ -86,7 +86,7 @@ Body:
 ### Optional:
 
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the newly created documents are indexed
-- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="2.9.2" />
 
 ---
 

--- a/doc/2/api/controllers/document/m-delete/index.md
+++ b/doc/2/api/controllers/document/m-delete/index.md
@@ -54,7 +54,7 @@ Body:
 ### Optional:
 
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the deletions are indexed
-- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="2.9.2" />
 
 ---
 

--- a/doc/2/api/controllers/document/m-replace/index.md
+++ b/doc/2/api/controllers/document/m-replace/index.md
@@ -76,7 +76,7 @@ Body:
 
 - `collection`: collection name
 - `index`: index name
-- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="2.9.2" />
 
 ### Optional:
 

--- a/doc/2/api/controllers/document/m-update/index.md
+++ b/doc/2/api/controllers/document/m-update/index.md
@@ -81,7 +81,7 @@ Body:
 
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the updates are indexed
 - `retryOnConflict`: conflicts may occur if the same document gets updated multiple times within a short timespan in a database cluster. You can set the `retryOnConflict` optional argument (with a retry count), to tell Kuzzle to retry the failing updates the specified amount of times before rejecting the request with an error.
-- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="2.9.2" />
 
 ---
 

--- a/doc/2/api/controllers/document/replace/index.md
+++ b/doc/2/api/controllers/document/replace/index.md
@@ -55,7 +55,7 @@ Body:
 ### Optional:
 
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the new document content is indexed
-- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="2.9.2" />
 
 ---
 

--- a/doc/2/api/controllers/document/update-by-query/index.md
+++ b/doc/2/api/controllers/document/update-by-query/index.md
@@ -81,7 +81,7 @@ Body:
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the update is indexed
 - `source`: if set to `true` Kuzzle will return the updated documents body in the response.
 - `lang`: specify the query language to use. By default, it's `elasticsearch` but `koncorde` can also be used. <SinceBadge version="2.8.0"/>
-- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="2.9.2" />
 
 ## Body properties
 

--- a/doc/2/api/controllers/document/update/index.md
+++ b/doc/2/api/controllers/document/update/index.md
@@ -54,7 +54,7 @@ Body:
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the update is indexed
 - `retryOnConflict`: conflicts may occur if the same document gets updated multiple times within a short timespan, in a database cluster. You can set the `retryOnConflict` optional argument (with a retry count), to tell Kuzzle to retry the failing updates the specified amount of times before rejecting the request with an error.
 - `source`: if set to `true` Kuzzle will return the entire updated document body in the response.
-- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="2.9.2" />
 
 ---
 

--- a/doc/2/api/controllers/document/upsert/index.md
+++ b/doc/2/api/controllers/document/upsert/index.md
@@ -68,7 +68,7 @@ Body:
 - `refresh`: if set to `wait_for`, Kuzzle will not respond until the document is indexed
 - `retryOnConflict`: conflicts may occur if the same document gets updated multiple times within a short timespan, in a database cluster. You can set the `retryOnConflict` optional argument (with a retry count), to tell Kuzzle to retry the failing updates the specified amount of times before rejecting the request with an error.
 - `source`: if set to `true` Kuzzle will return the entire updated document body in the response.
-- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="change-me" />
+- `silent`: if set, then Kuzzle will not generate notifications <SinceBadge version="2.9.2" />
 
 ---
 

--- a/lib/api/controller/document.js
+++ b/lib/api/controller/document.js
@@ -636,6 +636,7 @@ class DocumentController extends NativeController {
     let query = this.getBodyObject(request, 'query');
     const changes = this.getBodyObject(request, 'changes');
     const silent = this.getBoolean(request, 'silent');
+    const userId = this.getUserId(request);
     const refresh = this.getString(request, 'refresh', 'false');
     const source = this.getBoolean(request, 'source');
     const { index, collection } = this.getIndexAndCollection(request);
@@ -651,7 +652,7 @@ class DocumentController extends NativeController {
       collection,
       query,
       changes,
-      { refresh });
+      { refresh, userId });
 
     if (! silent) {
       await this.ask(

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -900,7 +900,7 @@ class ElasticSearch extends Service {
     collection,
     query,
     changes,
-    { refresh, size = 1000 } = {})
+    { refresh, size = 1000, userId=null } = {})
   {
 
     try {
@@ -926,7 +926,7 @@ class ElasticSearch extends Service {
         index,
         collection,
         documents,
-        { refresh });
+        { refresh, userId });
 
       return {
         errors,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "bin": {
     "kuzzle": "./bin/start-kuzzle-server"

--- a/test/api/controller/document.test.js
+++ b/test/api/controller/document.test.js
@@ -918,7 +918,7 @@ describe('DocumentController', () => {
         collection,
         { match: { foo: 'bar' } },
         { bar: 'foo' },
-        { refresh: 'wait_for' });
+        { refresh: 'wait_for', userId: null });
 
       should(kuzzle.ask).calledWith(
         'core:realtime:document:mNotify',

--- a/test/api/controller/document.test.js
+++ b/test/api/controller/document.test.js
@@ -873,6 +873,7 @@ describe('DocumentController', () => {
       };
       request.input.args.refresh = 'wait_for';
       request.input.args.source = true;
+      request.context.user = { _id: 'aschen' };
 
       const response = await documentController.updateByQuery(request);
 
@@ -882,7 +883,7 @@ describe('DocumentController', () => {
         collection,
         { match: { foo: 'bar' } },
         { bar: 'foo' },
-        { refresh: 'wait_for' });
+        { refresh: 'wait_for', userId: 'aschen' });
 
       should(kuzzle.ask).be.calledWith(
         'core:realtime:document:mNotify',

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -1283,39 +1283,37 @@ describe('Test: ElasticSearch service', () => {
         });
     });
 
-    it('should allow additional options', () => {
-      const promise = elasticsearch.updateByQuery(
+    it('should allow additional options', async () => {
+      const result = await elasticsearch.updateByQuery(
         index,
         collection,
         { filter: 'term' },
         { name: 'bar'},
-        { refresh: 'wait_for', size: 3 });
+        { refresh: 'wait_for', size: 3, userId: 'aschen' });
 
-      return promise
-        .then(result => {
-          should(elasticsearch._getAllDocumentsFromQuery).be.calledWithMatch({
-            index: esIndexName,
-            body: { query: { filter: 'term'} },
-            scroll: '5s',
-            size: 3
-          });
+      should(elasticsearch._getAllDocumentsFromQuery).be.calledWithMatch({
+        index: esIndexName,
+        body: { query: { filter: 'term'} },
+        scroll: '5s',
+        size: 3
+      });
 
-          should(elasticsearch.mUpdate).be.calledWithMatch(
-            index,
-            collection,
-            documents,
-            {
-              refresh: 'wait_for'
-            });
-
-          should(result).match({
-            successes: [
-              { _id: '_id1', _source: { name: 'bar' }, status: 200 },
-              { _id: '_id2', _source: { name: 'bar' }, status: 200 },
-            ],
-            errors: []
-          });
+      should(elasticsearch.mUpdate).be.calledWithMatch(
+        index,
+        collection,
+        documents,
+        {
+          refresh: 'wait_for',
+          userId: 'aschen',
         });
+
+      should(result).match({
+        successes: [
+          { _id: '_id1', _source: { name: 'bar' }, status: 200 },
+          { _id: '_id2', _source: { name: 'bar' }, status: 200 },
+        ],
+        errors: []
+      });
     });
 
     it('should reject if the number of impacted documents exceeds the configured limit', () => {


### PR DESCRIPTION
## What does this PR do ?

Metadata were not propagated correctly when execute `document:updateByQuery`.

This PR fix this.

### Boyscout

  - fix doc `change-me` tag