### PR TITLE
Expose Kuzzle API limits

### DIFF
--- a/doc/2/api/controllers/server/limits/index.md
+++ b/doc/2/api/controllers/server/limits/index.md
@@ -1,0 +1,55 @@
+---
+code: true
+type: page
+title: limits
+---
+
+# limits
+
+
+
+Returns the kuzzle configuration limits.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_limits
+Method: GET
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "server",
+  "action": "limits"
+}
+```
+
+---
+
+## Response
+
+Returns a `limits` property containing the configuration limits.
+
+```js
+{
+  "status": 200,
+  "error": null,
+  "controller": "server",
+  "action": "limits",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "limits": {
+      "concurrentRequests": 100,
+      "documentsFetchCount": 10000,
+      "documentsWriteCount": 200,
+      "loginsPerSecond": 1
+    }
+  }
+}
+```

--- a/features/ServerController.feature
+++ b/features/ServerController.feature
@@ -63,10 +63,10 @@ Feature: Server Controller
   Scenario: Get server limits
     When I successfully execute the action "server":"limits"
     Then The property "limits" of the result should match:
-      | concurrentRequests   | "100"   |
-      | documentsFetchCount  | "10000" |  
-      | documentsWriteCount  | "200"   |
-      | loginsPerSecond      | "1"     |
+      | concurrentRequests   | "_NUMBER_" |
+      | documentsFetchCount  | "_NUMBER_" |  
+      | documentsWriteCount  | "_NUMBER_" |
+      | loginsPerSecond      | "_NUMBER_" |
 
   # server:openapi ========================================================================
   @http

--- a/features/ServerController.feature
+++ b/features/ServerController.feature
@@ -59,6 +59,15 @@ Feature: Server Controller
       | memoryStorage | "green" |
       | storageEngine | "green" |
 
+# server:limits ================================================================
+  Scenario: Get server limits
+    When I successfully execute the action "server":"limits"
+    Then The property "limits" of the result should match:
+      | concurrentRequests   | "100"   |
+      | documentsFetchCount  | "10000" |  
+      | documentsWriteCount  | "200"   |
+      | loginsPerSecond      | "1"     |
+
   # server:openapi ========================================================================
   @http
   Scenario: Get our API in OpenApi format as a raw response

--- a/lib/api/controllers/serverController.js
+++ b/lib/api/controllers/serverController.js
@@ -179,7 +179,7 @@ class ServerController extends NativeController {
       documentsFetchCount: global.kuzzle.config.limits.documentsFetchCount,
       documentsWriteCount: global.kuzzle.config.limits.documentsWriteCount,
       loginsPerSecond: global.kuzzle.config.limits.loginsPerSecond,
-    }
+    };
 
     return { limits };
   }

--- a/lib/api/controllers/serverController.js
+++ b/lib/api/controllers/serverController.js
@@ -42,6 +42,7 @@ class ServerController extends NativeController {
       'getStats',
       'healthCheck',
       'info',
+      'limits',
       'now',
       'publicApi',
       'openapi'
@@ -167,6 +168,20 @@ class ServerController extends NativeController {
       }
     }
     return result;
+  }
+
+  /**
+   * @returns {Promise<Object>}
+   */
+  async limits () {
+    const limits = {  
+      concurrentRequests: global.kuzzle.config.limits.concurrentRequests,
+      documentsFetchCount: global.kuzzle.config.limits.documentsFetchCount,
+      documentsWriteCount: global.kuzzle.config.limits.documentsWriteCount,
+      loginsPerSecond: global.kuzzle.config.limits.loginsPerSecond,
+    }
+
+    return { limits };
   }
 
   /**

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -95,6 +95,7 @@ const routes = [
   { verb: 'get', path: '/_healthCheck', controller: 'server', action: 'healthCheck' },
   { verb: 'get', path: '/_serverInfo', controller: 'server', action: 'info' },
   { verb: 'get', path: '/_now', controller: 'server', action: 'now' },
+  { verb: 'get', path: '/_limits', controller: 'server', action: 'limits' },
   { verb: 'get', path: '/_publicApi', controller: 'server', action: 'publicApi', deprecated: { since: '2.5.0', message: 'Use this route instead: http://kuzzle:7512/_openapi' } }, // @deprecated
   { verb: 'get', path: '/_openapi', controller: 'server', action: 'openapi' },
 

--- a/test/api/controllers/serverController.test.js
+++ b/test/api/controllers/serverController.test.js
@@ -309,6 +309,21 @@ describe('ServerController', () => {
     });
   });
 
+  describe('#limits', () => {
+    it('should return the kuzzle configuration limits', () => {
+      return serverController.limits(request)
+        .then(response => {
+          should(response).be.instanceof(Object);
+          should(response).not.be.undefined();
+          should(response.limits).be.instanceof(Object);
+          should(response.limits.concurrentRequests).be.a.Number();
+          should(response.limits.documentsFetchCount).be.a.Number();
+          should(response.limits.documentsWriteCount).be.a.Number();
+          should(response.limits.loginsPerSecond).be.a.Number();
+        });
+    });
+  });
+
   describe('#publicApi', () => {
     it('should build the api definition', () => {
       const nativeController = new NativeController();


### PR DESCRIPTION
## What does this PR do ?

fix #1963 
Expose `server:limits` returning the following properties from kuzzle configuration:
  - concurrentRequests
  - documentsFetchCount
  - documentsWriteCount
  - loginsPerSecond

### How should this be manually tested?
  - Step 1 : kourou server:limits
