### PR TITLE
[kuzdoc] Install latest minor (2-dev)

### DIFF
--- a/.github/actions/deploy-doc/action.yml
+++ b/.github/actions/deploy-doc/action.yml
@@ -35,7 +35,7 @@ runs:
     - name: Build documentation
       run: |
         rm -fr doc/framework
-        npm ci
+        npm ci --production=false
         npm i --save-dev kuzdoc
         npm run doc-prepare
         npm run doc-build

--- a/.github/actions/deploy-doc/action.yml
+++ b/.github/actions/deploy-doc/action.yml
@@ -36,7 +36,7 @@ runs:
       run: |
         rm -fr doc/framework
         npm ci
-        npm i kuzdoc
+        npm i --save-dev kuzdoc
         npm run doc-prepare
         npm run doc-build
       env:

--- a/.github/actions/deploy-doc/action.yml
+++ b/.github/actions/deploy-doc/action.yml
@@ -35,7 +35,8 @@ runs:
     - name: Build documentation
       run: |
         rm -fr doc/framework
-        npm install --production=false
+        npm ci
+        npm i kuzdoc
         npm run doc-prepare
         npm run doc-build
       env:


### PR DESCRIPTION
Following the latest improvements in the Docs CI workflow, we need to have isomorphic dependencies (thus `npm ci`) but the latest Kuzdoc minor within the major specified by `package.json` (thus `npm i kuzdoc`). Having the latest minor of Kuzdoc enables us to easily deploy non-breaking changes to all the CIs without manually bump the Kuzdoc dependency (which would be the case if we just`npm ci`).
