### PR TITLE
Use API keys fingerprint as their default ID

### DIFF
--- a/lib/model/storage/apiKey.js
+++ b/lib/model/storage/apiKey.js
@@ -102,7 +102,7 @@ class ApiKey extends BaseModel {
     const apiKey = new ApiKey({
       description,
       expiresAt: token.expiresAt,
-      fingerprint: fingerprint,
+      fingerprint,
       token: token.jwt,
       ttl: token.ttl,
       userId: user._id,

--- a/lib/model/storage/apiKey.js
+++ b/lib/model/storage/apiKey.js
@@ -98,15 +98,16 @@ class ApiKey extends BaseModel {
       type: 'apiKey',
     });
 
+    const fingerprint = sha256(token.jwt);
     const apiKey = new ApiKey({
       description,
       expiresAt: token.expiresAt,
-      fingerprint: sha256(token.jwt),
+      fingerprint: fingerprint,
       token: token.jwt,
       ttl: token.ttl,
       userId: user._id,
     },
-    apiKeyId);
+    apiKeyId || fingerprint);
 
     await apiKey.save({ refresh, userId: creatorId });
 

--- a/test/model/storage/apiKey.test.js
+++ b/test/model/storage/apiKey.test.js
@@ -90,6 +90,15 @@ describe('ApiKey', () => {
 
       should(apiKey._id).be.eql('my-api-key-id');
     });
+
+    it('should use the fingerprint as default API key ID', async () => {
+      const apiKey = await ApiKey.create(
+        user,
+        'expiresIn',
+        'Sigfox API key',
+        {});
+      should(apiKey._id).be.eql(apiKey._source.fingerprint);
+    });
   });
 
   describe('ApiKey.load', () => {


### PR DESCRIPTION
## What does this PR do ?

Use the authentication token fingerprint as default api key ID.
#1882 

### How should this be manually tested?

  - Step 1 : create an api-key without apiKeyId
  - Step 2 : check the match of apiKeyId and fingerprint
