### PR TITLE
Update cluster topology during handshake

### DIFF
--- a/lib/cluster/node.js
+++ b/lib/cluster/node.js
@@ -437,6 +437,7 @@ class ClusterNode {
           this.remoteNodes.delete(nodeId);
         }
         else {
+          await this.idCardHandler.addNode(nodeId);
           subscriber.sync(handshakeData.lastMessageId);
           global.kuzzle.log.info(`Successfully completed the handshake with node ${nodeId}`);
         }

--- a/test/cluster/node.test.js
+++ b/test/cluster/node.test.js
@@ -640,6 +640,7 @@ describe('#Cluster Node', () => {
       should(node.command.getFullState).not.called();
       should(node.fullState.loadFullState).not.called();
       should(node.heartbeatTimer).not.be.null();
+      should(node.idCardHandler.addNode).not.called();
     });
 
     it('should abort if another node has the same IP as this one', async () => {
@@ -675,6 +676,11 @@ describe('#Cluster Node', () => {
 
       node.command.getFullState.resolves(fullstate);
       node.idCardHandler.getRemoteIdCards.resolves(nodes);
+      node.command.broadcastHandshake.resolves({
+        bar: {},
+        baz: {},
+        qux: {},
+      });
 
       await node.handshake();
 
@@ -694,6 +700,11 @@ describe('#Cluster Node', () => {
       should(node.command.broadcastHandshake).calledOnce().calledWith(nodes);
       should(node.fullState.loadFullState).calledOnce().calledWith(fullstate);
       should(node.heartbeatTimer).not.be.null();
+
+      should(node.idCardHandler.addNode).calledThrice();
+      should(node.idCardHandler.addNode).calledWith('bar');
+      should(node.idCardHandler.addNode).calledWith('baz');
+      should(node.idCardHandler.addNode).calledWith('qux');
     });
 
     it('should retry getting a fullstate if unable to get one the first time', async () => {
@@ -708,6 +719,11 @@ describe('#Cluster Node', () => {
 
       node.command.getFullState.onFirstCall().resolves(null);
       node.command.getFullState.onSecondCall().resolves(fullstate);
+      node.command.broadcastHandshake.resolves({
+        bar: {},
+        baz: {},
+        qux: {},
+      });
 
       node.idCardHandler.getRemoteIdCards.resolves(nodes);
 
@@ -730,6 +746,11 @@ describe('#Cluster Node', () => {
       should(node.command.broadcastHandshake).calledOnce().calledWith(nodes);
       should(node.heartbeatTimer).not.be.null();
 
+      should(node.idCardHandler.addNode).calledThrice();
+      should(node.idCardHandler.addNode).calledWith('bar');
+      should(node.idCardHandler.addNode).calledWith('baz');
+      should(node.idCardHandler.addNode).calledWith('qux');
+
       should(kuzzle.log.warn).calledWithMatch(/Retrying/);
     });
 
@@ -748,6 +769,7 @@ describe('#Cluster Node', () => {
 
       should(node.idCardHandler.createIdCard).calledOnce();
       should(node.idCardHandler.getRemoteIdCards).calledTwice();
+      should(node.idCardHandler.addNode).not.called();
 
       should(node.command.getFullState).calledTwice();
       should(node.command.broadcastHandshake).not.called();
@@ -794,6 +816,10 @@ describe('#Cluster Node', () => {
       should(node.command.broadcastHandshake).calledOnce().calledWith(nodes);
       should(node.fullState.loadFullState).calledOnce().calledWith(fullstate);
       should(node.heartbeatTimer).not.be.null();
+
+      should(node.idCardHandler.addNode).calledTwice();
+      should(node.idCardHandler.addNode).calledWith('bar');
+      should(node.idCardHandler.addNode).calledWith('qux');
     });
 
     it('should shutdown if unable to complete handshake before a timeout', async () => {


### PR DESCRIPTION
# Description

Each cluster node maintains its own cluster topology, meaning it keeps track of all nodes it is connected to.
This is used when a node leaves the cluster (normal exit, or due to an eviction): each node checks its own topology against every other node topologies, and if an inconsistency is found, the algorithm is made in such a way that nodes isolated from the cluster shut down to prevent cluster splits.

Now, there is a bug in the current implementation: the topology is only updated when a new node is added to the cluster. Meaning that when a new node is added, other nodes are notified about it and they update their topology.
But... due to an oversight, the topology wasn't updated during a handshake: this means that new nodes joining the cluster have an empty topology, whereas existing nodes will have that new node added to theirs.

This messes up the cluster consistency check obviously.

# How to reproduce the bug

Spawn a cluster of 3 nodes using the dev docker-compose. Kill the 1st node that spawned: the other two nodes will see that their topologies don't match:
* the second node that spawned has the third one in its topology (node added after the handshake)
* the third one has an empty topology (topology not updated during the handshake)

The cluster decides that the third one is isolated, and it is killed.

# Expected behavior

Once a handshake finishes, the joining node must add existing ones to its topology.
Killing the first node should not impact the other two ones (unless there is a real network split, obviously, but that shouldn't happen in test environments)
