### PR TITLE
Improve index cache loading

### DIFF
--- a/lib/core/storage/clientAdapter.js
+++ b/lib/core/storage/clientAdapter.js
@@ -21,8 +21,6 @@
 
 'use strict';
 
-const Bluebird = require('bluebird');
-
 const Elasticsearch = require('../../service/storage/elasticsearch');
 const IndexCache = require('./indexCache');
 const { isPlainObject } = require('../../util/safeObject');
@@ -160,15 +158,15 @@ class ClientAdapter {
    * @returns {Promise}
    */
   async populateCache () {
-    const indexes = await this.client.listIndexes();
+    const schema = await this.client.getSchema();
 
-    await Bluebird.map(indexes, async index => {
+    for (const [index, collections] of Object.entries(schema)) {
       this.cache.addIndex(index);
 
-      for (const collection of await this.client.listCollections(index)) {
+      for (const collection of collections) {
         this.cache.addCollection(index, collection);
       }
-    });
+    }
 
     const aliases = await this.client.listAliases();
 

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -1623,7 +1623,9 @@ class ElasticSearch extends Service {
 
     const esIndexes = body.map(({ index: esIndex }) => esIndex);
 
-    return this._extractCollections(esIndexes, index);
+    const schema = this._extractSchema(esIndexes);
+
+    return schema[index] || [];
   }
 
   /**
@@ -1637,13 +1639,35 @@ class ElasticSearch extends Service {
     try {
       ({ body } = await this._client.cat.indices({ format: 'json' }));
     }
-    catch(error) {
+    catch (error) {
       throw this._esWrapper.formatESError(error);
     }
 
     const esIndexes = body.map(({ index }) => index);
 
-    return this._extractIndexes(esIndexes);
+    const schema = this._extractSchema(esIndexes);
+
+    return Object.keys(schema);
+  }
+
+  /**
+   * Returns an object containing the list of indexes and collections
+   *
+   * @returns {Object.<String, String[]>} Object<index, collections>
+   */
+  async getSchema () {
+    let body;
+
+    try {
+      ({ body } = await this._client.cat.indices({ format: 'json' }));
+    }
+    catch (error) {
+      throw this._esWrapper.formatESError(error);
+    }
+
+    const esIndexes = body.map(({ index }) => index);
+
+    return this._extractSchema(esIndexes);
   }
 
   /**
@@ -2605,37 +2629,14 @@ class ElasticSearch extends Service {
   }
 
   /**
-   * Returns a list of index names from esIndex names.
+   * Returns an object containing index names as keys and their collections
+   * as value.
    *
    * @param {Array.<String>} esIndexes
-   * @returns {Array.<String>} index names
+   * @returns {Object.<String, String[]>} indexes and their collections
    */
-  _extractIndexes (esIndexes) {
-    const indexes = new Set();
-
-    for (const esIndex of esIndexes) {
-      const separatorIndex = esIndex.indexOf(NAME_SEPARATOR);
-
-      if ( esIndex[0] === this._indexPrefix
-        && separatorIndex !== -1
-        && separatorIndex !== esIndex.length -1
-      ) {
-        indexes.add(this._extractIndex(esIndex));
-      }
-    }
-
-    return Array.from(indexes);
-  }
-
-  /**
-   * Returns a list of collection names for an index from esIndex names
-   *
-   * @param {Array.<String>} esIndexes
-   * @param {string} index
-   * @returns {Array.<String>} collection names
-   */
-  _extractCollections (esIndexes, index) {
-    const collections = new Set();
+  _extractSchema (esIndexes) {
+    const schema = {};
 
     for (const esIndex of esIndexes) {
       const [ indexName, collectionName ] = esIndex
@@ -2643,14 +2644,19 @@ class ElasticSearch extends Service {
         .split(NAME_SEPARATOR);
 
       if ( esIndex[0] === this._indexPrefix
-        && indexName === index
         && collectionName !== HIDDEN_COLLECTION
       ) {
-        collections.add(collectionName);
+        if (! schema[indexName]) {
+          schema[indexName] = [];
+        }
+
+        if (! schema[indexName].includes(collectionName)) {
+          schema[indexName].push(collectionName);
+        }
       }
     }
 
-    return Array.from(collections);
+    return schema;
   }
 
   /**

--- a/test/mocks/elasticsearch.mock.js
+++ b/test/mocks/elasticsearch.mock.js
@@ -29,6 +29,7 @@ class ElasticsearchMock extends Elasticsearch {
     sinon.stub(this, 'getMapping').resolves();
     sinon.stub(this, 'truncateCollection').resolves();
     sinon.stub(this, 'import').resolves();
+    sinon.stub(this, 'getSchema').resolves({});
     sinon.stub(this, 'listCollections').resolves([]);
     sinon.stub(this, 'listIndexes').resolves([]);
     sinon.stub(this, 'listAliases').resolves([]);

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -4519,43 +4519,24 @@ describe('Test: ElasticSearch service', () => {
       });
     });
 
-    describe('#_extractIndexes', () => {
-      it('extract the index names from a list of esIndex name', () => {
+    describe('#_extractSchema', () => {
+      it('should extract the list of indexes and their collections', () => {
         const esIndexes = [
-          '%nepali.liia', '%nepali.mehry', '&india.darjeeling', '&vietnam.lfiduras'
+          '%nepali.liia', '%nepali.mehry',
+          '&nepali.panipokari', '&nepali._kuzzle_keep',
+          '&vietnam.lfiduras'
         ];
 
-        const
-          publicIndexes = publicES._extractIndexes(esIndexes),
-          internalIndexes = internalES._extractIndexes(esIndexes);
+        const publicSchema = publicES._extractSchema(esIndexes);
+        const internalSchema = internalES._extractSchema(esIndexes);
 
-        should(publicIndexes).be.eql(['india', 'vietnam']);
-        should(internalIndexes).be.eql(['nepali']);
-      });
-
-      it('does not extract malformated indexes', () => {
-        const esIndexes = ['nepali', '&india', '&vietnam.'];
-
-        const
-          publicIndexes = publicES._extractIndexes(esIndexes),
-          internalIndexes = internalES._extractIndexes(esIndexes);
-
-        should(publicIndexes).be.empty();
-        should(internalIndexes).be.empty();
-      });
-    });
-
-    describe('#_extractCollections', () => {
-      it('extract the collection names for an index from a list of esIndex name', () => {
-        const esIndexes = [
-          '%nepali.liia', '%nepali.mehry', '&nepali.panipokari', '&vietnam.lfiduras'];
-
-        const
-          publicCollections = publicES._extractCollections(esIndexes, 'nepali'),
-          internalCollections = internalES._extractCollections(esIndexes, 'nepali');
-
-        should(publicCollections).be.eql(['panipokari']);
-        should(internalCollections).be.eql(['liia', 'mehry']);
+        should(publicSchema).be.eql({
+          nepali: ['panipokari'],
+          vietnam: ['lfiduras'],
+        });
+        should(internalSchema).be.eql({
+          nepali: ['liia', 'mehry'],
+        });
       });
     });
   });


### PR DESCRIPTION
## What does this PR do ?

The index cache is populated when Kuzzle starts:
  - a first request to ES is made to list available indexes
  - then, another request is made for each indexes to list collections.
 
This is a typical N+1 query problem and it can be an issue when Kuzzle start because ES will receive a lot of requests. Specially in a cluster environment when multiples nodes starts at the same time.

We are actually inferring the list of indexes of collections by listing ES indices and then extracting Kuzzle indexes and collections names.
Meaning that to extract the entire list of indexes and collections we can make only 1 request to ES.

```
// List of ES indices from where we extract indexes and collections names
[
  "&nyc-open-data.green-taxi",
  "&jeodus.barfoo",
  "&jeodus.foobar",
  "&nyc-open-data.yellow-taxi",
]

// we can extract thoses indexes and collections

{
  jeodus: ['barfoo', 'foobar'],
  'nyc-open-data': ['green-taxi', 'yellow-taxi']
}
``` 
