### PR TITLE
ImpersonatedSDK should be able to execute most of the sdk actions

### DIFF
--- a/features/PluginContext.feature
+++ b/features/PluginContext.feature
@@ -74,6 +74,20 @@ Feature: Plugin context
     Then I should receive a result matching:
       | _source._kuzzle_info.author | "test-admin" |
 
+  Scenario: Test user impersonation as a whole workflow
+    Given a collection "nyc-open-data":"yellow-taxi"
+    And I successfully execute the action "functional-test-plugin/impersonate":"createDocumentAs" with args:
+      | kuid | "default-user" |
+    And I successfully execute the action "functional-test-plugin/impersonate":"createDocumentAs" with args:
+      | kuid | "test-admin" |
+    And I refresh the collection
+    When I successfully execute the action "functional-test-plugin/impersonate":"testAction" with args:
+      | checkRights | "true"                                                                                                                                                        |
+      | kuid        | "test-admin"                                                                                                                                                  |
+      | body        | { "controller": "document", "action": "search", "args": ["nyc-open-data", "yellow-taxi", { "query": { "match": { "shouldBeCreatedBy": "default-user" } } }] } |
+    Then I should receive a result matching:
+      | total | 1 |
+
   @security
   Scenario: Verify if a specific user is authorized to execute an action
     Given a collection "nyc-open-data":"yellow-taxi"
@@ -81,7 +95,7 @@ Feature: Plugin context
       | document | { "create": false } |
     When I execute the action "functional-test-plugin/impersonate":"createDocumentAs" with args:
       | kuid        | "default-user" |
-      | checkRights | "true"           |
+      | checkRights | "true"         |
     Then I should receive an error matching:
       | id | "security.rights.forbidden" |
 

