### PR TITLE
Access Logs: request responses may contain unserializable objects

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,11 +5,19 @@
 *.js.map
 
 /index.js
-lib/core/backend/index.js
+lib/core/backend/applicationManager.js
 lib/core/backend/backend.js
-lib/core/backend/backendPlugin.js
 lib/core/backend/backendCluster.js
+lib/core/backend/backendConfig.js
+lib/core/backend/backendController.js
+lib/core/backend/backendHook.js
+lib/core/backend/backendPipe.js
 lib/core/backend/backendPlugin.js
+lib/core/backend/backendPlugin.js
+lib/core/backend/backendStorage.js
+lib/core/backend/backendVault.js
+lib/core/backend/index.js
+lib/core/backend/internalLogger.js
 lib/core/shared/sdk/embeddedSdk.js
 lib/core/plugin/pluginContext.js
 lib/api/request/index.js

--- a/lib/core/network/accessLogger.js
+++ b/lib/core/network/accessLogger.js
@@ -82,10 +82,25 @@ class AccessLogger {
       return;
     }
 
+    const serialized = request.serialize();
+
+    // Users can set anything in the request response, as long as it can
+    // be stringified. Problem is: not all that can be stringified is
+    // serializable to worker threads (e.g. functions).
+    serialized.options.result = undefined;
+
+    // Since we won't pass the response to the worker thread, we need to
+    // compute its size beforehand, as this information is needed for access
+    // logs
+    const size = request.response
+      ? Buffer.byteLength(JSON.stringify(request.response)).toString()
+      : '-';
+
     this.worker.postMessage({
       connection,
       extra,
-      request: request.serialize(),
+      request: serialized,
+      size,
     });
   }
 }
@@ -100,10 +115,11 @@ class AccessLoggerWorker {
   init () {
     this.initTransport();
 
-    parentPort.on('message', ({ connection, extra, request }) => {
+    parentPort.on('message', ({ connection, extra, request, size }) => {
       this.logAccess(
         connection,
         new KuzzleRequest(request.data, request.options),
+        size,
         extra);
     });
   }
@@ -202,10 +218,10 @@ class AccessLoggerWorker {
   /**
    * @param {ClientConnection} connection
    * @param {Request} request
-   * @param {Number} ts -- log timestamp
-   * @param {object} extra
+   * @param {String} size - response size, in bytes
+   * @param {Object} [extra]
    */
-  logAccess (connection, request, extra = null) {
+  logAccess (connection, request, size, extra = null) {
     if (this.config.logs.accessLogFormat === 'logstash') {
       // custom kuzzle logs to be exported to logstash
       this.logger.info({
@@ -283,9 +299,6 @@ class AccessLoggerWorker {
     const ip = this.getIP(connection);
     const when = moment().format('DD/MMM/YYYY:HH:mm:ss ZZ');
     const status = request.status || '-';
-    const size = request.response
-      ? Buffer.byteLength(JSON.stringify(request.response))
-      : '-';
     const referer = connection.headers.referer
       ? `"${connection.headers.referer}"`
       : '-';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kuzzle",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kuzzle",
-      "version": "2.12.0",
+      "version": "2.12.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/elasticsearch": "^7.12.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "bin": {
     "kuzzle": "bin/start-kuzzle-server"


### PR DESCRIPTION
# Description

Since Kuzzle 2.12.0, access logs are isolated in a worker thread, to free resources for Kuzzle's main thread.
This gives a huge performances boost to Kuzzle.

Now, this requires the KuzzleRequest object to be serialized and passed over to the worker thread, so that it can, in turn, compute access logs information and send them to the winston transport(s).

Problem is: not everything can be serialized that way. Trying to pass unserializable content to a worker thread results in a `DataCloneError` from Node.js, which makes Kuzzle crash.

In that sense, serializing a KuzzleRequest is generally safe, apart from the RequestResponse sub-object, which contains whatever plugin developers set to it.
Kuzzle makes sure that request responses are stringifiable, but... objects that can be stringified might not be serializable.

This PR solves that issue by removing the request response from the object passed to the access logger thread. It is not needed anyway, apart from the content size that needs to be logged: so the main thread now takes care of computing it, and passing the result to the thread.

# How to reproduce

Write a custom plugin, extending the API. 
In the plugin's API response, return an object containing a Javascript function (functions are ignored during stringification, but trigger a DataCloneError when attempting to serialize them).

Plugin Example:

```js
class Foo {
  constructor() {
  }

  async init (config, context) {
    this.config = config;
    this.context = context;
    this.sdk = context.accessors.sdk;

    this.api = {
      foo: {
        actions: {
          bar: {
            handler: rq => this.ohnoes(rq),
          }
        },
      },
    };
  }

  async ohnoes (rq) {
    return { 
      foo: 'bar', 
      bar: function () { console.log('ohnoes'); } 
    };
  }
}
```

Load the plugin, call its API route, and watch Kuzzle die.