### PR TITLE
Fix after subscribe event

### DIFF
--- a/doc/2/framework/events/realtime/index.md
+++ b/doc/2/framework/events/realtime/index.md
@@ -147,6 +147,10 @@ The provided `subscription` object has the following properties:
 
 Triggered whenever a user leaves a room.
 
+:::info
+Pipes cannot listen to this event, only hooks can.
+:::
+
 <SinceBadge version="2.5.0"/>
 
 | Arguments        | Type              | Description                                                                     |

--- a/doc/2/framework/events/realtime/index.md
+++ b/doc/2/framework/events/realtime/index.md
@@ -20,9 +20,9 @@ Use `core:realtime:user:subscribe:after` instead.
 
 <DeprecatedBadge version="2.5.0">
 
-| Arguments  | Type              | Description                           |
-| ---------- | ----------------- | ------------------------------------- |
-| `subscription`     | <pre>object</pre> | Contains information about the added subscription |
+| Arguments      | Type              | Description                                       |
+|----------------|-------------------|---------------------------------------------------|
+| `subscription` | <pre>object</pre> | Contains information about the added subscription |
 
 Triggered whenever a [subscription](/core/2/api/controllers/realtime/subscribe) is added.
 
@@ -30,13 +30,13 @@ Triggered whenever a [subscription](/core/2/api/controllers/realtime/subscribe) 
 
 The provided `subscription` object has the following properties:
 
