### PR TITLE
Cluster: better IP inference and configuration

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -890,16 +890,27 @@
   //       Delay between 2 heartbeat frames. A higher value means less
   //       reactivity for detecting dead nodes, while a lower value might mean
   //       erroneous node evictions on slow networks.
+  //   * interface:
+  //      Network interface to use as the node IP address.
+  //      If the configured interface cannot be found, the node will refuse to
+  //      start.
+  //      Accepted values:
+  //        * interface name (e.g. eth0, wlan0, vmnet1, ...)
+  //        * IP address (v4 or v6)
+  //        * MAC address
+  //        * null value: no preferred network interface
   //   * ipv6:
   //       If true, asks nodes to use IPv6 to connect to each others
   //   * ip:
-  //       A string used to returns the address for the network interface on the
-  //       current system with the specified name:
-  //         * String: First `family` address of the interface.
-  //                   If not found first address with `ipv4` or
-  //                   loopback address `127.0.0.1`.
-  //         * 'public': the first public ip address of family.
-  //         * 'private': the first private ip address of family.
+  //       The type of IP address to use.
+  //       If no suitable IP address can be found, the node will refuse to
+  //       start.
+  //       Accepted values:
+  //         * 'public': will target only public IPs
+  //         * 'private': will target only private IPs (private addresses,
+  //           ULAs and link-local addresses)
+  //         * null (or blank string): no target preference. If this
+  //           property is left to null, it is advised to configure an interface
   //   * joinTimeout:
   //       The cluster join timeout (in ms): if that timeout is reached before
   //       the node could join the cluster, it will kill itself.
