### PR TITLE
Remove the _kuzzle_keep collection from non-empty indexes

### DIFF
--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -1215,7 +1215,6 @@ class ElasticSearch extends Service {
     this._checkDynamicProperty(mappings);
 
     const exists = await this.hasCollection(index, collection);
-
     if (exists) {
       return this.updateCollection(index, collection, { mappings, settings });
     }

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -1201,7 +1201,7 @@ class ElasticSearch extends Service {
         await this.deleteCollection(index, HIDDEN_COLLECTION);
       }
       catch (e) {
-        return this._esWrapper.reject(e);
+        throw this._esWrapper.formatESError(e);
       }
     }
     const esRequest = {

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -2674,8 +2674,7 @@ class ElasticSearch extends Service {
         .split(NAME_SEPARATOR);
 
       if ( esIndex[0] === this._indexPrefix 
-        && (collectionName !== HIDDEN_COLLECTION
-          || collectionName === HIDDEN_COLLECTION && includeHidden)
+        && (collectionName !== HIDDEN_COLLECTION || includeHidden)
       ) {
         if (! schema[indexName]) {
           schema[indexName] = [];

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -1192,6 +1192,18 @@ class ElasticSearch extends Service {
   async createCollection (index, collection, { mappings={}, settings={} } = {}) {
     this._assertValidIndexAndCollection(index, collection);
 
+    if (await this.hasCollection(index, HIDDEN_COLLECTION)) {
+      try {
+        await this._client.indices.delete(
+          {
+            body: {},
+            index: this._getESIndex(index, HIDDEN_COLLECTION)
+          });
+      }
+      catch (e) {
+        return this._esWrapper.reject(e);
+      }
+    }
     const esRequest = {
       body: {
         mappings: {},
@@ -1714,14 +1726,25 @@ class ElasticSearch extends Service {
    *
    * @returns {Promise}
    */
-  deleteCollection (index, collection) {
+  async deleteCollection (index, collection) {
     const esRequest = {
       index: this._getESIndex(index, collection)
     };
 
-    return this._client.indices.delete(esRequest)
-      .then(() => null)
-      .catch(error => this._esWrapper.reject(error));
+    try {
+      await this._client.indices.delete(esRequest);
+      if (await this.listCollections(index) === [])
+      {
+        await this._client.indices.create({
+          body: {},
+          index: this._getESIndex(index, HIDDEN_COLLECTION)
+        });
+      }
+    }
+    catch (e) {
+      return this._esWrapper.reject(e);
+    }
+    return null;
   }
 
   /**

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -1741,7 +1741,7 @@ class ElasticSearch extends Service {
       }
     }
     catch (e) {
-      return this._esWrapper.reject(e);
+      throw this._esWrapper.formatESError(e);
     }
     return null;
   }

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -1192,13 +1192,13 @@ class ElasticSearch extends Service {
   async createCollection (index, collection, { mappings={}, settings={} } = {}) {
     this._assertValidIndexAndCollection(index, collection);
 
-    if (await this.hasCollection(index, HIDDEN_COLLECTION)) {
+    if (collection === HIDDEN_COLLECTION) {
+      throw kerror.get('collection_reserved', HIDDEN_COLLECTION);
+    }
+
+    if (await this.hasCollection(index, HIDDEN_COLLECTION, true)) {
       try {
-        await this._client.indices.delete(
-          {
-            body: {},
-            index: this._getESIndex(index, HIDDEN_COLLECTION)
-          });
+        await this.deleteCollection(index, HIDDEN_COLLECTION);
       }
       catch (e) {
         return this._esWrapper.reject(e);
@@ -1211,10 +1211,6 @@ class ElasticSearch extends Service {
       },
       index: this._getESIndex(index, collection)
     };
-
-    if (collection === HIDDEN_COLLECTION) {
-      throw kerror.get('collection_reserved', HIDDEN_COLLECTION);
-    }
 
     this._checkDynamicProperty(mappings);
 
@@ -1627,10 +1623,11 @@ class ElasticSearch extends Service {
    * Retrieves the complete list of existing collections in the current index
    *
    * @param {String} index - Index name
+   * @param {Boolean} includeHidden - Optional: include HIDDEN_COLLECTION in results
    *
    * @returns {Promise.<Array>} Collection names
    */
-  async listCollections (index) {
+  async listCollections (index, includeHidden = false) {
     let body;
 
     try {
@@ -1642,7 +1639,7 @@ class ElasticSearch extends Service {
 
     const esIndexes = body.map(({ index: esIndex }) => esIndex);
 
-    const schema = this._extractSchema(esIndexes);
+    const schema = this._extractSchema(esIndexes, includeHidden);
 
     return schema[index] || [];
   }
@@ -1733,11 +1730,13 @@ class ElasticSearch extends Service {
 
     try {
       await this._client.indices.delete(esRequest);
-      if (await this.listCollections(index) === [])
+      const collections = await this.listCollections(index, true);
+      if (!collections.length)
       {
+        const esIndex = this._getESIndex(index, HIDDEN_COLLECTION);
         await this._client.indices.create({
           body: {},
-          index: this._getESIndex(index, HIDDEN_COLLECTION)
+          index: esIndex
         });
       }
     }
@@ -1758,7 +1757,6 @@ class ElasticSearch extends Service {
     if (indexes.length === 0) {
       return Bluebird.resolve([]);
     }
-
     const deleted = new Set();
 
     return this._client.cat.indices({ format: 'json' })
@@ -1866,11 +1864,12 @@ class ElasticSearch extends Service {
    *
    * @param {String} index - Index name
    * @param {String} collection - Collection name
+   * @param {Boolean} includeHidden - Optional: include HIDDEN_COLLECTION in results
    *
    * @returns {Promise.<boolean>}
    */
-  async hasCollection (index, collection) {
-    const collections = await this.listCollections(index);
+  async hasCollection (index, collection, includeHidden = false) {
+    const collections = await this.listCollections(index, includeHidden);
 
     return collections.some(col => col === collection);
   }
@@ -2663,9 +2662,10 @@ class ElasticSearch extends Service {
    * as value.
    *
    * @param {Array.<String>} esIndexes
+   * @param {Boolean} includeHidden
    * @returns {Object.<String, String[]>} indexes and their collections
    */
-  _extractSchema (esIndexes) {
+  _extractSchema (esIndexes, includeHidden = false) {
     const schema = {};
 
     for (const esIndex of esIndexes) {
@@ -2673,8 +2673,9 @@ class ElasticSearch extends Service {
         .substr(1, esIndex.length)
         .split(NAME_SEPARATOR);
 
-      if ( esIndex[0] === this._indexPrefix
-        && collectionName !== HIDDEN_COLLECTION
+      if ( esIndex[0] === this._indexPrefix 
+        && (collectionName !== HIDDEN_COLLECTION
+          || collectionName === HIDDEN_COLLECTION && includeHidden)
       ) {
         if (! schema[indexName]) {
           schema[indexName] = [];

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -2059,12 +2059,14 @@ describe('Test: ElasticSearch service', () => {
         settings = { index: { blocks: { write: true } } },
         mappings = { properties: { city: { type: 'keyword' } } };
 
-      sinon.stub(elasticsearch, 'hasCollection').resolves(true);
-      sinon.stub(elasticsearch, 'deleteCollection').resolves();
+      elasticsearch.hasCollection = sinon.stub().resolves(true);
       sinon.stub(elasticsearch, 'updateCollection').resolves({});
+      sinon.stub(elasticsearch, 'deleteCollection').resolves();
 
       await elasticsearch.createCollection(index, collection, { mappings, settings });
 
+      should(elasticsearch.hasCollection).be.calledWith(index, '_kuzzle_keep', true);
+      should(elasticsearch.deleteCollection).be.calledWith(index, '_kuzzle_keep');
       should(elasticsearch.hasCollection).be.calledWith(index, collection);
       should(elasticsearch.updateCollection).be.calledWithMatch(index, collection, {
         settings: { index: { blocks: { write: true } } },

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -2738,7 +2738,7 @@ describe('Test: ElasticSearch service', () => {
       });
     });
 
-    it.only('should allow listing all available collections', () => {
+    it('should allow listing all available collections', () => {
       const promise = elasticsearch.listCollections('nepali');
 
       return promise

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -4520,7 +4520,7 @@ describe('Test: ElasticSearch service', () => {
       });
     });
 
-    describe.only('#_extractSchema', () => {
+    describe('#_extractSchema', () => {
       it('should extract the list of indexes and their collections', () => {
         const esIndexes = [
           '%nepali.liia', '%nepali.mehry',

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -3000,7 +3000,7 @@ describe('Test: ElasticSearch service', () => {
   describe('#deleteCollection', () => {
     it('should allow to delete a collection', () => {
       const promise = elasticsearch.deleteCollection('nepali', 'liia');
-      elasticsearch.listCollections = sinon.stub().resolves(['nepali', 'liia']);
+      sinon.stub(elasticsearch, 'listCollections').resolves(['nepali', 'liia']);
       return promise
         .then(result => {
           should(elasticsearch._client.indices.delete).be.calledWithMatch({

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -2059,9 +2059,9 @@ describe('Test: ElasticSearch service', () => {
         settings = { index: { blocks: { write: true } } },
         mappings = { properties: { city: { type: 'keyword' } } };
 
-      elasticsearch.hasCollection = sinon.stub().resolves(true);
-      elasticsearch.deleteCollection = sinon.stub().resolves();
-      elasticsearch.updateCollection = sinon.stub().resolves({});
+      sinon.stub(elasticsearch, 'hasCollection').resolves(true);
+      sinon.stub(elasticsearch, 'deleteCollection').resolves();
+      sinon.stub(elasticsearch, 'updateCollection').resolves({});
 
       await elasticsearch.createCollection(index, collection, { mappings, settings });
 


### PR DESCRIPTION
<!--
  Thank you for submitting a Pull Request. Please:
    - Read our CONTRIBUTING guidelines.
      https://github.com/kuzzleio/kuzzle/blob/master/CONTRIBUTING.md
    - Associate an issue with the Pull Request.
    - IMPORTANT - Add the corresponding "changelog:xxx" label to your PR.
-->

<!--- This template is optional. -->

## What does this PR do ?

Remove the `_kuzzle_keep` when a collection is created in an empty index and re-create it again if the last collection of this index is deleted.

https://github.com/kuzzleio/kuzzle/issues/2076

### Other changes

Add an `includeHidden` option for `hasCollection` `listCollection` and `_extractSchema` functions to allow us to know if the `_kuzzle_keep` collection exists.

## Boyscout

Asyncify `deleteCollection` 