-| Properties     | Type                 | Description                                                                                                       |
-| -------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `roomId`       | <pre>string</pre>    | Room unique identifier                                                                                    |
-| `connectionId` | <pre>integer</pre>   | [ClientConnection](/core/2/guides/write-protocols/context/clientconnection) unique identifier                          |
-| `index`        | <pre>string</pre>    | Index                                                                                                             |
-| `collection`   | <pre>string</pre>    | Collection                                                                                                        |
-| `filters`      | <pre>object</pre>    | Filters in [Koncorde's normalized format](https://www.npmjs.com/package/koncorde#filter-unique-identifier)  |
+| Properties     | Type               | Description                                                                                                |
+|----------------|--------------------|------------------------------------------------------------------------------------------------------------|
+| `roomId`       | <pre>string</pre>  | Room unique identifier                                                                                     |
+| `connectionId` | <pre>integer</pre> | [ClientConnection](/core/2/guides/write-protocols/context/clientconnection) unique identifier              |
+| `index`        | <pre>string</pre>  | Index                                                                                                      |
+| `collection`   | <pre>string</pre>  | Collection                                                                                                 |
+| `filters`      | <pre>object</pre>  | Filters in [Koncorde's normalized format](https://www.npmjs.com/package/koncorde#filter-unique-identifier) |
 
 </DeprecatedBadge>
 
@@ -50,10 +50,10 @@ Use `core:realtime:user:unsubscribe:after` instead.
 
 <DeprecatedBadge version="2.5.0">
 
-| Arguments        | Type              | Description                                                                                  |
-| -----------------| ----------------- | -------------------------------------------------------------------------------------------- |
+| Arguments        | Type              | Description                                                                     |
+|------------------|-------------------|---------------------------------------------------------------------------------|
 | `RequestContest` | <pre>object</pre> | [requestContext](/core/2/guides/write-protocols/context/requestcontext/) object |
-| `room`           | <pre>object</pre> | Joined room information in Koncorde format                                                   |
+| `room`           | <pre>object</pre> | Joined room information in Koncorde format                                      |
 
 Triggered whenever a user is removed from a room. 
 
@@ -61,11 +61,11 @@ Triggered whenever a user is removed from a room.
 
 The provided `room` object has the following properties:
 
-| Properties     | Type                 | Description             |
-| -------------- | -------------------- | ----------------------- |
-| `id`           | <pre>string</pre>    | Room unique identifier  |
-| `index`        | <pre>string</pre>    | Index                   |
-| `collection`   | <pre>string</pre>    | Collection              |
+| Properties   | Type              | Description            |
+|--------------|-------------------|------------------------|
+| `id`         | <pre>string</pre> | Room unique identifier |
+| `index`      | <pre>string</pre> | Index                  |
+| `collection` | <pre>string</pre> | Collection             |
 
 </DeprecatedBadge>
 
@@ -82,7 +82,7 @@ Pipes cannot listen to this event, only hooks can.
 :::
 
 | Arguments | Type              | Description             |
-| --------- | ----------------- | ----------------------- |
+|-----------|-------------------|-------------------------|
 | `room`    | <pre>object</pre> | Joined room information |
 
 ### room
@@ -90,7 +90,7 @@ Pipes cannot listen to this event, only hooks can.
 The provided `room` object has the following properties:
 
 | Properties   | Type              | Description                    |
-| ------------ | ----------------- | ------------------------------ |
+|--------------|-------------------|--------------------------------|
 | `index`      | <pre>string</pre> | Index name                     |
 | `collection` | <pre>string</pre> | Collection name                |
 | `roomId`     | <pre>string</pre> | The new room unique identifier |
@@ -108,7 +108,7 @@ Pipes cannot listen to this event, only hooks can.
 :::
 
 | Arguments | Type              | Description            |
-| --------- | ----------------- | ---------------------- |
+|-----------|-------------------|------------------------|
 | `roomId`  | <pre>string</pre> | Room unique identifier |
 
 
@@ -118,24 +118,28 @@ Pipes cannot listen to this event, only hooks can.
 
 Triggered whenever a user makes a new [subscription](/core/2/api/controllers/realtime/subscribe).
 
+:::info
+Pipes cannot listen to this event, only hooks can.
+:::
+
 <SinceBadge version="2.5.0"/>
 
-| Arguments  | Type              | Description                           |
-| ---------- | ----------------- | ------------------------------------- |
-| `subscription`     | <pre>object</pre> | Contains information about the added subscription |
+| Arguments      | Type              | Description                                       |
+|----------------|-------------------|---------------------------------------------------|
+| `subscription` | <pre>object</pre> | Contains information about the added subscription |
 
 
 ### subscription
 
 The provided `subscription` object has the following properties:
 
-| Properties     | Type                 | Description                                                                                                       |
-| -------------- | -------------------- | --------------------------------------------------------------------------------------------------------- |
-| `roomId`       | <pre>string</pre>    | Room unique identifier                                                                                    |
-| `connectionId` | <pre>integer</pre>   | [ClientConnection](/core/2/guides/write-protocols/context/clientconnection) unique identifier                      |
-| `index`        | <pre>string</pre>    | Index                                                                                                     |
-| `collection`   | <pre>string</pre>    | Collection                                                                                                |
-| `filters`      | <pre>object</pre>    | Filters in [Koncorde's normalized format](https://www.npmjs.com/package/koncorde#filter-unique-identifier) |
+| Properties     | Type               | Description                                                                                                |
+|----------------|--------------------|------------------------------------------------------------------------------------------------------------|
+| `roomId`       | <pre>string</pre>  | Room unique identifier                                                                                     |
+| `connectionId` | <pre>integer</pre> | [ClientConnection](/core/2/guides/write-protocols/context/clientconnection) unique identifier              |
+| `index`        | <pre>string</pre>  | Index                                                                                                      |
+| `collection`   | <pre>string</pre>  | Collection                                                                                                 |
+| `filters`      | <pre>object</pre>  | Filters in [Koncorde's normalized format](https://www.npmjs.com/package/koncorde#filter-unique-identifier) |
 
 ---
 
@@ -145,27 +149,27 @@ Triggered whenever a user leaves a room.
 
 <SinceBadge version="2.5.0"/>
 
-| Arguments        | Type              | Description                                                                                  |
-| -----------------| ----------------- | -------------------------------------------------------------------------------------------- |
+| Arguments        | Type              | Description                                                                     |
+|------------------|-------------------|---------------------------------------------------------------------------------|
 | `RequestContest` | <pre>object</pre> | [requestContext](/core/2/guides/write-protocols/context/requestcontext/) object |
-| `room`           | <pre>object</pre> | Joined room information in Koncorde format                                                   |
+| `room`           | <pre>object</pre> | Joined room information in Koncorde format                                      |
 
 ### room
 
 The provided `room` object has the following properties:
 
-| Properties     | Type                 | Description             |
-| -------------- | -------------------- | ----------------------- |
-| `id`           | <pre>string</pre>    | Room unique identifier  |
-| `index`        | <pre>string</pre>    | Index                   |
-| `collection`   | <pre>string</pre>    | Collection              |
+| Properties   | Type              | Description            |
+|--------------|-------------------|------------------------|
+| `id`         | <pre>string</pre> | Room unique identifier |
+| `index`      | <pre>string</pre> | Index                  |
+| `collection` | <pre>string</pre> | Collection             |
 
 ---
 
 ## notify:dispatch
 
-| Arguments | Type                                                                     | Description                           |
-| --------- | ------------------------------------------------------------------------ | ------------------------------------- |
+| Arguments | Type                                                                    | Description                           |
+|-----------|-------------------------------------------------------------------------|---------------------------------------|
 | `message` | <pre><a href=/core/2/api/payloads/notifications>Notifications</a></pre> | The normalized real-time notification |
 
 Triggered whenever a real-time notification is about to be sent.
@@ -174,8 +178,8 @@ Triggered whenever a real-time notification is about to be sent.
 
 ## notify:document
 
-| Arguments | Type                                                                      | Description                           |
-| --------- | ------------------------------------------------------------------------- | ------------------------------------- |
+| Arguments | Type                                                                    | Description                           |
+|-----------|-------------------------------------------------------------------------|---------------------------------------|
 | `message` | <pre><a href=/core/2/api/payloads/notifications>Notifications</a></pre> | The normalized real-time notification |
 
 Triggered whenever a real-time document notification is about to be sent.
@@ -184,8 +188,8 @@ Triggered whenever a real-time document notification is about to be sent.
 
 ## notify:server
 
-| Arguments | Type                                                                      | Description                           |
-| --------- | ------------------------------------------------------------------------- | ------------------------------------- |
+| Arguments | Type                                                                    | Description                           |
+|-----------|-------------------------------------------------------------------------|---------------------------------------|
 | `message` | <pre><a href=/core/2/api/payloads/notifications>Notifications</a></pre> | The normalized real-time notification |
 
 Triggered whenever a real-time server notification is about to be sent.
@@ -194,8 +198,8 @@ Triggered whenever a real-time server notification is about to be sent.
 
 ## notify:user
 
-| Arguments | Type                                                                      | Description                           |
-| --------- | ------------------------------------------------------------------------- | ------------------------------------- |
+| Arguments | Type                                                                    | Description                           |
+|-----------|-------------------------------------------------------------------------|---------------------------------------|
 | `message` | <pre><a href=/core/2/api/payloads/notifications>Notifications</a></pre> | The normalized real-time notification |
 
 Triggered whenever a real-time user notification is about to be sent.
@@ -212,7 +216,7 @@ Use `core:realtime:room:create:after` instead.
 
 
 | Arguments | Type              | Description             |
-| --------- | ----------------- | ----------------------- |
+|-----------|-------------------|-------------------------|
 | `room`    | <pre>object</pre> | Joined room information |
 
 Triggered whenever a new [subscription](/core/2/api/controllers/realtime/subscribe) is created.
@@ -226,7 +230,7 @@ Pipes cannot listen to this event, only hooks can.
 The provided `room` object has the following properties:
 
 | Properties   | Type              | Description                    |
-| ------------ | ----------------- | ------------------------------ |
+|--------------|-------------------|--------------------------------|
 | `index`      | <pre>string</pre> | Index name                     |
 | `collection` | <pre>string</pre> | Collection name                |
 | `roomId`     | <pre>string</pre> | The new room unique identifier |
@@ -244,7 +248,7 @@ Use `core:realtime:room:remove:before` instead.
 <DeprecatedBadge version="2.5.0">
 
 | Arguments | Type              | Description            |
-| --------- | ----------------- | ---------------------- |
+|-----------|-------------------|------------------------|
 | `roomId`  | <pre>string</pre> | Room unique identifier |
 
 Triggered whenever a real-time subscription is cancelled.

--- a/lib/core/realtime/hotelClerk.js
+++ b/lib/core/realtime/hotelClerk.js
@@ -49,6 +49,16 @@ class Channel {
   }
 }
 
+class Subscription {
+  constructor (index, collection, filters, roomId, connectionId) {
+    this.index = index;
+    this.collection = collection;
+    this.filters = filters;
+    this.roomId = roomId;
+    this.connectionId = connectionId;
+  }
+}
+
 class HotelClerk {
   constructor (realtimeModule) {
     this.module = realtimeModule;
@@ -245,6 +255,15 @@ class HotelClerk {
         roomId: normalized.id,
       });
     }
+
+    const subscription = new Subscription(
+      normalized.index,
+      normalized.collection,
+      normalized.filters,
+      normalized.roomId,
+      request.context.connection.id);
+
+    global.kuzzle.emit('core:realtime:user:subscribe:after', subscription);
 
     return {
       channel,

--- a/lib/core/realtime/hotelClerk.js
+++ b/lib/core/realtime/hotelClerk.js
@@ -544,16 +544,24 @@ class HotelClerk {
       await global.kuzzle.pipe('core:realtime:unsubscribe:after', roomId);
 
       // @deprecated -- to be removed in next major version
-      const { index, collection } = room;
       await global.kuzzle.pipe('core:hotelClerk:removeRoomForCustomer', {
         requestContext,
         room: {
-          collection,
+          collection: room.collection,
           id: roomId,
-          index,
+          index: room.index,
         },
       });
     }
+
+    global.kuzzle.emit('core:realtime:user:unsubscribe:after', {
+      requestContext,
+      room: {
+        collection: room.collection,
+        id: roomId,
+        index: room.index,
+      }
+    });
   }
 
   /**

--- a/test/core/realtime/hotelClerk/subscribe.test.js
+++ b/test/core/realtime/hotelClerk/subscribe.test.js
@@ -64,9 +64,17 @@ describe('Test: hotelClerk.subscribe', () => {
   });
 
   it('should register a new room and customer', async () => {
+    const normalized = {
+      index: 'foo',
+      collection: 'bar',
+      id: null,
+      filters: request.input.body,
+      roomId: 'foobar'
+    };
+
     kuzzle.koncorde.normalize
-      .onFirstCall().resolves({id: 'foobar'})
-      .onSecondCall().resolves({id: 'barfoo'});
+      .onFirstCall().resolves({ ...normalized, id: 'foobar' })
+      .onSecondCall().resolves({ ...normalized, id: 'barfoo' });
 
     kuzzle.koncorde.store
       .onFirstCall().returns({id: 'foobar'})
@@ -87,6 +95,7 @@ describe('Test: hotelClerk.subscribe', () => {
       { count: 1 });
 
     const roomId = hotelClerk.rooms.get(response.roomId).id;
+
     const customer = hotelClerk.customers.get(connectionId);
 
     should(customer).have.value(roomId, request.input.volatile);
@@ -110,6 +119,14 @@ describe('Test: hotelClerk.subscribe', () => {
       request,
       'in',
       { count: 1 });
+
+    should(kuzzle.emit).be.calledWithMatch('core:realtime:user:subscribe:after', {
+      index: request.input.args.index,
+      collection: request.input.args.collection,
+      filters: request.input.body,
+      roomId,
+      connectionId,
+    });
   });
 
   it('should return the same response when the user has already subscribed to the filter', async () => {

--- a/test/core/realtime/hotelClerk/unsubscribe.test.js
+++ b/test/core/realtime/hotelClerk/unsubscribe.test.js
@@ -115,6 +115,18 @@ describe('Test: hotelClerk.unsubscribe', () => {
       },
       'out',
       { count: 0 });
+    should(kuzzle.emit).be.calledWithMatch('core:realtime:user:unsubscribe:after', {
+      requestContext: {
+        connection: {
+          id: connectionId
+        }
+      },
+      room: {
+        collection: 'collection',
+        id: roomId,
+        index: 'index',
+      }
+    });
   });
 
   it('should remove the room from the customer list and keep other existing rooms', async () => {


### PR DESCRIPTION
## Description

The event `core:realtime:user:subscribe:after` was not triggered after a successful new subscription
The event `core:realtime:user:unsubscribe:after` was not triggered after unsubscribing
