### PR TITLE
docs: fix invalid links and type formats

### DIFF
--- a/doc/2/api/controllers/auth/refresh-token/index.md
+++ b/doc/2/api/controllers/auth/refresh-token/index.md
@@ -52,7 +52,7 @@ Method: POST
 The result contains the following properties:
 
 * `_id`: user's [kuid](/core/2/guides/main-concepts/authentication#kuzzle-user-identifier-kuid) 
-* `jwt`: encrypted JSON Web Token, that must then be sent in the [requests headers](core/1/api/essentials/query-syntax#http) or in the [query](core/1/api/essentials/query-syntax#other-protocols)
+* `jwt`: encrypted authentication token, [that must then be sent in the requests](/core/2/guides/main-concepts/authentication#authentication-token)
 * `expiresAt`: new token expiration date, in Epoch-millis (UTC)
 * `ttl`: new token time to live, in milliseconds
 

--- a/doc/2/framework/events/api/index.md
+++ b/doc/2/framework/events/api/index.md
@@ -20,7 +20,7 @@ All API actions, without exception, trigger two of these three events:
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | `KuzzleRequest` | The normalized API [request](/core/2/framework/classes/kuzzle-request |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/properties>KuzzleRequest</a></pre> | The normalized API request |
 
 A `before` event is triggered before an API request starts.
 
@@ -37,7 +37,7 @@ The `before` event name is built using the following template:
 
 | API action                                                                                   | After event name                 |
 | -------------------------------------------------------------------------------------------- | -------------------------------- |
-| [auth:login](/core/2/api/controllers/auth/login)                               | `auth:beforeLogin`               |
+| [auth:login](/core/2/api/controllers/auth/login)                               | auth:beforeLogin`               |
 | [document:createOrReplace](/core/2/api/controllers/document/create-or-replace) | `document:beforeCreateOrReplace` |
 
 ---
@@ -46,7 +46,7 @@ The `before` event name is built using the following template:
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | `KuzzleRequest` | The normalized API [request](/core/2/framework/classes/kuzzle-request |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/properties>KuzzleRequest</a></pre> | The normalized API request |
 
 An `after` event is triggered after an API request succeeds.
 
@@ -72,7 +72,7 @@ The `after` event name is built using the following template:
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | `KuzzleRequest` | The normalized API [request](/core/2/framework/classes/kuzzle-request |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/properties>KuzzleRequest</a></pre> | The normalized API request |
 
 An `error` event is triggered after an API request fails.
 

--- a/doc/2/framework/events/core/index.md
+++ b/doc/2/framework/events/core/index.md
@@ -84,7 +84,7 @@ Pipes cannot listen to that event, only hooks can.
 
 | Arguments | Type              | Description                    |
 | --------- | ----------------- | ------------------------------ |
-| `fill`    | <pre>number</pre> | KuzzleRequest buffer fill percentage |
+| `fill`    | <pre>number</pre> | Request buffer fill percentage |
 
 Triggered when the requests buffer fills up more quickly than requests can be processed.
 

--- a/doc/2/framework/events/generic-document/index.md
+++ b/doc/2/framework/events/generic-document/index.md
@@ -36,8 +36,8 @@ All generic events share the same payload signature, and pipes plugged to them m
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| documents | `Array` | Array of documents (containing document `_id`) |
-| request | `KuzzleRequest` | [KuzzleRequest](/core/2/framework/classes/kuzzle-request) |
+| `documents` | <pre>Array</pre> | Array of documents (containing document `_id`) |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/properties>KuzzleRequest</a></pre> | The underlying API request |
 
 Triggered after documents have been deleted.
 
@@ -80,8 +80,8 @@ class PipePlugin {
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| documents | `Array` | Array of documents (containing documents `_id` and `_source`) |
-| request | `KuzzleRequest` | [KuzzleRequest](/core/2/framework/classes/kuzzle-request) |
+| `documents` | <pre>Array</pre> | Array of documents (containing documents `_id` and `_source`) |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/properties>KuzzleRequest</a></pre> | The underlying API request |
 
 Triggered after documents are fetched.
 
@@ -124,8 +124,8 @@ class PipePlugin {
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| documents | `Array` | Array of documents (containing a document `_id` and `_source` fields) |
-| request | `KuzzleRequest` | [KuzzleRequest](/core/2/framework/classes/kuzzle-request) |
+| `documents` | <pre>Array</pre> | Array of documents (containing a document `_id` and `_source` fields) |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/properties>KuzzleRequest</a></pre> | The underlying API request |
 
 Triggered after partial updates are applied to documents.
 
@@ -169,8 +169,8 @@ class PipePlugin {
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| documents | `Array` | Array of documents (containing a document `_id` and `_source` fields) |
-| request | `KuzzleRequest` | [KuzzleRequest](/core/2/framework/classes/kuzzle-request) |
+| `documents` | <pre>Array</pre> | Array of documents (containing a document `_id` and `_source` fields) |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/properties>KuzzleRequest</a></pre> | The underlying API request |
 
 Triggered after documents have been created or replaced.
 
@@ -216,8 +216,8 @@ class PipePlugin {
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| documents | `Array` | Array of documents (containing document `_id`) |
-| request | `KuzzleRequest` | [KuzzleRequest](/core/2/framework/classes/kuzzle-request) |
+| `documents` | <pre>Array</pre> | Array of documents (containing document `_id`) |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/properties>KuzzleRequest</a></pre> | The underlying API request |
 
 Triggered before documents are deleted.
 
@@ -264,8 +264,8 @@ class PipePlugin {
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| documents | `Array` | Array of documents (containing document `_id`) |
-| request | `KuzzleRequest` | [KuzzleRequest](/core/2/framework/classes/kuzzle-request) |
+| `documents` | <pre>Array</pre> | Array of documents (containing document `_id`) |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/properties>KuzzleRequest</a></pre> | The underlying API request |
 
 Triggered before documents are fetched.
 
@@ -310,8 +310,8 @@ class PipePlugin {
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| documents | `Array` | Array of documents (containing a document `_id` and `_source` fields) |
-| request | `KuzzleRequest` | [KuzzleRequest](/core/2/framework/classes/kuzzle-request) |
+| `documents` | <pre>Array</pre> | Array of documents (containing a document `_id` and `_source` fields) |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/properties>KuzzleRequest</a></pre> | The underlying API request |
 
 Triggered before partial updates are applied to documents.
 
@@ -354,8 +354,8 @@ class PipePlugin {
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| documents | `Array` | Array of documents (containing a document's `_id` and `_source` fields) |
-| request | `KuzzleRequest` | [KuzzleRequest](/core/2/framework/classes/kuzzle-request) |
+| `documents` | <pre>Array</pre> | Array of documents (containing a document's `_id` and `_source` fields) |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/properties>KuzzleRequest</a></pre> | The underlying API request |
 
 
 Triggered before documents are created or replaced.

--- a/doc/2/framework/events/hook/index.md
+++ b/doc/2/framework/events/hook/index.md
@@ -14,9 +14,9 @@ Handlers attached to this event will receive the following arguments:
 
 | Arguments    | Type     | Description                                   |
 |--------------|----------|-----------------------------------------------|
-| `pluginName` | `String` | Application or plugin name                    |
-| `event`      | `String` | Original event to which the hook was attached |
-| `error`      | `Error`  | Error object                                  |
+| `pluginName` | <pre>String</pre> | Application or plugin name                    |
+| `event`      | <pre>String</pre> | Original event to which the hook was attached |
+| `error`      | <pre>Error</pre>  | Error object                                  |
 
 ::: info
 To prevent infinite loops, if a hook attached to the `hook:onError` event fails, it won't trigger any other events.

--- a/doc/2/framework/events/http/index.md
+++ b/doc/2/framework/events/http/index.md
@@ -14,7 +14,7 @@ order: 100
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | <pre>KuzzleRequest</pre> | The normalized API [request](/core/2/framework/classes/kuzzle-request) |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/properties>KuzzleRequest</a></pre> | The normalized API request |
 
 Triggered whenever a request has been submitted through HTTP DELETE methods.
 
@@ -24,7 +24,7 @@ Triggered whenever a request has been submitted through HTTP DELETE methods.
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | <pre>KuzzleRequest</pre> | The normalized API [request](/core/2/framework/classes/kuzzle-request) |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/properties>KuzzleRequest</a></pre> | The normalized API request |
 
 Triggered whenever a request has been submitted through HTTP GET methods.
 
@@ -34,7 +34,7 @@ Triggered whenever a request has been submitted through HTTP GET methods.
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | <pre>KuzzleRequest</pre> | The normalized API [request](/core/2/framework/classes/kuzzle-request) |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/properties>KuzzleRequest</a></pre> | The normalized API request |
 
 Triggered whenever a request has been submitted through HTTP HEAD methods.
 
@@ -44,7 +44,7 @@ Triggered whenever a request has been submitted through HTTP HEAD methods.
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | <pre>KuzzleRequest</pre> | The normalized API [request](/core/2/framework/classes/kuzzle-request) |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/properties>KuzzleRequest</a></pre> | The normalized API request |
 
 Triggered whenever a request has been submitted through HTTP OPTIONS methods.
 
@@ -54,7 +54,7 @@ Triggered whenever a request has been submitted through HTTP OPTIONS methods.
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | <pre>KuzzleRequest</pre> | The normalized API [request](/core/2/framework/classes/kuzzle-request) |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/roperties>KuzzleRequest</a></pre> | The normalized API request |
 
 Triggered whenever a request has been submitted through HTTP PATCH methods.
 
@@ -64,7 +64,7 @@ Triggered whenever a request has been submitted through HTTP PATCH methods.
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | <pre>KuzzleRequest</pre> | The normalized API [request](/core/2/framework/classes/kuzzle-request) |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/properties>KuzzleRequest</a></pre> | The normalized API request |
 
 Triggered whenever a request has been submitted through HTTP POST methods.
 
@@ -74,6 +74,6 @@ Triggered whenever a request has been submitted through HTTP POST methods.
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | <pre>KuzzleRequest</pre> | The normalized API [request](/core/2/framework/classes/kuzzle-request) |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/properties>KuzzleRequest</a></pre> | The normalized API request |
 
 Triggered whenever a request has been submitted through HTTP PUT methods.

--- a/doc/2/framework/events/plugin/index.md
+++ b/doc/2/framework/events/plugin/index.md
@@ -25,7 +25,7 @@ All calls to plugins API actions trigger two of these three events:
 
 | Arguments | Type      | Description                                                                       |
 |-----------|-----------|-----------------------------------------------------------------------------------|
-| `request` | `KuzzleRequest` | The normalized API [request](/core/2/framework/classes/kuzzle-request |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/properties>KuzzleRequest</a></pre> | The normalized API request |
 
 A `before` event is triggered before a plugin API request starts.
 
@@ -51,7 +51,7 @@ The `before` event name is built using the following template:
 
 | Arguments | Type      | Description                                                                       |
 |-----------|-----------|-----------------------------------------------------------------------------------|
-| `request` | `KuzzleRequest` | The normalized API [request](/core/2/framework/classes/kuzzle-request |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/properties>KuzzleRequest</a></pre> | The normalized API request |
 
 An `after` event is triggered after a plugin API request succeeds.
 
@@ -77,7 +77,7 @@ The `after` event name is built using the following template:
 
 | Arguments | Type      | Description                                                                       |
 |-----------|-----------|-----------------------------------------------------------------------------------|
-| `request` | `KuzzleRequest` | The normalized API [request](/core/2/framework/classes/kuzzle-request |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/properties>KuzzleRequest</a></pre> | The normalized API request |
 
 An `error` event is triggered after a plugin API request fails.
 

--- a/doc/2/framework/events/realtime/index.md
+++ b/doc/2/framework/events/realtime/index.md
@@ -135,7 +135,7 @@ The provided `subscription` object has the following properties:
 | `connectionId` | <pre>integer</pre>   | [ClientConnection](/core/2/guides/write-protocols/context/clientconnection) unique identifier                      |
 | `index`        | <pre>string</pre>    | Index                                                                                                     |
 | `collection`   | <pre>string</pre>    | Collection                                                                                                |
-| `filters`      | <pre>object</pre>    | Filters in [Koncorde's normalized format](https://www.npmjs.com/package/koncorde#filter-unique-identifier)|
+| `filters`      | <pre>object</pre>    | Filters in [Koncorde's normalized format](https://www.npmjs.com/package/koncorde#filter-unique-identifier) |
 
 ---
 
@@ -166,7 +166,7 @@ The provided `room` object has the following properties:
 
 | Arguments | Type                                                                     | Description                           |
 | --------- | ------------------------------------------------------------------------ | ------------------------------------- |
-| `message` | [`Notification`](/core/2/api/payloads/notifications) | The normalized real-time notification |
+| `message` | <pre><a href=/core/2/api/payloads/notifications>Notifications</a></pre> | The normalized real-time notification |
 
 Triggered whenever a real-time notification is about to be sent.
 
@@ -176,7 +176,7 @@ Triggered whenever a real-time notification is about to be sent.
 
 | Arguments | Type                                                                      | Description                           |
 | --------- | ------------------------------------------------------------------------- | ------------------------------------- |
-| `message` | [`Notification`](/core/2/api/payloads/notifications) | The normalized real-time notification |
+| `message` | <pre><a href=/core/2/api/payloads/notifications>Notifications</a></pre> | The normalized real-time notification |
 
 Triggered whenever a real-time document notification is about to be sent.
 
@@ -186,7 +186,7 @@ Triggered whenever a real-time document notification is about to be sent.
 
 | Arguments | Type                                                                      | Description                           |
 | --------- | ------------------------------------------------------------------------- | ------------------------------------- |
-| `message` | [`Notification`](/core/2/api/payloads/notifications) | The normalized real-time notification |
+| `message` | <pre><a href=/core/2/api/payloads/notifications>Notifications</a></pre> | The normalized real-time notification |
 
 Triggered whenever a real-time server notification is about to be sent.
 
@@ -196,7 +196,7 @@ Triggered whenever a real-time server notification is about to be sent.
 
 | Arguments | Type                                                                      | Description                           |
 | --------- | ------------------------------------------------------------------------- | ------------------------------------- |
-| `message` | [`Notification`](/core/2/api/payloads/notifications) | The normalized real-time notification |
+| `message` | <pre><a href=/core/2/api/payloads/notifications>Notifications</a></pre> | The normalized real-time notification |
 
 Triggered whenever a real-time user notification is about to be sent.
 

--- a/doc/2/framework/events/request/index.md
+++ b/doc/2/framework/events/request/index.md
@@ -1,7 +1,7 @@
 ---
 type: page
 code: false
-title: KuzzleRequest
+title: Request
 description: KuzzleRequest events list
 order: 100
 ---
@@ -12,7 +12,7 @@ order: 100
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | `KuzzleRequest` | The normalized API [request](/core/2/framework/classes/kuzzle-request |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/properties>KuzzleRequest</a></pre> | The normalized API request |
 
 Triggered whenever a request passes authorization checks and is ready to be processed.
 
@@ -22,7 +22,7 @@ This event occurs before [before events](/core/2/framework/events/api#before).
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | `KuzzleRequest` | The normalized API [request](/core/2/framework/classes/kuzzle-request |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/properties>KuzzleRequest</a></pre> | The normalized API request |
 
 Triggered whenever a request execution fails.
 
@@ -32,7 +32,7 @@ This event occurs after [error events](/core/2/framework/events/api#error).
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | `KuzzleRequest` | The normalized API [request](/core/2/framework/classes/kuzzle-request |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/properties>KuzzleRequest</a></pre> | The normalized API request |
 
 Triggered whenever a request execution succeeds.
 
@@ -42,6 +42,6 @@ This event occurs after [after events](/core/2/framework/events/api#after).
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | `KuzzleRequest` | The normalized API [request](/core/2/framework/classes/kuzzle-request |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/properties>KuzzleRequest</a></pre> | The normalized API request |
 
 Triggered whenever a request fails authorization checks, and is about to be rejected with a `401` error code.

--- a/doc/2/framework/events/wildcard/index.md
+++ b/doc/2/framework/events/wildcard/index.md
@@ -21,7 +21,7 @@ Example: After document creation you will have `document:afterCreate` then `docu
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `*` | `*` | Depends on the event type |
+| `*` | <pre>*</pre> | Depends on the event type |
 
 You can catch all the actions of a controller by using a wildcard instead of the action name.
 
@@ -49,7 +49,7 @@ this.pipes =
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | <pre><a href=/plugins/1/constructors/request>KuzzleRequest</a></pre> | The normalized API request |
+| `request` | <pre><a href=/core/2/framework/classes/kuzzle-request/properties>KuzzleRequest</a></pre> | The normalized API request |
 
 Wildcards permit listening templated events.
 


### PR DESCRIPTION
# Description

Fix issues in the framework events documentation: 

1. Fix missing parens in links(e.g. in this page: https://docs.kuzzle.io/core/2/framework/events/request/ )
2. Fix a couple links still targeting the documentation for Kuzzle v1
3. Use `<pre>` tags for argument types description, instead of quotes (harmonization with the rest of our docs)
4. Fix a few "request" terms that have incorrectly been renamed "KuzzleRequest"

Before:

![Screenshot from 2021-02-19 14-38-19](https://user-images.githubusercontent.com/12997967/108511515-5200bf00-72c0-11eb-8b07-16a6aedf1f7b.png)

After:

![Screenshot from 2021-02-19 14-39-36](https://user-images.githubusercontent.com/12997967/108511526-56c57300-72c0-11eb-8d7c-cfb80f48861d.png)
