### PR TITLE
Throw when cookieAuth is present and CORS headers not properly configured

### DIFF
--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -373,6 +373,16 @@ class Funnel {
    */
   async checkRights (request) {
 
+    if ( global.kuzzle.config.http.accessControlAllowOrigin === '*'
+      && request.input.args.cookieAuth
+    ) {
+      throw kerror.get(
+        'security',
+        'cookie',
+        'unsupported'
+      );
+    }
+
     let skipTokenVerification = false;
     // When the Support of Cookie as Authentication Token is enabled we check if an auth token cookie is present
     // When a request is made with cookieAuth set to true

--- a/test/api/funnel/checkRights.test.js
+++ b/test/api/funnel/checkRights.test.js
@@ -193,31 +193,6 @@ describe('funnel.checkRights', () => {
     should(request.input.jwt).and.be.a.String().and.be.eql('hashed JWT');
   });
 
-  it('should throw security.cookie.unsupported when cookieAuth is true and accessControlAllowOrigin is a wildcard and both cookie and token are present', async () => {
-    kuzzle.config.http.accessControlAllowOrigin = '*';
-
-    request.input.jwt = 'hashed JWT';
-    request.input.args.cookieAuth = true;
-    request.input.headers = {cookie: 'authToken=foobar;' };
-    sinon.stub(loadedUser, 'isActionAllowed').resolves(true);
-
-    await should(funnel.checkRights(request)).be.rejectedWith({ id: 'security.cookie.unsupported' });
-
-  });
-
-  it('should not throw security.cookie.unsupported and use the token when cookieAuth is true and accessControlAllowOrigin is a wildcard and cookies are present but none of them belongs to kuzzle', async () => {
-    kuzzle.config.http.accessControlAllowOrigin = '*';
-
-    request.input.jwt = 'hashed JWT';
-    request.input.args.cookieAuth = true;
-    request.input.headers = {cookie: 'randomToken=foobar;' };
-    sinon.stub(loadedUser, 'isActionAllowed').resolves(true);
-
-    await should(funnel.checkRights(request)).not.be.rejectedWith({ id: 'security.cookie.unsupported' });
-
-    should(request.input.jwt).and.be.a.String().and.be.eql('hashed JWT');
-  });
-
   it('should not throw security.cookie.unsupported and use the token when cookieAuth is false and accessControlAllowOrigin is a wildcard and cookies are present but none of them belongs to kuzzle', async () => {
     kuzzle.config.http.accessControlAllowOrigin = '*';
 
@@ -231,7 +206,7 @@ describe('funnel.checkRights', () => {
     should(request.input.jwt).and.be.a.String().and.be.eql('hashed JWT');
   });
 
-  it('should throw security.cookie.unsupported when cookieAuth is true and accessControlAllowOrigin is a wildcard and only the cookie is present', async () => {
+  it('should throw security.cookie.unsupported when cookieAuth is true and accessControlAllowOrigin is a wildcard', async () => {
     kuzzle.config.http.accessControlAllowOrigin = '*';
 
     request.input.jwt = null;
@@ -241,19 +216,6 @@ describe('funnel.checkRights', () => {
 
     await should(funnel.checkRights(request)).be.rejectedWith({ id: 'security.cookie.unsupported' });
 
-  });
-
-  
-  it('should use the token when cookieAuth is true and accessControlAllowOrigin is a wildcard and only the token is present', async () => {
-    kuzzle.config.http.accessControlAllowOrigin = '*';
-
-    request.input.jwt = 'hashed JWT';
-    request.input.args.cookieAuth = true;
-    sinon.stub(loadedUser, 'isActionAllowed').resolves(true);
-
-    await funnel.checkRights(request);
-
-    should(request.input.jwt).and.be.a.String().and.be.eql('hashed JWT');
   });
 
   it('should throw security.token.verification_error when cookieAuth is false and accessControlAllowOrigin is not a wildcard and both cookie and token are present', async () => {


### PR DESCRIPTION



<!--
  Thank you for submitting a Pull Request. Please:
    - Read our CONTRIBUTING guidelines.
      https://github.com/kuzzleio/kuzzle/blob/master/CONTRIBUTING.md
    - Associate an issue with the Pull Request.
    - IMPORTANT - Add the corresponding "changelog:xxx" label to your PR.
-->

<!--- This template is optional. -->

## What does this PR do ?

This PR ensure that Kuzzle will throw an error if the option cookieAuth is present when the CORS headers are not properly configured to support the cookie authentication  feature
- Correct funnel behaviour
- Tests to ensure everything works properly
<!--
  Please include a summary of the change, relevant motivation and context.
  Also, list any dependencies that are required for this change.
-->