### PR TITLE
Support for elasticsearch 7.13.1

### DIFF
--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -1412,14 +1412,13 @@ class ElasticSearch extends Service {
    */
   async updateSettings (index, collection, settings = {}) {
     const esRequest = {
-      body: settings,
       index: this._getESIndex(index, collection)
     };
 
     await this._client.indices.close(esRequest);
 
     try {
-      await this._client.indices.putSettings(esRequest);
+      await this._client.indices.putSettings({ ...esRequest, body: settings });
     }
     catch (error) {
       throw this._esWrapper.formatESError(error);


### PR DESCRIPTION
## What does this PR do ?
This PR fixes a Breaking Changes introduced with ES-7.11.0 where the Rest APIs now throw when a body is present in a request when not needed by the requested API.


This was causing a `Forbidden/8/write  (api)` in the functionnal tests for the Scenario: `Update a collection mappings and settings` because of a body supplied to `indices.close` & `indices.open` when updating the index settings was causing the Kuzzle nodes to crash because of an unexpected error from ES, this was blocking the update of the settings that should have allowed the write operation.