### PR TITLE
Fix createOrReplace realtime notification not working

### DIFF
--- a/features/DocumentController.feature
+++ b/features/DocumentController.feature
@@ -249,6 +249,45 @@ Feature: Document Controller
     And The document "document-2" content match:
       | name | "document2" |
 
+  # document:createOrReplace ==================================================
+
+  @mappings
+  Scenario: CreateOrReplace on a non existing document
+    Given an existing collection "nyc-open-data":"yellow-taxi"
+    When I successfully execute the action "document":"createOrReplace" with args:
+      | index      | "nyc-open-data"         |
+      | collection | "yellow-taxi"           |
+      | _id        | "document-1"            |
+      | body       | { "name": "document1" } |
+    Then I should receive a result matching:
+      | _id     | "document-1"             |
+      | _source | { "name": "document1" }  |
+      | created | true                     |
+    And I refresh the collection
+    And I count 1 documents
+    And The document "document-1" content match:
+      | name | "document1" |
+  
+  @mappings
+  Scenario: CreateOrReplace on an existing document
+    Given an existing collection "nyc-open-data":"yellow-taxi"
+    And I "create" the following documents:
+      | _id          | body                               |
+      | "document-1" | { "name": "document1", "age": 42 } |
+    When I successfully execute the action "document":"createOrReplace" with args:
+      | index      | "nyc-open-data"         |
+      | collection | "yellow-taxi"           |
+      | _id        | "document-1"            |
+      | body       | { "name": "replaced1" } |
+    Then I should receive a result matching:
+      | _id     | "document-1"             |
+      | _source | { "name": "replaced1" }  |
+      | created | false                    |
+    And I refresh the collection
+    And I count 1 documents
+    And The document "document-1" content match:
+      | name | "replaced1" |
+
   # document:mCreateOrReplace ==================================================
 
   @mappings
@@ -262,9 +301,9 @@ Feature: Document Controller
       | "document-1" | { "name": "replaced1" } |
       | -            | { "name": "document2" } |
     Then I should receive a "successes" array of objects matching:
-      | _id          | _source                 | status | result    |
-      | "document-1" | { "name": "replaced1" } | 200    | "updated" |
-      | -            | { "name": "document2" } | 201    | "created" |
+      | _id          | _source                 | status | result    | created |
+      | "document-1" | { "name": "replaced1" } | 200    | "updated" | false   |
+      | -            | { "name": "document2" } | 201    | "created" | true    |
     And I should receive a empty "errors" array
     And I refresh the collection
     And I count 2 documents

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -618,7 +618,7 @@ class ElasticSearch extends Service {
         _id: body._id,
         _source: esRequest.body,
         _version: body._version,
-        created: body.created // Needed by the notifier
+        created: body.result === 'created' // Needed by the notifier
       }))
       .catch(error => this._esWrapper.reject(error));
   }
@@ -2478,7 +2478,7 @@ class ElasticSearch extends Service {
           _id: result._id,
           _source: documents[i]._source,
           _version: result._version,
-          created: result.created,
+          created: result.result === 'created',
           get: result.get,
           result: result.result,
           status: result.status, // used by mUpdate to get the full document body

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -659,7 +659,7 @@ describe('Test: ElasticSearch service', () => {
           _id: 'liia',
           _version: 1,
           _source: { city: 'Kathmandu' },
-          created: true
+          result: 'created'
         }
       });
     });


### PR DESCRIPTION
## What does this PR do ?

This PR fixes value `created` return by elasticsearch createOrReplace / _mExecute that was using an undefined value instead of doing a string comparison on `body.result === 'created'`