### PR TITLE
Deprecate listing of realtime collections

### DIFF
--- a/doc/2/api/controllers/collection/list/index.md
+++ b/doc/2/api/controllers/collection/list/index.md
@@ -42,10 +42,8 @@ Method: GET
 
 ### Optional:
 
-<DeprecatedBadge version="2.1.4" />
-
-- `from` and `size`: response pagination
-- `type`: filters the returned collections. Allowed values: `all`, `stored` and `realtime` (default : `all`).
+- `from` and `size`: response pagination <DeprecatedBadge version="2.1.4" />
+- `type`: filters the returned collections. Allowed values: `all`, `stored` and `realtime` (default : `all`). <DeprecatedBadge version="auto-version" />
 
 ---
 

--- a/doc/2/guides/getting-started/customize-api-behavior/index.md
+++ b/doc/2/guides/getting-started/customize-api-behavior/index.md
@@ -28,7 +28,7 @@ The format of those events is the following:
  - `<controller>:before<Action>`: emitted before processing
  - `<controller>:after<Action>`: emitted after processing, before sending back the response
 
-Restarts your application with the following command to display events: `DEBUG=kuzzle:events npm run dev`
+Restarts your application with the following command to display events: `DEBUG=kuzzle:events npm run dev:docker`
 
 ::: info
 Kuzzle uses the [debug](https://www.npmjs.com/package/debug) package to display messages.  

--- a/lib/api/controllers/collectionController.js
+++ b/lib/api/controllers/collectionController.js
@@ -300,7 +300,7 @@ class CollectionController extends NativeController {
     }
 
     if (request.input.args.type) {
-      request.addDeprecation('auto-version',
+      request.addDeprecation('2.10.2',
         'The "type" argument and this route returning a list of realtime collections have both been deprecated since Kuzzle version 2.10.1. This feature might be removed in a future major version. To get a list of realtime collections, use this API action instead: "realtime:list".');
     }
 

--- a/lib/api/controllers/collectionController.js
+++ b/lib/api/controllers/collectionController.js
@@ -297,7 +297,7 @@ class CollectionController extends NativeController {
     }
 
     if (request.input.args.type) {
-      request.addDeprecation('2.10.1',
+      request.addDeprecation('auto-version',
         'The "type" argument and this route returning a list of realtime collections have both been deprecated since Kuzzle version 2.10.1. This feature might be removed in a future major version. To get a list of realtime collections, use this API action instead: "realtime:list".');
     }
 

--- a/lib/api/controllers/collectionController.js
+++ b/lib/api/controllers/collectionController.js
@@ -58,6 +58,9 @@ class CollectionController extends NativeController {
    * @returns {Promise.<Object>}
    */
   async updateMapping (request) {
+    request.addDeprecation('2.1.0',
+      'This action has been deprecated since Kuzzle version 2.1.0. This feature might be removed in a future major version. To update a collection, use this API action instead: "collection:update".');
+
     const
       { index, collection } = this.getIndexAndCollection(request),
       mapping = this.getBody(request);
@@ -353,6 +356,8 @@ class CollectionController extends NativeController {
     // @deprecated sending directly the mappings is deprecated since 2.1.0
     if (body.properties || body.dynamic || body._meta) {
       config.mappings = body;
+      request.addDeprecation('2.1.0',
+        'Using "properties", "dynamic" or "_meta" fields in the body has been deprecated since Kuzzle version 2.1.0. This feature might be removed in a future major version. Use "settings" and "mappings" fields instead');
     }
     else {
       config = body;

--- a/lib/api/controllers/collectionController.js
+++ b/lib/api/controllers/collectionController.js
@@ -296,6 +296,11 @@ class CollectionController extends NativeController {
       throw kerror.get('api', 'assert', 'invalid_argument', '"all", "stored", "realtime"');
     }
 
+    if (request.input.args.type) {
+      request.addDeprecation('2.10.1',
+        'The "type" argument and this route returning a list of realtime collections have both been deprecated since Kuzzle version 2.10.1. This feature might be removed in a future major version. To get a list of realtime collections, use this API action instead: "realtime:list".');
+    }
+
     let collections = [];
 
     if (type === 'realtime' || type === 'all') {

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -44,7 +44,6 @@ const routes = [
   { verb: 'get', path: '/:index/:collection/_search', controller: 'document', action: 'search' },
   { verb: 'get', path: '/:index/:collection/_specifications', controller: 'collection', action: 'getSpecifications' },
   { verb: 'get', path: '/validations/_scroll/:scrollId', controller: 'collection', action: 'scrollSpecifications' },
-  { verb: 'get', path: '/:index/_list&type=realtime', controller: 'collection', action: 'list', deprecated: { since: '2.1.4', message: 'Use this route instead: http://kuzzle:7512/_listSubscriptions' } }, // @deprecated
   { verb: 'get', path: '/:index/_list', controller: 'collection', action: 'list' },
 
   { verb: 'post', path: '/admin/_resetCache', controller: 'admin', action: 'resetCache' },

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -44,6 +44,7 @@ const routes = [
   { verb: 'get', path: '/:index/:collection/_search', controller: 'document', action: 'search' },
   { verb: 'get', path: '/:index/:collection/_specifications', controller: 'collection', action: 'getSpecifications' },
   { verb: 'get', path: '/validations/_scroll/:scrollId', controller: 'collection', action: 'scrollSpecifications' },
+  { verb: 'get', path: '/:index/_list&type=realtime', controller: 'collection', action: 'list', deprecated: { since: '2.1.4', message: 'Use this route instead: http://kuzzle:7512/_listSubscriptions' } }, // @deprecated
   { verb: 'get', path: '/:index/_list', controller: 'collection', action: 'list' },
 
   { verb: 'post', path: '/admin/_resetCache', controller: 'admin', action: 'resetCache' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4221,9 +4221,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "inquirer": {
       "version": "7.3.3",


### PR DESCRIPTION
Closes #1822

## What does this PR do ?

Add deprecation to realtime listed collections route

### How should this be manually tested?
Try to access http://localhost:7512/index/_list?type=realtime of your instance of kuzzle in local and you see in the result a deprecated field

### Other changes
Doc updated

### Boyscout

- Fix a command given in this [section](https://docs.kuzzle.io/core/2/guides/getting-started/customize-api-behavior/#api-events) of the tutorial in order to be consistent with docker.
-  Adding deprecated for some actions in collectionController in order to match the doc