@@ -930,8 +941,9 @@
   "cluster": {
     "activityDepth": 50,
     "heartbeat": 2000,
+    "interface": null,
     "ipv6": false,
-    "ip": "public",
+    "ip": "private",
     "joinTimeout": 60000,
     "minimumNodes": 2,
     "ports": {

--- a/lib/cluster/node.js
+++ b/lib/cluster/node.js
@@ -72,10 +72,11 @@ function isPrivateIP(ip) {
 
 /**
  * Return the first IP address matching the provided configuration
- * @param  {String} options.family     [description]
- * @param  {[type]} options.interface: netInterface  [description]
- * @param  {[type]} options.ip         [description]
- * @return {[type]}                    [description]
+ * @param  {Object} [options]
+ * @param  {String} [options.family] IP family (IPv4 or IPv6)
+ * @param  {String} [options.interface] Network interface/IP/MAC to use
+ * @param  {String} [options.ip] Used to target public or private addresses
+ * @return {String|null}
  */
 function getIP ({ family = 'IPv4', interface: netInterface, ip } = {}) {
   const mustBePrivate = ip === 'private';

--- a/lib/cluster/node.js
+++ b/lib/cluster/node.js
@@ -59,9 +59,10 @@ function isPrivateIP(ip) {
   const exploded = ip.split('.').map(s => Number.parseInt(s));
 
   return exploded[0] === 10
-    || exploded[0] === 127
     || (exploded[0] === 172 && exploded[1] >= 16 && exploded[1] <= 31)
     || (exploded[0] === 192 && exploded[1] === 168)
+    // Should never be considered: this range is reserved for internal uses only
+    || exploded[0] === 127
     // 169.254.x.x addresses are... particular. I *think* they are usable if
     // multiple machines share the same DHCP rules, but I don't really know.
     // This might be an edge case.

--- a/lib/cluster/node.js
+++ b/lib/cluster/node.js
@@ -529,11 +529,11 @@ class ClusterNode {
         else {
           await this.idCardHandler.addNode(nodeId);
           subscriber.sync(handshakeData.lastMessageId);
-          global.kuzzle.log.info(`Successfully completed the handshake with node ${nodeId}`);
+          global.kuzzle.log.info(`[CLUSTER] Successfully completed the handshake with node ${nodeId}`);
         }
       }
 
-      global.kuzzle.log.info('Successfully joined the cluster.');
+      global.kuzzle.log.info('[CLUSTER] Successfully joined the cluster.');
       this.trackActivity(this.nodeId, this.ip, nodeActivityEnum.ADDED);
     }
     finally {

--- a/lib/cluster/node.js
+++ b/lib/cluster/node.js
@@ -23,6 +23,7 @@
 
 const os = require('os');
 const net = require('net');
+const assert = require('assert');
 
 const Bluebird = require('bluebird');
 const EventEmitter = require('eventemitter3');
@@ -45,9 +46,7 @@ const kuzzleStateEnum = require('../kuzzle/kuzzleStateEnum');
  * @return {Boolean}
  */
 function isPrivateIP(ip) {
-  if (net.isIP(ip) === 0) {
-    throw new Error(`[FATAL] "${ip}" is not a valid IP address`);
-  }
+  assert(net.isIP(ip) !== 0, `[CLUSTER] "${ip}" is not a valid IP address`);
 
   if (net.isIPv6(ip)) {
     const prefix = ip.split(':')[0];
@@ -141,9 +140,7 @@ class ClusterNode {
       ip: this.config.ip,
     });
 
-    if (this.ip === null) {
-      throw new Error(`[FATAL] Cluster: no suitable IP address found with the provided configuration (family: ${family}, interface: ${this.config.interface}, ip: ${this.config.ip})`);
-    }
+    assert(this.ip !== null, `[CLUSTER] No suitable IP address found with the provided configuration (family: ${family}, interface: ${this.config.interface}, ip: ${this.config.ip})`);
 
     this.nodeId = null;
     this.heartbeatTimer = null;
@@ -259,7 +256,7 @@ class ClusterNode {
    * @return {void}
    */
   async evictSelf (reason, error = null) {
-    global.kuzzle.log.error(`[FATAL] ${reason}`);
+    global.kuzzle.log.error(`[CLUSTER] ${reason}`);
 
     if (error) {
       global.kuzzle.log.error(error.stack);
@@ -435,7 +432,7 @@ class ClusterNode {
   async handshake () {
     const handshakeTimeout = setTimeout(
       () => {
-        global.kuzzle.log.error(`[FATAL] Failed to join the cluster: timed out (joinTimeout: ${this.config.joinTimeout}ms)`);
+        global.kuzzle.log.error(`[CLUSTER] Failed to join the cluster: timed out (joinTimeout: ${this.config.joinTimeout}ms)`);
         global.kuzzle.shutdown();
       },
       this.config.joinTimeout);
@@ -473,7 +470,7 @@ class ClusterNode {
         const duplicate = nodes.filter(node => node.ip === this.ip);
 
         if (duplicate.length > 0) {
-          global.kuzzle.log.error(`[FATAL] Another node share the same IP address as this one (${this.ip}): ${duplicate[0].id}. Shutting down.`);
+          global.kuzzle.log.error(`[CLUSTER] Another node share the same IP address as this one (${this.ip}): ${duplicate[0].id}. Shutting down.`);
           global.kuzzle.shutdown();
           return;
         }
@@ -494,7 +491,7 @@ class ClusterNode {
         // down.
         if (fullState === null) {
           if (retried) {
-            global.kuzzle.log.error('[FATAL] Could not connect to discovered cluster nodes (network split detected). Shutting down.');
+            global.kuzzle.log.error('[CLUSTER] Could not connect to discovered cluster nodes (network split detected). Shutting down.');
             global.kuzzle.shutdown();
             return;
           }
@@ -508,7 +505,7 @@ class ClusterNode {
           // Waits for a redis heartbeat round
           retried = true;
           const retryDelay = this.heartbeatDelay * 1.5;
-          global.kuzzle.log.warn(`Unable to connect to discovered cluster nodes. Retrying in ${retryDelay}ms...`);
+          global.kuzzle.log.warn(`[CLUSTER] Unable to connect to discovered cluster nodes. Retrying in ${retryDelay}ms...`);
           await Bluebird.delay(retryDelay);
         }
       }

--- a/lib/cluster/node.js
+++ b/lib/cluster/node.js
@@ -45,9 +45,7 @@ const kuzzleStateEnum = require('../kuzzle/kuzzleStateEnum');
  * @param  {String}  ip
  * @return {Boolean}
  */
-function isPrivateIP(ip) {
-  assert(net.isIP(ip) !== 0, `[CLUSTER] "${ip}" is not a valid IP address`);
-
+function isPrivateIP (ip) {
   if (net.isIPv6(ip)) {
     const prefix = ip.split(':')[0];
 
@@ -59,14 +57,31 @@ function isPrivateIP(ip) {
 
   return exploded[0] === 10
     || (exploded[0] === 172 && exploded[1] >= 16 && exploded[1] <= 31)
-    || (exploded[0] === 192 && exploded[1] === 168)
-    // Should never be considered: this range is reserved for internal uses only
-    || exploded[0] === 127
-    // 169.254.x.x addresses are... particular. I *think* they are usable if
-    // multiple machines share the same DHCP rules, but I don't really know.
-    // This might be an edge case.
-    // For now I'll consider them as private addresses, but we might want to
-    // consider them as internal ones if that poses problems in the future.
+    || (exploded[0] === 192 && exploded[1] === 168);
+}
+
+/**
+ * Some IPv4 addresses are reserved for internal uses only, and cannot be
+ * reached from other machines. We need to detect and filter them
+ * @param  {String}  ip
+ * @return {Boolean}
+ */
+function isInternalIP (ip) {
+  // To my knowledge, there aren't any reserved, non-loopback and non-routable
+  // IPv6 addresses
+  if (net.isIPv6(ip)) {
+    return false;
+  }
+
+  const exploded = ip.split('.').map(s => Number.parseInt(s));
+
+  // 127.x.x: loopback addresses are already flagged as "internal" by
+  // os.networkInterfaces.
+  return exploded[0] === 127
+    // 169.254.x.x addresses are APIPA addresses: temporary and non-routable.
+    // We need to remove them from the accepted list of IP addresses
+    // (this is a "just in case" scenario: APIPA addresses are obsolete and
+    // should not be used anymore, but we never know...)
     || (exploded[0] === 169 && exploded[1] === 254);
 }
 
@@ -94,6 +109,7 @@ function getIP ({ family = 'IPv4', interface: netInterface, ip } = {}) {
 
   interfaces = interfaces.filter(n => {
     return !n.internal
+      && !isInternalIP(n.address)
       && n.family === family
       && (!ip || mustBePrivate === isPrivateIP(n.address));
   });

--- a/lib/cluster/node.js
+++ b/lib/cluster/node.js
@@ -21,7 +21,9 @@
 
 'use strict';
 
-const getIP = require('ip');
+const os = require('os');
+const net = require('net');
+
 const Bluebird = require('bluebird');
 const EventEmitter = require('eventemitter3');
 const _ = require('lodash');
@@ -34,6 +36,85 @@ const ClusterSubscriber = require('./subscriber');
 const ClusterState = require('./state');
 const ClusterCommand = require('./command');
 const kuzzleStateEnum = require('../kuzzle/kuzzleStateEnum');
+
+
+/**
+ * Test an IP address and determine if it's in the public or private range.
+ *
+ * @param  {String}  ip
+ * @return {Boolean}
+ */
+function isPrivateIP(ip) {
+  if (net.isIP(ip) === 0) {
+    throw new Error(`[FATAL] "${ip}" is not a valid IP address`);
+  }
+
+  if (net.isIPv6(ip)) {
+    const prefix = ip.split(':')[0];
+
+    return (prefix.startsWith('fd') && prefix.length === 4) || prefix === 'fe80';
+  }
+
+  // IPv4
+  const exploded = ip.split('.').map(s => Number.parseInt(s));
+
+  return exploded[0] === 10
+    || exploded[0] === 127
+    || (exploded[0] === 172 && exploded[1] >= 16 && exploded[1] <= 31)
+    || (exploded[0] === 192 && exploded[1] === 168)
+    // 169.254.x.x addresses are... particular. I *think* they are usable if
+    // multiple machines share the same DHCP rules, but I don't really know.
+    // This might be an edge case.
+    // For now I'll consider them as private addresses, but we might want to
+    // consider them as internal ones if that poses problems in the future.
+    || (exploded[0] === 169 && exploded[1] === 254);
+}
+
+/**
+ * Return the first IP address matching the provided configuration
+ * @param  {String} options.family     [description]
+ * @param  {[type]} options.interface: netInterface  [description]
+ * @param  {[type]} options.ip         [description]
+ * @return {[type]}                    [description]
+ */
+function getIP ({ family = 'IPv4', interface: netInterface, ip } = {}) {
+  const mustBePrivate = ip === 'private';
+
+  let interfaces = [];
+
+  for (const [key, value] of Object.entries(os.networkInterfaces())) {
+    for (const _interface of value) {
+      interfaces.push({
+        interface: key,
+        ..._interface,
+      });
+    }
+  }
+
+  interfaces = interfaces.filter(n => {
+    return !n.internal
+      && n.family === family
+      && (!ip || mustBePrivate === isPrivateIP(n.address));
+  });
+
+  if (interfaces.length === 0) {
+    return null;
+  }
+
+  // take the first IP from the list if no interface has been defined
+  if (!netInterface) {
+    return interfaces[0].address;
+  }
+
+  for (const i of interfaces) {
+    if ([i.interface, i.address, i.mac].includes(netInterface)) {
+      return i.address;
+    }
+  }
+
+  return null;
+}
+
 
 /**
  * @typedef {nodeActivityEnum}
@@ -50,7 +131,17 @@ class ClusterNode {
     this.config = global.kuzzle.config.cluster;
     this.heartbeatDelay = this.config.heartbeat;
 
-    this.ip = getIP.address(this.config.ip, this.config.ipv6 ? 'ipv6' : 'ipv4');
+    const family = this.config.ipv6 ? 'IPv6' : 'IPv4';
+
+    this.ip = getIP({
+      family,
+      interface: this.config.interface,
+      ip: this.config.ip,
+    });
+
+    if (this.ip === null) {
+      throw new Error(`[FATAL] Cluster: no suitable IP address found with the provided configuration (family: ${family}, interface: ${this.config.interface}, ip: ${this.config.ip})`);
+    }
 
     this.nodeId = null;
     this.heartbeatTimer = null;

--- a/lib/cluster/subscriber.js
+++ b/lib/cluster/subscriber.js
@@ -240,7 +240,7 @@ class ClusterSubscriber {
    */
   async handleNodeEviction (message) {
     if (message.nodeId === this.localNode.nodeId) {
-      global.kuzzle.log.error(`[FATAL] Node evicted by ${message.evictor}. Reason: ${message.reason}`);
+      global.kuzzle.log.error(`[CLUSTER] Node evicted by ${message.evictor}. Reason: ${message.reason}`);
       global.kuzzle.shutdown();
       return;
     }

--- a/lib/config/default.config.js
+++ b/lib/config/default.config.js
@@ -362,8 +362,9 @@ module.exports = {
   cluster: {
     activityDepth: 50,
     heartbeat: 2000,
+    interface: null,
     ipv6: false,
-    ip: 'public',
+    ip: 'private',
     joinTimeout: 60000,
     minimumNodes: 1,
     ports: {

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -200,19 +200,19 @@ function checkClusterOptions (config) {
   const cfg = config.cluster;
 
   for (const prop of ['heartbeat', 'joinTimeout', 'minimumNodes', 'activityDepth', 'syncTimeout']) {
-    assert(typeof cfg[prop] === 'number' && cfg[prop] > 0, `[FATAL] kuzzlerc.cluster.${prop}: value must be a number greater than 0`);
+    assert(typeof cfg[prop] === 'number' && cfg[prop] > 0, `[CONFIG] kuzzlerc.cluster.${prop}: value must be a number greater than 0`);
   }
 
-  assert(cfg.syncTimeout < cfg.joinTimeout, '[FATAL] kuzzlerc.cluster.syncTimeout: value must be lower than kuzzlerc.cluster.joinTimeout');
+  assert(cfg.syncTimeout < cfg.joinTimeout, '[CONFIG] kuzzlerc.cluster.syncTimeout: value must be lower than kuzzlerc.cluster.joinTimeout');
 
   for (const prop of ['command', 'sync']) {
-    assert(typeof cfg.ports[prop] === 'number' && cfg.ports[prop] > 0, `[FATAL] kuzzlerc.cluster.ports.${prop}: value must be a number greater than 0`);
+    assert(typeof cfg.ports[prop] === 'number' && cfg.ports[prop] > 0, `[CONFIG] kuzzlerc.cluster.ports.${prop}: value must be a number greater than 0`);
   }
 
-  assert(typeof cfg.ipv6 === 'boolean', '[FATAL] kuzzlerc.cluster.ipv6: boolean expected');
+  assert(typeof cfg.ipv6 === 'boolean', '[CONFIG] kuzzlerc.cluster.ipv6: boolean expected');
 
-  assert(!cfg.ip || ['private', 'public'].includes(cfg.ip), '[FATAL] kuzzlerc.cluster.ip: invalid value (accepted values: public, private)');
-  assert(!cfg.interface || typeof cfg.interface === 'string', '[FATAL] kuzzlerc.cluster.interface: value must be either null, or a string');
+  assert(!cfg.ip || ['private', 'public'].includes(cfg.ip), '[CONFIG] kuzzlerc.cluster.ip: invalid value (accepted values: public, private)');
+  assert(!cfg.interface || typeof cfg.interface === 'string', '[CONFIG] kuzzlerc.cluster.interface: value must be either null, or a string');
 }
 
 function preprocessHttpOptions (config) {

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -56,7 +56,7 @@ function load () {
       seed: Buffer.from('^m&mOISKBvb1xpl1mRsrylaQXpjb&IJX')
     }
   };
-  
+
   preprocessHttpOptions(config);
   // Injects the current Kuzzle version
   config.version = packageJson.version;
@@ -211,7 +211,8 @@ function checkClusterOptions (config) {
 
   assert(typeof cfg.ipv6 === 'boolean', '[FATAL] kuzzlerc.cluster.ipv6: boolean expected');
 
-  assert(typeof cfg.ip === 'string', '[FATAL] kuzzlerc.cluster.ip: value must be a string');
+  assert(!cfg.ip || ['private', 'public'].includes(cfg.ip), '[FATAL] kuzzlerc.cluster.ip: invalid value (accepted values: public, private)');
+  assert(!cfg.interface || typeof cfg.interface === 'string', '[FATAL] kuzzlerc.cluster.interface: value must be either null, or a string');
 }
 
 function preprocessHttpOptions (config) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "eventemitter3": "^4.0.7",
         "inquirer": "^8.0.0",
         "ioredis": "^4.27.2",
-        "ip": "^1.1.5",
         "json-stable-stringify": "^1.0.1",
         "json2yaml": "^1.1.0",
         "jsonwebtoken": "^8.5.1",
@@ -13001,6 +13000,7 @@
       "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
       "dev": true,
       "requires": {
+        "@oclif/config": "^1.15.1",
         "@oclif/errors": "^1.3.3",
         "@oclif/parser": "^3.8.3",
         "@oclif/plugin-help": "^3",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "eventemitter3": "^4.0.7",
     "inquirer": "^8.0.0",
     "ioredis": "^4.27.2",
-    "ip": "^1.1.5",
     "json-stable-stringify": "^1.0.1",
     "json2yaml": "^1.1.0",
     "jsonwebtoken": "^8.5.1",

--- a/test/cluster/node.test.js
+++ b/test/cluster/node.test.js
@@ -129,6 +129,14 @@ describe('#Cluster Node', () => {
         internal: false,
       },
     ],
+    apipa: [
+      {
+        address: '169.254.2.3',
+        family: 'IPv4',
+        mac: 'ohnoes',
+        internal: false,
+      },
+    ],
   };
 
   before(() => {
@@ -210,6 +218,11 @@ describe('#Cluster Node', () => {
     it('should throw if no valid IP address can be found', () => {
       kuzzle.config.cluster.interface = 'foobar';
 
+      should(() => new ClusterNode()).throw(/^\[CLUSTER\] No suitable IP address found with the provided configuration/);
+    });
+
+    it('should throw if the only available address is an APIPA', () => {
+      kuzzle.config.cluster.interface = 'apipa';
       should(() => new ClusterNode()).throw(/^\[CLUSTER\] No suitable IP address found with the provided configuration/);
     });
   });

--- a/test/cluster/node.test.js
+++ b/test/cluster/node.test.js
@@ -210,7 +210,7 @@ describe('#Cluster Node', () => {
     it('should throw if no valid IP address can be found', () => {
       kuzzle.config.cluster.interface = 'foobar';
 
-      should(() => new ClusterNode()).throw(/^\[FATAL\] Cluster: no suitable IP address found with the provided configuration/);
+      should(() => new ClusterNode()).throw(/^\[CLUSTER\] No suitable IP address found with the provided configuration/);
     });
   });
 

--- a/test/cluster/node.test.js
+++ b/test/cluster/node.test.js
@@ -4,7 +4,6 @@ const sinon = require('sinon');
 const should = require('should');
 const mockRequire = require('mock-require');
 const Long = require('long');
-const getIP = require('ip');
 
 const { IdCard } = require('../../lib/cluster/idCardHandler');
 const kuzzleStateEnum = require('../../lib/kuzzle/kuzzleStateEnum');
@@ -100,6 +99,37 @@ describe('#Cluster Node', () => {
   let ClusterNode;
   let kuzzle;
   let node;
+  const networkInterfaces = {
+    lo: [ { internal: true } ],
+    private: [
+      {
+        address: '10.1.1.1',
+        family: 'IPv4',
+        mac: 'welp',
+        internal: false,
+      },
+      {
+        address: 'fe80::b468:a254:bb56:ea68',
+        family: 'IPv6',
+        mac: 'welp',
+        internal: false,
+      },
+    ],
+    public: [
+      {
+        address: '11.1.1.1',
+        family: 'IPv4',
+        mac: 'welp2',
+        internal: false,
+      },
+      {
+        address: 'fe81::b468:a254:bb56:ea68',
+        family: 'IPv6',
+        mac: 'welp2',
+        internal: false,
+      },
+    ],
+  };
 
   before(() => {
     mockRequire('../../lib/cluster/publisher', ClusterPublisherMock);
@@ -111,6 +141,7 @@ describe('#Cluster Node', () => {
       IdCard
     });
     mockRequire('../../lib/util/mutex', { Mutex: MutexMock });
+    mockRequire('os', { networkInterfaces: () => networkInterfaces });
 
     ClusterNode = mockRequire.reRequire('../../lib/cluster/node');
   });
@@ -128,12 +159,58 @@ describe('#Cluster Node', () => {
   describe('#constructor', () => {
     it('should select the correct IP address according to the configuration', () => {
       kuzzle.config.cluster.ip = 'private';
+      kuzzle.config.cluster.ipv6 = false;
+      kuzzle.config.interface = null;
       node = new ClusterNode();
-      should(node.ip).be.eql(getIP.address('private', 'ipv4'));
+      should(node.ip).be.eql('10.1.1.1');
+
+      kuzzle.config.cluster.ip = 'private';
+      kuzzle.config.cluster.ipv6 = true;
+      kuzzle.config.cluster.interface = null;
+      node = new ClusterNode();
+      should(node.ip).be.eql('fe80::b468:a254:bb56:ea68');
 
       kuzzle.config.cluster.ip = 'public';
+      kuzzle.config.cluster.ipv6 = false;
+      kuzzle.config.cluster.interface = null;
       node = new ClusterNode();
-      should(node.ip).be.eql(getIP.address('public', 'ipv4'));
+      should(node.ip).be.eql('11.1.1.1');
+
+      kuzzle.config.cluster.ip = 'public';
+      kuzzle.config.cluster.ipv6 = true;
+      kuzzle.config.cluster.interface = null;
+      node = new ClusterNode();
+      should(node.ip).be.eql('fe81::b468:a254:bb56:ea68');
+
+      kuzzle.config.cluster.ip = null;
+      kuzzle.config.cluster.ipv6 = false;
+      kuzzle.config.cluster.interface = 'welp2';
+      node = new ClusterNode();
+      should(node.ip).be.eql('11.1.1.1');
+
+      kuzzle.config.cluster.ip = null;
+      kuzzle.config.cluster.ipv6 = true;
+      kuzzle.config.cluster.interface = 'welp2';
+      node = new ClusterNode();
+      should(node.ip).be.eql('fe81::b468:a254:bb56:ea68');
+
+      kuzzle.config.cluster.ip = null;
+      kuzzle.config.cluster.ipv6 = false;
+      kuzzle.config.cluster.interface = null;
+      node = new ClusterNode();
+      should(node.ip).be.eql('10.1.1.1');
+
+      kuzzle.config.cluster.ip = null;
+      kuzzle.config.cluster.ipv6 = true;
+      kuzzle.config.cluster.interface = null;
+      node = new ClusterNode();
+      should(node.ip).be.eql('fe80::b468:a254:bb56:ea68');
+    });
+
+    it('should throw if no valid IP address can be found', () => {
+      kuzzle.config.cluster.interface = 'foobar';
+
+      should(() => new ClusterNode()).throw(/^\[FATAL\] Cluster: no suitable IP address found with the provided configuration/);
     });
   });
 


### PR DESCRIPTION
# Description

The current cluster configuration has problems with IP detection:
* when setting private addresses, the cluster regularly chooses the loopback IP address, which causes problems obviously as nodes will try to connect to themselves (partially mitigated with #2050)
* not enough configuration available: it's impossible to choose the right IP address if multiple network interfaces are available with the same IP family and the same type of IPs (public or private)
* the kuzzlerc documentation about the `ip` setting is vague, and it's easy to get it wrong

This PR solves these problem by:
* rewriting the `ip` configuration documentation in the kuzzlerc documentation
* introducing a new `interface` configuration, allowing admins to choose the network interface, IP or MAC address they want the node to use

To do that, I removed the obsolete and clunky `ip` NPM module. Instead, I rely on native Node.js features, and  sift through its results according to the provided configuration.
And I automatically remove any and all internal addresses, unfit for cluster communications (e.g. loopback addresses).

Also, the default `ip` target will now be "private", as the most common use case is to use a kuzzle cluster over a LAN.
It was switched to "public" because the "ip" module regularly returned the loopback address when asked for a private one. 