### PR TITLE
Upgrade script: URL validation didn't accept non-FQDN addresses

### DIFF
--- a/bin/.upgrades/versions/v1/checkConfiguration.js
+++ b/bin/.upgrades/versions/v1/checkConfiguration.js
@@ -25,24 +25,22 @@ const _ = require('lodash');
 
 module.exports = async function check (context) {
   let action = false;
-  const
-    warn = msg => context.log.warn(`[CONFIG. FILES] ${msg}`),
-    renamed = {
-      'services.db': 'services.storageEngine',
-      'services.internalEngine': 'services.internalIndex',
-      'services.storageEngine.commonMapping._kuzzle_info': 'services.storageEngine.commonMapping.properties._kuzzle_info',
-      'services.storageEngine.dynamic': 'services.storageEngine.commonMapping.dynamic'
-    },
-    deprecated = [
-      'realtime',
-      'server.entryPoints',
-      'server.protocols.socketio',
-      'server.proxy',
-      'services.garbageCollector',
-      'services.storageEngine.client.apiVersion',
-      'services.storageEngine.commonMapping.properties._kuzzle_info.deletedAt',
-      'services.storageEngine.commonMapping.properties._kuzzle_info.active'
-    ];
+  const warn = msg => context.log.warn(`[CONFIG. FILES] ${msg}`);
+  const renamed = {
+    'services.db': 'services.storageEngine',
+    'services.internalEngine': 'services.internalIndex',
+    'services.storageEngine.commonMapping._kuzzle_info': 'services.storageEngine.commonMapping.properties._kuzzle_info',
+    'services.storageEngine.dynamic': 'services.storageEngine.commonMapping.dynamic'
+  };
+  const deprecated = [
+    'server.entryPoints',
+    'server.protocols.socketio',
+    'server.proxy',
+    'services.garbageCollector',
+    'services.storageEngine.client.apiVersion',
+    'services.storageEngine.commonMapping.properties._kuzzle_info.deletedAt',
+    'services.storageEngine.commonMapping.properties._kuzzle_info.active'
+  ];
 
 
   for (const [oldName, newName] of Object.entries(renamed)) {

--- a/bin/.upgrades/versions/v1/index.js
+++ b/bin/.upgrades/versions/v1/index.js
@@ -21,10 +21,9 @@
 
 'use strict';
 
-const
-  checkConfiguration = require('./checkConfiguration'),
-  upgradeStorage = require('./upgradeStorage'),
-  upgradeCache = require('./upgradeCache');
+const checkConfiguration = require('./checkConfiguration');
+const upgradeStorage = require('./upgradeStorage');
+const upgradeCache = require('./upgradeCache');
 
 module.exports = async function upgrade (context) {
   context.log.notice('\n\n=== CONFIGURATION FILES ===');

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -23,33 +23,32 @@
 
 'use strict';
 
-const
-  yargs = require('yargs'),
-  Context = require('./.upgrades/lib/context');
+const yargs = require('yargs');
+const Context = require('./.upgrades/lib/context');
 
 const
   args = yargs
     .usage('USAGE: $0 [OPTIONS]')
     .options({
       C: {
-        type: 'boolean',
-        group: 'Optional',
         default: false,
-        describe: 'Disable colored messages in the terminal'
-      },
-      output: {
-        type: 'string',
-        alias: 'o',
+        describe: 'Disable colored messages in the terminal',
         group: 'Optional',
-        default: `upgrade-${Date.now()}.report`,
-        describe: 'Upgrade logs file name',
+        type: 'boolean',
       },
       R: {
-        type: 'boolean',
-        group: 'Optional',
         default: false,
         describe: 'Disable upgrades report in a log file',
-      }
+        group: 'Optional',
+        type: 'boolean',
+      },
+      output: {
+        alias: 'o',
+        default: `upgrade-${Date.now()}.report`,
+        describe: 'Upgrade logs file name',
+        group: 'Optional',
+        type: 'string',
+      },
     })
     .strict(true)
     .parse();
@@ -61,7 +60,8 @@ process.on('unhandledRejection', reason => {
   if (reason !== undefined) {
     context.log.error(reason.message);
     context.log.error(reason.stack);
-  } else {
+  }
+  else {
     context.log.error('FATAL: unexpected unhandled promise rejection');
   }
 


### PR DESCRIPTION
## What does this PR do ?

Fixes #1978 
Fixes #1979

When configuring Elasticsearch connections for the data migration, URLs that aren't fully qualified aren't accepted.

On the other hand, URLs without a protocol or port are accepted by the script, but not by the ES client.

This PR fixes this by harmonizing URL validation with what is expected by the ES client. Now, URLs entered by users must have a protocol set (http or https), a port (since ES isn't exposed through the port 80), and URLs that aren't fully-qualified are accepted (e.g. `http://localhost:9200`)

Also, the error message has been updated to act as an helper, providing an example of a valid URL.

### How should this be manually tested?

Run the upgrade script. When asked about a source Elasticsearch URL, try the following:

| URL | Result (before) | Result (after) |
| --- | --- | --- |
| `localhost:9200` | refused | refused |
| `http://localhost:9200` | refused | accepted |
| `10.0.0.1:9200` | accepted by the script, refused by the ES client | refused |
| `10.0.0.1` | accepted by the script, refused by the ES client | refused |
| `http://10.0.0.1` | accepted by the script, cannot connect to ES | refused |
| `http://10.0.0.1:9200` | accepted | accepted |

### Other changes

The `realtime` configuration entry was marked as deprecated, and so to be removed, by the upgrade script.
Though it's true that this option is deprecated (it's used to be able to use the PCRE engine with Koncorde instead of RE2, which is NOT RECOMMENDED for security reasons), it's still accepted by Kuzzle v2, and thus can be used.

This entry has been removed from the `deprecated` list, since this makes the upgrade script complain with our own default configuration file, which sounds like a bug to me.

### Boyscout

Converted a few scripts to our latest coding standards.
