### PR TITLE
Websocket cookie propagation after Upgrade

### DIFF
--- a/lib/core/network/protocols/httpwsProtocol.js
+++ b/lib/core/network/protocols/httpwsProtocol.js
@@ -144,6 +144,7 @@ class HttpWsProtocol extends Protocol {
     this.server.ws('/*', {
       ...this.wsConfig.opts,
       maxBackPressure: WS_PER_SOCKET_BACKPRESSURE_BUFFER_SIZE,
+      upgrade: this.wsOnUpgradeHandler.bind(this),
       open: this.wsOnOpenHandler.bind(this),
       close: this.wsOnCloseHandler.bind(this),
       message: this.wsOnMessageHandler.bind(this),
@@ -241,9 +242,21 @@ class HttpWsProtocol extends Protocol {
       message ? Buffer.from(message) : WS_GENERIC_CLOSE_MESSAGE);
   }
 
+  wsOnUpgradeHandler (res, req, context) {
+    res.upgrade(
+      {
+        cookie: req.getHeader('cookie'),
+      },
+      req.getHeader('sec-websocket-key'),
+      req.getHeader('sec-websocket-protocol'),
+      req.getHeader('sec-websocket-extensions'),
+      context
+    );
+  }
+
   wsOnOpenHandler (socket) {
     const ip = Buffer.from(socket.getRemoteAddressAsText()).toString();
-    const connection = new ClientConnection(this.name, [ip]);
+    const connection = new ClientConnection(this.name, [ip], {cookie: socket.cookie});
 
     this.entryPoint.newConnection(connection);
     this.connectionBySocket.set(socket, connection);

--- a/test/core/network/protocols/websocket.test.js
+++ b/test/core/network/protocols/websocket.test.js
@@ -137,7 +137,7 @@ describe('core/network/protocols/websocket', () => {
   describe('upgrade connection', () => {
     beforeEach(() => httpWs.init(entryPoint));
 
-    it('should upgrade the connection and forward and store the cookie if present when upgrading', () => {
+    it('should upgrade the connection and store the cookie in the UserData if present', () => {
       const response = new MockHttpResponse();
       const request = new MockHttpRequest(
         '',

--- a/test/mocks/uWS.mock.js
+++ b/test/mocks/uWS.mock.js
@@ -59,6 +59,8 @@ class MockHttpResponse {
     this.getRemoteAddressAsText = sinon.stub().returns('1.2.3.4');
     this.tryEnd = sinon.stub().returns([ true, null ]);
 
+    this.upgrade = sinon.stub();
+
     this.onData = sinon
       .stub()
       .callsFake(handler => (this._onDataHandler = handler));
@@ -139,6 +141,14 @@ class App {
     }
 
     this._wsConfig.drain(this._wsSocket);
+  }
+
+  _wsOnUpgrade (response, request, context) {
+    if (!this._wsConfig || !this._wsConfig.upgrade) {
+      throw new Error('Missing "upgrade" handler');
+    }
+
+    this._wsConfig.upgrade(response, request, context);
   }
 
   _httpOnMessage (method, url, qs, headers) {


### PR DESCRIPTION
<!--
  Thank you for submitting a Pull Request. Please:
    - Read our CONTRIBUTING guidelines.
      https://github.com/kuzzleio/kuzzle/blob/master/CONTRIBUTING.md
    - Associate an issue with the Pull Request.
    - IMPORTANT - Add the corresponding "changelog:xxx" label to your PR.
-->

<!--- This template is optional. -->

## What does this PR do ?

This PR finalize the websocket cookie support, by adding an handler when an http request needs to be upgraded to a websocket connection.
This upgrade handler retrieve the cookie if present in the http request and store it in the socket UserData before upgrading the request, this will then trigger the websocket connection and set the cookie header for every subsequent request made with the established connection.
