### PR TITLE
Allows dynamic pipe registration

### DIFF
--- a/doc/2/api/errors/error-codes/plugin/index.md
+++ b/doc/2/api/errors/error-codes/plugin/index.md
@@ -44,6 +44,7 @@ description: Error codes definitions
 | plugin.runtime.too_many_pipes<br/><pre>0x04020004</pre>  | [ServiceUnavailableError](/core/2/api/errors/error-codes#serviceunavailableerror) <pre>(503)</pre> | Request discarded: maximum number of executing pipe functions reached. | The number of running pipes exceeds the configured capacity (see configuration files). This may be caused by pipes being too slow, or by an insufficient number of Kuzzle nodes. |
 | plugin.runtime.already_started<br/><pre>0x04020005</pre>  | [PluginImplementationError](/core/2/api/errors/error-codes#pluginimplementationerror) <pre>(500)</pre> | Cannot use property "%s" when application is already running | Features definition cannot be changed after startup. |
 | plugin.runtime.unavailable_before_start<br/><pre>0x04020006</pre>  | [PluginImplementationError](/core/2/api/errors/error-codes#pluginimplementationerror) <pre>(500)</pre> | Cannot use property "%s" before application startup | The property is only accessible after application startup. |
+| plugin.runtime.unknown_pipe<br/><pre>0x04020007</pre>  | [PluginImplementationError](/core/2/api/errors/error-codes#pluginimplementationerror) <pre>(500)</pre> | Unknown pipe ID "%s" | The provided pipe identifier is unknown. |
 
 ---
 

--- a/docker/scripts/start-kuzzle-dev.ts
+++ b/docker/scripts/start-kuzzle-dev.ts
@@ -6,7 +6,7 @@
 import should from 'should';
 import { omit } from 'lodash';
 
-import { Backend, Request, Mutex } from '../../index';
+import { Backend, KuzzleRequest, Mutex } from '../../index';
 import { FunctionalTestsController } from './functional-tests-controller';
 
 const app = new Backend('functional-tests-app');
@@ -38,11 +38,11 @@ async function loadAdditionalPlugins() {
 
 if (! process.env.TRAVIS) {
   // Easier debug
-  app.hook.register('request:onError', async (request: Request) => {
+  app.hook.register('request:onError', async (request: KuzzleRequest) => {
     app.log.error(request.error);
   });
 
-  app.hook.register('hook:onError', async (request: Request) => {
+  app.hook.register('hook:onError', async (request: KuzzleRequest) => {
     app.log.error(request.error);
   });
 }
@@ -67,7 +67,7 @@ app.controller.register('pipes', {
       },
     },
     manage: {
-      handler: async (request: Request) => {
+      handler: async (request: KuzzleRequest) => {
         const payload = request.input.body;
         const state = request.input.args.state;
         const event = request.input.args.event;
@@ -105,24 +105,25 @@ app.hook.register('custom:event', async (name) => {
 });
 
 let syncedHello = 'World';
+let dynamicPipeId;
 
 app.controller.register('tests', {
   actions: {
     // Controller registration and http route definition
     sayHello: {
-      handler: async (request: Request) => {
+      handler: async (request: KuzzleRequest) => {
         return { greeting: `Hello, ${request.input.args.name}` };
       },
       http: [{ verb: 'post', path: '/hello/:name' }],
     },
 
     getSyncedHello: {
-      handler: async (request: Request) => `Hello, ${syncedHello}`,
+      handler: async (request: KuzzleRequest) => `Hello, ${syncedHello}`,
       http: [{ verb: 'get', path: '/hello' }],
     },
 
     syncHello: {
-      handler: async (request: Request) => {
+      handler: async (request: KuzzleRequest) => {
         syncedHello = request.input.args.name;
         await app.cluster.broadcast('sync:hello', { name: syncedHello });
         return 'OK';
@@ -132,7 +133,7 @@ app.controller.register('tests', {
 
     // Trigger custom event
     triggerEvent: {
-      handler: async (request: Request) => {
+      handler: async (request: KuzzleRequest) => {
         await app.trigger('custom:event', request.input.args.name);
 
         return { trigger: 'custom:event', payload: request.input.args.name };
@@ -144,9 +145,9 @@ app.controller.register('tests', {
       handler: async () => app.vault.secrets,
     },
 
-    // access storage client
+    // Access storage client
     storageClient: {
-      handler: async (request: Request) => {
+      handler: async (request: KuzzleRequest) => {
         const client = new app.storage.StorageClient();
         const esRequest = {
           body: request.input.body,
@@ -166,8 +167,9 @@ app.controller.register('tests', {
       http: [{ verb: 'post', path: '/tests/storage-client/:index' }],
     },
 
+    // Mutex class
     mutex: {
-      handler: async (request: Request) => {
+      handler: async (request: KuzzleRequest) => {
         const ttl = 5000;
         const mutex = new Mutex('functionalTestMutexHandler', {
           timeout: 0,
@@ -179,6 +181,27 @@ app.controller.register('tests', {
         return { locked };
       },
       http: [{ verb: 'get', path: '/tests/mutex/acquire' }],
+    },
+
+    // Dynamic pipe registration
+    'register-pipe': {
+      handler: async () => {
+        dynamicPipeId = app.pipe.register(
+          'server:afterNow',
+          async request => {
+            request.result.dynamicPipe = true;
+
+            return request;
+          },
+          { dynamic: true });
+
+        return dynamicPipeId;
+      }
+    },
+    'unregister-pipe': {
+      handler: async () => {
+        app.pipe.unregister(dynamicPipeId);
+      }
     },
   },
 });
@@ -195,6 +218,7 @@ loadAdditionalPlugins()
   .then(() => {
     // post-start methods here
 
+    // Cluster synchronization
     app.cluster.on('sync:hello', (payload) => {
       syncedHello = payload.name;
     });

--- a/docker/scripts/start-kuzzle-dev.ts
+++ b/docker/scripts/start-kuzzle-dev.ts
@@ -189,7 +189,7 @@ app.controller.register('tests', {
         dynamicPipeId = app.pipe.register(
           'server:afterNow',
           async request => {
-            request.result.dynamicPipe = true;
+            request.result.name = 'Ugo';
 
             return request;
           },

--- a/features/Application.feature
+++ b/features/Application.feature
@@ -74,8 +74,8 @@ Feature: Application
     When I successfully execute the action "tests":"register-pipe"
     And I successfully execute the action "server":"now"
     Then I should receive a result matching:
-      | dynamicPipe | true |
+      | name | "Ugo" |
     When I successfully execute the action "tests":"unregister-pipe"
     And I successfully execute the action "server":"now"
     Then I should receive a result matching:
-      | dynamicPipe | "_UNDEFINED_" |
+      | name | "_UNDEFINED_" |

--- a/features/Application.feature
+++ b/features/Application.feature
@@ -69,7 +69,8 @@ Feature: Application
     Then I should receive a result matching:
       | locked | true |
 
-  # Dynamic pipe registration
+  # Dynamic pipe registration (only websocket to avoid to develop a cluster sync mechanism)
+  @not-http
   Scenario: Register and unregister pipe dynamically
     When I successfully execute the action "tests":"register-pipe"
     And I successfully execute the action "server":"now"

--- a/features/Application.feature
+++ b/features/Application.feature
@@ -52,9 +52,9 @@ Feature: Application
   # Controller class usage
   Scenario: Check if Kuzzle can use a controller class
     When I successfully execute the action "functional-tests":"helloWorld" with args:
-    | name | "Martial" |
+      | name | "Martial" |
     Then I should receive a result matching:
-    | greeting | "Hello, Martial" |
+      | greeting | "Hello, Martial" |
 
   # Mutex
   Scenario: Check mutexes
@@ -68,3 +68,14 @@ Feature: Application
     And I successfully execute the action "tests":"mutex"
     Then I should receive a result matching:
       | locked | true |
+
+  # Dynamic pipe registration
+  Scenario: Register and unregister pipe dynamically
+    When I successfully execute the action "tests":"register-pipe"
+    And I successfully execute the action "server":"now"
+    Then I should receive a result matching:
+      | dynamicPipe | true |
+    When I successfully execute the action "tests":"unregister-pipe"
+    And I successfully execute the action "server":"now"
+    Then I should receive a result matching:
+      | dynamicPipe | "_UNDEFINED_" |

--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -91,6 +91,12 @@ Before({ tags: '@http' }, async function () {
   }
 });
 
+Before({ tags: '@not-http' }, async function () {
+  if (process.env.KUZZLE_PROTOCOL !== 'websocket') {
+    return 'skipped';
+  }
+});
+
 // firstAdmin hooks ============================================================
 
 Before({ tags: '@firstAdmin' }, async function () {

--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -92,7 +92,7 @@ Before({ tags: '@http' }, async function () {
 });
 
 Before({ tags: '@not-http' }, async function () {
-  if (process.env.KUZZLE_PROTOCOL !== 'websocket') {
+  if (process.env.KUZZLE_PROTOCOL === 'http') {
     return 'skipped';
   }
 });

--- a/index.ts
+++ b/index.ts
@@ -22,4 +22,4 @@ export class Koncorde extends KoncordeJS {
   }
 
   [key: string]: any;
-};
+}

--- a/index.ts
+++ b/index.ts
@@ -12,6 +12,14 @@ export * from './lib/kerror/errors';
 
 export * from './lib/util/mutex';
 
-export * from 'koncorde';
-
 export * from 'kuzzle-sdk';
+
+import KoncordeJS from 'koncorde';
+
+export class Koncorde extends KoncordeJS {
+  constructor (...args) {
+    super(...args);
+  }
+
+  [key: string]: any;
+};

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -23,6 +23,7 @@
 
 const { isEmpty, isNil } = require('lodash');
 const Bluebird = require('bluebird');
+const { v4: uuidv4 } = require('uuid');
 
 const { KuzzleError } = require('../../kerror/errors');
 const { Request } = require('../request');
@@ -32,7 +33,6 @@ const ApiKey = require('../../model/storage/apiKey');
 const kerror = require('../../kerror');
 const { has, get } = require('../../util/safeObject');
 const nameGenerator = require('../../util/name-generator');
-const { v4: uuidv4 } = require('uuid');
 
 /**
  * @class SecurityController
@@ -1169,7 +1169,7 @@ class SecurityController extends NativeController {
     const generator = humanReadableId ? nameGenerator : uuidv4;
     const credentials = this.getBodyObject(request, 'credentials', {});
     const strategies = Object.keys(credentials);
-    
+
     let id = '';
     let alreadyExists = false;
     // Early checks before the user is created
@@ -1183,7 +1183,7 @@ class SecurityController extends NativeController {
           return `kuid-${generator()}`;
         }
       );
-      
+
       for (const strategy of strategies) {
         if (!global.kuzzle.pluginsManager.listStrategies().includes(strategy)) {
           throw kerror.get(
@@ -1207,7 +1207,7 @@ class SecurityController extends NativeController {
             id);
         }
       }
-      
+
     } while (alreadyExists);
 
     const user = await this.ask(

--- a/lib/core/backend/backend.ts
+++ b/lib/core/backend/backend.ts
@@ -67,7 +67,7 @@ class BackendPipe extends ApplicationManager {
    */
   register (event: string, handler: EventHandler, options: any = {}): string | void {
     if (this._application.started && options.dynamic !== true) {
-      throw runtimeError.get('already_started', 'pipe');
+      throw runtimeError.get('already_started', 'pipe.register');
     }
 
     if (typeof handler !== 'function') {
@@ -90,6 +90,10 @@ class BackendPipe extends ApplicationManager {
   }
 
   unregister (pipeId: string): void {
+    if (! this._application.started) {
+      throw runtimeError.get('unavailable_before_start', 'pipe.unregister');
+    }
+
     global.kuzzle.pluginsManager.unregisterPipe(pipeId);
   }
 }

--- a/lib/core/backend/backend.ts
+++ b/lib/core/backend/backend.ts
@@ -64,10 +64,9 @@ class BackendPipe extends ApplicationManager {
    *
    * @param event - Event name
    * @param handler - Function to execute when the event is triggered
-   *
    */
-  register (event: string, handler: EventHandler): void {
-    if (this._application.started) {
+  register (event: string, handler: EventHandler, options: any = {}): string | void {
+    if (this._application.started && options.dynamic !== true) {
       throw runtimeError.get('already_started', 'pipe');
     }
 
@@ -75,11 +74,23 @@ class BackendPipe extends ApplicationManager {
       throw assertionError.get('invalid_pipe', event);
     }
 
-    if (! this._application._pipes[event]) {
-      this._application._pipes[event] = [];
+    if (this._application.started) {
+      return global.kuzzle.pluginsManager.registerPipe(
+        global.kuzzle.pluginsManager.application,
+        event,
+        handler);
     }
+    else {
+      if (! this._application._pipes[event]) {
+        this._application._pipes[event] = [];
+      }
 
-    this._application._pipes[event].push(handler);
+      this._application._pipes[event].push(handler);
+    }
+  }
+
+  unregister (pipeId: string): void {
+    global.kuzzle.pluginsManager.unregisterPipe(pipeId);
   }
 }
 

--- a/lib/core/backend/backend.ts
+++ b/lib/core/backend/backend.ts
@@ -80,13 +80,12 @@ class BackendPipe extends ApplicationManager {
         event,
         handler);
     }
-    else {
-      if (! this._application._pipes[event]) {
-        this._application._pipes[event] = [];
-      }
 
-      this._application._pipes[event].push(handler);
+    if (! this._application._pipes[event]) {
+      this._application._pipes[event] = [];
     }
+
+    this._application._pipes[event].push(handler);
   }
 
   unregister (pipeId: string): void {

--- a/lib/core/plugin/pluginsManager.js
+++ b/lib/core/plugin/pluginsManager.js
@@ -442,12 +442,6 @@ class PluginsManager {
             })
             .catch(error => cb(error));
         }
-        else if (pipeResponse instanceof Error) {
-          cb(pipeResponse);
-        }
-        else {
-          cb(null, pipeResponse);
-        }
       }
       catch (error) {
         cb(error instanceof KuzzleError

--- a/lib/core/plugin/pluginsManager.js
+++ b/lib/core/plugin/pluginsManager.js
@@ -203,7 +203,7 @@ class PluginsManager {
         plugin.init(plugin.name);
       }
 
-      const { pipeWarnTime, initTimeout } = this.config.common;
+      const { initTimeout } = this.config.common;
 
       debug(
         '[%s] starting plugin in "%s" mode',
@@ -250,7 +250,7 @@ class PluginsManager {
           }
 
           if (! _.isEmpty(plugin.instance.pipes)) {
-            this._initPipes(plugin, pipeWarnTime);
+            this._initPipes(plugin);
           }
 
           debug('[%s] plugin started', plugin.name);
@@ -399,9 +399,15 @@ class PluginsManager {
    * @param {number} warnDelay - delay before a warning is issued
    * @param {string} event name
    * @param {Function} handler - function to attach
+   *
+   * @returns {string} pipeId
    */
-  registerPipe (plugin, warnDelay, event, handler) {
+  registerPipe (plugin, event, handler) {
     debug('[%s] registering pipe on event "%s"', plugin.name, event);
+
+    const warnDelay = plugin.config.pipeWarnTime !== undefined
+      ? plugin.config.pipeWarnTime
+      : this.config.common.pipeWarnTime;
 
     const wrapper = (...data) => {
       const now = warnDelay ? Date.now() : null;
@@ -436,6 +442,12 @@ class PluginsManager {
             })
             .catch(error => cb(error));
         }
+        else if (pipeResponse instanceof Error) {
+          cb(pipeResponse);
+        }
+        else {
+          cb(null, pipeResponse);
+        }
       }
       catch (error) {
         cb(error instanceof KuzzleError
@@ -444,7 +456,11 @@ class PluginsManager {
       }
     };
 
-    global.kuzzle.registerPluginPipe(event, wrapper);
+    return global.kuzzle.registerPluginPipe(event, wrapper);
+  }
+
+  unregisterPipe (pipeId) {
+    global.kuzzle.unregisterPluginPipe(pipeId);
   }
 
   /**
@@ -563,13 +579,8 @@ class PluginsManager {
    * @param {object} plugin
    * @param {number} pipeWarnTime
    */
-  _initPipes (plugin, pipeWarnTime) {
+  _initPipes (plugin) {
     const methodsList = getMethods(plugin.instance);
-    let _warnTime = pipeWarnTime;
-
-    if (plugin.config && plugin.config.pipeWarnTime !== undefined) {
-      _warnTime = plugin.config.pipeWarnTime;
-    }
 
     for (const [event, fn] of Object.entries(plugin.instance.pipes)) {
       const list = Array.isArray(fn) ? fn : [fn];
@@ -600,7 +611,7 @@ class PluginsManager {
           handler = target.bind(plugin.instance);
         }
 
-        this.registerPipe(plugin, _warnTime, event, handler);
+        this.registerPipe(plugin, event, handler);
       }
     }
   }

--- a/lib/kerror/codes/4-plugin.json
+++ b/lib/kerror/codes/4-plugin.json
@@ -129,6 +129,12 @@
           "code": 6,
           "message": "Cannot use property \"%s\" before application startup",
           "class": "PluginImplementationError"
+        },
+        "unknown_pipe": {
+          "description": "The provided pipe identifier is unknown.",
+          "code": 7,
+          "message": "Unknown pipe ID \"%s\"",
+          "class": "PluginImplementationError"
         }
       }
     },

--- a/lib/kuzzle/event/kuzzleEventEmitter.js
+++ b/lib/kuzzle/event/kuzzleEventEmitter.js
@@ -41,7 +41,7 @@ class PluginPipeDefinition {
     this.event = event;
     this.handler = handler;
 
-    this.pipeId = pipeId || uuidv4()
+    this.pipeId = pipeId || uuidv4();
   }
 }
 

--- a/lib/kuzzle/event/kuzzleEventEmitter.js
+++ b/lib/kuzzle/event/kuzzleEventEmitter.js
@@ -29,11 +29,21 @@ const assert = require('assert');
 const EventEmitter = require('eventemitter3');
 const Bluebird = require('bluebird');
 const debug = require('debug')('kuzzle:events');
+const { v4: uuidv4 } = require('uuid');
 
 const Promback = require('../../util/promback');
 const memoize = require('../../util/memoize');
 const PipeRunner = require('./pipeRunner');
 const kerror = require('../../kerror');
+
+class PluginPipeDefinition {
+  constructor (event, handler, pipeId = null) {
+    this.event = event;
+    this.handler = handler;
+
+    this.pipeId = pipeId || uuidv4()
+  }
+}
 
 class KuzzleEventEmitter extends EventEmitter {
   constructor (maxConcurrentPipes, pipesBufferSize) {
@@ -41,8 +51,20 @@ class KuzzleEventEmitter extends EventEmitter {
     this.superEmit = super.emit;
     this.pipeRunner = new PipeRunner(maxConcurrentPipes, pipesBufferSize);
 
-    // register caches
+    /**
+     * Map of plugin pipe handler functions by event
+     *
+     * @type Map<string, Function[]>
+     */
     this.pluginPipes = new Map();
+
+    /**
+     * Map of plugin pipe definitions by pipeId
+     *
+     * @type Map<string, PluginPipeDefinition>
+     */
+    this.pluginPipeDefinitions = new Map();
+
     this.corePipes = new Map();
     this.coreAnswerers = new Map();
   }
@@ -203,12 +225,32 @@ class KuzzleEventEmitter extends EventEmitter {
     });
   }
 
-  registerPluginPipe (event, fn) {
-    if (!this.pluginPipes.has(event)) {
+  registerPluginPipe (event, handler) {
+    if (! this.pluginPipes.has(event)) {
       this.pluginPipes.set(event, []);
     }
 
-    this.pluginPipes.get(event).push(fn);
+    this.pluginPipes.get(event).push(handler);
+
+    const definition = new PluginPipeDefinition(event, handler);
+
+    this.pluginPipeDefinitions.set(definition.pipeId, definition);
+
+    return definition.pipeId;
+  }
+
+  unregisterPluginPipe (pipeId) {
+    const definition = this.pluginPipeDefinitions.get(pipeId);
+
+    if (! definition) {
+      throw kerror.get('plugin', 'runtime', 'unknown_pipe', pipeId);
+    }
+
+    const handlers = this.pluginPipes.get(definition.event);
+    handlers.splice(handlers.indexOf(definition.handler), 1);
+    this.pluginPipes.set(definition.event, handlers);
+
+    this.pluginPipeDefinitions.delete(pipeId);
   }
 
   /**

--- a/lib/kuzzle/event/kuzzleEventEmitter.js
+++ b/lib/kuzzle/event/kuzzleEventEmitter.js
@@ -248,7 +248,12 @@ class KuzzleEventEmitter extends EventEmitter {
 
     const handlers = this.pluginPipes.get(definition.event);
     handlers.splice(handlers.indexOf(definition.handler), 1);
-    this.pluginPipes.set(definition.event, handlers);
+    if (handlers.length > 0) {
+      this.pluginPipes.set(definition.event, handlers);
+    }
+    else {
+      this.pluginPipes.delete(definition.event);
+    }
 
     this.pluginPipeDefinitions.delete(pipeId);
   }

--- a/test/core/backend/Backend.test.js
+++ b/test/core/backend/Backend.test.js
@@ -4,6 +4,7 @@ const util = require('util');
 
 const _ = require('lodash');
 const should = require('should');
+const sinon = require('sinon');
 const mockrequire = require('mock-require');
 const { Client: ElasticsearchClient } = require('@elastic/elasticsearch');
 
@@ -114,7 +115,7 @@ describe('Backend', () => {
     });
   });
 
-  describe('PipeManager#register', () => {
+  describe('BackendPipe#register', () => {
     it('should registers a new pipe', () => {
       const handler = async () => {};
       const handler_bis = async () => {};
@@ -133,12 +134,57 @@ describe('Backend', () => {
       }).throwError({ id: 'plugin.assert.invalid_pipe' });
     });
 
-    it('should throw an error if the application is already started', () => {
+    it('should throw an error if the application is already started without opt-in dynamic option', () => {
       application.started = true;
 
       should(() => {
         application.pipe.register('kuzzle:state:ready', async () => {});
       }).throwError({ id: 'plugin.runtime.already_started' });
+    });
+
+    it('should allows to register pipe at runtime with opt-in dynamic option', () => {
+      const handler = async () => {};
+      application.started = true;
+      global.kuzzle = {
+        pluginsManager: {
+          registerPipe: sinon.stub().returns('pipe-unique-id')
+        }
+      };
+
+      const pipeId = application.pipe.register(
+        'kuzzle:state:ready',
+        handler,
+        { dynamic: true });
+
+      should(pipeId).be.eql('pipe-unique-id');
+      should(global.kuzzle.pluginsManager.registerPipe).be.calledWith(
+        global.kuzzle.pluginsManager.application,
+        'kuzzle:state:ready',
+        handler);
+    });
+  });
+
+  describe('BackendPipe#unregister', () => {
+    it('should allows to unregister a dynamic pipe', () => {
+      application.started = true;
+      global.kuzzle = {
+        pluginsManager: {
+          unregisterPipe: sinon.stub()
+        }
+      };
+
+      application.pipe.unregister('unique-pipe-id');
+
+      should(global.kuzzle.pluginsManager.unregisterPipe)
+        .be.calledWith('unique-pipe-id');
+    });
+
+    it('should throw an error if the application is not started', () => {
+      application.started = false;
+
+      should(() => {
+        application.pipe.unregister('unique-pipe-id');
+      }).throwError({ id: 'plugin.runtime.unavailable_before_start' });
     });
   });
 

--- a/test/core/plugin/pluginsManager.test.js
+++ b/test/core/plugin/pluginsManager.test.js
@@ -165,7 +165,7 @@ describe('Plugin', () => {
 
       should(pluginsManager._initApi).be.calledWith(application);
       should(pluginsManager._initHooks).be.calledWith(application);
-      should(pluginsManager._initPipes).be.calledWith(application, 42);
+      should(pluginsManager._initPipes).be.calledWith(application);
       should(pluginsManager._initControllers).be.calledWith(plugin);
       should(pluginsManager._initAuthenticators).be.calledWith(plugin);
       should(pluginsManager._initStrategies).be.calledWith(plugin);
@@ -1264,17 +1264,16 @@ describe('Plugin', () => {
     });
 
     it('should log a warning in case a pipe plugin exceeds the warning delay', async () => {
-      plugin.instance.pipes = {
-        'foo:bar': 'foo',
-      };
-
-      plugin.instance.foo = () => {};
-
-      const fooStub = sinon.stub(plugin.instance, 'foo').callsFake((ev, cb) => {
+      const fooStub = sinon.stub().callsFake((ev, cb) => {
         setTimeout(() => cb(null), 15);
       });
+      plugin.instance.pipes = {
+        'foo:bar': fooStub,
+      };
 
-      await pluginsManager._initPipes(plugin, 10);
+      plugin.config.pipeWarnTime = 10;
+
+      await pluginsManager._initPipes(plugin);
       await kuzzle.pipe('foo:bar');
 
       should(fooStub).be.calledOnce();

--- a/test/kuzzle/event/kuzzleEventEmitter.test.js
+++ b/test/kuzzle/event/kuzzleEventEmitter.test.js
@@ -378,7 +378,7 @@ describe('#KuzzleEventEmitter', () => {
         pipeId,
         handler,
       });
-    })
+    });
   });
 
   describe('unregisterPluginPipe', () => {
@@ -398,6 +398,6 @@ describe('#KuzzleEventEmitter', () => {
       }).throwError({
         id: 'plugin.runtime.unknown_pipe'
       });
-    })
+    });
   });
 });

--- a/test/kuzzle/event/kuzzleEventEmitter.test.js
+++ b/test/kuzzle/event/kuzzleEventEmitter.test.js
@@ -364,4 +364,40 @@ describe('#KuzzleEventEmitter', () => {
       should(listener3).calledOnce().calledWith('foo', 'bar');
     });
   });
+
+  describe('registerPluginPipe', () => {
+    it('should register the pipe handler and pipe description', () => {
+      const handler = () => {};
+
+      const pipeId = emitter.registerPluginPipe('event', handler);
+
+      should(pipeId).be.a.String();
+      should(emitter.pluginPipes.get('event')).be.eql([handler]);
+      should(emitter.pluginPipeDefinitions.get(pipeId)).match({
+        event: 'event',
+        pipeId,
+        handler,
+      });
+    })
+  });
+
+  describe('unregisterPluginPipe', () => {
+    it('should unregister the pipe handler and remove pipe description', () => {
+      const handler = () => {};
+      const pipeId = emitter.registerPluginPipe('event', handler);
+
+      emitter.unregisterPluginPipe(pipeId);
+
+      should(emitter.pluginPipes.get('event')).be.undefined();
+      should(emitter.pluginPipeDefinitions.get(pipeId)).be.undefined();
+    });
+
+    it('should throw an error if the pipeId does not exists', () => {
+      should(() => {
+        emitter.unregisterPluginPipe('unknown-pipe-id');
+      }).throwError({
+        id: 'plugin.runtime.unknown_pipe'
+      });
+    })
+  });
 });


### PR DESCRIPTION
## What does this PR do ?

Allows to dynamically register pipes.

When the application is already started, `app.pipe.register` can be used with the `dynamic: true` option to dynamically register a pipe.  
The method will returns a `pipeId` which can be then used later to unregistere the pipe with `app.pipe.unregister`.

Defining dynamic pipes at return need to maintain a state of the registered pipes so new nodes joining the cluster can also register the same pipes.  
This dynamic state management is not handled by Kuzzle so developers should implements their own state management routines.

This feature is meant to be left undocumented since it's quite and advanced usage and we didn't had other use cases than our Workflows plugin.

### How should this be manually tested?

  - Step 1 : Run functional tests


### Other

 - Expose an usable version of Koncorde 