### PR TITLE
Add “suggest” to the whitelisted ES search body keys

### DIFF
--- a/doc/2/guides/main-concepts/querying/index.md
+++ b/doc/2/guides/main-concepts/querying/index.md
@@ -27,6 +27,7 @@ Elasticsearch supports many keywords in a search query root level. For security 
   - `search_timeout`
   - `size`
   - `sort`
+  - `suggest`
   - `_name`
   - `_source`
   - `_source_excludes`

--- a/lib/api/controllers/documentController.js
+++ b/lib/api/controllers/documentController.js
@@ -95,6 +95,7 @@ class DocumentController extends NativeController {
       hits: result.hits,
       remaining: result.remaining,
       scrollId: result.scrollId,
+      suggest: result.suggest,
       total: result.total,
     };
   }

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -116,6 +116,7 @@ class ElasticSearch extends Service {
       'search_timeout',
       'size',
       'sort',
+      'suggest',
       '_name',
       '_source',
       '_source_excludes',

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -331,7 +331,7 @@ class ElasticSearch extends Service {
    * @param {Object} searchBody - Search request body (query, sort, etc.)
    * @param {Object} options - from (undefined), size (undefined), scroll (undefined)
    *
-   * @returns {Promise.<{ scrollId, hits, aggregations, total }>}
+   * @returns {Promise.<{ scrollId, hits, aggregations, suggest, total }>}
    */
   async search (
     index,
@@ -394,6 +394,7 @@ class ElasticSearch extends Service {
       hits,
       remaining: body.remaining,
       scrollId: body._scroll_id,
+      suggest: body.suggest,
       total: body.hits.total.value,
     };
   }

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -312,6 +312,14 @@ describe('Test: ElasticSearch service', () => {
             ],
             total: { value: 1 },
           },
+          suggest: {
+            'some-suggestion': {
+              text: 'snowflake',
+              term: {
+                field: 'matter'
+              }
+            }
+          },
           _scroll_id: 'i-am-scroll-id',
         }
       });
@@ -323,6 +331,7 @@ describe('Test: ElasticSearch service', () => {
         body: { query: { match_all: {} } },
         from: undefined,
         size: undefined,
+        suggest: undefined,
         scroll: undefined,
         trackTotalHits: true,
       });
@@ -343,6 +352,14 @@ describe('Test: ElasticSearch service', () => {
           },
         ],
         remaining: 0,
+        suggest: {
+          'some-suggestion': {
+            text: 'snowflake',
+            term: {
+              field: 'matter'
+            }
+          }
+        },
         scrollId: 'i-am-scroll-id',
         total: 1,
       });

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -312,14 +312,7 @@ describe('Test: ElasticSearch service', () => {
             ],
             total: { value: 1 },
           },
-          suggest: {
-            'some-suggestion': {
-              text: 'snowflake',
-              term: {
-                field: 'matter'
-              }
-            }
-          },
+          suggest: { some: 'suggest' },
           _scroll_id: 'i-am-scroll-id',
         }
       });
@@ -331,7 +324,6 @@ describe('Test: ElasticSearch service', () => {
         body: { query: { match_all: {} } },
         from: undefined,
         size: undefined,
-        suggest: undefined,
         scroll: undefined,
         trackTotalHits: true,
       });
@@ -352,14 +344,7 @@ describe('Test: ElasticSearch service', () => {
           },
         ],
         remaining: 0,
-        suggest: {
-          'some-suggestion': {
-            text: 'snowflake',
-            term: {
-              field: 'matter'
-            }
-          }
-        },
+        suggest: { some: 'suggest' },
         scrollId: 'i-am-scroll-id',
         total: 1,
       });


### PR DESCRIPTION
## What does this PR do ?

Adds the [`suggest`](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/search-suggesters.html) keyword to whitelisted ES search body.
