### PR TITLE
Faster collection truncating with deleteByQuery

### DIFF
--- a/doc/2/api/controllers/collection/truncate/index.md
+++ b/doc/2/api/controllers/collection/truncate/index.md
@@ -19,7 +19,7 @@ Documents removed that way do not trigger real-time notifications.
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/<index>/<collection>/_truncate
+URL: http://kuzzle:7512/<index>/<collection>/_truncate[?strategy=<documents|collection>]
 Method: DELETE
 ```
 
@@ -30,7 +30,10 @@ Method: DELETE
   "index": "<index>",
   "collection": "<collection>",
   "controller": "collection",
-  "action": "truncate"
+  "action": "truncate",
+
+  // optional
+  "strategy": "<documents|collection>"
 }
 ```
 
@@ -40,8 +43,20 @@ Method: DELETE
 
 - `collection`: collection name
 - `index`: index name
+- `strategy`: truncate strategy <SinceBadge version="auto-version" />
 
 ---
+
+### strategy
+
+<SinceBadge version="auto-version" />
+
+Two strategies are available when truncating a collection:
+  - `collection`: delete and re-create the underlaying collection
+  - `documents`: search and deletes every documents in the collection
+
+Both methods offer similar performances when truncating a collection with < 10 million documents.    
+However when truncating many collection, it's faster to use the `documents` strategy because the storage engine is able to perform those actions simultaneously.
 
 ## Response
 

--- a/doc/2/api/controllers/collection/truncate/index.md
+++ b/doc/2/api/controllers/collection/truncate/index.md
@@ -19,7 +19,7 @@ Documents removed that way do not trigger real-time notifications.
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/<index>/<collection>/_truncate[?strategy=<documents|collection>]
+URL: http://kuzzle:7512/<index>/<collection>/_truncate
 Method: DELETE
 ```
 
@@ -30,10 +30,7 @@ Method: DELETE
   "index": "<index>",
   "collection": "<collection>",
   "controller": "collection",
-  "action": "truncate",
-
-  // optional
-  "strategy": "<documents|collection>"
+  "action": "truncate"
 }
 ```
 
@@ -43,20 +40,8 @@ Method: DELETE
 
 - `collection`: collection name
 - `index`: index name
-- `strategy`: truncate strategy <SinceBadge version="auto-version" />
 
 ---
-
-### strategy
-
-<SinceBadge version="auto-version" />
-
-Two strategies are available when truncating a collection:
-  - `collection`: delete and re-create the underlaying collection
-  - `documents`: search and deletes every documents in the collection
-
-Both methods offer similar performances when truncating a collection with < 10 million documents.    
-However when truncating many collection, it's faster to use the `documents` strategy because the storage engine is able to perform those actions simultaneously.
 
 ## Response
 

