### PR TITLE
Cluster: prevent node from starting if IP already used

### DIFF
--- a/lib/cluster/node.js
+++ b/lib/cluster/node.js
@@ -376,6 +376,15 @@ class ClusterNode {
           return;
         }
 
+        // Verify that no other node share the same IP address as this one
+        const duplicate = nodes.filter(node => node.ip === this.ip);
+
+        if (duplicate.length > 0) {
+          global.kuzzle.log.error(`[FATAL] Another node share the same IP address as this one (${this.ip}): ${duplicate.id}. Shutting down.`);
+          global.kuzzle.shutdown();
+          return;
+        }
+
         // Subscribe to remote nodes and start buffering sync messages
         await Bluebird.map(nodes, ({ id, ip }) => {
           const subscriber = new ClusterSubscriber(this, id, ip);

--- a/lib/cluster/node.js
+++ b/lib/cluster/node.js
@@ -380,7 +380,7 @@ class ClusterNode {
         const duplicate = nodes.filter(node => node.ip === this.ip);
 
         if (duplicate.length > 0) {
-          global.kuzzle.log.error(`[FATAL] Another node share the same IP address as this one (${this.ip}): ${duplicate.id}. Shutting down.`);
+          global.kuzzle.log.error(`[FATAL] Another node share the same IP address as this one (${this.ip}): ${duplicate[0].id}. Shutting down.`);
           global.kuzzle.shutdown();
           return;
         }

--- a/test/cluster/node.test.js
+++ b/test/cluster/node.test.js
@@ -661,7 +661,7 @@ describe('#Cluster Node', () => {
       should(node.command.broadcastHandshake).not.called();
       should(node.fullState.loadFullState).not.called();
 
-      should(kuzzle.log.error).calledWithMatch(/Another node share the same IP address as this one/);
+      should(kuzzle.log.error).calledWithMatch(/Another node share the same IP address as this one \(2.3.4.2\): baz/);
       should(kuzzle.shutdown).calledOnce();
     });
 


### PR DESCRIPTION
# Description

Add a safeguard preventing a node from starting if its IP address is already used by another node.
