### PR TITLE
Better error on wrong search query

### DIFF
--- a/doc/2/api/errors/error-codes/api/index.md
+++ b/doc/2/api/errors/error-codes/api/index.md
@@ -27,7 +27,7 @@ description: Error codes definitions
 | api.assert.unexpected_type_assertion<br/><pre>0x02010009</pre>  | [InternalError](/core/2/api/errors/error-codes#internalerror) <pre>(500)</pre> | An unexepected type assertion "%s" has been invoked on attribute "%s". | Unexpected type assertion |
 | api.assert.invalid_id<br/><pre>0x0201000a</pre>  | [BadRequestError](/core/2/api/errors/error-codes#badrequesterror) <pre>(400)</pre> | Invalid "_id" value: cannot start with an underscore | _id values cannot start with an underscore |
 | api.assert.forbidden_argument<br/><pre>0x0201000b</pre>  | [BadRequestError](/core/2/api/errors/error-codes#badrequesterror) <pre>(400)</pre> | The argument "%s" is not allowed by this API action. | A forbidden argument has been provided |
-| api.assert.koncorde_unknown_keyword<br/><pre>0x0201000c</pre>  | [BadRequestError](/core/2/api/errors/error-codes#badrequesterror) <pre>(400)</pre> | The keyword "%s" is not one of the Koncorde filters DSL keywords. | An unknown keyword has been provided in filters |
+| api.assert.koncorde_unknown_keyword<br/><pre>0x0201000c</pre>  | [BadRequestError](/core/2/api/errors/error-codes#badrequesterror) <pre>(400)</pre> | The keyword "%s" is not part of Koncorde filters DSL keywords. Are you trying to use an Elasticsearch query? | An unknown keyword has been provided in filters |
 | api.assert.koncorde_restricted_keyword<br/><pre>0x0201000d</pre>  | [BadRequestError](/core/2/api/errors/error-codes#badrequesterror) <pre>(400)</pre> | The %s "%s" of Koncorde DSL is not supported for search queries. | A restricted keyword has been provided in filters |
 
 ---

--- a/doc/2/api/errors/error-codes/api/index.md
+++ b/doc/2/api/errors/error-codes/api/index.md
@@ -29,6 +29,7 @@ description: Error codes definitions
 | api.assert.forbidden_argument<br/><pre>0x0201000b</pre>  | [BadRequestError](/core/2/api/errors/error-codes#badrequesterror) <pre>(400)</pre> | The argument "%s" is not allowed by this API action. | A forbidden argument has been provided |
 | api.assert.koncorde_unknown_keyword<br/><pre>0x0201000c</pre>  | [BadRequestError](/core/2/api/errors/error-codes#badrequesterror) <pre>(400)</pre> | The keyword "%s" is not part of Koncorde filters DSL keywords. Are you trying to use an Elasticsearch query? | An unknown keyword has been provided in filters |
 | api.assert.koncorde_restricted_keyword<br/><pre>0x0201000d</pre>  | [BadRequestError](/core/2/api/errors/error-codes#badrequesterror) <pre>(400)</pre> | The %s "%s" of Koncorde DSL is not supported for search queries. | A restricted keyword has been provided in filters |
+| api.assert.koncorde_dsl_error<br/><pre>0x0201000e</pre>  | [BadRequestError](/core/2/api/errors/error-codes#badrequesterror) <pre>(400)</pre> | %s | Provided filters contains an error |
 
 ---
 

--- a/doc/2/api/errors/error-codes/services/index.md
+++ b/doc/2/api/errors/error-codes/services/index.md
@@ -57,6 +57,7 @@ description: Error codes definitions
 | services.storage.invalid_collection_name<br/><pre>0x0101002a</pre>  | [BadRequestError](/core/2/api/errors/error-codes#badrequesterror) <pre>(400)</pre> | The collection name "%s" is invalid | A provided collection name is invalid |
 | services.storage.strict_mapping_rejection<br/><pre>0x0101002b</pre>  | [BadRequestError](/core/2/api/errors/error-codes#badrequesterror) <pre>(400)</pre> | Cannot create document. Field "%s" is not present in collection "%s:%s" strict mapping | Document rejected because it contains a field that is not declared in the strict mapping. |
 | services.storage.scroll_duration_too_great<br/><pre>0x0101002c</pre>  | [BadRequestError](/core/2/api/errors/error-codes#badrequesterror) <pre>(400)</pre> | Scroll duration "%s" is too great. | The scroll duration exceed the configured maxium value. (See config.services.storageEngine.maxScrollDuration) |
+| services.storage.unknown_query_keyword<br/><pre>0x0101002d</pre>  | [BadRequestError](/core/2/api/errors/error-codes#badrequesterror) <pre>(400)</pre> | The keyword "%s" is not part of Elasticsearch Query DSL. Are you trying to use a Koncorde query? | An unknown keyword has been provided in the search query |
 
 ---
 

--- a/doc/2/guides/getting-started/store-and-access-data/index.md
+++ b/doc/2/guides/getting-started/store-and-access-data/index.md
@@ -105,7 +105,7 @@ Select the `nyc-open-data` index and then the `yellow-taxi` collection. You shou
 
 ### Search for documents
 
-Kuzzle directly exposes directly the data through the API by allowing client to express a query to match documents they need. 
+Kuzzle allows to search for documents through its API, with different query languages depending on your needs.
 
 We'll now use that to search for the documents we're interested in.
 

--- a/doc/2/guides/getting-started/store-and-access-data/index.md
+++ b/doc/2/guides/getting-started/store-and-access-data/index.md
@@ -105,7 +105,7 @@ Select the `nyc-open-data` index and then the `yellow-taxi` collection. You shou
 
 ### Search for documents
 
-Kuzzle directly exposes [Elasticsearch's query language](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-dsl.html) in a secure way. 
+Kuzzle directly exposes directly the data through the API by allowing client to express a query to match documents they need. 
 
 We'll now use that to search for the documents we're interested in.
 
@@ -131,22 +131,20 @@ Then we are going to use the [document:search](/core/2/api/controllers/document/
  - `age` is greater than `30`
  - `city` is equal to `Antalya`
 
-For this, we need to write a [Boolean Query](/core/2/guides/main-concepts/querying#boolean-query):
+For this, we need to write a [Koncorde Query](/core/2/guides/main-concepts/querying/#koncorde-query):
 
 ```js
 {
-  bool: {
-    must: [
-      {
-        range: {
-          age: { gt: 30 }
-        }
-      },
-      {
-        term: { city: "Antalya" }
+  and: [
+    {
+      range: {
+        age: { gt: 30 }
       }
-    ]
-  }
+    },
+    {
+      equals: { city: "Antalya" }
+    }
+  ]
 }
 ```
 
@@ -154,18 +152,16 @@ And to execute this query we are going to use Kourou again:
 
 ```bash
 kourou document:search nyc-open-data yellow-taxi '{
-  bool: {
-    must: [
-      {
-        range: {
-          age: { gt: 30 }
-        }
-      },
-      {
-        term: { city: "Antalya" }
+  and: [
+    {
+      range: {
+        age: { gt: 30 }
       }
-    ]
-  }
+    },
+    {
+      equals: { city: "Antalya" }
+    }
+  ]
 }'
 ```
 

--- a/doc/2/guides/main-concepts/querying/index.md
+++ b/doc/2/guides/main-concepts/querying/index.md
@@ -198,7 +198,7 @@ You can use the `term` clause to find documents based on a precise value such as
 ```bash
 kourou document:search ktm-open-data thamel-taxi '{
   term: { name: "Jenow" }
-}'
+}' --lang elasticsearch
 ```
 
 ::: info
@@ -226,7 +226,7 @@ The `match` clause as well as the content of a `text` fields are [analyzed](http
 ```bash
 kourou document:search ktm-open-data thamel-taxi '{
   match: { description: "java" }
-}'
+}' --lang elasticsearch
 ```
 
 ### `range` clause
@@ -246,7 +246,7 @@ kourou document:search ktm-open-data thamel-taxi '{
       lte: 42
     }
   }
-}'
+}' --lang elasticsearch
 ```
 
 ### `ids` clause
@@ -259,7 +259,7 @@ kourou document:search ktm-open-data thamel-taxi '{
   ids: {
     values: ["aschen", "liia"]
   }
-}'
+}' --lang elasticsearch
 ```
 
 ::: info
@@ -297,7 +297,7 @@ kourou document:search ktm-open-data thamel-taxi '{
       { term: { city: "Kathmandu" } },
     ]
   }
-}'
+}' --lang elasticsearch
 ```
 
 ## Koncorde Query
@@ -321,7 +321,7 @@ kourou document:search ktm-open-data thamel-taxi '{
     { equals: { city: "Tirana" } },
     { range: { age: { gte: 32 } } }
   ]
-}' --arg lang=koncorde
+}'
 ```
 
 ## Sorting

--- a/lib/api/controllers/baseController.js
+++ b/lib/api/controllers/baseController.js
@@ -82,9 +82,14 @@ class NativeController extends BaseController {
       return {};
     }
 
-    // @todo throw "koncorde_unknown_keyword" when Koncorde will throw
-    // just the keyword name
-    await global.kuzzle.koncorde.validate(koncordeFilters);
+    try {
+      await global.kuzzle.koncorde.validate(koncordeFilters);
+    }
+    catch (error) {
+      const [, keyword] = error.message.split('Unknown DSL keyword: ');
+
+      throw kerror.getFrom(error, 'api', 'assert', 'koncorde_unknown_keyword', keyword);
+    }
 
     if (typeof koncordeFilters !== 'object') {
       throw kerror.get(

--- a/lib/api/controllers/baseController.js
+++ b/lib/api/controllers/baseController.js
@@ -86,9 +86,13 @@ class NativeController extends BaseController {
       await global.kuzzle.koncorde.validate(koncordeFilters);
     }
     catch (error) {
-      const [, keyword] = error.message.split('Unknown DSL keyword: ');
+      if (error.message.includes('Unknown DSL keyword: ')) {
+        const [, keyword] = error.message.split('Unknown DSL keyword: ');
 
-      throw kerror.getFrom(error, 'api', 'assert', 'koncorde_unknown_keyword', keyword);
+        throw kerror.getFrom(error, 'api', 'assert', 'koncorde_unknown_keyword', keyword);
+      }
+
+      throw kerror.getFrom(error, 'api', 'assert', 'koncorde_dsl_error', error.message);
     }
 
     if (typeof koncordeFilters !== 'object') {

--- a/lib/core/realtime/hotelClerk.js
+++ b/lib/core/realtime/hotelClerk.js
@@ -415,10 +415,16 @@ class HotelClerk {
       return kerror.reject('api', 'assert', 'missing_argument', 'collection');
     }
 
-    const normalized = await global.kuzzle.koncorde.normalize(
-      index,
-      collection,
-      filters);
+    let normalized;
+    try {
+      normalized = await global.kuzzle.koncorde.normalize(
+        index,
+        collection,
+        filters);
+    }
+    catch (error) {
+      throw kerror.getFrom(error, 'api', 'assert', 'koncorde_dsl_error', error.message);
+    }
 
     if (this.rooms.has(normalized.id)) {
       return {

--- a/lib/kerror/codes/1-services.json
+++ b/lib/kerror/codes/1-services.json
@@ -251,6 +251,12 @@
           "code": 44,
           "message": "Scroll duration \"%s\" is too great.",
           "class": "BadRequestError"
+        },
+        "unknown_query_keyword": {
+          "description": "An unknown keyword has been provided in the search query",
+          "code": 45,
+          "message": "The keyword \"%s\" is not part of Elasticsearch Query DSL. Are you trying to use a Koncorde query?",
+          "class": "BadRequestError"
         }
       }
     },

--- a/lib/kerror/codes/2-api.json
+++ b/lib/kerror/codes/2-api.json
@@ -73,7 +73,7 @@
         "koncorde_unknown_keyword": {
           "description": "An unknown keyword has been provided in filters",
           "code": 12,
-          "message": "The keyword \"%s\" is not one of the Koncorde filters DSL keywords.",
+          "message": "The keyword \"%s\" is not part of Koncorde filters DSL keywords. Are you trying to use an Elasticsearch query?",
           "class": "BadRequestError"
         },
         "koncorde_restricted_keyword": {

--- a/lib/kerror/codes/2-api.json
+++ b/lib/kerror/codes/2-api.json
@@ -81,6 +81,12 @@
           "code": 13,
           "message": "The %s \"%s\" of Koncorde DSL is not supported for search queries.",
           "class": "BadRequestError"
+        },
+        "koncorde_dsl_error": {
+          "description": "Provided filters contains an error",
+          "code": 14,
+          "message": "%s",
+          "class": "BadRequestError"
         }
       }
     },

--- a/lib/kerror/index.js
+++ b/lib/kerror/index.js
@@ -144,21 +144,6 @@ function reject (domain, subdomain, error, ...placeholders) {
 }
 
 /**
- * Returns a promise rejected with the corresponding error, with its stack
- * trace derivated from a provided source error
- *
- * @param  {Error}  source
- * @param  {string} domain - Domain (eg: 'external')
- * @param  {string} subdomain - Subdomain (eg: 'elasticsearch')
- * @param  {string} error - Error name: (eg: 'index_not_found')
- * @param  {...any} placeholders - Placeholders value to inject in error message
- */
-function rejectFrom (source, domain, subdomain, error, ...placeholders) {
-  return Bluebird.reject(
-    getFrom(source, domain, subdomain, error, ...placeholders));
-}
-
-/**
  * Construct and return the corresponding error, with its stack
  * trace derivated from a provided source error
  *
@@ -171,7 +156,16 @@ function rejectFrom (source, domain, subdomain, error, ...placeholders) {
 function getFrom (source, domain, subdomain, error, ...placeholders) {
   const derivedError = get(domain, subdomain, error, ...placeholders);
 
-  derivedError.stack = source.stack;
+  // If a stacktrace is present, we need to modify the first line because it
+  // still contains the original error message
+  if (derivedError.stack && derivedError.stack.length) {
+    const stackArray = source.stack.split('\n');
+    stackArray.shift();
+    derivedError.stack = [
+      `${derivedError.constructor.name}: ${derivedError.message}`,
+      ...stackArray
+    ].join('\n');
+  }
 
   return derivedError;
 }
@@ -197,12 +191,6 @@ function wrap (domain, subdomain) {
       subdomain,
       error,
       ...placeholders),
-    rejectFrom: (source, error, ...placeholders) => rejectFrom(
-      source,
-      domain,
-      subdomain,
-      error,
-      ...placeholders)
   };
 }
 
@@ -210,6 +198,5 @@ module.exports = {
   get,
   getFrom,
   reject,
-  rejectFrom,
   wrap,
 };

--- a/lib/service/storage/esWrapper.js
+++ b/lib/service/storage/esWrapper.js
@@ -139,7 +139,18 @@ const errorMessagesMapping = [
       return [matches[1], index, collection];
     }
   },
-
+  {
+    // [and] query malformed, no start_object after query name
+    regex: /^\[(.*)\] query malformed, no start_object after query name/,
+    subcode: 'unknown_query_keyword',
+    getPlaceholders: (esError, matches) => [matches[1]]
+  },
+  {
+    // no [query] registered for [equals]
+    regex: /^no \[query\] registered for \[(.*)\]/,
+    subcode: 'unknown_query_keyword',
+    getPlaceholders: (esError, matches) => [matches[1]]
+  },
 ];
 
 class ESWrapper {

--- a/test/core/backend/Backend.test.js
+++ b/test/core/backend/Backend.test.js
@@ -429,7 +429,6 @@ describe('Backend', () => {
     should(application.kerror.get).be.a.Function();
     should(application.kerror.reject).be.a.Function();
     should(application.kerror.getFrom).be.a.Function();
-    should(application.kerror.rejectFrom).be.a.Function();
     should(application.kerror.wrap).be.a.Function();
   });
 

--- a/test/service/storage/esWrapper.test.js
+++ b/test/service/storage/esWrapper.test.js
@@ -74,6 +74,21 @@ describe('Test: ElasticSearch Wrapper', () => {
       });
     });
 
+    it('should handle unknown DSL keyword', () => {
+      const error = new Error('');
+      error.meta = { body: { error: { reason: '[and] query malformed, no start_object after query name' } } };
+
+      should(esWrapper.formatESError(error)).be.match({
+        id: 'services.storage.unknown_query_keyword'
+      });
+
+      error.meta = { body: { error: { reason: 'no [query] registered for [equals]' } } };
+
+      should(esWrapper.formatESError(error)).be.match({
+        id: 'services.storage.unknown_query_keyword'
+      });
+    });
+
     describe('logging in production', () => {
       let nodeEnv;
 


### PR DESCRIPTION
## What does this PR do ?

Send better errors when users use the wrong language for search queries.

### How should this be manually tested?

<details><summary>Examples</summary>

```
kourou document:search nyc-open-data yellow-taxi '{
  and: [         
    {
      range: {
        age: { gt: 30 }
      }
    },
    {
      term: { city: "Antalya" }
    }
  ] 
}' --lang elasticsearch
```

```
kourou document:search nyc-open-data yellow-taxi '{
  bool: { must: [
    {
      range: {
        age: { gt: 30 }
      }
    },
    {
      equals: { city: "Antalya" }
    }
  ]}
}' --lang elasticsearch
```

```
kourou document:search nyc-open-data yellow-taxi '{
  bool: { must: [
    {
      range: {
        age: { gt: 30 }
      }
    },
    {
      term: { city: "Antalya" }  
    }
  ]}
}'
```

</details>

### Other changes

  - update documentation example
