### PR TITLE
Add segfault handler that logs segfault stacktraces

### DIFF
--- a/lib/kuzzle/kuzzle.js
+++ b/lib/kuzzle/kuzzle.js
@@ -27,7 +27,7 @@ const { murmurHash128: murmur } = require('murmurhash-native');
 const stringify = require('json-stable-stringify');
 const { Koncorde } = require('koncorde');
 const Bluebird = require('bluebird');
-const segfaultHandler = require('segfault-handler')
+const segfaultHandler = require('segfault-handler');
 
 const kuzzleStateEnum = require('./kuzzleStateEnum');
 const KuzzleEventEmitter = require('./event/kuzzleEventEmitter');

--- a/lib/kuzzle/kuzzle.js
+++ b/lib/kuzzle/kuzzle.js
@@ -27,6 +27,7 @@ const { murmurHash128: murmur } = require('murmurhash-native');
 const stringify = require('json-stable-stringify');
 const { Koncorde } = require('koncorde');
 const Bluebird = require('bluebird');
+const segfaultHandler = require('segfault-handler')
 
 const kuzzleStateEnum = require('./kuzzleStateEnum');
 const KuzzleEventEmitter = require('./event/kuzzleEventEmitter');
@@ -398,6 +399,8 @@ class Kuzzle extends KuzzleEventEmitter {
         this.shutdown();
       });
     }
+
+    segfaultHandler.registerHandler();
   }
 
   async dumpAndExit (suffix) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7677,6 +7677,15 @@
       "integrity": "sha1-KpsZ4lCoFwmSMaW5mk2vgLf77VQ=",
       "dev": true
     },
+    "segfault-handler": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/segfault-handler/-/segfault-handler-1.3.0.tgz",
+      "integrity": "sha512-p7kVHo+4uoYkr0jmIiTBthwV5L2qmWtben/KDunDZ834mbos+tY+iO0//HpAJpOFSQZZ+wxKWuRo4DxV02B7Lg==",
+      "requires": {
+        "bindings": "^1.2.1",
+        "nan": "^2.14.0"
+      }
+    },
     "semver": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "passport": "^0.4.1",
     "protobufjs": "~6.11.2",
     "rc": "1.2.8",
+    "segfault-handler": "^1.3.0",
     "semver": "^7.3.5",
     "sorted-array": "^2.0.4",
     "uWebSockets.js": "https://github.com/uNetworking/uWebSockets.js/archive/refs/tags/v18.14.0.tar.gz",


### PR DESCRIPTION
## What does this PR do ?

This PR add a segfault handler that will log the stacktrace when a segfault occurs in production / development.
This will be helpful to help us investigate the cause of the segfault.

![image](https://user-images.githubusercontent.com/19224148/127162706-e2a71f8d-e8c7-437b-878d-4d3ed3ecf3f0.png)