### PR TITLE
Add a configurable maximum TTL for API keys

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -240,6 +240,16 @@
       "maxTTL": -1,
       "secret": null
     },
+    // [apiKey]
+    // configuration for the api keys
+    //
+    //   * maxTTL:
+    //      Maximum duration in milliseconds a token can be requested
+    //      to be valid.
+    //      If set to -1 (default), no maximum duration is set.
+    "apiKey": {
+      "maxTTL": -1
+    },
     // [default]
     // The default role defines permissions for all users,
     // until an administrator configures the backend rights

--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -241,12 +241,11 @@
       "secret": null
     },
     // [apiKey]
-    // configuration for the api keys
+    // API Keys configuration
     //
     //   * maxTTL:
-    //      Maximum duration in milliseconds a token can be requested
-    //      to be valid.
-    //      If set to -1 (default), no maximum duration is set.
+    //      Maximum time to live of an API Key, in milliseconds
+    //      If set to -1 (default), API Keys can be created with an infinite duration.
     "apiKey": {
       "maxTTL": -1
     },

--- a/doc/2/guides/advanced/api-keys/index.md
+++ b/doc/2/guides/advanced/api-keys/index.md
@@ -25,6 +25,9 @@ By default, **API keys do not expire**. But it is possible to specify the durati
 ::: info
 It is also possible to set a maximum validity period for an API key under the key `security.apiKey.maxTTL` in the Kuzzle configuration.
 This limit will only apply to API key created with the `auth` controller.
+Possible values: 
+  - `<= -1`: disable the use of maxTTL
+  - `>= 0`: enable maxTTL with setted value (`0` will invalid all your API keys at their creation)
 :::
 
 It is also necessary to **provide a description** of the API key.

--- a/doc/2/guides/advanced/api-keys/index.md
+++ b/doc/2/guides/advanced/api-keys/index.md
@@ -24,6 +24,7 @@ By default, **API keys do not expire**. But it is possible to specify the durati
 
 ::: info
 It is also possible to set a maximum validity period for an API key under the key `security.apiKey.maxTTL` in the Kuzzle configuration.
+This limit will only apply to API key created with the `auth` controller.
 :::
 
 It is also necessary to **provide a description** of the API key.