--- a/lib/core/shared/sdk/impersonatedSdk.js
+++ b/lib/core/shared/sdk/impersonatedSdk.js
@@ -52,6 +52,7 @@ class ImpersonatedSDK {
             this[controllerProxy] = new Proxy(global.app.sdk[controllerName], {
               get: (controllerInstance, actionName) => {
                 const customContext = {
+                  kuzzle: global.app.sdk,
                   query: (request, opts) => {
                     request.controller = controllerName;
 
@@ -60,9 +61,17 @@ class ImpersonatedSDK {
                   }
                 };
 
-                // Return the original SDK action method and context BUT also add this local context
-                // containing our custom 'query' method
-                return controllerInstance[actionName].bind({ ...controllerInstance, ...customContext });
+                // Make sure we bring any local methods into our new custom context
+                Object.getOwnPropertyNames(Object.getPrototypeOf(global.app.sdk[controllerName]))
+                  .forEach((localMethod) => {
+                    if (!['constructor', 'query'].includes(localMethod)) {
+                      customContext[localMethod] = controllerInstance[localMethod];
+                    }
+                  });
+
+                // Return the original SDK action method AND also bind our merged custom context
+                // containing our 'query' method and any original local methods
+                return controllerInstance[actionName].bind(customContext);
               }
             });
           }

--- a/plugins/available/functional-test-plugin/functionalTestPlugin.js
+++ b/plugins/available/functional-test-plugin/functionalTestPlugin.js
@@ -119,12 +119,22 @@ class FunctionalTestPlugin {
 
 
     // Embedded SDK.as() Impersonation =========================================
-    this.controllers.impersonate = { createDocumentAs: 'createDocumentAs' };
+    this.controllers.impersonate = {
+      createDocumentAs: 'createDocumentAs',
+      testAction: 'testImpersonatedAction'
+    };
 
     this.routes.push({
       action: 'createDocumentAs',
       controller: 'impersonate',
       path: '/impersonate/createDocumentAs/:kuid',
+      verb: 'post',
+    });
+
+    this.routes.push({
+      action: 'testAction',
+      controller: 'impersonate',
+      path: '/impersonate/testAction/:kuid',
       verb: 'post',
     });
 
@@ -295,13 +305,29 @@ class FunctionalTestPlugin {
     if (request.input.args.checkRights !== undefined) {
       options.checkRights = request.input.args.checkRights;
     }
-    const sdkInstance = await this.sdk.as({ _id: request.input.args.kuid }, options);
+    const sdkInstance = this.sdk.as({ _id: request.input.args.kuid }, options);
 
     return sdkInstance.document.create(
       'nyc-open-data',
       'yellow-taxi',
       { shouldBeCreatedBy: request.input.args.kuid },
     );
+  }
+
+  /**
+   * Use this action tool to verify impersonated actions
+   */
+  async testImpersonatedAction (request) {
+    const { controller, action, args } = request.input.body;
+    const options = {};
+
+    if (request.input.args.checkRights !== undefined) {
+      options.checkRights = request.input.args.checkRights;
+    }
+
+    const sdkInstance = this.sdk.as({ _id: request.input.args.kuid }, options);
+
+    return sdkInstance[controller][action](...args);
   }
 }
 


### PR DESCRIPTION
## What does this PR do ?
Some sdk methods **use** locally stored/defined methods/variables that are unlinked/removed (context lost) when the `impersonatedSdk` proxies each controller.

To be able to _recreate_ the old context, add the following to our new `customContext`:
1. The base **sdk**.
2. Any methods found on the source `controllerInstance` prototype.

All **except** the following actions should work with **sdk.as**:

- `auth:getCurrentUser`
- `auth:logout`
- `auth:refreshToken`

### Todo:

- [x] Find a solution to make _most_ of the **sdk** actions work correctly.
- [x] Figure a way to test our **sdk** through the eyes of an `impersonatedSdk` for **future-proofing**.
- - **A:** :x: Unit test that local controller context is taking care of. (I tried, test not working as intended.)
- - **B:** :heavy_check_mark:  Create a functional test (functional-test-plugin)

> :information_source: Testing `document.search` action proves that the **ImpersonatedSdk** now correctly merges controller context (local functions).

### How should this be manually tested?
To be able to find actions that were broken (mostly) after loosing their context:

1. Create a `test.ts` file at the root of the repository.
2. Run kuzzle services (es, reddis)
2. Run `npm run dev test.ts`

```ts
import { Backend } from './lib/core/backend'

const app = new Backend('playground')

const api = {
  auth: [
    'checkRights', 'checkToken', 'createApiKey',
    'createMyCredentials', 'credentialsExist', 'deleteApiKey', 'deleteMyCredentials', 'getCurrentUser',
    'getMyCredentials', 'getMyRights', 'getStrategies', 'login', 'logout',
    'refreshToken', 'searchApiKeys', 'updateMyCredentials', 'updateSelf', 'validateMyCredentials',
  ],
  bulk: [
    'import', 'write', 'mWrite', 'deleteByQuery'
  ],
  collection: [
    'create', 'delete', 'deleteSpecifications', 'exists', 'getMapping',
    'getSpecifications', 'list', 'refresh', 'searchSpecifications',
    'truncate', 'update', 'updateMapping', 'updateSpecifications', 'validateSpecifications',
  ],
  document: [
    'count', 'create', 'createOrReplace', 'delete', 'deleteByQuery',
    'exists', 'get', 'mCreate', 'mCreateOrReplace', 'mDelete', 'mGet', 'mReplace',
    'mUpdate', 'replace', 'search', 'update', 'upsert', 'updateByQuery', 'validate'
  ],
  index: [
    'create',
    'delete',
    'exists',
    'list',
    'mDelete'
  ],
  // ms: [ // These just work...
  //   'append', 'get', 'scan', 'ttl'
  // ],
  realtime: [
    'count', 'publish', 'subscribe', 'unsubscribe',
  ],
  security: [
    'checkRights', 'createApiKey', 'createCredentials', 'createFirstAdmin',
    'createOrReplaceProfile', 'createOrReplaceRole', 'createProfile', 'createRestrictedUser', 'createRole', 'createUser', 'deleteApiKey', 'deleteCredentials', 'deleteProfile',
    'deleteRole', 'deleteUser', 'getAllCredentialFields', 'getCredentialFields', 'getCredentials', 'getCredentialsById', 'getProfile', 'getProfileMapping', 'getProfileRights', 'getRole',
    'getRoleMapping', 'getUser', 'getUserMapping', 'getUserRights', 'hasCredentials', 'mDeleteProfiles',
    'mDeleteRoles', 'mDeleteUsers', 'mGetProfiles', 'mGetRoles', 'mGetUsers', 'refresh', 'replaceUser', 'searchApiKeys',
    'searchProfiles', 'searchRoles', 'searchUsers', 'updateCredentials', 'updateProfile', 'updateProfileMapping', 'updateRole', 'updateRoleMapping', 'updateUser', 'updateUserMapping', 'validateCredentials'
  ],
  server: [
    'adminExists',
    'getAllStats',
    'getConfig',
    'getLastStats',
    'getStats',
    'info',
    'now',
  ]
}

app.start()
  .then(async () => {
    // Setup
    try {
      await app.sdk.index.create('test');
      await app.sdk.collection.create('test', 'test', {});
      await app.sdk.security.createUser('leo', { content: { profileIds: ['admin'] } });
    } catch (error) { } // Ignore.

    const proxyInstance = app.sdk.as({ _id: 'leo' }, { checkRights: true });

    for (const [controller, actions] of Object.entries(api)) {
      for (const action of actions) {
        try {
          if (typeof proxyInstance[controller][action] === 'function') {
            await proxyInstance[controller][action]();
          }
        } catch (e) {
          if (![
            'api.assert.missing_argument',
            'api.process.admin_exists',
            'api.assert.body_required',
          ].includes(e.id)) {
            console.log('✖', { controller, action }, e)
          } else {
            console.log('✔', { controller, action });
          }
        }
      }
    }
  })
```
![image](https://user-images.githubusercontent.com/2495908/113902035-c2f82980-97cf-11eb-835b-36902e632903.png)

Closes #2037 