### PR TITLE
Allow overriding configuration properties with JSON strings

### DIFF
--- a/doc/2/guides/advanced/configuration/index.md
+++ b/doc/2/guides/advanced/configuration/index.md
@@ -44,6 +44,16 @@ For example, the `.kuzzlerc` parameter `services.storageEngine.host` in example 
 export kuzzle_services__storageEngine__host="http://localhost:9200"
 ```
 
+You can also pass stringified JSON values this way to override non-scalar values such as objects or arrays.  
+To do so, prefix a valid stringified JSON with `*json:` to instruct Kuzzle to parse the content of the value as JSON.
+
+Examples:
+
+```bash
+export kuzzle_security__restrictedProfileIds='*json:["default","foo","bar"]'
+export kuzzle_services__common='*json:{"defaultInitTimeout":120000, "retryInterval":1000}'
+```
+
 ### Docker Compose
 
 Environment variables are particularly handy when running Kuzzle in a **Docker** container. Using **Docker Compose**, they can easily be configured in the `environment` section of the `docker-compose.yml` file. For example, here's how we pass environment variables to Kuzzle in our default docker-compose file:

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -78,6 +78,14 @@ function unstringify (cfg) {
         else if (cfg[k] === 'false') {
           cfg[k] = false;
         }
+        else if (cfg[k].startsWith('*json:')) {
+          try {
+            cfg[k] = JSON.parse(cfg[k].replace(/^\*json:/, ''));
+          }
+          catch (e) {
+            throw kerror.get('cannot_parse', `the key "${k}" does not contain a valid stringified JSON (${cfg[k]})`);
+          }
+        }
         else if (/^(-|\+)?([0-9]+)$/.test(cfg[k])) {
           cfg[k] = Number.parseInt(cfg[k]);
         }

--- a/test/config/index.test.js
+++ b/test/config/index.test.js
@@ -84,6 +84,29 @@ describe('lib/config/index.js', () => {
       should(result.bar).be.exactly(0.25);
     });
 
+    it('should convert JSON strings', () => {
+      mockedConfigContent = {
+        bar: '*json:["foo", null, 123, 123.45, true]',
+        baz: '*json:{"this": { "goes": ["to", 11] } }',
+      };
+
+      const result = config.load();
+
+      should(result.bar).match(['foo', null, 123, 123.45, true]);
+      should(result.baz).match({this: { goes: [ 'to', 11 ] } });
+    });
+
+    it('should throw if an invalid JSON string is provided for parsing', () => {
+      mockedConfigContent = {
+        foo: '*json:{ ahah: "I am using teh internet", nothing = to see here}',
+      };
+
+      should(() => config.load()).throw({
+        id: 'core.configuration.cannot_parse',
+        message: /the key "foo" does not contain a valid stringified JSON/,
+      });
+    });
+
     it('should be recursive', () => {
       mockedConfigContent = {
         foo: '42',


### PR DESCRIPTION
# Description

Properties of the `kuzzlerc` configuration file can be overridden using environment variables. This is a native property of the `rc` module that we use to load configuration values.

Problem is: `rc` does only handle scalar values. Meaning that users cannot update arrays using environment variables.

This PR proposes to solve this issue by allowing users to pass JSON strings in their environment variable: with this PR, Kuzzle will parse those strings as a post-processing to the `rc` configuration loading.

This is done by passing the `*json:` prefix to a JSON string (see the updated documentation for examples).

# How to test this PR

Run Kuzzle with, for instance, this environment variable:

`kuzzle_foo__bar__baz='*json:{"hey": { "this": [ "is", "pretty", "cool" ] } }'`

And then run a `server:getConfig` action:

```bash
kourou server:getConfig
```

The configuration should show something like this: 

```
...
"foo": {
  "bar": {
    "baz": {
      "hey": {
        "this": [ "is", "pretty", "cool" ]
      }
    }
  }
}
...
```