### PR TITLE
Fix usage of empty koncorde filters in document:search

### DIFF
--- a/lib/api/controllers/baseController.js
+++ b/lib/api/controllers/baseController.js
@@ -78,6 +78,10 @@ class NativeController extends BaseController {
   }
 
   async translateKoncorde (koncordeFilters) {
+    if (Object.keys(koncordeFilters).length === 0) {
+      return {};
+    }
+
     // @todo throw "koncorde_unknown_keyword" when Koncorde will throw
     // just the keyword name
     await global.kuzzle.koncorde.validate(koncordeFilters);

--- a/lib/api/controllers/documentController.js
+++ b/lib/api/controllers/documentController.js
@@ -80,7 +80,7 @@ class DocumentController extends NativeController {
     this.assertNotExceedMaxFetch(size - from);
 
     if (lang === 'koncorde') {
-      searchBody.query = await this.translateKoncorde(searchBody.query);
+      searchBody.query = await this.translateKoncorde(searchBody.query || {});
     }
 
     const result = await this.ask(

--- a/test/api/controllers/baseController.test.js
+++ b/test/api/controllers/baseController.test.js
@@ -85,6 +85,14 @@ describe('#base/native controller', () => {
         BadRequestError,
         { id: 'api.assert.koncorde_restricted_keyword' });
     });
+
+    it('should return an empty object of the filters are empty', async () => {
+      const esQuery = await nativeController.translateKoncorde({});
+
+      should(kuzzle.ask).not.be.called();
+
+      should(esQuery).be.eql({});
+    });
   });
 
   describe('#getLangParam', () => {

--- a/test/api/controllers/baseController.test.js
+++ b/test/api/controllers/baseController.test.js
@@ -86,7 +86,7 @@ describe('#base/native controller', () => {
         { id: 'api.assert.koncorde_restricted_keyword' });
     });
 
-    it('should return an empty object of the filters are empty', async () => {
+    it('should return an empty object if the filters are empty', async () => {
       const esQuery = await nativeController.translateKoncorde({});
 
       should(kuzzle.ask).not.be.called();


### PR DESCRIPTION
## What does this PR do ?

Allows the usage of empty koncorde filters in `document:search` to match all documents

Fix #1981 

### How should this be manually tested?

```
kourou collection:create test test
kourou sdk:query document:search --index test --collection test -a query='{}' -a lang=koncorde
```
