### PR TITLE
Cluster: die if unable to refresh the ID card in time

### DIFF
--- a/lib/cluster/idCardHandler.js
+++ b/lib/cluster/idCardHandler.js
@@ -61,10 +61,11 @@ class IdCard {
  * Handles the ID Key stored in Redis, holding node information
  */
 class ClusterIdCardHandler {
-  constructor (ip, refreshDelay) {
+  constructor (node) {
+    this.node = node;
     this.idCard = null;
-    this.ip = ip;
-    this.refreshDelay = refreshDelay;
+    this.ip = node.ip;
+    this.refreshDelay = node.heartbeatDelay;
     this.refreshTimer = null;
     this.nodeId = null;
     this.nodeIdKey = null;
@@ -101,10 +102,16 @@ class ClusterIdCardHandler {
     this.refreshTimer = setInterval(
       async () => {
         if (!this.disposed) {
-          await global.kuzzle.ask(
+          const refreshed = await global.kuzzle.ask(
             'core:cache:internal:pexpire',
             this.nodeIdKey,
             this.refreshDelay * 1.5);
+
+          // Unable to refresh the key in time before it expires
+          // => this node is too slow, we need to remove it from the cluster
+          if (refreshed === 0) {
+            await this.node.evictSelf('Node too slow: ID card expired');
+          }
         }
       },
       this.refreshDelay);

--- a/lib/cluster/node.js
+++ b/lib/cluster/node.js
@@ -55,7 +55,7 @@ class ClusterNode {
     this.nodeId = null;
     this.heartbeatTimer = null;
 
-    this.idCardHandler = new ClusterIdCardHandler(this.ip, this.heartbeatDelay);
+    this.idCardHandler = new ClusterIdCardHandler(this);
     this.publisher = new ClusterPublisher(this);
     this.fullState = new ClusterState();
     this.command = new ClusterCommand(this);


### PR DESCRIPTION
# Description

Each cluster node maintains its own ID card in redis, allowing other nodes to discover the node, and connect to it.

ID cards are temporary redis key, meaning that they disappear after a time. It's intended: if a node crashes, its ID card disappears and future nodes won't try to connect to it.

But if a node is too slow to refresh its own ID card, then the key disappears: future nodes don't know that this node exists, they never form a cluster, and this makes the cluster inconsistent.

With this PR, each time a node refreshes its ID card, it checks that the refresh was successful: Redis returns 1 if the key is refreshed, and 0 if the key doesn't exist. In the latter case, the node now detects it, and shuts itself down.
