### PR TITLE
Fix auth:logout expiring apikey

### DIFF
--- a/doc/2/api/controllers/auth/logout/index.md
+++ b/doc/2/api/controllers/auth/logout/index.md
@@ -8,7 +8,8 @@ title: logout
 
 
 
-Revokes the provided authentication token.
+Revokes the provided authentication token if it's not an ApiKey.
+If you are trying to delete an ApiKey, see [auth:deleteApiKey](/core/2/api/controllers/auth/delete-api-key).
 
 If there were any, real-time subscriptions are cancelled.
 
@@ -43,7 +44,7 @@ Headers: Authorization: "Bearer <authentication token>"
 
 ### Optional:
 
-* `global`: if `true`, also revokes all other active sessions instead of just the current one (default: `false`)
+* `global`: if `true`, also revokes all other active sessions that aren't using an ApiKey, instead of just the current one (default: `false`)
 
 * `cookieAuth`: Erase of the token in the [HTTP Cookie](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies)
   - This only works in a Browser and only if Kuzzle CORS is properly configured. see [Authentication Token in the Browser](/core/2/guides/main-concepts/authentication)

--- a/doc/2/api/controllers/auth/logout/index.md
+++ b/doc/2/api/controllers/auth/logout/index.md
@@ -8,8 +8,8 @@ title: logout
 
 
 
-Revokes the provided authentication token if it's not an ApiKey.
-If you are trying to delete an ApiKey, see [auth:deleteApiKey](/core/2/api/controllers/auth/delete-api-key).
+Revokes the provided authentication token if it's not an API key.
+If you are trying to delete an API key, see [auth:deleteApiKey](/core/2/api/controllers/auth/delete-api-key).
 
 If there were any, real-time subscriptions are cancelled.
 
@@ -44,7 +44,7 @@ Headers: Authorization: "Bearer <authentication token>"
 
 ### Optional:
 
