### PR TITLE
Development features must be opt-in instead of opt-out

### DIFF
--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -143,7 +143,7 @@ class ElasticSearch extends Service {
       return;
     }
 
-    if ( global.NODE_ENV === 'production'
+    if ( global.NODE_ENV !== 'development'
       && this._config.commonMapping.dynamic === 'true'
     ) {
       global.kuzzle.log.warn([

--- a/lib/service/storage/esWrapper.js
+++ b/lib/service/storage/esWrapper.js
@@ -158,7 +158,7 @@ class ESWrapper {
       return error;
     }
 
-    if (global.NODE_ENV === 'production') {
+    if (global.NODE_ENV !== 'development') {
       global.kuzzle.log.info(JSON.stringify({
         message: `Elasticsearch Client error: ${error.message}`,
         // /!\ not all ES error classes have a "meta" property

--- a/lib/util/deprecate.js
+++ b/lib/util/deprecate.js
@@ -22,7 +22,7 @@
 'use strict';
 
 const deprecationWarning = (logger, ...args) => {
-  if (global.NODE_ENV !== 'production') {
+  if (global.NODE_ENV === 'development') {
     logger.warn('DEPRECATION WARNING');
     logger.warn(...args);
   }
@@ -49,7 +49,7 @@ const warnIfDeprecated = (logger, deprecations, member) => {
 };
 
 const deprecateProperties = (logger, target, deprecations = {}) => {
-  if (global.NODE_ENV === 'production') {
+  if (global.NODE_ENV !== 'development') {
     return target;
   }
 

--- a/lib/util/didYouMean.js
+++ b/lib/util/didYouMean.js
@@ -24,7 +24,7 @@
 const didYouMean = require('didyoumean');
 
 function printDidYouMean(...args) {
-  if (global.NODE_ENV === 'production') {
+  if (global.NODE_ENV !== 'development') {
     return '';
   }
 
@@ -34,7 +34,7 @@ function printDidYouMean(...args) {
     return '';
   }
 
-  return ` Did you mean "${result}" ?`;
+  return ` Did you mean "${result}"?`;
 }
 
 module.exports = printDidYouMean;

--- a/test/core/plugin/pluginsManager.test.js
+++ b/test/core/plugin/pluginsManager.test.js
@@ -418,9 +418,12 @@ describe('Plugin', () => {
       plugin.instance.functionName = () => {};
       plugin.instance.foo = () => {};
 
-      should(() => {
-        pluginsManager._initControllers(plugin);
-      }).throwError({ message: /Did you mean "foo"/ });
+      global.NODE_ENV = 'development';
+
+      should(() => pluginsManager._initControllers(plugin)).throw({
+        id: 'plugin.controller.invalid_action',
+        message: /Did you mean "foo"/,
+      });
     });
 
     it('should not add an invalid route to the API', () => {
@@ -430,47 +433,53 @@ describe('Plugin', () => {
         }
       };
 
+      global.NODE_ENV = 'development';
+
       plugin.instance.functionName = () => {};
 
       plugin.instance.routes = [
         {vert: 'get', url: '/bar/:name', controller: 'foo', action: 'bar'}
       ];
 
-      should(() => {
-        pluginsManager._initControllers(plugin);
-      }).throwError({ message: /Did you mean "verb"/ });
+      should(() => pluginsManager._initControllers(plugin)).throw({
+        id: 'plugin.controller.unexpected_route_property',
+        message: /Did you mean "verb"/,
+      });
 
       plugin.instance.routes = [
         {verb: 'post', url: ['/bar'], controller: 'foo', action: 'bar'}
       ];
 
-      should(() => {
-        pluginsManager._initControllers(plugin);
-      }).throwError(PluginImplementationError);
+      should(() => pluginsManager._initControllers(plugin)).throw({
+        id: 'plugin.controller.invalid_route_property',
+      });
 
       plugin.instance.routes = [
         {verb: 'posk', url: '/bar', controller: 'foo', action: 'bar'}
       ];
 
-      should(() => {
-        pluginsManager._initControllers(plugin);
-      }).throwError({ message: /Did you mean "post"/ });
+      should(() => pluginsManager._initControllers(plugin)).throw({
+        id: 'plugin.controller.unsupported_verb',
+        message: /Did you mean "post"/,
+      });
 
       plugin.instance.routes = [
         {verb: 'get', url: '/bar/:name', controller: 'foo', action: 'baz'}
       ];
 
-      should(() => {
-        pluginsManager._initControllers(plugin);
-      }).throwError({ message: /Did you mean "bar"/ });
+      should(() => pluginsManager._initControllers(plugin)).throw({
+        id: 'plugin.controller.undefined_action',
+        message: /Did you mean "bar"/,
+      });
 
       plugin.instance.routes = [
         {verb: 'get', url: '/bar/:name', controller: 'fou', action: 'bar'}
       ];
 
-      should(() => {
-        pluginsManager._initControllers(plugin);
-      }).throwError({ message: /Did you mean "foo"/ });
+      should(() => pluginsManager._initControllers(plugin)).throw({
+        id: 'plugin.controller.undefined_controller',
+        message: /Did you mean "foo"/,
+      });
 
       plugin.instance.routes = [
         { verb: 'get', url: '/bar/:name', controler: 'foo', action: 'bar' }
@@ -1113,10 +1122,11 @@ describe('Plugin', () => {
 
       plugin.instance.foo = () => {};
 
-      return should(() => {
-        pluginsManager._initHooks(plugin);
-      })
-        .be.throwError({ message: /Did you mean "foo"/ });
+      global.NODE_ENV = 'development';
+      should(() => pluginsManager._initHooks(plugin)).throw({
+        id: 'plugin.assert.invalid_hook',
+        message: /Did you mean "foo"/,
+      });
     });
   });
 
@@ -1227,9 +1237,11 @@ describe('Plugin', () => {
 
       plugin.instance.foo = () => {};
 
-      return should(() => {
-        pluginsManager._initPipes(plugin);
-      }).throwError({ message: /Did you mean "foo"/ });
+      global.NODE_ENV = 'development';
+      should(() => pluginsManager._initPipes(plugin)).throw({
+        id: 'plugin.assert.invalid_pipe',
+        message: /Did you mean "foo"/,
+      });
     });
 
     it('should attach pipes event and reject if an attached function return an error', () => {

--- a/test/core/shared/sdk/embeddedSdk.test.js
+++ b/test/core/shared/sdk/embeddedSdk.test.js
@@ -8,8 +8,9 @@ const {
   PluginImplementationError,
 } = require('../../../../index');
 
-const { EmbeddedSDK } = require('../../../../lib/core/shared/sdk/embeddedSdk');
 const KuzzleMock = require('../../../mocks/kuzzle.mock');
+
+const { EmbeddedSDK } = require('../../../../lib/core/shared/sdk/embeddedSdk');
 
 describe('EmbeddedSDK', () => {
   let kuzzle;
@@ -27,17 +28,21 @@ describe('EmbeddedSDK', () => {
       const SpyImpersonatedSdk = sinon.spy();
       mockrequire('../../../../lib/core/shared/sdk/impersonatedSdk', SpyImpersonatedSdk);
       const { EmbeddedSDK: MockEmbeddedSDK } = mockrequire.reRequire('../../../../lib/core/shared/sdk/embeddedSdk');
-      const user = { _id: 'gordon' };
 
-      embeddedSdk = new MockEmbeddedSDK();
-      const returnedInstance = embeddedSdk.as(user);
+      try {
+        const user = { _id: 'gordon' };
+        embeddedSdk = new MockEmbeddedSDK();
+        const returnedInstance = embeddedSdk.as(user);
 
-      should(SpyImpersonatedSdk).be.calledWith(user._id);
-      should(returnedInstance).be.instanceOf(SpyImpersonatedSdk);
+        should(SpyImpersonatedSdk).be.calledWith(user._id);
+        should(returnedInstance).be.instanceOf(SpyImpersonatedSdk);
 
-      embeddedSdk.as(user, { checkRights: true });
-      should(SpyImpersonatedSdk).be.calledWith(user._id, { checkRights: true });
-      mockrequire.stopAll();
+        embeddedSdk.as(user, { checkRights: true });
+        should(SpyImpersonatedSdk).be.calledWith(user._id, { checkRights: true });
+      }
+      finally {
+        mockrequire.stopAll();
+      }
     });
 
     it('should throw if the required user object is invalid', () => {

--- a/test/util/didYouMean.test.js
+++ b/test/util/didYouMean.test.js
@@ -55,7 +55,7 @@ describe('Test: Deprecate util', () => {
     it('should return a string with the item returned by the library', () => {
       didYouMeanLibraryStub.returns('foo');
 
-      should(didYouMean(item, list)).be.eql(' Did you mean "foo" ?');
+      should(didYouMean(item, list)).be.eql(' Did you mean "foo"?');
     });
   });
 });


### PR DESCRIPTION
# Description

A few development features are available depending on the value of the `NODE_ENV` environment variable.

Some of those features are deactivated if `NODE_ENV=production` (opt-out), but this should be considered bad practice.
Instead, they should be opt-in, and activated only if `NODE_ENV` is explicitly set to `development`

# Boyscout

Enforce a check on thrown error IDs on a few unit tests, to ensure that the right error is thrown.