### PR TITLE
Fix WebSocket rate limiter timer

### DIFF
--- a/docker/scripts/reloader.js
+++ b/docker/scripts/reloader.js
@@ -29,7 +29,7 @@ const chokidar = require('chokidar');
 const clc = require('cli-color');
 
 const config = {
-  cwd: '/var/app',
+  cwd: '.',
   killDelay: 5000,
   watch: [
     'lib',
@@ -127,6 +127,7 @@ async function stopProcess () {
 }
 
 const watcher = chokidar.watch(script);
+console.log(config.watch.map(dir => path.join(config.cwd, dir)))
 watcher.add(config.watch.map(dir => path.join(config.cwd, dir)));
 
 watcher.on('change', async file => {

--- a/lib/core/network/protocols/httpwsProtocol.js
+++ b/lib/core/network/protocols/httpwsProtocol.js
@@ -94,7 +94,7 @@ class HttpWsProtocol extends Protocol {
     // Used to limit the rate of messages on websocket
     this.now = Date.now();
     this.nowInterval = setInterval(() => {
-      this.activityTimestamp = Date.now();
+      this.now = Date.now();
     }, 1000);
 
     // Map<uWS.WebSocket, ClientConnection>


### PR DESCRIPTION
## What does this PR do ?

In the WebSocket rate limiter, we were assigning the wrong value as lats frame timestamp.
I didn't added an unit test in purpose because the only way to test this is to wait 1 sec and it will slow down everything
### Other changes
 
 - fix reloader to work both in local and docker environments
