### PR TITLE
Hotfix duplicated cors headers on HTTP Request

### DIFF
--- a/lib/api/request/requestResponse.ts
+++ b/lib/api/request/requestResponse.ts
@@ -322,11 +322,16 @@ export class RequestResponse {
   /**
    * Adds new multiple headers.
    */
-  setHeaders (headers: JSONObject) {
+  setHeaders (headers: JSONObject, ifNotPresent:boolean = false) {
     assert.assertObject('headers', headers);
 
     if (headers) {
-      Object.keys(headers).forEach(name => this.setHeader(name, headers[name]));
+      Object.keys(headers).forEach(name => {
+        // When ifNotPresent is set to true, only set the header if no value has been defined before
+        if (!ifNotPresent || this.getHeader(name) === undefined) {
+          this.setHeader(name, headers[name]);
+        }
+      });
     }
   }
 

--- a/lib/api/request/requestResponse.ts
+++ b/lib/api/request/requestResponse.ts
@@ -326,7 +326,7 @@ export class RequestResponse {
     assert.assertObject('headers', headers);
 
     if (headers) {
-      for (const name in headers) {
+      for (const name of Object.keys(headers)) {
         // When ifNotPresent is set to true, only set the header if no value has been defined before
         if (!ifNotPresent || this.getHeader(name) === undefined) {
           this.setHeader(name, headers[name]);

--- a/lib/api/request/requestResponse.ts
+++ b/lib/api/request/requestResponse.ts
@@ -322,7 +322,7 @@ export class RequestResponse {
   /**
    * Adds new multiple headers.
    */
-  setHeaders (headers: JSONObject, ifNotPresent:boolean = false) {
+  setHeaders (headers: JSONObject, ifNotPresent = false) {
     assert.assertObject('headers', headers);
 
     if (headers) {

--- a/lib/api/request/requestResponse.ts
+++ b/lib/api/request/requestResponse.ts
@@ -326,12 +326,12 @@ export class RequestResponse {
     assert.assertObject('headers', headers);
 
     if (headers) {
-      Object.keys(headers).forEach(name => {
+      for (const name in headers) {
         // When ifNotPresent is set to true, only set the header if no value has been defined before
         if (!ifNotPresent || this.getHeader(name) === undefined) {
           this.setHeader(name, headers[name]);
         }
-      });
+      }
     }
   }
 

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -336,9 +336,9 @@ const routes = [
   { verb: 'put', path: '/:index/:collection/_mCreateOrReplace', controller: 'document', action: 'mCreateOrReplace' },
   { verb: 'put', path: '/:index/:collection/:_id/_replace', controller: 'document', action: 'replace' },
   { verb: 'put', path: '/:index/:collection/_mReplace', controller: 'document', action: 'mReplace' },
-  { verb: 'put', path: '/:index/:collection/_mUpdate', controller: 'document', action: 'mUpdate', deprecated: { since: '2.11.0', message: 'Use this route with PATCH instead of PUT' } }, // @deprecated
-  { verb: 'put', path: '/:index/:collection/:_id/_update', controller: 'document', action: 'update', deprecated: { since: '2.11.0', message: 'Use this route with PATCH instead of PUT' } }, // @deprecated
-  { verb: 'put', path: '/:index/:collection/:_id/_upsert', controller: 'document', action: 'upsert', deprecated: { since: '2.11.0', message: 'Use this route with POST instead of PUT' } }, // @deprecated
+  { verb: 'put', path: '/:index/:collection/_mUpdate', controller: 'document', action: 'mUpdate', deprecated: { since: '2.11.0', message: 'Use "document:mUpdate" route with PATCH instead of PUT' } }, // @deprecated
+  { verb: 'put', path: '/:index/:collection/:_id/_update', controller: 'document', action: 'update', deprecated: { since: '2.11.0', message: 'Use "document:update" route with PATCH instead of PUT' } }, // @deprecated
+  { verb: 'put', path: '/:index/:collection/:_id/_upsert', controller: 'document', action: 'upsert', deprecated: { since: '2.11.0', message: 'Use "document:upsert" route with POST instead of PUT' } }, // @deprecated
   { verb: 'put', path: '/:index/:collection/_query', controller: 'document', action: 'updateByQuery' },
 
   { verb: 'put', path: '/profiles/:_id', controller: 'security', action: 'createOrReplaceProfile' },

--- a/lib/core/network/httpRouter/index.js
+++ b/lib/core/network/httpRouter/index.js
@@ -153,7 +153,8 @@ class Router {
     try {
       routeHandler = this.routes[message.method].getHandler(message);
 
-      routeHandler.request.response.setHeaders(this.defaultHeaders);
+      // Set Headers if not present
+      routeHandler.request.response.setHeaders(this.defaultHeaders, true);
 
       if (routeHandler.handler === null) {
         throw kerror.get('url_not_found', routeHandler.url);
@@ -165,7 +166,8 @@ class Router {
       let request;
       if (!routeHandler || !routeHandler._request) {
         request = new Request({requestId: message.requestId}, {});
-        request.response.setHeaders(this.defaultHeaders);
+        // Set Headers if not present
+        request.response.setHeaders(this.defaultHeaders, true);
       }
       else {
         request = routeHandler.request;
@@ -192,7 +194,8 @@ class Router {
         { requestId: message.requestId },
         requestContext && requestContext.toJSON());
 
-    request.response.setHeaders(this.defaultHeaders);
+    // Set Headers if not present
+    request.response.setHeaders(this.defaultHeaders, true);
 
     if (message.method === 'OPTIONS') {
       request.input.headers = message.headers;

--- a/lib/core/network/protocols/httpwsProtocol.js
+++ b/lib/core/network/protocols/httpwsProtocol.js
@@ -578,7 +578,10 @@ class HttpWsProtocol extends Protocol {
           response.writeStatus(Buffer.from(request.response.status.toString()));
 
           for (const header of this.httpConfig.headers) {
-            response.writeHeader(header[0], header[1]);
+            // If header is missing, add the default one
+            if (request.response.headers[header[2]] === undefined) {
+              response.writeHeader(header[0], header[1]);
+            }
           }
 
           for (const [key, value] of Object.entries(request.response.headers)) {
@@ -866,6 +869,7 @@ class HttpWsProtocol extends Protocol {
     ];
 
     for (const header of headers) {
+      header[2] = header[0]; // Save the raw header name in the third slot
       header[0] = Buffer.from(header[0]);
       header[1] = Buffer.from(header[1]);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "bin": {
     "kuzzle": "bin/start-kuzzle-server"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.11.2",
+  "version": "2.11.1",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "bin": {
     "kuzzle": "bin/start-kuzzle-server"

--- a/test/api/request/requestResponse.test.js
+++ b/test/api/request/requestResponse.test.js
@@ -159,10 +159,28 @@ describe('#RequestResponse', () => {
       response.setHeader('X-Foo', 'foo');
       response.setHeader('test', 'test');
 
+
       response.setHeaders({ test: 'test', banana: '42' });
 
       should(response.headers).have.property('X-Foo');
       should(response.headers).have.property('test', 'test, test');
+      should(response.headers).have.property('banana', '42');
+    });
+
+    it('should not set headers if already existing', () => {
+      response.setHeader('X-Foo', 'foo');
+      response.setHeader('test', 'test');
+
+      const map = { test: 'foobar', banana: '42' };
+      Object.keys(map).forEach(name => {
+        if (!true && response.getHeader(name) === undefined) {
+          console.log(name);
+        }
+      });
+      response.setHeaders({ test: 'foobar', banana: '42' }, true);
+
+      should(response.headers).have.property('X-Foo');
+      should(response.headers).have.property('test', 'test');
       should(response.headers).have.property('banana', '42');
     });
 

--- a/test/api/request/requestResponse.test.js
+++ b/test/api/request/requestResponse.test.js
@@ -159,7 +159,6 @@ describe('#RequestResponse', () => {
       response.setHeader('X-Foo', 'foo');
       response.setHeader('test', 'test');
 
-
       response.setHeaders({ test: 'test', banana: '42' });
 
       should(response.headers).have.property('X-Foo');
@@ -171,12 +170,6 @@ describe('#RequestResponse', () => {
       response.setHeader('X-Foo', 'foo');
       response.setHeader('test', 'test');
 
-      const map = { test: 'foobar', banana: '42' };
-      Object.keys(map).forEach(name => {
-        if (!true && response.getHeader(name) === undefined) {
-          console.log(name);
-        }
-      });
       response.setHeaders({ test: 'foobar', banana: '42' }, true);
 
       should(response.headers).have.property('X-Foo');

--- a/test/core/network/protocols/http.test.js
+++ b/test/core/network/protocols/http.test.js
@@ -480,51 +480,52 @@ describe('core/network/protocols/http', () => {
       should(response.writeStatus).calledOnce().calledWithMatch(Buffer.from('200'));
 
       should(response.writeHeader)
-      .not.be.calledWithMatch(
-        Buffer.from('Access-Control-Allow-Headers'),
-        Buffer.from(kuzzle.config.http.accessControlAllowHeaders)
-      );
+        .not.be.calledWithMatch(
+          Buffer.from('Access-Control-Allow-Headers'),
+          Buffer.from(kuzzle.config.http.accessControlAllowHeaders)
+        );
 
       should(response.writeHeader)
-      .be.calledWithMatch(
-        Buffer.from('Access-Control-Allow-Headers'),
-        Buffer.from('foo')
-      );
+        .be.calledWithMatch(
+          Buffer.from('Access-Control-Allow-Headers'),
+          Buffer.from('foo')
+        );
 
       should(response.writeHeader)
-      .not.be.calledWithMatch(
-        Buffer.from('Access-Control-Allow-Methods'),
-        Buffer.from(kuzzle.config.http.accessControlAllowMethods)
-      );
+        .not.be.calledWithMatch(
+          Buffer.from('Access-Control-Allow-Methods'),
+          Buffer.from(kuzzle.config.http.accessControlAllowMethods)
+        );
 
       should(response.writeHeader)
-      .be.calledWithMatch(
-        Buffer.from('Access-Control-Allow-Methods'),
-        Buffer.from('foo')
-      );
+        .be.calledWithMatch(
+          Buffer.from('Access-Control-Allow-Methods'),
+          Buffer.from('foo')
+        );
 
       should(response.writeHeader)
-      .not.be.calledWithMatch(
-        Buffer.from('Access-Control-Allow-Origin'),
-        Buffer.from(kuzzle.config.http.accessControlAllowOrigin)
-      );
-
-      should(response.writeHeader).be.calledWithMatch(
-        Buffer.from('Access-Control-Allow-Origin'),
-        Buffer.from('foo')
-      );
+        .not.be.calledWithMatch(
+          Buffer.from('Access-Control-Allow-Origin'),
+          Buffer.from(kuzzle.config.http.accessControlAllowOrigin)
+        );
 
       should(response.writeHeader)
-      .not.be.calledWithMatch(
-        Buffer.from('Content-Type'),
-        Buffer.from('application/json')
-      );
+        .be.calledWithMatch(
+          Buffer.from('Access-Control-Allow-Origin'),
+          Buffer.from('foo')
+        );
 
       should(response.writeHeader)
-      .be.calledWithMatch(
-        Buffer.from('Content-Type'),
-        Buffer.from('foo')
-      );
+        .not.be.calledWithMatch(
+          Buffer.from('Content-Type'),
+          Buffer.from('application/json')
+        );
+
+      should(response.writeHeader)
+        .be.calledWithMatch(
+          Buffer.from('Content-Type'),
+          Buffer.from('foo')
+        );
 
       should(response.writeHeader.calledBefore(response.tryEnd));
 


### PR DESCRIPTION
<!--
  Thank you for submitting a Pull Request. Please:
    - Read our CONTRIBUTING guidelines.
      https://github.com/kuzzleio/kuzzle/blob/master/CONTRIBUTING.md
    - Associate an issue with the Pull Request.
    - IMPORTANT - Add the corresponding "changelog:xxx" label to your PR.
-->

<!--- This template is optional. -->

## What does this PR do ?
This PR is fixes the unwanted behaviour of CORS headers being duplicated when kuzzle is responding to an HTTP Request.
Duplicating CORS headers on a Response causes the browsers that sent the request to throw a CORS error.

I also added more test cases to avoid this issue in the future.