--- a/doc/2/guides/advanced/api-keys/index.md
+++ b/doc/2/guides/advanced/api-keys/index.md
@@ -22,6 +22,10 @@ Administrators can create API keys for other users using the [security:createApi
 
 By default, **API keys do not expire**. But it is possible to specify the duration of an API key using the argument `expiresIn`.
 
+::: info
+It is also possible to set a maximum validity period for an API key under the key `security.apiKey.maxTTL` in the Kuzzle configuration.
+:::
+
 It is also necessary to **provide a description** of the API key.
 
 **Example: _Create an API key for the user "melis" and valid for 30 days_**

--- a/doc/2/guides/main-concepts/authentication/index.md
+++ b/doc/2/guides/main-concepts/authentication/index.md
@@ -110,6 +110,9 @@ When authentication is successful, **Kuzzle returns an authentication token**. T
 It is possible to request an authentication token valid for more than 1 hours with the argument `expiresIn`.  
 The default validity period is configurable under the key `security.jwt.expiresIn`.  
 It is also possible to set a maximum validity period for a token under the key `security.jwt.maxTTL`.
+Possible values: 
+  - `<= -1`: disable the use of maxTTL
+  - `>= 0`: enable maxTTL with setted value (`0` will invalid all your authentication tokens at their creation)
 :::
 
 

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -119,6 +119,7 @@ class AuthController extends NativeController {
       apiKeyId,
       creatorId: user._id,
       refresh,
+      bypassMaxTTL: false
     });
 
     return apiKey.serialize({ includeToken: true });

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -117,7 +117,6 @@ class AuthController extends NativeController {
 
     const apiKey = await ApiKey.create(user, expiresIn, description, {
       apiKeyId,
-      bypassMaxTTL: false,
       creatorId: user._id,
       refresh,
     });

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -117,9 +117,9 @@ class AuthController extends NativeController {
 
     const apiKey = await ApiKey.create(user, expiresIn, description, {
       apiKeyId,
+      bypassMaxTTL: false,
       creatorId: user._id,
       refresh,
-      bypassMaxTTL: false
     });
 
     return apiKey.serialize({ includeToken: true });

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -144,9 +144,9 @@ class SecurityController extends NativeController {
 
     const apiKey = await ApiKey.create(user, expiresIn, description, {
       apiKeyId,
+      bypassMaxTTL: true,
       creatorId,
       refresh,
-      bypassMaxTTL: true
     });
 
     global.kuzzle.log.info(`[SECURITY] User "${creatorId}" applied action "${request.input.action}" on user "${userId}."`);

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -146,6 +146,7 @@ class SecurityController extends NativeController {
       apiKeyId,
       creatorId,
       refresh,
+      bypassMaxTTL: true
     });
 
     global.kuzzle.log.info(`[SECURITY] User "${creatorId}" applied action "${request.input.action}" on user "${userId}."`);

--- a/lib/config/default.config.js
+++ b/lib/config/default.config.js
@@ -112,6 +112,9 @@ module.exports = {
       maxTTL: -1,
       secret: null
     },
+    apiKey: {
+      maxTTL: -1
+    },
     default: {
       role: {
         controllers: {

--- a/lib/core/security/tokenRepository.js
+++ b/lib/core/security/tokenRepository.js
@@ -194,7 +194,7 @@ class TokenRepository extends Repository {
       : global.kuzzle.config.security.jwt.maxTTL;
 
     if ( ! bypassMaxTTL
-      && maxTTL > 0
+      && maxTTL > -1
       && ( parsedExpiresIn > maxTTL
         || parsedExpiresIn === -1)
     ) {

--- a/lib/core/security/tokenRepository.js
+++ b/lib/core/security/tokenRepository.js
@@ -189,9 +189,16 @@ class TokenRepository extends Repository {
 
     const parsedExpiresIn = parseTimespan(expiresIn);
 
+    let maxTTL;
+    if (type === 'apiKey') {
+      maxTTL = global.kuzzle.config.security.apiKey.maxTTL;
+    } else {
+      maxTTL = global.kuzzle.config.security.jwt.maxTTL;
+    }
+
     if ( ! bypassMaxTTL
-      && global.kuzzle.config.security.jwt.maxTTL > 0
-      && ( parsedExpiresIn > global.kuzzle.config.security.jwt.maxTTL
+      && maxTTL > 0
+      && ( parsedExpiresIn > maxTTL
         || parsedExpiresIn === -1)
     ) {
       throw securityError.get('ttl_exceeded');

--- a/lib/core/security/tokenRepository.js
+++ b/lib/core/security/tokenRepository.js
@@ -189,12 +189,9 @@ class TokenRepository extends Repository {
 
     const parsedExpiresIn = parseTimespan(expiresIn);
 
-    let maxTTL;
-    if (type === 'apiKey') {
-      maxTTL = global.kuzzle.config.security.apiKey.maxTTL;
-    } else {
-      maxTTL = global.kuzzle.config.security.jwt.maxTTL;
-    }
+    const maxTTL = type === 'apiKey'
+      ? global.kuzzle.config.security.apiKey.maxTTL
+      : global.kuzzle.config.security.jwt.maxTTL;
 
     if ( ! bypassMaxTTL
       && maxTTL > 0

--- a/lib/model/storage/apiKey.js
+++ b/lib/model/storage/apiKey.js
@@ -82,7 +82,7 @@ class ApiKey extends BaseModel {
    * @param {User} user
    * @param {String} expiresIn - API key expiration date in ms format
    * @param {String} description
-   * @param {Object} options - creatorId (null), apiKeyId (null), refresh (null)
+   * @param {Object} options - creatorId (null), apiKeyId (null), refresh (null), bypassMaxTTL (false)
    *
    * @returns {ApiKey}
    */

--- a/lib/model/storage/apiKey.js
+++ b/lib/model/storage/apiKey.js
@@ -90,10 +90,10 @@ class ApiKey extends BaseModel {
     user,
     expiresIn,
     description,
-    { creatorId=null, apiKeyId=null, refresh } = {}
+    { creatorId=null, apiKeyId=null, refresh, bypassMaxTTL=false } = {}
   ) {
     const token = await global.kuzzle.ask('core:security:token:create', user, {
-      bypassMaxTTL: true,
+      bypassMaxTTL,
       expiresIn,
       type: 'apiKey',
     });

--- a/test/model/storage/apiKey.test.js
+++ b/test/model/storage/apiKey.test.js
@@ -81,15 +81,17 @@ describe('ApiKey', () => {
       });
     });
 
-    it.only('should not be able to create a new API key with an exceed ttl', async () => {
-      kuzzle.config.security.apiKey.maxTTL = 42;
-
-      return should(ApiKey.create(
+    it('should be able to create a new API key with a bypassMaxTTL option', async () => {
+      await ApiKey.create(
         user,
-        '1m',
+        'expiresIn',
         'Sigfox API key',
-        { creatorId: 'aschen', refresh: 'wait_for' }))
-        .be.rejectedWith(BadRequestError, {id: 'security.token.ttl_exceeded'});
+        { creatorId: 'aschen', refresh: 'wait_for', bypassMaxTTL: false });
+
+      should(createTokenStub).be.calledWith(
+        createTokenEvent,
+        user,
+        { expiresIn: 'expiresIn', bypassMaxTTL: false, type: 'apiKey' });
     });
 
     it('should allow to specify the API key ID', async () => {

--- a/test/model/storage/apiKey.test.js
+++ b/test/model/storage/apiKey.test.js
@@ -62,7 +62,7 @@ describe('ApiKey', () => {
         user,
         'expiresIn',
         'Sigfox API key',
-        { creatorId: 'aschen', refresh: 'wait_for' });
+        { creatorId: 'aschen', refresh: 'wait_for', bypassMaxTTL: true });
 
       should(createTokenStub).be.calledWith(
         createTokenEvent,
@@ -79,6 +79,17 @@ describe('ApiKey', () => {
         ttl: '1y',
         token: 'jwt-token-encrypted'
       });
+    });
+
+    it.only('should not be able to create a new API key with an exceed ttl', async () => {
+      kuzzle.config.security.apiKey.maxTTL = 42;
+
+      return should(ApiKey.create(
+        user,
+        '1m',
+        'Sigfox API key',
+        { creatorId: 'aschen', refresh: 'wait_for' }))
+        .be.rejectedWith(BadRequestError, {id: 'security.token.ttl_exceeded'});
     });
 
     it('should allow to specify the API key ID', async () => {


### PR DESCRIPTION
## What does this PR do ?

Add an `apiKey` section and a `maxTTL` property to default config
Force to `bypassMaxTTL` when api key creation requested from `security` controller
Use apiKey `maxTTL` value for api-keys
#2075 

### How should this be manually tested?
  - Step 1 : Set an `apiKey.maxTTL` in config
  - Step 2 : Try api key creation using both `auth` and `security` controllers and with higher/lower ttl