-* `global`: if `true`, also revokes all other active sessions that aren't using an ApiKey, instead of just the current one (default: `false`)
+* `global`: if `true`, also revokes all other active sessions that aren't using an API key, instead of just the current one (default: `false`)
 
 * `cookieAuth`: Erase of the token in the [HTTP Cookie](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies)
   - This only works in a Browser and only if Kuzzle CORS is properly configured. see [Authentication Token in the Browser](/core/2/guides/main-concepts/authentication)

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -175,7 +175,7 @@ class AuthController extends NativeController {
    * @param {KuzzleRequest} request
    * @returns {Promise<object>}
    */
-  async logout(request) {
+  async logout (request) {
     if (!global.kuzzle.config.internal.cookieAuthentication
       || !request.getBoolean('cookieAuth')
     ) {
@@ -191,10 +191,7 @@ class AuthController extends NativeController {
           {keepApiKeys: true});
       }
       else if ( request.context.token 
-        && !await global.kuzzle.ask(
-          'core:security:token:isApiKey',
-          request.context.token.jwt
-        )
+        && request.context.token.type !== 'apiKey'
       ) {
         await global.kuzzle.ask(
           'core:security:token:delete',

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -175,8 +175,8 @@ class AuthController extends NativeController {
    * @param {KuzzleRequest} request
    * @returns {Promise<object>}
    */
-  async logout (request) {
-    if ( !global.kuzzle.config.internal.cookieAuthentication
+  async logout(request) {
+    if (!global.kuzzle.config.internal.cookieAuthentication
       || !request.getBoolean('cookieAuth')
     ) {
       this.assertIsAuthenticated(request);
@@ -187,9 +187,13 @@ class AuthController extends NativeController {
       if (request.getBoolean('global')) {
         await global.kuzzle.ask(
           'core:security:token:deleteByKuid',
-          request.getKuid());
+          request.getKuid(),
+          {keepApiKeys: true});
       }
-      else {
+      else if (! await global.kuzzle.ask(
+        'core:security:token:isApiKey',
+        request.context.token
+      )) {
         await global.kuzzle.ask(
           'core:security:token:delete',
           request.context.token);

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -190,13 +190,16 @@ class AuthController extends NativeController {
           request.getKuid(),
           {keepApiKeys: true});
       }
-      else if (! await global.kuzzle.ask(
-        'core:security:token:isApiKey',
-        request.context.token
-      )) {
+      else if ( request.context.token 
+        && !await global.kuzzle.ask(
+          'core:security:token:isApiKey',
+          request.context.token.jwt
+        )
+      ) {
         await global.kuzzle.ask(
           'core:security:token:delete',
-          request.context.token);
+          request.context.token
+        );
       }
 
     }

--- a/lib/core/security/tokenRepository.js
+++ b/lib/core/security/tokenRepository.js
@@ -335,6 +335,10 @@ class TokenRepository extends Repository {
    * @returns {Boolean}
    */
   isApiKey(token) {
+    if (!token) {
+      return false;
+    }
+    
     return token.startsWith(TokenRepository.APIKEY_PREFIX);
   }
 
@@ -396,13 +400,14 @@ class TokenRepository extends Repository {
       .filter(key => key !== null);
 
     await Bluebird.map(ids, async token => {
-      if (keepApiKeys && await this.isApiKey(token)) {
-        return;
-      }
 
       const cacheToken = await this.load(token);
 
       if (cacheToken !== null) {
+        if (keepApiKeys && await this.isApiKey(cacheToken.jwt)) {
+          return;
+        }
+        
         await this.expire(cacheToken);
       }
     });

--- a/lib/core/security/tokenRepository.js
+++ b/lib/core/security/tokenRepository.js
@@ -54,7 +54,7 @@ class TokenRepository extends Repository {
     }
 
     this.tokenGracePeriod = Math.floor(global.kuzzle.config.security.jwt.gracePeriod);
-    this.anonymousToken = new Token({userId: '-1'});
+    this.anonymousToken = new Token({ userId: '-1' });
   }
 
   async init() {
@@ -131,14 +131,6 @@ class TokenRepository extends Repository {
       'core:security:token:verify',
       hash => this.verifyToken(hash));
     
-    /**
-     * Verifies if a token is an ApiKey.
-     *  @param  {Token} token to verify
-     *  @returns {Boolean}
-     */
-    global.kuzzle.onAsk(
-      'core:security:token:isApiKey',
-      (token) => this.isApiKey(token));
   }
 
   /**
@@ -234,10 +226,10 @@ class TokenRepository extends Repository {
     }
 
     if (type === 'apiKey') {
-      encodedToken = TokenRepository.APIKEY_PREFIX + encodedToken;
+      encodedToken = Token.APIKEY_PREFIX + encodedToken;
     }
     else {
-      encodedToken = TokenRepository.AUTH_PREFIX + encodedToken;
+      encodedToken = Token.AUTH_PREFIX + encodedToken;
     }
 
     return this.persistForUser(encodedToken, user._id, parsedExpiresIn);
@@ -260,7 +252,7 @@ class TokenRepository extends Repository {
       expiresAt,
       jwt: encodedToken,
       ttl,
-      userId
+      userId,
     });
 
     try {
@@ -325,21 +317,8 @@ class TokenRepository extends Repository {
 
   removeTokenPrefix (token) {
     return token
-      .replace(TokenRepository.AUTH_PREFIX, '')
-      .replace(TokenRepository.APIKEY_PREFIX, '');
-  }
-
-  /** Verifies if a token is an ApiKey
-   * 
-   * @param {String} encodedToken
-   * @returns {Boolean}
-   */
-  isApiKey(token) {
-    if (!token) {
-      return false;
-    }
-    
-    return token.startsWith(TokenRepository.APIKEY_PREFIX);
+      .replace(Token.AUTH_PREFIX, '')
+      .replace(Token.APIKEY_PREFIX, '');
   }
 
   loadForUser (userId, encodedToken) {
@@ -370,7 +349,7 @@ class TokenRepository extends Repository {
    * @param {string} kuid
    * @returns {Promise}
    */
-  async deleteByKuid (kuid, {keepApiKeys = false} = {}) {
+  async deleteByKuid (kuid, {keepApiKeys = true} = {}) {
     const emptyKeyLength = super.getCacheKey('').length;
     const userKey = super.getCacheKey(`${kuid}#*`);
 
@@ -404,7 +383,7 @@ class TokenRepository extends Repository {
       const cacheToken = await this.load(token);
 
       if (cacheToken !== null) {
-        if (keepApiKeys && await this.isApiKey(cacheToken.jwt)) {
+        if (keepApiKeys && cacheToken.type === 'apiKey') {
           return;
         }
         
@@ -482,9 +461,6 @@ class TokenRepository extends Repository {
     // Around the world, around the world.
   }
 }
-
-TokenRepository.AUTH_PREFIX = 'kauth-';
-TokenRepository.APIKEY_PREFIX = 'kapikey-';
 
 module.exports = TokenRepository;
 

--- a/lib/core/security/tokenRepository.js
+++ b/lib/core/security/tokenRepository.js
@@ -90,10 +90,11 @@ class TokenRepository extends Repository {
     /**
      * Deletes all tokens assigned to the provided user ID.
      * @param  {String} userId
+     * @param  {Objects} opts (keepApiKeys)
      */
     global.kuzzle.onAsk(
       'core:security:token:deleteByKuid',
-      kuid => this.deleteByKuid(kuid));
+      (kuid, opts) => this.deleteByKuid(kuid, opts));
 
     /**
      * Gets a token
@@ -129,6 +130,15 @@ class TokenRepository extends Repository {
     global.kuzzle.onAsk(
       'core:security:token:verify',
       hash => this.verifyToken(hash));
+    
+    /**
+     * Verifies if a token is an ApiKey.
+     *  @param  {Token} token to verify
+     *  @returns {Boolean}
+     */
+    global.kuzzle.onAsk(
+      'core:security:token:isApiKey',
+      (token) => this.isApiKey(token));
   }
 
   /**
@@ -319,6 +329,15 @@ class TokenRepository extends Repository {
       .replace(TokenRepository.APIKEY_PREFIX, '');
   }
 
+  /** Verifies if a token is an ApiKey
+   * 
+   * @param {String} encodedToken
+   * @returns {Boolean}
+   */
+  isApiKey(token) {
+    return token.startsWith(TokenRepository.APIKEY_PREFIX);
+  }
+
   loadForUser (userId, encodedToken) {
     return this.load(`${userId}#${encodedToken}`);
   }
@@ -347,7 +366,7 @@ class TokenRepository extends Repository {
    * @param {string} kuid
    * @returns {Promise}
    */
-  async deleteByKuid (kuid) {
+  async deleteByKuid (kuid, {keepApiKeys = false} = {}) {
     const emptyKeyLength = super.getCacheKey('').length;
     const userKey = super.getCacheKey(`${kuid}#*`);
 
@@ -377,6 +396,10 @@ class TokenRepository extends Repository {
       .filter(key => key !== null);
 
     await Bluebird.map(ids, async token => {
+      if (keepApiKeys && await this.isApiKey(token)) {
+        return;
+      }
+
       const cacheToken = await this.load(token);
 
       if (cacheToken !== null) {

--- a/lib/model/security/token.js
+++ b/lib/model/security/token.js
@@ -34,6 +34,16 @@ class Token {
     this.jwt = data.jwt || null;
     this.refreshed = Boolean(data.refreshed);
   }
+
+  get type() {
+    if (this.jwt && this.jwt.startsWith(Token.APIKEY_PREFIX)) {
+      return 'apiKey';
+    }
+    return 'authToken';
+  }
 }
+
+Token.AUTH_PREFIX = 'kauth-';
+Token.APIKEY_PREFIX = 'kapikey-';
 
 module.exports = Token;

--- a/lib/types/Token.ts
+++ b/lib/types/Token.ts
@@ -59,5 +59,10 @@ export interface Token extends JSONObject {
    * True if the token has been refreshed with the current request
    */
   refreshed: boolean;
+
+  /**
+   * Token type, could be authToken or apiKey
+   */
+  type: string;
 }
 

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -483,7 +483,7 @@ describe('Test the auth controller', () => {
       const response = await authController.logout(request);
 
       should(kuzzle.ask)
-        .calledWith('core:security:token:isApiKey', request.context.token);
+        .calledWith('core:security:token:isApiKey', request.context.token.jwt);
 
       should(kuzzle.ask)
         .calledWith('core:security:token:delete', request.context.token);
@@ -567,7 +567,7 @@ describe('Test the auth controller', () => {
       const response = await authController.logout(request);
 
       should(kuzzle.ask)
-        .calledWith('core:security:token:isApiKey', request.context.token);
+        .calledWith('core:security:token:isApiKey', request.context.token.jwt);
 
       should(kuzzle.ask)
         .calledWith('core:security:token:delete', request.context.token);

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -124,7 +124,7 @@ describe('Test the auth controller', () => {
         jwt: 'bar',
         userId: 'foobar',
         expiresAt: 4567,
-        ttl: 1234
+        ttl: 1234,
       });
 
       createTokenStub.resolves(token);
@@ -141,7 +141,7 @@ describe('Test the auth controller', () => {
         _id: 'foobar',
         jwt: 'bar',
         expiresAt: 4567,
-        ttl: 1234
+        ttl: 1234,
       });
 
       should(createTokenStub).calledOnce();
@@ -153,14 +153,14 @@ describe('Test the auth controller', () => {
         jwt: 'foo',
         userId: 'foobar',
         expiresAt: 4567,
-        ttl: 1234
+        ttl: 1234,
       });
       const token = new Token({
         _id: 'foobar#bar',
         jwt: 'bar',
         userId: 'foobar',
         expiresAt: 4567,
-        ttl: 1234
+        ttl: 1234,
       });
 
       createTokenStub.resolves(token);
@@ -234,7 +234,7 @@ describe('Test the auth controller', () => {
         jwt: 'bar',
         userId: 'foobar',
         expiresAt: 4567,
-        ttl: 1234
+        ttl: 1234,
       });
 
       createTokenStub.resolves(token);
@@ -287,7 +287,7 @@ describe('Test the auth controller', () => {
         jwt: 'bar',
         userId: 'foobar',
         expiresAt: 4567,
-        ttl: 1234
+        ttl: 1234,
       });
 
       createTokenStub.resolves(token);
@@ -320,14 +320,14 @@ describe('Test the auth controller', () => {
         jwt: 'foo',
         userId: 'foobar',
         expiresAt: 4567,
-        ttl: 1234
+        ttl: 1234,
       });
       const token = new Token({
         _id: 'foobar#bar',
         jwt: 'bar',
         userId: 'foobar',
         expiresAt: 4567,
-        ttl: 1234
+        ttl: 1234,
       });
 
       createTokenStub.resolves(token);
@@ -413,7 +413,7 @@ describe('Test the auth controller', () => {
         jwt: 'bar',
         userId: 'foobar',
         expiresAt: 4567,
-        ttl: 1234
+        ttl: 1234,
       });
 
       createTokenStub.resolves(token);
@@ -465,7 +465,7 @@ describe('Test the auth controller', () => {
       const t = new Token({
         _id: 'foo#' + signedToken,
         userId: 'foo',
-        jwt: signedToken
+        jwt: signedToken,
       });
 
       request = new Request({
@@ -483,15 +483,12 @@ describe('Test the auth controller', () => {
       const response = await authController.logout(request);
 
       should(kuzzle.ask)
-        .calledWith('core:security:token:isApiKey', request.context.token.jwt);
-
-      should(kuzzle.ask)
         .calledWith('core:security:token:delete', request.context.token);
 
       should(response.responseObject).be.instanceof(Object);
     });
 
-    it('should expire all tokens that are not ApiKeys at once', async () => {
+    it('should expire all tokens that are not API Keys at once', async () => {
       request.input.args.global = true;
 
       await authController.logout(request);
@@ -515,9 +512,8 @@ describe('Test the auth controller', () => {
         {id: 'security.rights.unauthorized'});
     });
 
-    it('should not expires the token if this is an apikey', async () => {
-      kuzzle.ask.withArgs('core:security:token:isApiKey').resolves(true);
-
+    it('should not expires the token if this is an API Key', async () => {
+      Object.defineProperty(request.context.token, 'type', { get: () => 'apiKey'});
       const response = await authController.logout(request);
 
       should(kuzzle.ask)
@@ -538,7 +534,7 @@ describe('Test the auth controller', () => {
       const t = new Token({
         _id: 'foo#' + signedToken,
         userId: 'foo',
-        jwt: signedToken
+        jwt: signedToken,
       });
 
       request = new Request({
@@ -567,9 +563,6 @@ describe('Test the auth controller', () => {
       const response = await authController.logout(request);
 
       should(kuzzle.ask)
-        .calledWith('core:security:token:isApiKey', request.context.token.jwt);
-
-      should(kuzzle.ask)
         .calledWith('core:security:token:delete', request.context.token);
 
       should(response.responseObject).be.instanceof(Object);
@@ -592,8 +585,7 @@ describe('Test the auth controller', () => {
     });
 
     it('should not expires the token if this is an apikey', async () => {
-      kuzzle.ask.withArgs('core:security:token:isApiKey').resolves(true);
-
+      Object.defineProperty(request.context.token, 'type', { get: () => 'apiKey'});
       const response = await authController.logout(request);
 
       should(kuzzle.ask)

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -483,17 +483,20 @@ describe('Test the auth controller', () => {
       const response = await authController.logout(request);
 
       should(kuzzle.ask)
+        .calledWith('core:security:token:isApiKey', request.context.token);
+
+      should(kuzzle.ask)
         .calledWith('core:security:token:delete', request.context.token);
 
       should(response.responseObject).be.instanceof(Object);
     });
 
-    it('should expire all tokens at once', async () => {
+    it('should expire all tokens that are not ApiKeys at once', async () => {
       request.input.args.global = true;
 
       await authController.logout(request);
 
-      should(kuzzle.ask).calledWith('core:security:token:deleteByKuid', 'foo');
+      should(kuzzle.ask).calledWith('core:security:token:deleteByKuid', 'foo', {keepApiKeys: true});
     });
 
     it('should emit an error if the token cannot be expired', () => {
@@ -510,6 +513,17 @@ describe('Test the auth controller', () => {
       return should(authController.logout(request)).rejectedWith(
         UnauthorizedError,
         {id: 'security.rights.unauthorized'});
+    });
+
+    it('should not expires the token if this is an apikey', async () => {
+      kuzzle.ask.withArgs('core:security:token:isApiKey').resolves(true);
+
+      const response = await authController.logout(request);
+
+      should(kuzzle.ask)
+        .not.be.calledWith('core:security:token:delete', request.context.token);
+      
+      should(response.responseObject).be.instanceof(Object);
     });
   });
 
@@ -553,17 +567,20 @@ describe('Test the auth controller', () => {
       const response = await authController.logout(request);
 
       should(kuzzle.ask)
+        .calledWith('core:security:token:isApiKey', request.context.token);
+
+      should(kuzzle.ask)
         .calledWith('core:security:token:delete', request.context.token);
 
       should(response.responseObject).be.instanceof(Object);
     });
 
-    it('should expire all tokens at once', async () => {
+    it('should expire all tokens that are not ApiKeys at once', async () => {
       request.input.args.global = true;
 
       await authController.logout(request);
 
-      should(kuzzle.ask).calledWith('core:security:token:deleteByKuid', 'foo');
+      should(kuzzle.ask).calledWith('core:security:token:deleteByKuid', 'foo', {keepApiKeys: true});
     });
 
     it('should emit an error if the token cannot be expired', () => {
@@ -572,6 +589,17 @@ describe('Test the auth controller', () => {
       kuzzle.ask.withArgs('core:security:token:delete').rejects(error);
 
       return should(authController.logout(request)).be.rejectedWith(error);
+    });
+
+    it('should not expires the token if this is an apikey', async () => {
+      kuzzle.ask.withArgs('core:security:token:isApiKey').resolves(true);
+
+      const response = await authController.logout(request);
+
+      should(kuzzle.ask)
+        .not.be.calledWith('core:security:token:delete', request.context.token);
+      
+      should(response.responseObject).be.instanceof(Object);
     });
   });
 

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -514,12 +514,10 @@ describe('Test the auth controller', () => {
 
     it('should not expires the token if this is an API Key', async () => {
       Object.defineProperty(request.context.token, 'type', { get: () => 'apiKey'});
-      const response = await authController.logout(request);
+      await authController.logout(request);
 
       should(kuzzle.ask)
         .not.be.calledWith('core:security:token:delete', request.context.token);
-      
-      should(response.responseObject).be.instanceof(Object);
     });
   });
 
@@ -584,7 +582,7 @@ describe('Test the auth controller', () => {
       return should(authController.logout(request)).be.rejectedWith(error);
     });
 
-    it('should not expires the token if this is an apikey', async () => {
+    it('should not expire the token if this is an apikey', async () => {
       Object.defineProperty(request.context.token, 'type', { get: () => 'apiKey'});
       const response = await authController.logout(request);
 

--- a/test/core/auth/tokenManager.test.js
+++ b/test/core/auth/tokenManager.test.js
@@ -109,7 +109,7 @@ describe('Test: token manager core component', () => {
           _id: 'foo2#bar2',
           userId: 'foo2',
           jwt: 'bar2',
-          expiresAt: Date.now()+10000
+          expiresAt: Date.now()+10000,
         });
 
       tokenManager.link(tokenAfter, 'foo2', 'bar2');
@@ -171,7 +171,7 @@ describe('Test: token manager core component', () => {
         _id: 'foo2#bar2',
         userId: 'foo2',
         jwt: 'bar2',
-        expiresAt: Date.now()+1000
+        expiresAt: Date.now()+1000,
       });
 
       tokenManager.tokens.array.push(token);
@@ -203,11 +203,11 @@ describe('Test: token manager core component', () => {
       const runTimerStub = sinon.stub(tokenManager, 'runTimer');
 
       tokenManager.link(
-        new Token({_id: 'bar', expiresAt}),
+        new Token({_id: 'bar', expiresAt }),
         'connectionId1',
         'roomId1');
       tokenManager.link(
-        new Token({_id: 'foo', expiresAt}),
+        new Token({_id: 'foo', expiresAt }),
         'connectionId2',
         'roomId2');
 
@@ -224,11 +224,11 @@ describe('Test: token manager core component', () => {
       const runTimerStub = sinon.stub(tokenManager, 'runTimer');
 
       tokenManager.link(
-        new Token({_id: 'bar', expiresAt: now + 1000000}),
+        new Token({_id: 'bar', expiresAt: now + 1000000 }),
         'connectionId1',
         'roomId1');
       tokenManager.link(
-        new Token({_id: 'foo', expiresAt: now - 1000}),
+        new Token({_id: 'foo', expiresAt: now - 1000 }),
         'connectionId2',
         'roomId2');
 
@@ -250,7 +250,7 @@ describe('Test: token manager core component', () => {
       const runTimerStub = sinon.stub(tokenManager, 'runTimer');
 
       tokenManager.link(
-        new Token({_id: 'api-key-1', expiresAt: -1}),
+        new Token({_id: 'api-key-1', expiresAt: -1 }),
         'connectionId1',
         'roomId1');
 
@@ -272,7 +272,7 @@ describe('Test: token manager core component', () => {
       const runTimerStub = sinon.stub(tokenManager, 'runTimer');
 
       tokenManager.link(
-        new Token({_id: 'foo', expiresAt: now - 1000}),
+        new Token({_id: 'foo', expiresAt: now - 1000 }),
         'connectionId2',
         'roomId2');
 
@@ -317,7 +317,7 @@ describe('Test: token manager core component', () => {
         rooms: new Set(['bar'])
       });
 
-      tokenManager.unlink(new Token({_id: 'i am the beyonder'}), 'bar');
+      tokenManager.unlink(new Token({_id: 'i am the beyonder' }), 'bar');
       should(tokenManager.tokens.array)
         .be.an.Array()
         .and.have.length(1);
@@ -364,8 +364,8 @@ describe('Test: token manager core component', () => {
 
     it('should do nothing if the provided token is not linked', () => {
       tokenManager.refresh(
-        new Token({_id: 'i am the beyonder'}),
-        new Token({_id: 'i am the mountain'}));
+        new Token({_id: 'i am the beyonder' }),
+        new Token({_id: 'i am the mountain' }));
 
       should(tokenManager.tokens.array).have.length(1);
       should(tokenManager.tokens.array[0].idx)
@@ -373,7 +373,7 @@ describe('Test: token manager core component', () => {
     });
 
     it('should replace the old token with the new one', () => {
-      const newT = new Token({_id: '...I got better'});
+      const newT = new Token({_id: '...I got better' });
       tokenManager.refresh(token, newT);
 
       should(tokenManager.tokens.array).have.length(1);

--- a/test/core/security/tokenRepository.test.js
+++ b/test/core/security/tokenRepository.test.js
@@ -80,6 +80,29 @@ describe('Test: security/tokenRepository', () => {
     });
   });
 
+  describe('#isApiKey', () => {
+    it('should return true if the token is an ApiKey', async () => {
+      const user = new User();
+      user._id = 'id';
+      const token = await tokenRepository.generateToken(user, {
+        expiresIn: '1000y',
+        type: 'apiKey'
+      });
+
+      should(tokenRepository.isApiKey(token.jwt)).be.true();
+    });
+
+    it('should return true if the token is not an ApiKey', async () => {
+      const user = new User();
+      user._id = 'id';
+      const token = await tokenRepository.generateToken(user, {
+        expiresIn: '1000y',
+      });
+
+      should(tokenRepository.isApiKey(token.jwt)).be.false();
+    });
+  });
+
   describe('#verify', () => {
     beforeEach(() => {
       kuzzle.ask.withArgs('core:cache:internal:get').resolves(null);
@@ -486,29 +509,60 @@ describe('Test: security/tokenRepository', () => {
       kuzzle.ask.withArgs('core:cache:internal:searchKeys').resolves([
         'repos/kuzzle/token/foo#foo',
         'repos/kuzzle/token/foo#bar',
-        'repos/kuzzle/token/foo#baz',
+        `repos/kuzzle/token/foo#${TokenRepository.APIKEY_PREFIX}baz`,
       ]);
 
       kuzzle.ask.withArgs('core:cache:internal:get').onFirstCall().resolves(
-        JSON.stringify({ userId: 'foo', _id: 'foo', expiresAt: 1 }));
+        JSON.stringify({ userId: 'foo', _id: 'foo', expiresAt: 1, jwt: 'foo' }));
 
       kuzzle.ask.withArgs('core:cache:internal:get').onSecondCall().resolves(
-        JSON.stringify({ userId: 'foo', _id: 'bar', expiresAt: 2 }));
+        JSON.stringify({ userId: 'foo', _id: 'bar', expiresAt: 2, jwt: 'bar' }));
 
       kuzzle.ask.withArgs('core:cache:internal:get').onThirdCall().resolves(
-        JSON.stringify({ userId: 'foo', _id: 'baz', expiresAt: 3 }));
-
-      await tokenRepository.deleteByKuid('foo');
+        JSON.stringify({ userId: 'foo', _id: `${TokenRepository.APIKEY_PREFIX}baz`, expiresAt: 3, jwt: `${TokenRepository.APIKEY_PREFIX}baz`}));
+      
+      await tokenRepository.deleteByKuid('foo', {keepApiKeys: false});
 
       should(kuzzle.ask)
         .calledWith('core:cache:internal:expire', 'repos/kuzzle/token/foo', -1)
         .calledWith('core:cache:internal:expire', 'repos/kuzzle/token/bar', -1)
-        .calledWith('core:cache:internal:expire', 'repos/kuzzle/token/baz', -1);
+        .calledWith('core:cache:internal:expire', `repos/kuzzle/token/${TokenRepository.APIKEY_PREFIX}baz`, -1);
 
       should(kuzzle.tokenManager.expire)
         .calledWithMatch({userId: 'foo', _id: 'foo', expiresAt: 1})
         .calledWithMatch({userId: 'foo', _id: 'bar', expiresAt: 2})
-        .calledWithMatch({userId: 'foo', _id: 'baz', expiresAt: 3});
+        .calledWithMatch({userId: 'foo', _id: `${TokenRepository.APIKEY_PREFIX}baz`, expiresAt: 3});
+    });
+
+
+    it('should delete the tokens associated to a user identifier except the ones that are ApiKeys', async () => {
+      sinon.stub(tokenRepository, 'refreshCacheTTL');
+      kuzzle.ask.withArgs('core:cache:internal:searchKeys').resolves([
+        'repos/kuzzle/token/foo#foo',
+        'repos/kuzzle/token/foo#bar',
+        `repos/kuzzle/token/foo#${TokenRepository.APIKEY_PREFIX}baz`,
+      ]);
+
+      kuzzle.ask.withArgs('core:cache:internal:get').onFirstCall().resolves(
+        JSON.stringify({ userId: 'foo', _id: 'foo', expiresAt: 1, jwt: 'foo' }));
+
+      kuzzle.ask.withArgs('core:cache:internal:get').onSecondCall().resolves(
+        JSON.stringify({ userId: 'foo', _id: 'bar', expiresAt: 2, jwt: 'bar' }));
+
+      kuzzle.ask.withArgs('core:cache:internal:get').onThirdCall().resolves(
+        JSON.stringify({ userId: 'foo', _id: `${TokenRepository.APIKEY_PREFIX}baz`, expiresAt: 3, jwt: `${TokenRepository.APIKEY_PREFIX}baz`}));
+      
+      await tokenRepository.deleteByKuid('foo', {keepApiKeys: true});
+
+      should(kuzzle.ask)
+        .calledWith('core:cache:internal:expire', 'repos/kuzzle/token/foo', -1)
+        .calledWith('core:cache:internal:expire', 'repos/kuzzle/token/bar', -1)
+        .not.calledWith('core:cache:internal:expire', `repos/kuzzle/token/${TokenRepository.APIKEY_PREFIX}baz`, -1);
+
+      should(kuzzle.tokenManager.expire)
+        .calledWithMatch({userId: 'foo', _id: 'foo', expiresAt: 1})
+        .calledWithMatch({userId: 'foo', _id: 'bar', expiresAt: 2})
+        .not.calledWithMatch({userId: 'foo', _id: `${TokenRepository.APIKEY_PREFIX}baz`, expiresAt: 3});
     });
 
     it('should not delete tokens if the internal cache return a false positive', async () => {


### PR DESCRIPTION
<!--
  Thank you for submitting a Pull Request. Please:
    - Read our CONTRIBUTING guidelines.
      https://github.com/kuzzleio/kuzzle/blob/master/CONTRIBUTING.md
    - Associate an issue with the Pull Request.
    - IMPORTANT - Add the corresponding "changelog:xxx" label to your PR.
-->

<!--- This template is optional. -->

## What does this PR do ?

This PR fixes an unwanted behaviour where ApiKeys used to login were expired when `auth:logout` was called
We now check if the token we are trying to expires is an ApiKey before deleting it.
`TokenRepository.deleteByKuid` has now an option named `keepApiKeys` that specifies that ApiKeys should be preserved, this is used when calling `auth:logout` with the `global=true` option, to avoid revoking sessions that are logged in with an ApiKeys, thus expiring the ApiKeys.

Added documentation and tests