### PR TITLE
Kuzzle action with ES queries should not tolerate script keyword

### DIFF
--- a/doc/2/api/errors/error-codes/services/index.md
+++ b/doc/2/api/errors/error-codes/services/index.md
@@ -59,6 +59,7 @@ description: Error codes definitions
 | services.storage.scroll_duration_too_great<br/><pre>0x0101002c</pre>  | [BadRequestError](/core/2/api/errors/error-codes#badrequesterror) <pre>(400)</pre> | Scroll duration "%s" is too great. | The scroll duration exceed the configured maxium value. (See config.services.storageEngine.maxScrollDuration) |
 | services.storage.unknown_query_keyword<br/><pre>0x0101002d</pre>  | [BadRequestError](/core/2/api/errors/error-codes#badrequesterror) <pre>(400)</pre> | The keyword "%s" is not part of Elasticsearch Query DSL. Are you trying to use a Koncorde query? | An unknown keyword has been provided in the search query |
 | services.storage.incomplete_update<br/><pre>0x0101002e</pre>  | [MultipleErrorsError](/core/2/api/errors/error-codes#multipleerrorserror) <pre>(400)</pre> | %s documents were successfully updated before an error occured | Couldn't update all the requested documents |
+| services.storage.invalid_query_keyword<br/><pre>0x0101002f</pre>  | [BadRequestError](/core/2/api/errors/error-codes#badrequesterror) <pre>(400)</pre> | The "%s" keyword is not allowed in this query. | A forbidden keyword has been provided in the query |
 
 ---
 

--- a/lib/kerror/codes/1-services.json
+++ b/lib/kerror/codes/1-services.json
@@ -263,6 +263,12 @@
           "code": 46,
           "message": "%s documents were successfully updated before an error occured",
           "class": "MultipleErrorsError"
+        },
+        "invalid_query_keyword": {
+          "description": "A forbidden keyword has been provided in the query",
+          "code": 47,
+          "message": "The \"%s\" keyword is not allowed in this query.",
+          "class": "BadRequestError"
         }
       }
     },

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -2729,7 +2729,7 @@ class ElasticSearch extends Service {
   _scriptCheck(object) {
     for (const [key, value] of Object.entries(object)) {
       if (this.scriptKeys.includes(key)) {
-        throw kerror.get('invalid_search_query', key);
+        throw kerror.get('invalid_query_keyword', key);
       }
       else if (typeof value === 'object' && value !== null) {
         this._scriptCheck(value);

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -124,6 +124,12 @@ class ElasticSearch extends Service {
       '_source_includes'
     ];
 
+    // Forbidden keys in a query
+    this.scriptKeys = [
+      'script',
+      '_script'
+    ];
+
 
     this.maxScrollDuration = this._loadMsConfig('maxScrollDuration');
 
@@ -1495,6 +1501,7 @@ class ElasticSearch extends Service {
     };
 
     assertWellFormedRefresh(esRequest);
+    this._scriptCheck(documents);
 
     let lastAction; // NOSONAR
 
@@ -2702,6 +2709,9 @@ class ElasticSearch extends Service {
       }
     }
 
+    // Ensure that the body does not include a script
+    this._scriptCheck(searchBody);
+
     // Avoid empty queries that causes ES to respond with an error.
     // Empty queries are turned into match_all queries
     if (_.isEmpty(searchBody.query)) {
@@ -2709,6 +2719,22 @@ class ElasticSearch extends Service {
     }
 
     return searchBody;
+  }
+
+  /**
+   * Throw if any script keyword is contained in the object  
+   * 
+   * @param {Object} object
+   */
+  _scriptCheck(object) {
+    for (const [key, value] of Object.entries(object)) {
+      if (this.scriptKeys.includes(key)) {
+        throw kerror.get('invalid_search_query', key);
+      }
+      else if (typeof value === 'object' && value !== null) {
+        this._scriptCheck(value);
+      }
+    }
   }
 
   /**

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -2731,6 +2731,7 @@ class ElasticSearch extends Service {
       if (this.scriptKeys.includes(key)) {
         throw kerror.get('invalid_query_keyword', key);
       }
+      // Every object must be checked here, even the ones nested into an array
       else if (typeof value === 'object' && value !== null) {
         this._scriptCheck(value);
       }

--- a/lib/util/safeObject.js
+++ b/lib/util/safeObject.js
@@ -36,7 +36,7 @@ function get (o, prop) {
 }
 
 function isPlainObject (o) {
-  return o !== null && typeof o === 'object' && !Array.isArray(o);
+  return Object.prototype.toString.call(o) === '[object Object]';
 }
 
 module.exports = { get, has, isPlainObject };

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -4563,23 +4563,23 @@ describe('Test: ElasticSearch service', () => {
       let searchBody;
 
       it('should return the same query if all top level keywords are valid', () => {
-        searchBody = {}
+        searchBody = {};
         for (const key of publicES.searchBodyKeys) {
-          searchBody[key] = { foo: 'bar' }
+          searchBody[key] = { foo: 'bar' };
         }
 
         const result = publicES._sanitizeSearchBody(Object.assign({}, searchBody));
 
-        should(result).be.deepEqual(searchBody)
+        should(result).be.deepEqual(searchBody);
       });
 
       it('should throw if any top level keyword is not in the white list', () => {
         searchBody = {
           unknown: {}
-        }
+        };
 
         should(() => publicES._sanitizeSearchBody(searchBody))
-          .throw(BadRequestError, { id: 'services.storage.invalid_search_query'})
+          .throw(BadRequestError, { id: 'services.storage.invalid_search_query'});
       });
 
       it('should throw if any script keyword is found in the query (even deeply nested)', () => {
@@ -4603,17 +4603,17 @@ describe('Test: ElasticSearch service', () => {
         };
 
         should(() => publicES._sanitizeSearchBody(searchBody))
-          .throw(BadRequestError, { id: 'services.storage.invalid_search_query'})
+          .throw(BadRequestError, { id: 'services.storage.invalid_query_keyword'});
       });
 
       it('should turn empty queries into match_all queries', () => {
         searchBody = {
           query: {}
-        }
+        };
 
         const result = publicES._sanitizeSearchBody(searchBody);
 
-        should(result).be.deepEqual({ query: { match_all: {} }})
+        should(result).be.deepEqual({ query: { match_all: {} }});
       });
     });
 
@@ -4621,9 +4621,9 @@ describe('Test: ElasticSearch service', () => {
       let object;
 
       it('should not throw when there is not a single script', () => {
-        object = { foo: 'bar' }
+        object = { foo: 'bar' };
 
-        should(() => publicES._scriptCheck(object)).not.throw()
+        should(() => publicES._scriptCheck(object)).not.throw();
       });
 
       it('should throw if any script keyword is found in the query', () => {
@@ -4641,7 +4641,7 @@ describe('Test: ElasticSearch service', () => {
         };
 
         should(() => publicES._sanitizeSearchBody(object))
-          .throw(BadRequestError, { id: 'services.storage.invalid_search_query'})
+          .throw(BadRequestError, { id: 'services.storage.invalid_query_keyword'});
       });
 
       it('should throw if any deeply nested script keyword is found in the query', () => {
@@ -4665,7 +4665,7 @@ describe('Test: ElasticSearch service', () => {
         };
 
         should(() => publicES._sanitizeSearchBody(object))
-          .throw(BadRequestError, { id: 'services.storage.invalid_search_query'})
+          .throw(BadRequestError, { id: 'services.storage.invalid_query_keyword'});
       });
     });
   });

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -4558,5 +4558,115 @@ describe('Test: ElasticSearch service', () => {
         should(internalCollections).be.eql(['liia', 'mehry']);
       });
     });
+
+    describe('#_sanitizeSearchBody', () => {
+      let searchBody;
+
+      it('should return the same query if all top level keywords are valid', () => {
+        searchBody = {}
+        for (const key of publicES.searchBodyKeys) {
+          searchBody[key] = { foo: 'bar' }
+        }
+
+        const result = publicES._sanitizeSearchBody(Object.assign({}, searchBody));
+
+        should(result).be.deepEqual(searchBody)
+      });
+
+      it('should throw if any top level keyword is not in the white list', () => {
+        searchBody = {
+          unknown: {}
+        }
+
+        should(() => publicES._sanitizeSearchBody(searchBody))
+          .throw(BadRequestError, { id: 'services.storage.invalid_search_query'})
+      });
+
+      it('should throw if any script keyword is found in the query (even deeply nested)', () => {
+        searchBody = {
+          query: {
+            bool: {
+              filter: [
+                {
+                  script: {
+                    script: {
+                      inline: 'doc[message.keyword].value.length() > params.length',
+                      params: {
+                        length: 25
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        };
+
+        should(() => publicES._sanitizeSearchBody(searchBody))
+          .throw(BadRequestError, { id: 'services.storage.invalid_search_query'})
+      });
+
+      it('should turn empty queries into match_all queries', () => {
+        searchBody = {
+          query: {}
+        }
+
+        const result = publicES._sanitizeSearchBody(searchBody);
+
+        should(result).be.deepEqual({ query: { match_all: {} }})
+      });
+    });
+
+    describe('#_scriptCheck', () => {
+      let object;
+
+      it('should not throw when there is not a single script', () => {
+        object = { foo: 'bar' }
+
+        should(() => publicES._scriptCheck(object)).not.throw()
+      });
+
+      it('should throw if any script keyword is found in the query', () => {
+        object = {
+          query: {
+            match: {
+              script: {
+                inline: 'doc[message.keyword].value.length() > params.length',
+                params: {
+                  length: 25
+                }
+              }
+            }
+          }
+        };
+
+        should(() => publicES._sanitizeSearchBody(object))
+          .throw(BadRequestError, { id: 'services.storage.invalid_search_query'})
+      });
+
+      it('should throw if any deeply nested script keyword is found in the query', () => {
+        object = {
+          query: {
+            bool: {
+              filter: [
+                {
+                  script: {
+                    script: {
+                      inline: 'doc[message.keyword].value.length() > params.length',
+                      params: {
+                        length: 25
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        };
+
+        should(() => publicES._sanitizeSearchBody(object))
+          .throw(BadRequestError, { id: 'services.storage.invalid_search_query'})
+      });
+    });
   });
 });


### PR DESCRIPTION
## What does this PR do ?

Ensure that scripts are forbidden in an ES query.
A check has been added in _sanitizeSearchBody which should be fine for almost all requests (current and future) and bulk import has been specifically handled.
A new related error has been created. Tests have been added for both new _scriptCheck and old _sanitizeSearchBody

### How should this be manually tested?

Follow the instructions written in the linked issue #2067

### Boyscout

Safer isPlainObject helper