### PR TITLE
Implement requestResponse.configure()

### DIFF
--- a/doc/2/framework/classes/request-response/configure/index.md
+++ b/doc/2/framework/classes/request-response/configure/index.md
@@ -9,7 +9,8 @@ description: RequestResponse class configure() method
 
 <SinceBadge version="auto-version" />
 
-Allows to directly set internal configuration options.
+Allows to configure how the API response should be sent to the requesting client.
+
 
 ### Arguments
 

--- a/doc/2/framework/classes/request-response/configure/index.md
+++ b/doc/2/framework/classes/request-response/configure/index.md
@@ -26,11 +26,11 @@ configure(
 
 The `options` object may contain the following properties:
 
-| Name | Type | Description                      | Default |
-|------|------|----------------------------------|---------|
-| `headers` | <pre>JSONObject</pre> | Additional response protocol headers | `null` |
-| `status` | <pre>integer</pre> | KuzzleRequest status code, following the HTTP standard | `200` |
-| `format` | <pre>string</pre> | The response format, as a `standard` Kuzzle response or in a unwrapped `raw` format instead | `null` |
+| Name | Type | Description<br/>(default)        |
+|------|------|----------------------------------|
+| `headers` | <pre>JSONObject</pre>(`null`) | Additional response protocol headers |
+| `status` | <pre>integer</pre>(`200`) | KuzzleRequest status code, following the HTTP standard |
+| `format` | <pre>string</pre>(`null`) | The response format, as a `standard` Kuzzle response or in a unwrapped `raw` format instead |
 
 ### Example
 

--- a/doc/2/framework/classes/request-response/configure/index.md
+++ b/doc/2/framework/classes/request-response/configure/index.md
@@ -1,0 +1,45 @@
+---
+code: true
+type: page
+title: configure
+description: RequestResponse class configure() method
+---
+
+# configure
+
+<SinceBadge version="auto-version" />
+
+Allows to directly set internal configuration options.
+
+### Arguments
+
+```ts
+configure(
+  options: {
+    headers?: JSONObject;
+    status?: number;
+    raw?: boolean;
+  }): void;
+```
+
+</br>
+
+The `options` object may contain the following properties:
+
+| Name | Type | Description                      | Default |
+|------|------|----------------------------------|---------|
+| `headers` | <pre>JSONObject</pre> | Additional response protocol headers | `null` |
+| `status` | <pre>integer</pre> | KuzzleRequest status code, following the HTTP standard | `200` |
+| `raw` | <pre>boolean</pre> | Instead of a Kuzzle response, forward the result directly to the client, without being converted to an API response payload (can be used to answer in a different format than JSON) | `false` |
+
+### Example
+
+```js
+request.response.configure(
+  headers: {
+    'Location': 'http://kuzzle.io'
+  },
+  status: 302,
+  raw: true,
+);
+```

--- a/doc/2/framework/classes/request-response/configure/index.md
+++ b/doc/2/framework/classes/request-response/configure/index.md
@@ -16,9 +16,9 @@ Allows to directly set internal configuration options.
 ```ts
 configure(
   options: {
-    headers?: JSONObject;
-    status?: number;
-    raw?: boolean;
+    headers?: JSONObject,
+    status?: number,
+    format?: 'standard' | 'raw'
   }): void;
 ```
 
@@ -30,16 +30,16 @@ The `options` object may contain the following properties:
 |------|------|----------------------------------|---------|
 | `headers` | <pre>JSONObject</pre> | Additional response protocol headers | `null` |
 | `status` | <pre>integer</pre> | KuzzleRequest status code, following the HTTP standard | `200` |
-| `raw` | <pre>boolean</pre> | Instead of a Kuzzle response, forward the result directly to the client, without being converted to an API response payload (can be used to answer in a different format than JSON) | `false` |
+| `format` | <pre>string</pre> | The response format, as a `standard` Kuzzle response or in a unwrapped `raw` format instead | `null` |
 
 ### Example
 
 ```js
-request.response.configure(
+request.response.configure({
   headers: {
     'Location': 'http://kuzzle.io'
   },
   status: 302,
-  raw: true,
-);
+  format: 'raw',
+});
 ```

--- a/doc/2/framework/classes/request-response/properties/index.md
+++ b/doc/2/framework/classes/request-response/properties/index.md
@@ -10,5 +10,5 @@ description: RequestResponse class properties
 Kuzzle normalized API response
 
 ::: info
-This object is only meant to be used internaly by Kuzzle.  
+This object is only mostly meant to be used internaly by Kuzzle.
 :::

--- a/doc/2/framework/classes/request-response/properties/index.md
+++ b/doc/2/framework/classes/request-response/properties/index.md
@@ -10,5 +10,5 @@ description: RequestResponse class properties
 Kuzzle normalized API response
 
 ::: info
-This object is mostly meant to be used internaly by Kuzzle.
+This object is mostly meant to be used internally by Kuzzle.
 :::

--- a/doc/2/framework/classes/request-response/properties/index.md
+++ b/doc/2/framework/classes/request-response/properties/index.md
@@ -10,5 +10,5 @@ description: RequestResponse class properties
 Kuzzle normalized API response
 
 ::: info
-This object is only mostly meant to be used internaly by Kuzzle.
+This object is mostly meant to be used internaly by Kuzzle.
 :::

--- a/lib/api/request/requestResponse.ts
+++ b/lib/api/request/requestResponse.ts
@@ -267,6 +267,12 @@ export class RequestResponse {
 
   /**
    * Configure the response
+   *
+   * @param {Object} [options]
+   * @param {JSONObject} [options.headers] - Additional protocol headers
+   * @param {Number} [options.status=200] - HTTP status code
+   * @param {String} [options.format] - Response format, standard or raw
+   * @returns void
    */
   configure (
     options: {

--- a/lib/api/request/requestResponse.ts
+++ b/lib/api/request/requestResponse.ts
@@ -266,11 +266,24 @@ export class RequestResponse {
   }
 
   /**
-   * Makes the response to be a raw one
-   * With no Kuzzle wrapping
+   * Configure the response
    */
-  makeRaw (): void {
-    this.raw = true;
+  configure (
+    options: {
+      headers?: JSONObject | null;
+      status?: number;
+      raw?: boolean;
+    } = {}
+  ): void {
+    if (options.headers) {
+      this.setHeaders(options.headers);
+    }
+
+    this.status = options.status || 200;
+
+    if (options.raw !== undefined) {
+      this.raw = options.raw;
+    }
   }
 
   /**

--- a/lib/api/request/requestResponse.ts
+++ b/lib/api/request/requestResponse.ts
@@ -268,10 +268,10 @@ export class RequestResponse {
   /**
    * Configure the response
    *
-   * @param {Object} [options]
-   * @param {JSONObject} [options.headers] - Additional protocol headers
-   * @param {Number} [options.status=200] - HTTP status code
-   * @param {String} [options.format] - Response format, standard or raw
+   * @param [options]
+   * @param [options.headers] - Additional protocol headers
+   * @param [options.status=200] - HTTP status code
+   * @param [options.format] - Response format, standard or raw
    * @returns void
    */
   configure (

--- a/lib/api/request/requestResponse.ts
+++ b/lib/api/request/requestResponse.ts
@@ -270,9 +270,9 @@ export class RequestResponse {
    */
   configure (
     options: {
-      headers?: JSONObject | null;
+      headers?: JSONObject;
       status?: number;
-      raw?: boolean;
+      format?: 'standard' | 'raw';
     } = {}
   ): void {
     if (options.headers) {
@@ -281,8 +281,13 @@ export class RequestResponse {
 
     this.status = options.status || 200;
 
-    if (options.raw !== undefined) {
-      this.raw = options.raw;
+    switch (options.format) {
+      case 'raw':
+        this.raw = true;
+        break;
+      case 'standard':
+        this.raw = false;
+        break;
     }
   }
 

--- a/lib/api/request/requestResponse.ts
+++ b/lib/api/request/requestResponse.ts
@@ -264,6 +264,15 @@ export class RequestResponse {
   get node (): string {
     return (global as any).kuzzle.id;
   }
+
+  /**
+   * Makes the response to be a raw one
+   * With no Kuzzle wrapping
+   */
+  makeRaw (): void {
+    this.raw = true;
+  }
+
   /**
    * Gets a header value (case-insensitive)
    */

--- a/test/api/request/requestResponse.test.js
+++ b/test/api/request/requestResponse.test.js
@@ -271,7 +271,7 @@ describe('#RequestResponse', () => {
     });
   });
 
-  describe('configure', () => {
+  describe.only('configure', () => {
     let response;
 
     beforeEach(() => {
@@ -290,9 +290,11 @@ describe('#RequestResponse', () => {
       should(response.status).eql(402);
     });
 
-    it('should allow the user to configure the raw status of the response', () => {
-      response.configure({ raw: true });
+    it('should allow the user to configure the format of the response', () => {
+      response.configure({ format: 'raw' });
       should(response.raw).be.true();
+      response.configure({ format: 'standard' });
+      should(response.raw).be.false();
     });
   });
 

--- a/test/api/request/requestResponse.test.js
+++ b/test/api/request/requestResponse.test.js
@@ -271,7 +271,7 @@ describe('#RequestResponse', () => {
     });
   });
 
-  describe.only('makeRaw', () => {
+  describe('makeRaw', () => {
     it('should set the raw property to true', () => {
       const response = new RequestResponse(req);
 

--- a/test/api/request/requestResponse.test.js
+++ b/test/api/request/requestResponse.test.js
@@ -271,12 +271,27 @@ describe('#RequestResponse', () => {
     });
   });
 
-  describe('makeRaw', () => {
-    it('should set the raw property to true', () => {
-      const response = new RequestResponse(req);
+  describe.only('configure', () => {
+    let response;
 
-      should(response.raw).be.false();
-      response.makeRaw();
+    beforeEach(() => {
+      response = new RequestResponse(req);
+    });
+
+    it('should allow the user to configure the headers of the response', () => {
+      const testHeader = { 'X-Foo': 'foo' };
+
+      response.configure({ headers: testHeader });
+      should(response.getHeader('X-Foo')).eql('foo');
+    });
+
+    it('should allow the user to configure the status of the response', () => {
+      response.configure({ status: 402 });
+      should(response.status).eql(402);
+    });
+
+    it('should allow the user to configure the raw status of the response', () => {
+      response.configure({ raw: true });
       should(response.raw).be.true();
     });
   });

--- a/test/api/request/requestResponse.test.js
+++ b/test/api/request/requestResponse.test.js
@@ -271,7 +271,7 @@ describe('#RequestResponse', () => {
     });
   });
 
-  describe.only('configure', () => {
+  describe('configure', () => {
     let response;
 
     beforeEach(() => {

--- a/test/api/request/requestResponse.test.js
+++ b/test/api/request/requestResponse.test.js
@@ -271,6 +271,16 @@ describe('#RequestResponse', () => {
     });
   });
 
+  describe.only('makeRaw', () => {
+    it('should set the raw property to true', () => {
+      const response = new RequestResponse(req);
+
+      should(response.raw).be.false();
+      response.makeRaw();
+      should(response.raw).be.true();
+    });
+  });
+
   describe('toJSON', () => {
     it('should return a valid JSON object in Kuzzle format', () => {
       let response = new RequestResponse(req);


### PR DESCRIPTION
## What does this PR do ?
Adds a **configure** function in our **requestResponse** class in order to ease **response.raw** access.

`request.response.configure()`

> Nvm _codecov_ 🤦 is taking the wrong branch/commit

Closes #1658 