--- a/lib/api/controllers/collectionController.js
+++ b/lib/api/controllers/collectionController.js
@@ -271,13 +271,29 @@ class CollectionController extends NativeController {
   /**
    * Reset a collection by removing all documents while keeping the existing mapping.
    *
-   * @param {Request} request
+   * @param {KuzzleRequest} request
    * @returns {Promise.<Object>}
    */
   async truncate (request) {
     const { index, collection } = request.getIndexAndCollection();
+    const strategy = request.getString('strategy', 'documents')
 
-    await this.ask('core:storage:public:collection:truncate', index, collection);
+    if (! ['collection', 'documents'].includes(strategy)) {
+      throw kerror.get('api', 'assert', 'invalid_argument', '"collection", "documents"');
+    }
+
+    if (strategy === 'collection') {
+      await this.ask('core:storage:public:collection:truncate', index, collection);
+    }
+    else {
+      await this.ask('core:storage:public:collection:refresh', index, collection);
+      await this.ask(
+        'core:storage:public:document:deleteByQuery',
+        index,
+        collection,
+        {},
+        { refresh: 'wait_for', fetch: false });
+    }
 
     return {
       acknowledged: true
@@ -294,7 +310,7 @@ class CollectionController extends NativeController {
     const size = request.getInteger('size', 0);
     const type = request.getString('type', 'all');
 
-    if (['all', 'stored', 'realtime'].indexOf(type) === -1) {
+    if (! ['all', 'stored', 'realtime'].includes(type)) {
       throw kerror.get('api', 'assert', 'invalid_argument', '"all", "stored", "realtime"');
     }
 

--- a/lib/api/controllers/collectionController.js
+++ b/lib/api/controllers/collectionController.js
@@ -269,31 +269,21 @@ class CollectionController extends NativeController {
   }
 
   /**
-   * Reset a collection by removing all documents while keeping the existing mapping.
+   * Reset a collection by removing all documents
    *
    * @param {KuzzleRequest} request
    * @returns {Promise.<Object>}
    */
   async truncate (request) {
     const { index, collection } = request.getIndexAndCollection();
-    const strategy = request.getString('strategy', 'documents')
 
-    if (! ['collection', 'documents'].includes(strategy)) {
-      throw kerror.get('api', 'assert', 'invalid_argument', '"collection", "documents"');
-    }
-
-    if (strategy === 'collection') {
-      await this.ask('core:storage:public:collection:truncate', index, collection);
-    }
-    else {
-      await this.ask('core:storage:public:collection:refresh', index, collection);
-      await this.ask(
-        'core:storage:public:document:deleteByQuery',
-        index,
-        collection,
-        {},
-        { refresh: 'wait_for', fetch: false });
-    }
+    await this.ask('core:storage:public:collection:refresh', index, collection);
+    await this.ask(
+      'core:storage:public:document:deleteByQuery',
+      index,
+      collection,
+      {},
+      { fetch: false, refresh: 'wait_for' });
 
     return {
       acknowledged: true

--- a/test/api/controllers/collectionController.test.js
+++ b/test/api/controllers/collectionController.test.js
@@ -119,13 +119,30 @@ describe('Test: collection controller', () => {
       const response = await collectionController.truncate(request);
 
       should(kuzzle.ask).be.calledWith(
-        'core:storage:public:collection:truncate',
+        'core:storage:public:collection:refresh',
         index,
         collection);
+      should(kuzzle.ask).be.calledWith(
+        'core:storage:public:document:deleteByQuery',
+        index,
+        collection,
+        {},
+        { refresh: 'wait_for', fetch: false });
 
       should(response).match({
         acknowledged: true
       });
+    });
+
+    it('should allows to use another truncate strategy', async () => {
+      request.input.args.strategy = 'collection';
+
+      await collectionController.truncate(request);
+
+      should(kuzzle.ask).be.calledWith(
+        'core:storage:public:collection:truncate',
+        index,
+        collection);
     });
   });
 

--- a/test/api/controllers/collectionController.test.js
+++ b/test/api/controllers/collectionController.test.js
@@ -133,17 +133,6 @@ describe('Test: collection controller', () => {
         acknowledged: true
       });
     });
-
-    it('should allows to use another truncate strategy', async () => {
-      request.input.args.strategy = 'collection';
-
-      await collectionController.truncate(request);
-
-      should(kuzzle.ask).be.calledWith(
-        'core:storage:public:collection:truncate',
-        index,
-        collection);
-    });
   });
 
   describe('#getSpecifications', () => {


### PR DESCRIPTION
## What does this PR do ?

When truncating a collection, Kuzzle delete and then re-create the underlying Elasticsearch indice.   
However indice creation is not parallelizable inside an ES cluster so if we truncate many collections it will be quite slow when the deleteByQuery action is completely parallel. 

This PR change `collection:truncate` to use `deleteByQuery` which is almost always faster. 

```
// 2 000 000 documents
Big collection: delete + create collection: 192.851ms
Big collection: delete documents: 347.221ms

// 10 000 documents
Medium collection: delete + create collection: 186.285ms
Medium collection: delete documents: 90.816ms

// 1000 documents
Small collection: delete + create collection: 139.613ms
Small collection: delete documents: 79.563ms

Truncate 10 collections in parallel: documents: 64.560ms
Truncate 10 collections in parallel: collection: 1263.654ms
```
