### PR TITLE
Adapt default encrypted secret file path for kaaf

### DIFF
--- a/features/step_definitions/websocket-steps.js
+++ b/features/step_definitions/websocket-steps.js
@@ -7,6 +7,9 @@ const ws = require('ws');
 Given('I open a new local websocket connection', function () {
   return new Promise((resolve) => {
     this.props.client = new ws('ws://localhost:7512');
+    this.props.client.on('message', (data) =>{
+      this.props.result = JSON.parse(data);
+    });
     this.props.client.on('open', () =>{
       return resolve();
     });
@@ -19,10 +22,12 @@ When('I send the message {string} to Kuzzle through websocket', function (messag
 
 Then('I wait to receive a websocket response from Kuzzle', function() {
   return new Promise((resolve) => {
-    this.props.client.on('message', data => {
-      this.props.result = JSON.parse(data);
-      return resolve();
-    });
+    const interval = setInterval(() => {
+      if (this.props.result) {
+        clearInterval(interval);
+        return resolve();
+      }
+    }, 200);
   });
 });
 

--- a/lib/kuzzle/vault.js
+++ b/lib/kuzzle/vault.js
@@ -28,8 +28,10 @@ const _ = require('lodash');
 const { Vault } = require('kuzzle-vault');
 
 function load (vaultKey, secretsFile) {
-  const defaultEncryptedSecretsFile =
+  const defaultEncryptedSecretsFile = __dirname.includes('node_modules') ?
+    path.resolve(`${__dirname}/../../../../config/secrets.enc.json`) :
     path.resolve(`${__dirname}/../../config/secrets.enc.json`);
+
   const encryptedSecretsFile =
     secretsFile || process.env.KUZZLE_SECRETS_FILE || defaultEncryptedSecretsFile;
 

--- a/lib/kuzzle/vault.js
+++ b/lib/kuzzle/vault.js
@@ -28,7 +28,7 @@ const _ = require('lodash');
 const { Vault } = require('kuzzle-vault');
 
 function load (vaultKey, secretsFile) {
-  const defaultEncryptedSecretsFile = __dirname.includes('node_modules') ?
+  const defaultEncryptedSecretsFile = __dirname.endsWith('/node_modules/kuzzle/lib/kuzzle') ?
     path.resolve(`${__dirname}/../../../../config/secrets.enc.json`) :
     path.resolve(`${__dirname}/../../config/secrets.enc.json`);
 

--- a/lib/kuzzle/vault.js
+++ b/lib/kuzzle/vault.js
@@ -28,6 +28,8 @@ const _ = require('lodash');
 const { Vault } = require('kuzzle-vault');
 
 function load (vaultKey, secretsFile) {
+  // Using KaaF kuzzle is an npm package and is located under node_modules folder
+  // We need to get back to root folder of the project to get the secret file
   const defaultEncryptedSecretsFile = __dirname.endsWith('/node_modules/kuzzle/lib/kuzzle') ?
     path.resolve(`${__dirname}/../../../../config/secrets.enc.json`) :
     path.resolve(`${__dirname}/../../config/secrets.enc.json`);


### PR DESCRIPTION
## What does this PR do ?
fix #1945 
Adapt `defaultEncryptedSecretsFile` path for kaaf

### How should this be manually tested?
  - Step 1 : try to load a `secret.enc.json` file from `project/config/secret.enc.json` instead of `project/node_modules/kuzzle/config/secret.enc.json` 

### Other changes
fix websocket functionnal test