### PR TITLE
Fix request unauthorized event

### DIFF
--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -454,10 +454,16 @@ class Funnel {
       }
     }
 
-    // If the verification should be skipped, we pass a null token, this way the verification will be made as anonymous
-    request.context.token = await global.kuzzle.ask(
-      'core:security:token:verify',
-      !skipTokenVerification && request.input.jwt || null);
+    try {
+      // If the verification should be skipped, we pass a null token, this way the verification will be made as anonymous
+      request.context.token = await global.kuzzle.ask(
+        'core:security:token:verify',
+        !skipTokenVerification && request.input.jwt || null);
+    }
+    catch (error) {
+      await global.kuzzle.pipe('request:onUnauthorized', request);
+      throw error;
+    }
 
     const userId = request.context.token.userId;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "2.13.3",
+  "version": "2.13.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.13.3",
+  "version": "2.13.4",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "bin": {
     "kuzzle": "bin/start-kuzzle-server"

--- a/test/api/funnel/checkRights.test.js
+++ b/test/api/funnel/checkRights.test.js
@@ -91,7 +91,7 @@ describe('funnel.checkRights', () => {
     should(kuzzle.pipe).calledWith('request:onUnauthorized', request);
   });
 
-  it('should forward a token:verify exception', async () => {
+  it('should forward a token:verify exception and trigger event', async () => {
     const error = new Error('foo');
 
     verifyTokenStub.rejects(error);
@@ -102,7 +102,7 @@ describe('funnel.checkRights', () => {
     should(getUserEvent).not.called();
 
     should(kuzzle.pipe).not.calledWith('request:onAuthorized', request);
-    should(kuzzle.pipe).not.calledWith('request:onUnauthorized', request);
+    should(kuzzle.pipe).be.calledWith('request:onUnauthorized', request);
   });
 
   it('should forward a user:get exception', async () => {


### PR DESCRIPTION
## What does this PR do ?

The `request:onUnauthorized` event was not triggered when the authentication token was invalid or expired.