### PR TITLE
Allows to manually enable or disable cookie authentication

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -17,9 +17,14 @@
     // * accessControlAllowHeaders:
     //    sets the default Access-Control-Allow-Headers
     // (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS)
+    // * cookieAuthentication:
+    //    Allows browser clients to connect to Kuzzle with cookies.
+    //    /!\ This should not be allowed if the "http.accessControlAllowOrigin"
+    //    configuration contains a wildcard ("*").
     "accessControlAllowOrigin": "*",
     "accessControlAllowMethods": "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD",
-    "accessControlAllowHeaders": "Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding, Content-Length, X-Kuzzle-Volatile"
+    "accessControlAllowHeaders": "Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding, Content-Length, X-Kuzzle-Volatile",
+    "cookieAuthentication": true
   },
 
   // Kuzzle configured limits

--- a/doc/2/guides/main-concepts/authentication/index.md
+++ b/doc/2/guides/main-concepts/authentication/index.md
@@ -182,7 +182,7 @@ This is possible thanks to the option [cookieAuth](/core/2/api/protocols/http#co
 You can disable the cookie authentication by setting`http.cookieAuthentication` to `false` in [Kuzzle Configuration](/core/2/guides/advanced/configuration).
 
 ::: warning
-For security reasons, cookie authentication should not be enabled if CORS config `http.accessControlAllowOrigin` contains a wildcard (`*`).
+Cookie authentication does not works if `http.accessControlAllowOrigin` contains a wildcard (`*`).
 ::: 
 
 ### `local` Strategy Configuration

--- a/doc/2/guides/main-concepts/authentication/index.md
+++ b/doc/2/guides/main-concepts/authentication/index.md
@@ -179,10 +179,11 @@ When you're sending HTTP requests from a browser you can instruct Kuzzle
 to `load` and `store` authentication tokens within an [HTTP Cookie](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies).
 This is possible thanks to the option [cookieAuth](/core/2/api/protocols/http#cookieAuth) in [auth:login](/core/2/api/controllers/auth/login), [auth:logout](/core/2/api/controllers/auth/logout), [auth:checkToken](/core/2/api/controllers/auth/checkToken), [auth:refreshToken](/core/2/api/controllers/auth/refresh-token)
 
-::: warning
-This only works if the option `http.accessControlAllowOrigin` is not defined to `*` in the [Kuzzle Configuration](/core/2/guides/advanced/configuration)
-:::
+You can disable the cookie authentication by setting`http.cookieAuthentication` to `false` in [Kuzzle Configuration](/core/2/guides/advanced/configuration).
 
+::: warning
+For security reasons, cookie authentication should not be enabled if CORS config `http.accessControlAllowOrigin` contains a wildcard (`*`).
+::: 
 
 ### `local` Strategy Configuration
 

--- a/doc/2/guides/main-concepts/authentication/index.md
+++ b/doc/2/guides/main-concepts/authentication/index.md
@@ -181,10 +181,6 @@ This is possible thanks to the option [cookieAuth](/core/2/api/protocols/http#co
 
 You can disable the cookie authentication by setting`http.cookieAuthentication` to `false` in [Kuzzle Configuration](/core/2/guides/advanced/configuration).
 
-::: warning
-Cookie authentication does not works if `http.accessControlAllowOrigin` contains a wildcard (`*`).
-::: 
-
 ### `local` Strategy Configuration
 
 The strategy can be configured under the `plugins.kuzzle-plugin-auth-passport-local` configuration key.

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -176,7 +176,7 @@ class AuthController extends NativeController {
    * @returns {Promise<object>}
    */
   async logout (request) {
-    if ( !global.kuzzle.config.internal.cookieAuthentication
+    if ( !global.kuzzle.config.http.cookieAuthentication
       || !request.getBoolean('cookieAuth')
     ) {
       this.assertIsAuthenticated(request);
@@ -197,7 +197,7 @@ class AuthController extends NativeController {
 
     }
 
-    if ( global.kuzzle.config.internal.cookieAuthentication
+    if ( global.kuzzle.config.http.cookieAuthentication
       && request.getBoolean('cookieAuth')
     ) {
       request.response.configure({
@@ -224,7 +224,7 @@ class AuthController extends NativeController {
     // otherwise we should send a normal response because
     // even if the SDK / Browser can handle the cookie,
     // Kuzzle would not be capable of doing anything with it
-    if ( global.kuzzle.config.internal.cookieAuthentication
+    if ( global.kuzzle.config.http.cookieAuthentication
       && request.getBoolean('cookieAuth')
     ) {
       // Here we are not sending auth token when cookieAuth is set to true
@@ -395,7 +395,7 @@ class AuthController extends NativeController {
   async checkToken (request) {
     let token = '';
 
-    if ( global.kuzzle.config.internal.cookieAuthentication
+    if ( global.kuzzle.config.http.cookieAuthentication
       && request.getBoolean('cookieAuth')
     ) {
       token = request.input.jwt;

--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -392,7 +392,7 @@ class Funnel {
    * @returns {Promise<Request>}
    */
   async checkRights (request) {
-    if ( !global.kuzzle.config.internal.cookieAuthentication
+    if ( !global.kuzzle.config.http.cookieAuthentication
       && request.getBoolean('cookieAuth')
     ) {
       throw kerror.get(
@@ -426,7 +426,7 @@ class Funnel {
       if (cookie.authToken
         && cookie.authToken !== 'null'
       ) {
-        if (!global.kuzzle.config.internal.cookieAuthentication) {
+        if (!global.kuzzle.config.http.cookieAuthentication) {
           throw kerror.get(
             'security',
             'cookie',

--- a/lib/config/default.config.js
+++ b/lib/config/default.config.js
@@ -50,6 +50,7 @@ module.exports = {
     accessControlAllowOrigin: '*',
     accessControlAllowMethods: 'GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD',
     accessControlAllowHeaders: 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding, Content-Length, X-Kuzzle-Volatile',
+    cookieAuthentication: true
   },
 
   limits: {

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -191,6 +191,7 @@ function checkHttpOptions (config) {
   const maxFormFileSize = bytes(cfg.maxFormFileSize);
   assert(Number.isInteger(maxFormFileSize) && maxFormFileSize >= 0, `[http] "maxFormFileSize" parameter: cannot parse "${cfg.maxFormFileSize}"`);
   cfg.maxFormFileSize = maxFormFileSize;
+  assert(typeof config.http.cookieAuthentication === 'boolean', `[http] "cookieAuthentication" parameter: invalid value "${config.http.cookieAuthentication }" (boolean expected)`);
 }
 
 
@@ -227,8 +228,8 @@ function preprocessHttpOptions (config) {
         .map(value => value.trim());
   }
 
-  config.internal.allowAllOrigins = httpConfig.accessControlAllowOrigin.includes('*'); // Stored to avoid doing includes multiple times later
-  config.internal.cookieAuthentication = !httpConfig.accessControlAllowOrigin.includes('*'); // If there is no wild card, cookieAuthentication is enabled
+  // Stored to avoid doing includes multiple times later
+  config.internal.allowAllOrigins = httpConfig.accessControlAllowOrigin.includes('*');
 }
 
 module.exports = { load };

--- a/lib/core/network/httpRouter/index.js
+++ b/lib/core/network/httpRouter/index.js
@@ -49,7 +49,7 @@ class Router {
       'content-type': 'application/json'
     };
 
-    if (global.kuzzle.config.internal.cookieAuthentication) {
+    if (global.kuzzle.config.http.cookieAuthentication) {
       this.defaultHeaders['Access-Control-Allow-Credentials'] = 'true';
     }
 
@@ -227,9 +227,9 @@ class Router {
 
 /**
  * Set the Header Access-Control-Allow-Origin based on the kuzzle configuration and request origin
- * 
- * @param {HttpMessage} message 
- * @param {Request} request 
+ *
+ * @param {HttpMessage} message
+ * @param {Request} request
  */
 function applyACAOHeader(message, request) {
   if (message.headers && message.headers.origin) {

--- a/lib/core/network/httpRouter/index.js
+++ b/lib/core/network/httpRouter/index.js
@@ -41,7 +41,7 @@ const debug = require('../../../util/debug')('kuzzle:http:router');
  * @class Router
  */
 class Router {
-  constructor() {
+  constructor () {
     this.defaultHeaders = {
       'Accept-Encoding': 'identity',
       'Access-Control-Allow-Headers': global.kuzzle.config.http.accessControlAllowHeaders,
@@ -79,7 +79,7 @@ class Router {
    * @param {string} path
    * @param {Function} handler
    */
-  get(path, handler) {
+  get (path, handler) {
     attach(path, handler, this.routes.GET);
   }
 
@@ -89,7 +89,7 @@ class Router {
    * @param {string} path
    * @param {Function} handler
    */
-  post(path, handler) {
+  post (path, handler) {
     attach(path, handler, this.routes.POST);
   }
 
@@ -99,7 +99,7 @@ class Router {
    * @param {string} path
    * @param {Function} handler
    */
-  put(path, handler) {
+  put (path, handler) {
     attach(path, handler, this.routes.PUT);
   }
 
@@ -109,7 +109,7 @@ class Router {
    * @param {string} path
    * @param {Function} handler
    */
-  patch(path, handler) {
+  patch (path, handler) {
     attach(path, handler, this.routes.PATCH);
   }
 
@@ -119,7 +119,7 @@ class Router {
    * @param {string} path
    * @param {Function} handler
    */
-  delete(path, handler) {
+  delete (path, handler) {
     attach(path, handler, this.routes.DELETE);
   }
 
@@ -129,7 +129,7 @@ class Router {
    * @param {string} path
    * @param {Function} handler
    */
-  head(path, handler) {
+  head (path, handler) {
     attach(path, handler, this.routes.HEAD);
   }
 
@@ -139,7 +139,7 @@ class Router {
    * @param {HttpMessage} message - Parsed HTTP message
    * @param {function} cb
    */
-  route(message, cb) {
+  route (message, cb) {
     debug('Routing HTTP message: %a', message);
 
     if (!has(this.routes, message.method)) {
@@ -231,19 +231,15 @@ class Router {
  * @param {HttpMessage} message
  * @param {Request} request
  */
-function applyACAOHeader(message, request) {
+function applyACAOHeader (message, request) {
   if (message.headers && message.headers.origin) {
-    if (global.kuzzle.config.internal.allowAllOrigins) {
-      request.response.setHeaders({'Access-Control-Allow-Origin': '*'}, true);
-    } else {
-      request.response.setHeaders(
-        {
-          'Access-Control-Allow-Origin': message.headers.origin,
-          'Vary': 'Origin',
-        },
-        true
-      );
-    }
+    request.response.setHeaders(
+      {
+        'Access-Control-Allow-Origin': message.headers.origin,
+        'Vary': 'Origin',
+      },
+      true
+    );
   }
 }
 
@@ -254,7 +250,7 @@ function applyACAOHeader(message, request) {
  * @param {Function} handler
  * @param {RoutePart} target
  */
-function attach(path, handler, target) {
+function attach (path, handler, target) {
   const sanitized = path[path.length - 1] === '/' ? path.slice(0, -1) : path;
 
   if (!attachParts(sanitized.split('/'), handler, target)) {
@@ -270,7 +266,7 @@ function attach(path, handler, target) {
  * @param {Array<string>} placeholders
  * @returns {Boolean} If false, failed to attach because of a duplicate
  */
-function attachParts(parts, handler, target, placeholders = []) {
+function attachParts (parts, handler, target, placeholders = []) {
   let part;
 
   do {
@@ -305,7 +301,7 @@ function attachParts(parts, handler, target, placeholders = []) {
  * @param {Request} request
  * @param {Error} error
  */
-function replyWithError(cb, request, error) {
+function replyWithError (cb, request, error) {
   request.setError(error);
 
   cb(request);

--- a/lib/core/network/protocols/httpwsProtocol.js
+++ b/lib/core/network/protocols/httpwsProtocol.js
@@ -602,15 +602,15 @@ class HttpWsProtocol extends Protocol {
           }
 
           // Access-Control-Allow-Origin Logic
-          if (request.response.headers['Access-Control-Allow-Origin'] === undefined) {
-            if (message.headers && message.headers.origin) {
-              if (global.kuzzle.config.internal.allowAllOrigins) {
-                response.writeHeader(HTTP_HEADER_ACCESS_CONTROL_ALLOW_ORIGIN, WILDCARD);
-              } else {
-                response.writeHeader(HTTP_HEADER_ACCESS_CONTROL_ALLOW_ORIGIN, Buffer.from(message.headers.origin));
-                response.writeHeader(HTTP_HEADER_VARY, ORIGIN);
-              }
-            }
+          if ( request.response.headers['Access-Control-Allow-Origin'] === undefined
+            && message.headers
+            && message.headers.origin
+          ) {
+            response.writeHeader(
+              HTTP_HEADER_ACCESS_CONTROL_ALLOW_ORIGIN,
+              Buffer.from(message.headers.origin));
+
+            response.writeHeader(HTTP_HEADER_VARY, ORIGIN);
           }
 
           for (const [key, value] of Object.entries(request.response.headers)) {
@@ -681,7 +681,7 @@ class HttpWsProtocol extends Protocol {
           response.writeHeader(HTTP_HEADER_VARY, ORIGIN);
         }
       }
-      
+
 
       response.writeHeader(
         HTTP_HEADER_CONTENT_LENGTH,

--- a/test/api/controllers/authController.test.js
+++ b/test/api/controllers/authController.test.js
@@ -29,7 +29,7 @@ describe('Test the auth controller', () => {
   beforeEach(() => {
     kuzzle = new KuzzleMock();
     kuzzle.config.security.jwt.secret = 'test-secret';
-    kuzzle.config.internal.cookieAuthentication = false;
+    kuzzle.config.http.cookieAuthentication = false;
     kuzzle.ask.withArgs('core:security:user:anonymous:get').resolves({_id: '-1'});
 
     user = new User();
@@ -277,7 +277,7 @@ describe('Test the auth controller', () => {
     let createTokenStub;
 
     beforeEach(() => {
-      kuzzle.config.internal.cookieAuthentication = true;
+      kuzzle.config.http.cookieAuthentication = true;
       createTokenStub = kuzzle.ask.withArgs('core:security:token:create');
     });
 
@@ -515,7 +515,7 @@ describe('Test the auth controller', () => {
 
   describe('#logout with cookies', () => {
     beforeEach(() => {
-      kuzzle.config.internal.cookieAuthentication = true;
+      kuzzle.config.http.cookieAuthentication = true;
 
       const signedToken = jwt.sign(
         {_id: 'admin'},
@@ -664,7 +664,7 @@ describe('Test the auth controller', () => {
     let testToken;
 
     beforeEach(() => {
-      kuzzle.config.internal.cookieAuthentication = true;
+      kuzzle.config.http.cookieAuthentication = true;
 
       request = new Request(
         {
@@ -782,7 +782,7 @@ describe('Test the auth controller', () => {
   describe('#refreshToken with cookies', () => {
     beforeEach(() => {
       kuzzle.config.internal.allowAllOrigins = false;
-      kuzzle.config.internal.cookieAuthentication = true;
+      kuzzle.config.http.cookieAuthentication = true;
     });
 
     it('should reject if the user is not authenticated', () => {

--- a/test/api/funnel/checkRights.test.js
+++ b/test/api/funnel/checkRights.test.js
@@ -132,7 +132,7 @@ describe('funnel.checkRights', () => {
   });
 
   it('should use the token in the cookie when cookieAuth is true and internal.cookieAuthentication is true and only the cookie is present', async () => {
-    kuzzle.config.internal.cookieAuthentication = true;
+    kuzzle.config.http.cookieAuthentication = true;
 
     request.input.jwt = null;
     request.input.args.cookieAuth = true;
@@ -145,7 +145,7 @@ describe('funnel.checkRights', () => {
   });
 
   it('should use the token when cookieAuth is true and internal.cookieAuthentication is true and only the token is present', async () => {
-    kuzzle.config.internal.cookieAuthentication = true;
+    kuzzle.config.http.cookieAuthentication = true;
 
     request.input.jwt = 'hashed JWT';
     request.input.args.cookieAuth = true;
@@ -157,7 +157,7 @@ describe('funnel.checkRights', () => {
   });
 
   it('should throw security.token.verification_error when cookieAuth is true and internal.cookieAuthentication is true and both cookie that belongs to kuzzle and token are present', async () => {
-    kuzzle.config.internal.cookieAuthentication = true;
+    kuzzle.config.http.cookieAuthentication = true;
 
     request.input.jwt = 'hashed JWT';
     request.input.args.cookieAuth = true;
@@ -168,7 +168,7 @@ describe('funnel.checkRights', () => {
   });
 
   it('should not throw security.token.verification_error when cookieAuth is true and internal.cookieAuthentication is true and both cookie that does not belongs to kuzzle and token are present', async () => {
-    kuzzle.config.internal.cookieAuthentication = true;
+    kuzzle.config.http.cookieAuthentication = true;
 
     request.input.jwt = 'hashed JWT';
     request.input.args.cookieAuth = true;
@@ -181,7 +181,7 @@ describe('funnel.checkRights', () => {
   });
 
   it('should use the token when cookieAuth is true and internal.cookieAuthentication is true and both cookie and token are present, but cookie is set to null', async () => {
-    kuzzle.config.internal.cookieAuthentication = true;
+    kuzzle.config.http.cookieAuthentication = true;
 
     request.input.jwt = 'hashed JWT';
     request.input.args.cookieAuth = true;
@@ -194,7 +194,7 @@ describe('funnel.checkRights', () => {
   });
 
   it('should not throw security.cookie.unsupported and use the token when cookieAuth is false and internal.cookieAuthentication is false and cookies are present but none of them belongs to kuzzle', async () => {
-    kuzzle.config.internal.cookieAuthentication = false;
+    kuzzle.config.http.cookieAuthentication = false;
 
     request.input.jwt = 'hashed JWT';
     request.input.args.cookieAuth = false;
@@ -207,7 +207,7 @@ describe('funnel.checkRights', () => {
   });
 
   it('should throw security.cookie.unsupported when cookieAuth is true and internal.cookieAuthentication is false', async () => {
-    kuzzle.config.internal.cookieAuthentication = false;
+    kuzzle.config.http.cookieAuthentication = false;
 
     request.input.jwt = null;
     request.input.args.cookieAuth = true;
@@ -219,7 +219,7 @@ describe('funnel.checkRights', () => {
   });
 
   it('should throw security.token.verification_error when cookieAuth is false and internal.cookieAuthentication is true and both cookie and token are present', async () => {
-    kuzzle.config.internal.cookieAuthentication = true;
+    kuzzle.config.http.cookieAuthentication = true;
 
     request.input.jwt = 'hashed JWT';
     request.input.args.cookieAuth = false;
@@ -230,7 +230,7 @@ describe('funnel.checkRights', () => {
   });
 
   it('should use the token in the cookie when cookieAuth is false and internal.cookieAuthentication is true and only the cookie is present', async () => {
-    kuzzle.config.internal.cookieAuthentication = true;
+    kuzzle.config.http.cookieAuthentication = true;
 
     request.input.jwt = null;
     request.input.args.cookieAuth = false;
@@ -243,7 +243,7 @@ describe('funnel.checkRights', () => {
   });
 
   it('should use the token in the jwt when cookieAuth is false and internal.cookieAuthentication is true and only the token is present', async () => {
-    kuzzle.config.internal.cookieAuthentication = true;
+    kuzzle.config.http.cookieAuthentication = true;
 
     request.input.jwt = 'hashed JWT';
     request.input.args.cookieAuth = false;
@@ -255,7 +255,7 @@ describe('funnel.checkRights', () => {
   });
 
   it('should throw security.cookie.unsupported when cookieAuth is false and internal.cookieAuthentication is false and both cookie and token are present', async () => {
-    kuzzle.config.internal.cookieAuthentication = false;
+    kuzzle.config.http.cookieAuthentication = false;
 
     request.input.jwt = 'hashed JWT';
     request.input.args.cookieAuth = false;
@@ -266,7 +266,7 @@ describe('funnel.checkRights', () => {
   });
 
   it('should throw security.cookie.unsupported when cookieAuth is false and internal.cookieAuthentication is false and only the cookie is present', async () => {
-    kuzzle.config.internal.cookieAuthentication = false;
+    kuzzle.config.http.cookieAuthentication = false;
 
     request.input.jwt = null;
     request.input.args.cookieAuth = false;
@@ -277,7 +277,7 @@ describe('funnel.checkRights', () => {
   });
 
   it('should use the token in the jwt when cookieAuth is false and internal.cookieAuthentication is false and only the token is present', async () => {
-    kuzzle.config.internal.cookieAuthentication = false;
+    kuzzle.config.http.cookieAuthentication = false;
 
     request.input.jwt = 'hashed JWT';
     request.input.args.cookieAuth = false;

--- a/test/config/index.test.js
+++ b/test/config/index.test.js
@@ -411,23 +411,6 @@ describe('lib/config/index.js', () => {
       ]);
     });
 
-    it('should set internal cookieAuthentication to false if * is present in accessControlAllowOrigin', () => {
-      mockedConfigContent = getcfg({
-        http: {
-          accessControlAllowOrigin: 'foo, bar, *'
-        }
-      });
-
-      const cfg = config.load();
-
-      should(cfg.http.accessControlAllowOrigin).be.eql([
-        'foo',
-        'bar',
-        '*'
-      ]);
-      should(cfg.internal.cookieAuthentication).be.false();
-    });
-
     it('should set internal allowAllOrigins to true if * is present in accessControlAllowOrigin', () => {
       mockedConfigContent = getcfg({
         http: {

--- a/test/core/network/httpRouter/httpRouter.test.js
+++ b/test/core/network/httpRouter/httpRouter.test.js
@@ -80,6 +80,7 @@ describe('core/network/httpRouter', () => {
         'content-type': 'application/json',
         'Accept-Encoding': 'gzip,deflate,identity',
         'Access-Control-Allow-Methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD',
+        'Access-Control-Allow-Credentials': 'true',
         'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Content-Encoding, Content-Length, X-Kuzzle-Volatile'
       });
     });

--- a/test/core/network/httpRouter/httpRouter.test.js
+++ b/test/core/network/httpRouter/httpRouter.test.js
@@ -26,7 +26,7 @@ describe('core/network/httpRouter', () => {
     router = new Router();
     handler = sinon.stub().yields();
     kuzzleMock.config.internal.allowAllOrigins = true;
-    kuzzleMock.config.internal.cookieAuthentication = false;
+    kuzzleMock.config.http.cookieAuthentication = false;
   });
 
   afterEach(() => {
@@ -345,7 +345,7 @@ describe('core/network/httpRouter', () => {
     it('should register a default / route with the HEAD verb', done => {
       kuzzleMock.config.internal.allowAllOrigins = false;
       kuzzleMock.config.http.accessControlAllowOrigin = ['foo'];
-      
+
       const req = new MockHttpRequest('head', '/', '', {
         'content-type': 'application/json',
         foo: 'bar',

--- a/test/core/network/protocols/http.test.js
+++ b/test/core/network/protocols/http.test.js
@@ -58,7 +58,7 @@ describe('core/network/protocols/http', () => {
       'foo'
     ];
     kuzzle.config.internal.allowAllOrigins = false;
-    kuzzle.config.internal.cookieAuthentication = true;
+    kuzzle.config.http.cookieAuthentication = true;
     httpWs = new HttpWs();
   });
 
@@ -522,7 +522,7 @@ describe('core/network/protocols/http', () => {
           Buffer.from('Access-Control-Allow-Origin'),
           Buffer.from('foobar')
         );
-      
+
       should(response.writeHeader)
         .not.be.calledWithMatch(
           Buffer.from('Vary'),


### PR DESCRIPTION
## What does this PR do ?

Cookie authentication was enabled by default but automatically disabled if `accessControlAllowOrigin` contained a wildcard.

This PR introduce a new configuration option that allows to manually enable or disable cookie authentication.
