### PR TITLE
[Hotfix] startup loading of indexes with 0 collections in index cache

### DIFF
--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -1679,7 +1679,13 @@ class ElasticSearch extends Service {
 
     const esIndexes = body.map(({ index }) => index);
 
-    return this._extractSchema(esIndexes);
+    const schema = this._extractSchema(esIndexes, { includeHidden: true });
+
+    for (const [index, collections] of Object.entries(schema)) {
+      schema[index] = collections.filter(c => c !== HIDDEN_COLLECTION);
+    }
+
+    return schema;
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "bin": {
     "kuzzle": "bin/start-kuzzle-server"


### PR DESCRIPTION
## What does this PR do ?

Indexes with 0 collections were not loaded in the index cache and thus not available in the API.

It was because the hidden collection was not returned by the `Elasticsearch.getSchema` method used by the index cache

