### PR TITLE
Prevent conflicting names/characters in new indexes/collections

### DIFF
--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -49,7 +49,7 @@ const HIDDEN_COLLECTION = '_kuzzle_keep';
 const PRIVATE_PREFIX = '%';
 const PUBLIC_PREFIX = '&';
 const NAME_SEPARATOR = '.';
-const FORBIDDEN_CHARS = `\\/*?"<>| \t\r\n,#:${NAME_SEPARATOR}${PUBLIC_PREFIX}${PRIVATE_PREFIX}`;
+const FORBIDDEN_CHARS = `\\/*?"<>| \t\r\n,+#:${NAME_SEPARATOR}${PUBLIC_PREFIX}${PRIVATE_PREFIX}`;
 const DYNAMIC_PROPERTY_VALUES = ['true', 'false', 'strict'];
 
 // used to check whether we need to wait for ES to initialize or not
@@ -2117,7 +2117,7 @@ class ElasticSearch extends Service {
     const { rejected, extractedDocuments } = this._extractMDocuments(
       documents,
       kuzzleMeta,
-      { 
+      {
         prepareMUpsert: true,
         requireId: true
       }
@@ -2559,9 +2559,7 @@ class ElasticSearch extends Service {
    * @returns {String} esIndex name (eg: '&nepali#liia')
    */
   _getESIndex (index, collection) {
-    if (! index || ! collection) {
-      return null;
-    }
+    this._assertValidIndexAndCollection(index, collection || '');
 
     return `${this._indexPrefix}${index}${NAME_SEPARATOR}${collection}`;
   }
@@ -2935,6 +2933,10 @@ function _isObjectNameValid (name) {
   }
 
   if (Buffer.from(name).length > 126) {
+    return false;
+  }
+
+  if (name === '_all') {
     return false;
   }
 

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -1396,7 +1396,7 @@ describe('Test: ElasticSearch service', () => {
     let query;
     let changes;
     let request;
-  
+
     beforeEach(() => {
       query = {
         match: { foo: 'bar' }
@@ -3703,7 +3703,7 @@ describe('Test: ElasticSearch service', () => {
       toImport[1]._source.default.country = 'Vietnam';
 
       const result = await elasticsearch.mUpsert(index, collection, documents);
-    
+
       should(elasticsearch._mExecute).be.calledWithMatch(
         esRequest,
         toImport,
@@ -4463,12 +4463,31 @@ describe('Test: ElasticSearch service', () => {
 
     describe('#_getESIndex', () => {
       it('return esIndex name for a collection', () => {
-        const
-          publicESIndex = publicES._getESIndex('nepali', 'liia'),
-          internalESIndex = internalES._getESIndex('nepali', 'mehry');
+        const publicESIndex = publicES._getESIndex('nepali', 'liia');
+        const internalESIndex = internalES._getESIndex('nepali', 'mehry');
 
         should(publicESIndex).be.eql('&nepali.liia');
         should(internalESIndex).be.eql('%nepali.mehry');
+      });
+
+      it('should throw if the index is invalid', () => {
+        for (const invalid of [ null, '', 123, true, 'foo+bar', '_all', 'HELP']) {
+          // eslint-disable-next-line no-loop-func
+          should(() => publicES._getESIndex(invalid, 'foo'))
+            .throw(BadRequestError, {
+              id: 'services.storage.invalid_index_name',
+            });
+        }
+      });
+
+      it('should throw if the collection is invalid or null', () => {
+        for (const invalid of [ null, '', 123, true, 'foo+bar', '_all', 'HELP']) {
+          // eslint-disable-next-line no-loop-func
+          should(() => publicES._getESIndex('foo', invalid))
+            .throw(BadRequestError, {
+              id: 'services.storage.invalid_collection_name',
+            });
+        }
       });
     });
 


### PR DESCRIPTION
# Description

When creating indexes or collections, it is possible to include a `+` character in them, or to name them `_all`.
This makes those indexes/collections unusable: Kuzzle impose a strict control to prevent multi-indexes queries, which suppose the use of either a `+` character or the `_all` ES keyword.

Since ES index names are not escapable to prevent multi-indexes queries, we have to forbid those characters/keywords from being used in index/collection names.

# How to reproduce

Create a new collection with a `+` character in its name, or name it `_all`:

* `kourou collection:create foo 'bar+qux'`
* `kourou collection:create foo _all`

Then try to use these collections to create documents or try to search in those: Kuzzle will complain and will make the query fail.

With this PR, it is no longer possible to create such indexes or collections.