### PR TITLE
Use aliases instead of indices by default in ElasticSearch

### DIFF
--- a/doc/2/api/errors/error-codes/services/index.md
+++ b/doc/2/api/errors/error-codes/services/index.md
@@ -60,7 +60,7 @@ description: Error codes definitions
 | services.storage.unknown_query_keyword<br/><pre>0x0101002d</pre>  | [BadRequestError](/core/2/api/errors/error-codes#badrequesterror) <pre>(400)</pre> | The keyword "%s" is not part of Elasticsearch Query DSL. Are you trying to use a Koncorde query? | An unknown keyword has been provided in the search query |
 | services.storage.incomplete_update<br/><pre>0x0101002e</pre>  | [MultipleErrorsError](/core/2/api/errors/error-codes#multipleerrorserror) <pre>(400)</pre> | %s documents were successfully updated before an error occured | Couldn't update all the requested documents |
 | services.storage.invalid_query_keyword<br/><pre>0x0101002f</pre>  | [BadRequestError](/core/2/api/errors/error-codes#badrequesterror) <pre>(400)</pre> | The "%s" keyword is not allowed in this query. | A forbidden keyword has been provided in the query |
-| services.storage.multiple_index_alias<br/><pre>0x01010030</pre>  | [PreconditionError](/core/2/api/errors/error-codes#preconditionerror) <pre>(412)</pre> | An "%s" is not allowed to be associated with multiple "%ses". This is probably not linked to this request but rather the consequence of previous actions on ElasticSearch. | The unique association between an index and its alias has not been respected |
+| services.storage.multiple_indice_alias<br/><pre>0x01010030</pre>  | [PreconditionError](/core/2/api/errors/error-codes#preconditionerror) <pre>(412)</pre> | An "%s" is not allowed to be associated with multiple "%". This is probably not linked to this request but rather the consequence of previous actions on ElasticSearch. | The unique association between an indice and its alias has not been respected |
 
 ---
 

--- a/doc/2/api/errors/error-codes/services/index.md
+++ b/doc/2/api/errors/error-codes/services/index.md
@@ -60,6 +60,7 @@ description: Error codes definitions
 | services.storage.unknown_query_keyword<br/><pre>0x0101002d</pre>  | [BadRequestError](/core/2/api/errors/error-codes#badrequesterror) <pre>(400)</pre> | The keyword "%s" is not part of Elasticsearch Query DSL. Are you trying to use a Koncorde query? | An unknown keyword has been provided in the search query |
 | services.storage.incomplete_update<br/><pre>0x0101002e</pre>  | [MultipleErrorsError](/core/2/api/errors/error-codes#multipleerrorserror) <pre>(400)</pre> | %s documents were successfully updated before an error occured | Couldn't update all the requested documents |
 | services.storage.invalid_query_keyword<br/><pre>0x0101002f</pre>  | [BadRequestError](/core/2/api/errors/error-codes#badrequesterror) <pre>(400)</pre> | The "%s" keyword is not allowed in this query. | A forbidden keyword has been provided in the query |
+| services.storage.multiple_index_alias<br/><pre>0x01010030</pre>  | [PreconditionError](/core/2/api/errors/error-codes#preconditionerror) <pre>(412)</pre> | An "%s" is not allowed to be associated with multiple "%ses". This is probably not linked to this request but rather the consequence of previous actions on ElasticSearch. | The unique association between an index and its alias has not been respected |
 
 ---
 

--- a/doc/2/guides/main-concepts/data-storage/index.md
+++ b/doc/2/guides/main-concepts/data-storage/index.md
@@ -10,7 +10,7 @@ order: 200
 
 Kuzzle uses Elasticsearch as a **NoSQL document storage**.
 
-The data storage is organized in 4 levels: 
+The data storage is organized in 4 levels:
   - Indexes
   - Collections
   - Documents
@@ -35,23 +35,25 @@ Elasticsearch is **primarily designed to be a search engine**, so there are **li
 
 ## Internal Representation
 
-Elasticsearch does not have this notion of our two levels document-oriented storage.  
+Elasticsearch does not have this notion of our two levels document-oriented storage.
 
 ::: info
 As the word index refers to Kuzzle indexes but also Elasticsearch indexes, we will rather **use the term indices for Elasticsearch indexes** to avoid confusion (also present in Elasticsearch documentation).
 :::
 
 Kuzzle indexes and collections are emulated in Elasticsearch in the following way:
- - **indexes does not physically exist in Elasticsearch** but are only logical application containers. When an index is created, an empty indice is created in Elasticsearch to reserve the index name (e.g. `&nyc-open-data._kuzzle_keep`)
+ - **indexes does not physically exist in Elasticsearch** but are only logical application containers. When an index is created, an empty indice is created in Elasticsearch to reserve the index name (e.g. `&nyc-open-data._kuzzle_keep`) as long as an alias name (e.g. `@&nyc-open-data._kuzzle_keep`)
  - **collections correspond to Elasticsearch indexes** with all their properties (e.g. [mappings](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/mapping.html), [settings](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/index-modules.html#index-modules-settings), etc)
 
-Kuzzle distinguishes two types of storage: 
+Kuzzle distinguishes two types of storage:
   - **private**: internal Kuzzle index, plugin private indexes. Those indexes can never be accessed directly from the Kuzzle API
   - **public**: indexes available through the Kuzzle API
 
 Elasticsearch indices must comply to the following naming convention:
  - **private**: `%<kuzzle-index-name>.<kuzzle-collection-name>`
  - **public**: `&<kuzzle-index-name>.<kuzzle-collection-name>`
+
+Each indice is doubled with an alias allowing more flexibility and maintainability. Aliases are formatted with an `@` prefix followed by their associated indice name.
 
 You can list Elasticsearch indices with this command:
 ```bash
@@ -156,7 +158,7 @@ Refer to the Elasticsearch documentation for an exhaustive list of available typ
 
 #### Arrays
 
-With Elasticsearch, **every field can be an array**. 
+With Elasticsearch, **every field can be an array**.
 
 To store an array of values, you can just send it as-is instead of a single value:
 ```bash
@@ -175,7 +177,7 @@ kourou document:update ktm-open-data thamel-taxi '{
 ```
 
 ::: info
-If you need to frequently insert and remove values to a field then you should either use a nested object instead or use a [scripting language](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting-painless.html) to modify the array.  
+If you need to frequently insert and remove values to a field then you should either use a nested object instead or use a [scripting language](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting-painless.html) to modify the array.
 For security reasons, Kuzzle does not provide any access to scripts through its API. Scripts are only supported through the [Integrated Elasticsearch Client](/core/2/guides/main-concepts/data-storage#integrated-elasticsearch-client) available to applications and to plugins.
 :::
 
@@ -213,7 +215,7 @@ kourou collection:create ktm-open-data thamel-taxi '{
 For each collection, you can set the **policy against new fields that are not referenced** in the collection mapping by modifying the `dynamic` root field.
 
 The value of this configuration will change the way Elasticsearch manages the creation of new fields that are not declared in the collection mappings.
-  - `"true"`: stores the document and updates the collection mapping with the inferred type 
+  - `"true"`: stores the document and updates the collection mapping with the inferred type
   - `"false"`: stores the document and does not update the collection mappings (fields are not indexed)
   - `"strict"`: rejects the document
 
@@ -226,7 +228,7 @@ Refer to Elasticsearch documentation for more informations: [Elasticsearch dynam
 The default policy for new collections is `"true"` and is configurable in the [kuzzlerc](/core/2/guides/advanced/configuration) file under the key `services.storageEngine.commonMapping.dynamic`.
 
 ::: warning
-We advise not to let Elasticsearch dynamically infer the type of new fields in production.  
+We advise not to let Elasticsearch dynamically infer the type of new fields in production.
 Allowing dynamic fields can be a problem because then the mappings cannot be modified, not to mention the cost of indexing potentially unwanted new fields.
 :::
 
@@ -295,9 +297,9 @@ kourou collection:getMapping ktm-open-data thamel-taxi
 
 ### Load Mappings
 
-It is possible to **load mappings from several collections** at once using the [admin:loadMappings](/core/2/api/controllers/admin/load-mappings) action.  
+It is possible to **load mappings from several collections** at once using the [admin:loadMappings](/core/2/api/controllers/admin/load-mappings) action.
 
-This action takes as parameter a definition of a set of indexes and collections with their associated mappings.  
+This action takes as parameter a definition of a set of indexes and collections with their associated mappings.
 
 The expected format is the following:
 ```js
@@ -347,7 +349,7 @@ kourou admin:loadMappings < mappings.json
 Kourou can read file content and put it the request body.
 :::
 
-<!-- 
+<!--
   @todo load at startup with Kaaf
 -->
 
@@ -364,7 +366,7 @@ kourou collection:create ktm-open-data:yellow-taxi '{
     "analysis": {
       "analyzer": {
         "my_custom_analyzer": {
-          "type": "custom", 
+          "type": "custom",
           "tokenizer": "standard",
           "char_filter": [
             "html_strip"
@@ -427,8 +429,8 @@ kourou document:create ktm-open-data thamel-taxi '{
 ```
 
 ::: info
-Metadata cannot be edited manually (except with [bulk:write](/core/2/api/controllers/bulk/write), [bulk:mWrite](/core/2/api/controllers/bulk/m-write) or [bulk:updateByQuery](/core/2/api/controllers/bulk/update-by-query) actions). Kuzzle will discard any `_kuzzle_info` property sent in document content.  
-::: 
+Metadata cannot be edited manually (except with [bulk:write](/core/2/api/controllers/bulk/write), [bulk:mWrite](/core/2/api/controllers/bulk/m-write) or [bulk:updateByQuery](/core/2/api/controllers/bulk/update-by-query) actions). Kuzzle will discard any `_kuzzle_info` property sent in document content.
+:::
 
 ### Metadata mappings
 
@@ -466,7 +468,7 @@ For example, to sort documents by creation date, we can use the following search
 
 ```bash
 kourou document:search ktm-open-data thamel-taxi --sort '{
-  "_kuzzle_info.createdAt": "asc" 
+  "_kuzzle_info.createdAt": "asc"
 }'
 ```
 
@@ -502,7 +504,7 @@ kourou document:update ktm-open-data thamel-taxi '{
 
 ### Write Multiple Documents
 
-If you need to **write multiple documents at once**, it is recommended to use one of the `m*` actions.  
+If you need to **write multiple documents at once**, it is recommended to use one of the `m*` actions.
 
 ::: info
 If you need to create large volume of documents the fastest way possible then you should use the [bulk:import](/core/2/api/controllers/bulk/import) action.
@@ -512,7 +514,7 @@ These actions work in the same way as single document actions (`createOrReplace`
 
 **Example:** _Create multiple documents with the [document:mCreate](/core/2/api/controllers/document/m-create) action_
 
-<!-- 
+<!--
   @todo deprecate "body" and use "content" instead
 -->
 
@@ -606,7 +608,7 @@ To perform lower level actions, it is possible to use the [bulk](/core/2/api/con
 
 The actions of this controller may not follow some of the API principles such as:
  - adding [Kuzzle Metadata](/core/2/guides/main-concepts/data-storage#kuzzle-metadata)
- - triggering [Database Notifications](/core/2/guides/main-concepts/realtime-engine#database-notifications) 
+ - triggering [Database Notifications](/core/2/guides/main-concepts/realtime-engine#database-notifications)
  - application of [Data Validation](/core/2/guides/advanced/data-validation) rules
  - respect of [write limit](/core/2/guides/main-concepts/data-storage#write-limit)
 
@@ -618,13 +620,13 @@ The following actions are available:
  - [bulk:updateByQuery](/core/2/api/controllers/bulk/update-by-query): update large volume of documents matching a query
 
 ::: warning
-Bulk actions are intended to be used by administrators and scripts.  
+Bulk actions are intended to be used by administrators and scripts.
 It is considered harmful to let end users execute those actions.
 :::
 
 ## Integrated Elasticsearch Client
 
-Kuzzle uses and exposes the [Elasticsearch Javascript SDK](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-reference.html). 
+Kuzzle uses and exposes the [Elasticsearch Javascript SDK](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-reference.html).
 
 It is possible to **interact directly with Elasticsearch** through clients exposed in the [Backend.storage](/core/2/framework/classes/backend-storage) property.
 

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -32,7 +32,7 @@ const formatProcessing = require('../../core/auth/formatProcessing');
 const ApiKey = require('../../model/storage/apiKey');
 const kerror = require('../../kerror');
 const { has, get } = require('../../util/safeObject');
-const nameGenerator = require('../../util/name-generator');
+const { generateRandomName } = require('../../util/name-generator');
 
 /**
  * @class SecurityController
@@ -1199,7 +1199,7 @@ class SecurityController extends NativeController {
     const credentials = request.getBodyObject('credentials', {});
     const strategies = Object.keys(credentials);
     const generator = humanReadableId
-      ? () => nameGenerator('kuid')
+      ? () => generateRandomName('kuid')
       : () => 'kuid-' + uuidv4();
 
     let id = '';

--- a/lib/cluster/idCardHandler.js
+++ b/lib/cluster/idCardHandler.js
@@ -21,7 +21,7 @@
 
 'use strict';
 
-const nameGenerator = require('../util/name-generator');
+const { generateRandomName } = require('../util/name-generator');
 
 const REDIS_PREFIX = '{cluster/node}/';
 
@@ -87,7 +87,7 @@ class ClusterIdCardHandler {
     let reserved;
 
     do {
-      this.nodeId = nameGenerator('knode');
+      this.nodeId = generateRandomName('knode');
       this.nodeIdKey = `${REDIS_PREFIX}${this.nodeId}`;
       this.idCard = new IdCard({
         birthdate: Date.now(),

--- a/lib/core/storage/clientAdapter.js
+++ b/lib/core/storage/clientAdapter.js
@@ -152,7 +152,7 @@ class ClientAdapter {
   }
 
   /**
-   * Populates the index cache with existing index/collection and aliases.
+   * Populates the index cache with existing index/collection.
    * Also checks for duplicated index names.
    *
    * @returns {Promise}
@@ -166,12 +166,6 @@ class ClientAdapter {
       for (const collection of collections) {
         this.cache.addCollection(index, collection);
       }
-    }
-
-    const aliases = await this.client.listAliases();
-
-    for (const { collection, index } of aliases) {
-      this.cache.addCollection(index, collection);
     }
   }
 

--- a/lib/kerror/codes/1-services.json
+++ b/lib/kerror/codes/1-services.json
@@ -270,10 +270,10 @@
           "message": "The \"%s\" keyword is not allowed in this query.",
           "class": "BadRequestError"
         },
-        "multiple_index_alias": {
-          "description": "The unique association between an index and its alias has not been respected",
+        "multiple_indice_alias": {
+          "description": "The unique association between an indice and its alias has not been respected",
           "code": 48,
-          "message": "An \"%s\" is not allowed to be associated with multiple \"%ses\". This is probably not linked to this request but rather the consequence of previous actions on ElasticSearch.",
+          "message": "An \"%s\" is not allowed to be associated with multiple \"%\". This is probably not linked to this request but rather the consequence of previous actions on ElasticSearch.",
           "class": "PreconditionError"
         }
       }

--- a/lib/kerror/codes/1-services.json
+++ b/lib/kerror/codes/1-services.json
@@ -269,6 +269,12 @@
           "code": 47,
           "message": "The \"%s\" keyword is not allowed in this query.",
           "class": "BadRequestError"
+        },
+        "multiple_index_alias": {
+          "description": "The unique association between an index and its alias has not been respected",
+          "code": 48,
+          "message": "An \"%s\" is not allowed to be associated with multiple \"%ses\". This is probably not linked to this request but rather the consequence of previous actions on ElasticSearch.",
+          "class": "PreconditionError"
         }
       }
     },

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -2783,7 +2783,7 @@ class ElasticSearch extends Service {
         index[INDEX_PREFIX_POSITON_IN_INDEX] === this._indexPrefix
         && ! aliases.some((alias) => alias.name === index));
 
-      let esRequest = { actions : [] };
+      const esRequest = { actions : [] };
       for (const index of indexesWithoutAlias) {
         esRequest.actions.push({ add : { alias: `@${index}`, index } });
       }
@@ -2819,7 +2819,7 @@ class ElasticSearch extends Service {
    * @returns {String} index name
    */
   _extractIndex (esIndex) {
-    let prefixPosition = esIndex.search(ALIAS_PREFIX) === -1
+    const prefixPosition = esIndex.search(ALIAS_PREFIX) === -1
       ? INDEX_PREFIX_POSITON_IN_INDEX
       : INDEX_PREFIX_POSITON_IN_ALIAS;
 

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -1235,10 +1235,10 @@ class ElasticSearch extends Service {
     }
 
     const esRequest = {
-      aliases: {
-        [this._getESIndex(index, collection)]: {}
-      },
       body: {
+        aliases: {
+          [this._getESIndex(index, collection)]: {}
+        },
         mappings: {},
         settings
       },
@@ -1289,7 +1289,7 @@ class ElasticSearch extends Service {
    */
   async getMapping (index, collection, { includeKuzzleMeta=false } = {}) {
     const
-      esIndex = this._getESIndex(index, collection),
+      esIndex = await this._getESIndexFromAlias(index, collection),
       esRequest = {
         index: esIndex
       };
@@ -1325,7 +1325,7 @@ class ElasticSearch extends Service {
    */
   async updateCollection (index, collection, { mappings={}, settings={} } = {}) {
     const esRequest = {
-      index: this._getESIndex(index, collection)
+      index: await this._getESIndexFromAlias(index, collection)
     };
 
     // If either the putMappings or the putSettings operation fail, we need to
@@ -1501,10 +1501,12 @@ class ElasticSearch extends Service {
 
       await this._client.indices.create({
         ...esRequest,
-        aliases: {
-          [this._getESIndex(index, collection)]: {}
-        },
-        body: { mappings },
+        body: {
+          aliases: {
+            [this._getESIndex(index, collection)]: {}
+          },
+          mappings
+        }
       });
 
       return null;
@@ -2739,9 +2741,7 @@ class ElasticSearch extends Service {
    * @returns {boolean} `true` if the raw ES index name is available, `false` otherwise
    */
   async _isESIndexAvailable (esIndex) {
-    const { body } = await this._client.indices.get({ index: esIndex });
-
-    return body.length === 0;
+    return ! await this._client.indices.exists({ index: esIndex }).body;
   }
 
   /**
@@ -2783,12 +2783,14 @@ class ElasticSearch extends Service {
         index[INDEX_PREFIX_POSITON_IN_INDEX] === this._indexPrefix
         && ! aliases.some((alias) => alias.name === index));
 
-      const esRequest = { actions : [] };
+      const esRequest = { body:{ actions : [] } };
       for (const index of indexesWithoutAlias) {
-        esRequest.actions.push({ add : { alias: `@${index}`, index } });
+        esRequest.body.actions.push({ add : { alias: `@${index}`, index } });
       }
 
-      await this._client.indices.updateAliases(esRequest);
+      if (esRequest.body.actions.length > 0) {
+        await this._client.indices.updateAliases(esRequest);
+      }
     }
     catch (error) {
       throw this._esWrapper.formatESError(error);
@@ -2883,10 +2885,10 @@ class ElasticSearch extends Service {
 
     try {
       await this._client.indices.create({
-        aliases: {
-          [this._getESIndex(index, HIDDEN_COLLECTION)]: {}
-        },
         body: {
+          aliases: {
+            [this._getESIndex(index, HIDDEN_COLLECTION)]: {}
+          },
           settings: {
             number_of_replicas: 1,
             number_of_shards: 1,

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -39,6 +39,7 @@ const { isPlainObject } = require('../../util/safeObject');
 const scopeEnum = require('../../core/storage/storeScopeEnum');
 const extractFields = require('../../util/extractFields');
 const { Mutex } = require('../../util/mutex');
+const { generateRandomCustom } = require('../../util/name-generator');
 
 const SCROLL_CACHE_PREFIX = '_docscroll_';
 
@@ -49,6 +50,8 @@ const CHILD_MAPPING_PROPERTIES = ['type'];
 const HIDDEN_COLLECTION = '_kuzzle_keep';
 const PRIVATE_PREFIX = '%';
 const PUBLIC_PREFIX = '&';
+const INDEX_PREFIX_POS = 1; // For index alias name (O for raw index name)
+const ALIAS_PREFIX = '@'; // @todo next major release: Add ALIAS_PREFIX in FORBIDDEN_CHARS
 const NAME_SEPARATOR = '.';
 const FORBIDDEN_CHARS = `\\/*?"<>| \t\r\n,+#:${NAME_SEPARATOR}${PUBLIC_PREFIX}${PRIVATE_PREFIX}`;
 const DYNAMIC_PROPERTY_VALUES = ['true', 'false', 'strict'];
@@ -235,11 +238,11 @@ class ElasticSearch extends Service {
     let size = 0;
 
     for (const [esIndex, esIndexInfo] of Object.entries(body.indices)) {
-      const [ indexName, collectionName ] = esIndex
-        .substr(1, esIndex.length)
-        .split(NAME_SEPARATOR);
+      const alias = this._getAliasFromESIndex(esIndex);
+      const indexName = this._extractIndex(alias);
+      const collectionName = this._extractCollection(alias);
 
-      if ( esIndex[0] !== this._indexPrefix || collectionName === HIDDEN_COLLECTION ) {
+      if ( alias[INDEX_PREFIX_POS] !== this._indexPrefix || collectionName === HIDDEN_COLLECTION ) {
         continue;
       }
 
@@ -416,7 +419,7 @@ class ElasticSearch extends Service {
    *
    * @returns {Promise.<{ _id, _version, _source }>}
    */
-  get (index, collection, id) {
+  async get (index, collection, id) {
     const esRequest = {
       id,
       index: this._getESIndex(index, collection)
@@ -431,13 +434,18 @@ class ElasticSearch extends Service {
 
     debug('Get document: %o', esRequest);
 
-    return this._client.get(esRequest)
-      .then(({ body }) => ({
+    try {
+      const { body } = await this._client.get(esRequest);
+
+      return {
         _id: body._id,
         _source: body._source,
         _version: body._version
-      }))
-      .catch(error => this._esWrapper.reject(error));
+      };
+    }
+    catch (error) {
+      this._esWrapper.reject(error);
+    }
   }
 
   /**
@@ -506,7 +514,7 @@ class ElasticSearch extends Service {
    *
    * @returns {Promise.<Number>} count
    */
-  count (index, collection, searchBody = {}) {
+  async count (index, collection, searchBody = {}) {
     const esRequest = {
       body: this._sanitizeSearchBody(searchBody),
       index: this._getESIndex(index, collection)
@@ -514,9 +522,13 @@ class ElasticSearch extends Service {
 
     debug('Count: %o', esRequest);
 
-    return this._client.count(esRequest)
-      .then(({ body }) => body.count)
-      .catch(error => this._esWrapper.reject(error));
+    try {
+      const { body } = await this._client.count(esRequest);
+      return body.count;
+    }
+    catch (error) {
+      this._esWrapper.reject(error);
+    }
   }
 
   /**
@@ -584,7 +596,7 @@ class ElasticSearch extends Service {
    *
    * @returns {Promise.<Object>} { _id, _version, _source, created }
    */
-  createOrReplace (
+  async createOrReplace (
     index,
     collection,
     id,
@@ -613,14 +625,19 @@ class ElasticSearch extends Service {
 
     debug('Create or replace document: %o', esRequest);
 
-    return this._client.index(esRequest)
-      .then(({ body }) => ({
+    try {
+      const { body } = await this._client.index(esRequest);
+
+      return {
         _id: body._id,
         _source: esRequest.body,
         _version: body._version,
         created: body.result === 'created' // Needed by the notifier
-      }))
-      .catch(error => this._esWrapper.reject(error));
+      };
+    }
+    catch (error) {
+      this._esWrapper.reject(error);
+    }
   }
 
   /**
@@ -634,7 +651,7 @@ class ElasticSearch extends Service {
    *
    * @returns {Promise.<{ _id, _version }>}
    */
-  update (
+  async update (
     index,
     collection,
     id,
@@ -661,13 +678,17 @@ class ElasticSearch extends Service {
 
     debug('Update document: %o', esRequest);
 
-    return this._client.update(esRequest)
-      .then(({ body }) => ({
+    try {
+      const { body } = await this._client.update(esRequest);
+      return {
         _id: body._id,
         _source: body.get._source,
         _version: body._version
-      }))
-      .catch(error => this._esWrapper.reject(error));
+      };
+    }
+    catch (error) {
+      this._esWrapper.reject(error);
+    }
   }
 
   /**
@@ -745,7 +766,7 @@ class ElasticSearch extends Service {
    *
    * @returns {Promise.<{ _id, _version, _source }>}
    */
-  replace (
+  async replace (
     index,
     collection,
     id,
@@ -772,21 +793,26 @@ class ElasticSearch extends Service {
       updater: getKuid(userId)
     };
 
-    return this._client.exists({ id, index: esIndex })
-      .then(({ body: exists }) => {
-        if (! exists) {
-          throw kerror.get('not_found', id, index, collection);
-        }
+    try {
+      const { body: exists } = await this._client.exists({ id, index: esIndex });
 
-        debug('Replace document: %o', esRequest);
-        return this._client.index(esRequest);
-      })
-      .then(({ body }) => ({
+      if (! exists) {
+        throw kerror.get('not_found', id, index, collection);
+      }
+
+      debug('Replace document: %o', esRequest);
+
+      const { body } = await this._client.index(esRequest);
+
+      return {
         _id: id,
         _source: esRequest.body,
         _version: body._version
-      }))
-      .catch(error => this._esWrapper.reject(error));
+      };
+    }
+    catch (error) {
+      this._esWrapper.reject(error);
+    }
   }
 
   /**
@@ -799,7 +825,7 @@ class ElasticSearch extends Service {
    *
    * @returns {Promise}
    */
-  delete (
+  async delete (
     index,
     collection,
     id,
@@ -814,9 +840,13 @@ class ElasticSearch extends Service {
     assertWellFormedRefresh(esRequest);
 
     debug('Delete document: %o', esRequest);
-    return this._client.delete(esRequest)
-      .then(() => null)
-      .catch(error => this._esWrapper.reject(error));
+
+    try {
+      await this._client.delete(esRequest);
+    }
+    catch (error) {
+      this._esWrapper.reject(error);
+    }
   }
 
   /**
@@ -1146,18 +1176,18 @@ class ElasticSearch extends Service {
     let body;
 
     try {
-      ({ body } = await this._client.cat.indices({ format: 'json' })); // NOSONAR
+      ({ body } = await this._client.cat.aliases({ format: 'json' })); // NOSONAR
     }
     catch (e) {
       return this._esWrapper.reject(e);
     }
 
-    const esIndexes = body.map(({ index: name }) => name);
+    const esIndexes = body.map(({ alias: name }) => name);
     for (const esIndex of esIndexes) {
       const indexName = this._extractIndex(esIndex);
 
       if (index === indexName) {
-        const indexType = esIndex[0] === PRIVATE_PREFIX
+        const indexType = esIndex[INDEX_PREFIX_POS] === PRIVATE_PREFIX
           ? 'private'
           : 'public';
 
@@ -1203,11 +1233,14 @@ class ElasticSearch extends Service {
     }
 
     const esRequest = {
+      aliases: {
+        [this._getESIndex(index, collection)]: {}
+      },
       body: {
         mappings: {},
         settings
       },
-      index: this._getESIndex(index, collection)
+      index: this._getSafeESIndex(index, collection),
     };
 
     this._checkDynamicProperty(mappings);
@@ -1252,7 +1285,7 @@ class ElasticSearch extends Service {
    *
    * @returns {Promise.<{ dynamic, _meta, properties }>}
    */
-  getMapping (index, collection, { includeKuzzleMeta=false } = {}) {
+  async getMapping (index, collection, { includeKuzzleMeta=false } = {}) {
     const
       esIndex = this._getESIndex(index, collection),
       esRequest = {
@@ -1261,19 +1294,22 @@ class ElasticSearch extends Service {
 
     debug('Get mapping: %o', esRequest);
 
-    return this._client.indices.getMapping(esRequest)
-      .then(({ body }) => {
-        const properties = includeKuzzleMeta
-          ? body[esIndex].mappings.properties
-          : _.omit(body[esIndex].mappings.properties, '_kuzzle_info');
+    try {
+      const { body } = await this._client.indices.getMapping(esRequest);
 
-        return {
-          _meta: body[esIndex].mappings._meta,
-          dynamic: body[esIndex].mappings.dynamic,
-          properties
-        };
-      })
-      .catch(error => this._esWrapper.reject(error));
+      const properties = includeKuzzleMeta
+        ? body[esIndex].mappings.properties
+        : _.omit(body[esIndex].mappings.properties, '_kuzzle_info');
+
+      return {
+        _meta: body[esIndex].mappings._meta,
+        dynamic: body[esIndex].mappings.dynamic,
+        properties
+      };
+    }
+    catch (error) {
+      this._esWrapper.reject(error);
+    }
   }
 
   /**
@@ -1449,22 +1485,29 @@ class ElasticSearch extends Service {
    *
    * @returns {Promise}
    */
-  truncateCollection (index, collection) {
+  async truncateCollection (index, collection) {
     let mappings;
 
     const esRequest = {
-      index: this._getESIndex(index, collection)
+      index: this._getESIndexFromAlias(index, collection)
     };
 
-    return this.getMapping(index, collection, { includeKuzzleMeta: true })
-      .then(collectionMappings => {
-        mappings = collectionMappings;
+    try {
+      mappings = await this.getMapping(index, collection, { includeKuzzleMeta: true });
 
-        return this._client.indices.delete(esRequest);
-      })
-      .then(() => this._client.indices.create({ ...esRequest, body: { mappings } }))
-      .then(() => null)
-      .catch(error => this._esWrapper.reject(error));
+      await this._client.indices.delete(esRequest);
+
+      await this._client.indices.create({
+        ...esRequest,
+        aliases: {
+          [this._getESIndex(index, collection)]: {}
+        },
+        body: { mappings },
+      });
+    }
+    catch (error) {
+      this._esWrapper.reject(error);
+    }
   }
 
   /**
@@ -1627,13 +1670,13 @@ class ElasticSearch extends Service {
     let body;
 
     try {
-      ({ body } = await this._client.cat.indices({ format: 'json' }));
+      ({ body } = await this._client.cat.aliases({ format: 'json' }));
     }
     catch (error) {
       throw this._esWrapper.formatESError(error);
     }
 
-    const esIndexes = body.map(({ index: esIndex }) => esIndex);
+    const esIndexes = body.map(({ alias: esIndex }) => esIndex);
 
     const schema = this._extractSchema(esIndexes, { includeHidden });
 
@@ -1649,13 +1692,13 @@ class ElasticSearch extends Service {
     let body;
 
     try {
-      ({ body } = await this._client.cat.indices({ format: 'json' }));
+      ({ body } = await this._client.cat.aliases({ format: 'json' }));
     }
     catch (error) {
       throw this._esWrapper.formatESError(error);
     }
 
-    const esIndexes = body.map(({ index }) => index);
+    const esIndexes = body.map(({ alias: index }) => index);
 
     const schema = this._extractSchema(esIndexes);
 
@@ -1668,16 +1711,19 @@ class ElasticSearch extends Service {
    * @returns {Object.<String, String[]>} Object<index, collections>
    */
   async getSchema () {
-    let body;
+    // This check avoids a breaking change for those who were using Kuzzle before
+    // alias attribution for each ES index was the standard ('auto-version')
+    this._ensureAliasConsistency();
 
+    let body;
     try {
-      ({ body } = await this._client.cat.indices({ format: 'json' }));
+      ({ body } = await this._client.cat.aliases({ format: 'json' }));
     }
     catch (error) {
       throw this._esWrapper.formatESError(error);
     }
 
-    const esIndexes = body.map(({ index }) => index);
+    const esIndexes = body.map(({ alias: index }) => index);
 
     const schema = this._extractSchema(esIndexes, { includeHidden: true });
 
@@ -1706,7 +1752,7 @@ class ElasticSearch extends Service {
     const aliases = [];
 
     for (const { alias, index: esIndex } of body) {
-      if (alias[0] === this._indexPrefix) {
+      if (alias[INDEX_PREFIX_POS] === this._indexPrefix) {
         aliases.push({
           collection: this._extractCollection(alias),
           index: this._extractIndex(alias),
@@ -1727,7 +1773,7 @@ class ElasticSearch extends Service {
    */
   async deleteCollection (index, collection) {
     const esRequest = {
-      index: this._getESIndex(index, collection)
+      index: this._getESIndexFromAlias(index, collection)
     };
 
     const mutex = new Mutex(`hiddenCollection/delete/${index}`);
@@ -1757,37 +1803,37 @@ class ElasticSearch extends Service {
    *
    * @returns {Promise.<String[]>}
    */
-  deleteIndexes (indexes = []) {
+  async deleteIndexes (indexes = []) {
     if (indexes.length === 0) {
       return Bluebird.resolve([]);
     }
     const deleted = new Set();
 
-    return this._client.cat.indices({ format: 'json' })
-      .then(({ body }) => {
-        const
-          esIndexes = body
-            .map(({ index }) => index)
-            .filter(esIndex => {
-              const index = this._extractIndex(esIndex);
+    try {
+      const { body } = await this._client.cat.aliases({ format: 'json' });
 
-              if (esIndex[0] !== this._indexPrefix || ! indexes.includes(index)) {
-                return false;
-              }
+      const esRequest = body.reduce((request, { alias, index: esIndex }) => {
+        const index = this._extractIndex(alias);
 
-              deleted.add(index);
+        if (alias[INDEX_PREFIX_POS] !== this._indexPrefix || ! indexes.includes(index)) {
+          return request;
+        }
 
-              return true;
-            }),
-          esRequest = {
-            index: esIndexes
-          };
+        deleted.add(index);
+        request.index.push(esIndex);
 
-        debug('Delete indexes: %o', esRequest);
-        return this._client.indices.delete(esRequest);
-      })
-      .then(() => Array.from(deleted))
-      .catch(error => this._esWrapper.reject(error));
+        return request;
+      }, { index: [] });
+
+      debug('Delete indexes: %o', esRequest);
+
+      await this._client.indices.delete(esRequest);
+    }
+    catch (error) {
+      this._esWrapper.reject(error);
+    }
+
+    return Array.from(deleted);
   }
 
   /**
@@ -1839,28 +1885,20 @@ class ElasticSearch extends Service {
    *
    * @returns {Promise.<boolean>}
    */
-  exists (index, collection, id) {
+  async exists (index, collection, id) {
     const esRequest = {
       id,
       index: this._getESIndex(index, collection)
     };
 
-    return this._client.exists(esRequest)
-      .then(({ body: exists }) => exists)
-      .catch(error => this._esWrapper.reject(error));
-  }
+    try {
+      const { body: exists} = await this._client.exists(esRequest);
 
-  /**
-   * Returns true if the index exists
-   *
-   * @param {String} index - Index name
-   *
-   * @returns {Promise.<boolean>}
-   */
-  async hasIndex (index) {
-    const indexes = await this.listIndexes();
-
-    return indexes.some(idx => idx === index);
+      return exists;
+    }
+    catch (error) {
+      this._esWrapper.reject(error);
+    }
   }
 
   /**
@@ -2620,15 +2658,124 @@ class ElasticSearch extends Service {
   }
 
   /**
-   * Gets the name of an esIndex for an index + collection
+   * Given index + collection, returns the well formated esIndex alias name
    *
    * @param {String} index
    * @param {String} collection
    *
-   * @returns {String} esIndex name (eg: '&nepali#liia')
+   * @returns {String} esIndex name (eg: '@&nepali.liia')
    */
   _getESIndex (index, collection) {
-    return `${this._indexPrefix}${index}${NAME_SEPARATOR}${collection}`;
+    return `${ALIAS_PREFIX}${this._indexPrefix}${index}${NAME_SEPARATOR}${collection}`;
+  }
+
+  /**
+   * Gets the concrete esIndex name from an alias (index + collection)
+   *
+   * @param {String} index
+   * @param {String} collection
+   *
+   * @returns {String} esIndex name (eg: '&nepali.liia')
+   * @throws If there is no esIndex related to this alias (index + collection)
+   */
+  async _getESIndexFromAlias (index, collection) {
+    const alias = `${ALIAS_PREFIX}${this._indexPrefix}${index}${NAME_SEPARATOR}${collection}`;
+    const { body } = await this._client.cat.aliases({ format: 'json', name: alias });
+
+    if (body.length() < 1) {
+      throw kerror.get('unknown_index_collection');
+    }
+    else if (body.length() > 1) {
+      throw kerror.get('multiple_index_alias', 'alias', 'index');
+    }
+
+    return body[0].index;
+  }
+
+  /**
+   * Gets the alias name from a concrete esIndex
+   *
+   * @param {String} esIndex
+   *
+   * @returns {String} alias name (eg: '@&nepali.liia')
+   * @throws If there is no alias related to this esIndex
+   */
+  async _getAliasFromESIndex (esIndex) {
+    const { body } = await this._client.indices.getAlias({ index: esIndex});
+    const aliases = Object.keys(body[esIndex].aliases);
+
+    if (aliases.length() < 1) {
+      throw kerror.get('unknown_index_collection');
+    }
+    else if (body.length() > 1) {
+      throw kerror.get('multiple_index_alias', 'index', 'alias');
+    }
+
+    return aliases[0];
+  }
+
+  /**
+   * Gets the concrete esIndex name from an alias (index + collection)
+   *
+   * @param {String} esIndex
+   *
+   * @returns {boolean} `true` if the raw ES index name is available, `false` otherwise
+   */
+  async _isESIndexAvailable (esIndex) {
+    const { body } = await this._client.indices.get({ index: esIndex });
+
+    return body.length() === 0;
+  }
+
+  /**
+   * Gets the concrete esIndex name from an alias (index + collection)
+   *
+   * @param {String} index
+   * @param {String} collection Default to `HIDDEN_COLLECTION`
+   *
+   * @returns {String} Available esIndex name (eg: '&nepali.liia')
+   */
+  async _getSafeESIndex (index, collection = HIDDEN_COLLECTION) {
+    let esIndex = `${this._indexPrefix}${index}${NAME_SEPARATOR}${collection}`;
+    let available = await this._isESIndexAvailable(esIndex);
+
+    while (! available) {
+      esIndex = generateRandomCustom(
+        (adjective, name) => `${this._indexPrefix}${adjective}${NAME_SEPARATOR}${name}`);
+
+      available = Buffer.from(esIndex).length < 255 && await this._isESIndexAvailable(esIndex);
+    }
+
+    return esIndex;
+  }
+
+  /**
+   * Check for each ES index whether it has an alias or not.
+   * When the latter is missing, create one based on the actual index name.
+   *
+   * This check avoids a breaking change for those who were using Kuzzle before
+   * alias attribution for each ES index turned into a standard ('auto-version').
+   */
+  async _ensureAliasConsistency () {
+    try {
+      const { body } = await this._client.cat.indices({ format: 'json' });
+      const esIndexes = body.map(({ index }) => index);
+      const aliases = await this.listAliases();
+
+      const indexesWithoutAlias = esIndexes.filter((index) => {
+        return ! aliases.some((alias) => alias.name === index);
+      });
+
+      let esRequest = { actions : [] };
+      for (const index of indexesWithoutAlias) {
+        esRequest.actions.push({ add : { alias: `@${index}`, index } });
+      }
+
+      await this._client.indices.updateAliases(esRequest);
+    }
+    catch (error) {
+      throw this._esWrapper.formatESError(error);
+    }
   }
 
   /**
@@ -2655,7 +2802,9 @@ class ElasticSearch extends Service {
    * @returns {String} index name
    */
   _extractIndex (esIndex) {
-    return esIndex.substr(1, esIndex.indexOf(NAME_SEPARATOR) - 1);
+    return esIndex.substr(
+      esIndex.indexOf(this._indexPrefix) + 1,
+      esIndex.indexOf(NAME_SEPARATOR) - 1 );
   }
 
   /**
@@ -2685,10 +2834,10 @@ class ElasticSearch extends Service {
 
     for (const esIndex of esIndexes) {
       const [ indexName, collectionName ] = esIndex
-        .substr(1, esIndex.length)
+        .substr(esIndex.indexOf(this._indexPrefix) + 1, esIndex.length)
         .split(NAME_SEPARATOR);
 
-      if ( esIndex[0] === this._indexPrefix
+      if ( esIndex[INDEX_PREFIX_POS] === this._indexPrefix
         && (collectionName !== HIDDEN_COLLECTION || includeHidden)
       ) {
         if (! schema[indexName]) {
@@ -2710,15 +2859,19 @@ class ElasticSearch extends Service {
    * @param {String} index Index name
    */
   async _createHiddenCollection (index) {
+
     try {
       await this._client.indices.create({
+        aliases: {
+          [this._getESIndex(index, HIDDEN_COLLECTION)]: {}
+        },
         body: {
           settings: {
             number_of_replicas: 1,
             number_of_shards: 1,
           }
         },
-        index: this._getESIndex(index, HIDDEN_COLLECTION),
+        index: this._getSafeESIndex(index),
       });
     }
     catch (e) {

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -50,7 +50,8 @@ const CHILD_MAPPING_PROPERTIES = ['type'];
 const HIDDEN_COLLECTION = '_kuzzle_keep';
 const PRIVATE_PREFIX = '%';
 const PUBLIC_PREFIX = '&';
-const INDEX_PREFIX_POS = 1; // For index alias name (O for raw index name)
+const INDEX_PREFIX_POSITON_IN_INDEX = 0;
+const INDEX_PREFIX_POSITON_IN_ALIAS = 1;
 const ALIAS_PREFIX = '@'; // @todo next major release: Add ALIAS_PREFIX in FORBIDDEN_CHARS
 const NAME_SEPARATOR = '.';
 const FORBIDDEN_CHARS = `\\/*?"<>| \t\r\n,+#:${NAME_SEPARATOR}${PUBLIC_PREFIX}${PRIVATE_PREFIX}`;
@@ -242,7 +243,7 @@ class ElasticSearch extends Service {
       const indexName = this._extractIndex(alias);
       const collectionName = this._extractCollection(alias);
 
-      if ( alias[INDEX_PREFIX_POS] !== this._indexPrefix || collectionName === HIDDEN_COLLECTION ) {
+      if ( alias[INDEX_PREFIX_POSITON_IN_ALIAS] !== this._indexPrefix || collectionName === HIDDEN_COLLECTION ) {
         continue;
       }
 
@@ -1187,7 +1188,7 @@ class ElasticSearch extends Service {
       const indexName = this._extractIndex(esIndex);
 
       if (index === indexName) {
-        const indexType = esIndex[INDEX_PREFIX_POS] === PRIVATE_PREFIX
+        const indexType = esIndex[INDEX_PREFIX_POSITON_IN_ALIAS] === PRIVATE_PREFIX
           ? 'private'
           : 'public';
 
@@ -1752,7 +1753,7 @@ class ElasticSearch extends Service {
     const aliases = [];
 
     for (const { alias, index: esIndex } of body) {
-      if (alias[INDEX_PREFIX_POS] === this._indexPrefix) {
+      if (alias[INDEX_PREFIX_POSITON_IN_ALIAS] === this._indexPrefix) {
         aliases.push({
           collection: this._extractCollection(alias),
           index: this._extractIndex(alias),
@@ -1815,7 +1816,7 @@ class ElasticSearch extends Service {
       const esRequest = body.reduce((request, { alias, index: esIndex }) => {
         const index = this._extractIndex(alias);
 
-        if (alias[INDEX_PREFIX_POS] !== this._indexPrefix || ! indexes.includes(index)) {
+        if (alias[INDEX_PREFIX_POSITON_IN_ALIAS] !== this._indexPrefix || ! indexes.includes(index)) {
           return request;
         }
 
@@ -2676,7 +2677,7 @@ class ElasticSearch extends Service {
    * @param {String} collection
    *
    * @returns {String} esIndex name (eg: '&nepali.liia')
-   * @throws If there is no esIndex related to this alias (index + collection)
+   * @throws If there is not exactly one esIndex related to this alias (index + collection)
    */
   async _getESIndexFromAlias (index, collection) {
     const alias = `${ALIAS_PREFIX}${this._indexPrefix}${index}${NAME_SEPARATOR}${collection}`;
@@ -2698,7 +2699,7 @@ class ElasticSearch extends Service {
    * @param {String} esIndex
    *
    * @returns {String} alias name (eg: '@&nepali.liia')
-   * @throws If there is no alias related to this esIndex
+   * @throws If there is not exactly one alias related to this esIndex
    */
   async _getAliasFromESIndex (esIndex) {
     const { body } = await this._client.indices.getAlias({ index: esIndex});
@@ -2736,7 +2737,7 @@ class ElasticSearch extends Service {
    * @returns {String} Available esIndex name (eg: '&nepali.liia')
    */
   async _getSafeESIndex (index, collection = HIDDEN_COLLECTION) {
-    let esIndex = `${this._indexPrefix}${index}${NAME_SEPARATOR}${collection}`;
+    let esIndex = this._getESIndex(index, collection).substr(INDEX_PREFIX_POSITON_IN_ALIAS);
     let available = await this._isESIndexAvailable(esIndex);
 
     while (! available) {
@@ -2762,9 +2763,9 @@ class ElasticSearch extends Service {
       const esIndexes = body.map(({ index }) => index);
       const aliases = await this.listAliases();
 
-      const indexesWithoutAlias = esIndexes.filter((index) => {
-        return ! aliases.some((alias) => alias.name === index);
-      });
+      const indexesWithoutAlias = esIndexes.filter((index) =>
+        index[INDEX_PREFIX_POSITON_IN_INDEX] !== this._indexPrefix
+        && ! aliases.some((alias) => alias.name === index));
 
       let esRequest = { actions : [] };
       for (const index of indexesWithoutAlias) {
@@ -2837,7 +2838,7 @@ class ElasticSearch extends Service {
         .substr(esIndex.indexOf(this._indexPrefix) + 1, esIndex.length)
         .split(NAME_SEPARATOR);
 
-      if ( esIndex[INDEX_PREFIX_POS] === this._indexPrefix
+      if ( esIndex[INDEX_PREFIX_POSITON_IN_ALIAS] === this._indexPrefix
         && (collectionName !== HIDDEN_COLLECTION || includeHidden)
       ) {
         if (! schema[indexName]) {

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -39,7 +39,7 @@ const { isPlainObject } = require('../../util/safeObject');
 const scopeEnum = require('../../core/storage/storeScopeEnum');
 const extractFields = require('../../util/extractFields');
 const { Mutex } = require('../../util/mutex');
-const { generateRandomCustom } = require('../../util/name-generator');
+const { randomNumber } = require('../../util/name-generator');
 
 const SCROLL_CACHE_PREFIX = '_docscroll_';
 
@@ -48,11 +48,11 @@ const CHILD_MAPPING_PROPERTIES = ['type'];
 
 // Used for collection emulation
 const HIDDEN_COLLECTION = '_kuzzle_keep';
+const ALIAS_PREFIX = '@'; // @todo next major release: Add ALIAS_PREFIX in FORBIDDEN_CHARS
 const PRIVATE_PREFIX = '%';
 const PUBLIC_PREFIX = '&';
-const INDEX_PREFIX_POSITON_IN_INDEX = 0;
-const INDEX_PREFIX_POSITON_IN_ALIAS = 1;
-const ALIAS_PREFIX = '@'; // @todo next major release: Add ALIAS_PREFIX in FORBIDDEN_CHARS
+const INDEX_PREFIX_POSITION_IN_INDICE = 0;
+const INDEX_PREFIX_POSITION_IN_ALIAS = 1;
 const NAME_SEPARATOR = '.';
 const FORBIDDEN_CHARS = `\\/*?"<>| \t\r\n,+#:${NAME_SEPARATOR}${PUBLIC_PREFIX}${PRIVATE_PREFIX}`;
 const DYNAMIC_PROPERTY_VALUES = ['true', 'false', 'strict'];
@@ -238,12 +238,13 @@ class ElasticSearch extends Service {
     const indexes = {};
     let size = 0;
 
-    for (const [esIndex, esIndexInfo] of Object.entries(body.indices)) {
-      const alias = await this._getAliasFromESIndex(esIndex);
+    for (const [indice, indiceInfo] of Object.entries(body.indices)) {
+      const alias = await this._getAliasFromIndice(indice);
       const indexName = this._extractIndex(alias);
       const collectionName = this._extractCollection(alias);
 
-      if ( alias[INDEX_PREFIX_POSITON_IN_ALIAS] !== this._indexPrefix || collectionName === HIDDEN_COLLECTION ) {
+      if ( alias[INDEX_PREFIX_POSITION_IN_ALIAS] !== this._indexPrefix
+        || collectionName === HIDDEN_COLLECTION ) {
         continue;
       }
 
@@ -255,12 +256,12 @@ class ElasticSearch extends Service {
         };
       }
       indexes[indexName].collections.push({
-        documentCount: esIndexInfo.total.docs.count,
+        documentCount: indiceInfo.total.docs.count,
         name: collectionName,
-        size: esIndexInfo.total.store.size_in_bytes,
+        size: indiceInfo.total.store.size_in_bytes,
       });
-      indexes[indexName].size += esIndexInfo.total.store.size_in_bytes;
-      size += esIndexInfo.total.store.size_in_bytes;
+      indexes[indexName].size += indiceInfo.total.store.size_in_bytes;
+      size += indiceInfo.total.store.size_in_bytes;
     }
 
     return {
@@ -354,7 +355,7 @@ class ElasticSearch extends Service {
     const esRequest = {
       body: this._sanitizeSearchBody(searchBody),
       from,
-      index: this._getESIndex(index, collection),
+      index: this._getAlias(index, collection),
       scroll,
       size,
       trackTotalHits: true,
@@ -423,7 +424,7 @@ class ElasticSearch extends Service {
   async get (index, collection, id) {
     const esRequest = {
       id,
-      index: this._getESIndex(index, collection)
+      index: this._getAlias(index, collection)
     };
 
     // Just in case the user make a GET on url /mainindex/test/_search
@@ -445,7 +446,7 @@ class ElasticSearch extends Service {
       };
     }
     catch (error) {
-      return this._esWrapper.reject(error);
+      throw this._esWrapper.formatESError(error);
     }
   }
 
@@ -465,13 +466,11 @@ class ElasticSearch extends Service {
       return { errors: [], item: [] };
     }
 
-    const
-      esIndex = this._getESIndex(index, collection),
-      esRequest = {
-        body: {
-          docs: ids.map(_id => ({ _id, _index: esIndex }))
-        }
-      };
+    const esRequest = {
+      body: {
+        docs: ids.map(_id => ({ _id, _index: this._getAlias(index, collection)}))
+      }
+    };
 
     debug('Multi-get documents: %o', esRequest);
 
@@ -518,7 +517,7 @@ class ElasticSearch extends Service {
   async count (index, collection, searchBody = {}) {
     const esRequest = {
       body: this._sanitizeSearchBody(searchBody),
-      index: this._getESIndex(index, collection)
+      index: this._getAlias(index, collection)
     };
 
     debug('Count: %o', esRequest);
@@ -528,7 +527,7 @@ class ElasticSearch extends Service {
       return body.count;
     }
     catch (error) {
-      return this._esWrapper.reject(error);
+      throw this._esWrapper.formatESError(error);
     }
   }
 
@@ -554,7 +553,7 @@ class ElasticSearch extends Service {
     const esRequest = {
       body: content,
       id,
-      index: this._getESIndex(index, collection),
+      index: this._getAlias(index, collection),
       op_type: id ? 'create' : 'index',
       refresh
     };
@@ -582,7 +581,7 @@ class ElasticSearch extends Service {
       };
     }
     catch (error) {
-      return this._esWrapper.reject(error);
+      throw this._esWrapper.formatESError(error);
     }
   }
 
@@ -607,7 +606,7 @@ class ElasticSearch extends Service {
     const esRequest = {
       body: content,
       id,
-      index: this._getESIndex(index, collection),
+      index: this._getAlias(index, collection),
       refresh
     };
 
@@ -637,7 +636,7 @@ class ElasticSearch extends Service {
       };
     }
     catch (error) {
-      return this._esWrapper.reject(error);
+      throw this._esWrapper.formatESError(error);
     }
   }
 
@@ -663,7 +662,7 @@ class ElasticSearch extends Service {
       _source: true,
       body: { doc: content },
       id,
-      index: this._getESIndex(index, collection),
+      index: this._getAlias(index, collection),
       refresh,
       retry_on_conflict: retryOnConflict || this._config.defaults.onUpdateConflictRetries
     };
@@ -688,7 +687,7 @@ class ElasticSearch extends Service {
       };
     }
     catch (error) {
-      return this._esWrapper.reject(error);
+      throw this._esWrapper.formatESError(error);
     }
   }
 
@@ -718,7 +717,7 @@ class ElasticSearch extends Service {
         upsert: { ...defaultValues, ...content },
       },
       id,
-      index: this._getESIndex(index, collection),
+      index: this._getAlias(index, collection),
       refresh,
       retry_on_conflict: retryOnConflict || this._config.defaults.onUpdateConflictRetries,
     };
@@ -774,14 +773,13 @@ class ElasticSearch extends Service {
     content,
     { refresh, userId=null } = {})
   {
-    const
-      esIndex = this._getESIndex(index, collection),
-      esRequest = {
-        body: content,
-        id,
-        index: esIndex,
-        refresh
-      };
+    const alias = this._getAlias(index, collection);
+    const esRequest = {
+      body: content,
+      id,
+      index: alias,
+      refresh
+    };
 
     assertNoRouting(esRequest);
     assertWellFormedRefresh(esRequest);
@@ -795,7 +793,7 @@ class ElasticSearch extends Service {
     };
 
     try {
-      const { body: exists } = await this._client.exists({ id, index: esIndex });
+      const { body: exists } = await this._client.exists({ id, index: alias });
 
       if (! exists) {
         throw kerror.get('not_found', id, index, collection);
@@ -812,7 +810,7 @@ class ElasticSearch extends Service {
       };
     }
     catch (error) {
-      return this._esWrapper.reject(error);
+      throw this._esWrapper.formatESError(error);
     }
   }
 
@@ -834,7 +832,7 @@ class ElasticSearch extends Service {
   {
     const esRequest = {
       id,
-      index: this._getESIndex(index, collection),
+      index: this._getAlias(index, collection),
       refresh
     };
 
@@ -846,7 +844,7 @@ class ElasticSearch extends Service {
       await this._client.delete(esRequest);
     }
     catch (error) {
-      return this._esWrapper.reject(error);
+      throw this._esWrapper.formatESError(error);
     }
     return null;
   }
@@ -875,7 +873,7 @@ class ElasticSearch extends Service {
   {
     const esRequest = {
       body: this._sanitizeSearchBody({ query }),
-      index: this._getESIndex(index, collection),
+      index: this._getAlias(index, collection),
       scroll: '5s',
       size
     };
@@ -928,10 +926,10 @@ class ElasticSearch extends Service {
     fields,
     { refresh, userId=null } = {})
   {
-    const esIndex = this._getESIndex(index, collection);
+    const alias = this._getAlias(index, collection);
     const esRequest = {
       id,
-      index: esIndex,
+      index: alias,
     };
 
     try {
@@ -953,7 +951,7 @@ class ElasticSearch extends Service {
       const newEsRequest = {
         body: body._source,
         id,
-        index: esIndex,
+        index: alias,
         refresh
       };
 
@@ -994,7 +992,7 @@ class ElasticSearch extends Service {
     try {
       const esRequest = {
         body: this._sanitizeSearchBody({ query }),
-        index: this._getESIndex(index, collection),
+        index: this._getAlias(index, collection),
         scroll: '5s',
         size
       };
@@ -1061,7 +1059,7 @@ class ElasticSearch extends Service {
         query: this._sanitizeSearchBody({ query }).query,
         script,
       },
-      index: this._getESIndex(index, collection),
+      index: this._getAlias(index, collection),
       refresh
     };
 
@@ -1109,7 +1107,7 @@ class ElasticSearch extends Service {
     const esRequest = {
       body: this._sanitizeSearchBody({ query }),
       from: 0,
-      index: this._getESIndex(index, collection),
+      index: this._getAlias(index, collection),
       scroll: scrollTTl,
       size
     };
@@ -1180,16 +1178,16 @@ class ElasticSearch extends Service {
     try {
       ({ body } = await this._client.cat.aliases({ format: 'json' })); // NOSONAR
     }
-    catch (e) {
-      return this._esWrapper.reject(e);
+    catch (error) {
+      throw this._esWrapper.formatESError(error);
     }
 
-    const esIndexes = body.map(({ alias: name }) => name);
-    for (const esIndex of esIndexes) {
-      const indexName = this._extractIndex(esIndex);
+    const aliases = body.map(({ alias: name }) => name);
+    for (const alias of aliases) {
+      const indexName = this._extractIndex(alias);
 
       if (index === indexName) {
-        const indexType = esIndex[INDEX_PREFIX_POSITON_IN_ALIAS] === PRIVATE_PREFIX
+        const indexType = alias[INDEX_PREFIX_POSITION_IN_ALIAS] === PRIVATE_PREFIX
           ? 'private'
           : 'public';
 
@@ -1237,12 +1235,12 @@ class ElasticSearch extends Service {
     const esRequest = {
       body: {
         aliases: {
-          [this._getESIndex(index, collection)]: {}
+          [this._getAlias(index, collection)]: {}
         },
         mappings: {},
         settings
       },
-      index: await this._getSafeESIndex(index, collection),
+      index: await this._getAvailableIndice(index, collection),
     };
 
     this._checkDynamicProperty(mappings);
@@ -1267,7 +1265,7 @@ class ElasticSearch extends Service {
     }
     catch (error) {
       if (_.get(error, 'meta.body.error.type') === 'resource_already_exists_exception') {
-        // race condition: the index has been created between the "exists"
+        // race condition: the indice has been created between the "exists"
         // check above and this "create" attempt
         return null;
       }
@@ -1289,9 +1287,9 @@ class ElasticSearch extends Service {
    */
   async getMapping (index, collection, { includeKuzzleMeta=false } = {}) {
     const
-      esIndex = await this._getESIndexFromAlias(index, collection),
+      indice = await this._getIndice(index, collection),
       esRequest = {
-        index: esIndex
+        index: indice
       };
 
     debug('Get mapping: %o', esRequest);
@@ -1300,17 +1298,17 @@ class ElasticSearch extends Service {
       const { body } = await this._client.indices.getMapping(esRequest);
 
       const properties = includeKuzzleMeta
-        ? body[esIndex].mappings.properties
-        : _.omit(body[esIndex].mappings.properties, '_kuzzle_info');
+        ? body[indice].mappings.properties
+        : _.omit(body[indice].mappings.properties, '_kuzzle_info');
 
       return {
-        _meta: body[esIndex].mappings._meta,
-        dynamic: body[esIndex].mappings.dynamic,
+        _meta: body[indice].mappings._meta,
+        dynamic: body[indice].mappings.dynamic,
         properties
       };
     }
     catch (error) {
-      return this._esWrapper.reject(error);
+      throw this._esWrapper.formatESError(error);
     }
   }
 
@@ -1325,17 +1323,17 @@ class ElasticSearch extends Service {
    */
   async updateCollection (index, collection, { mappings={}, settings={} } = {}) {
     const esRequest = {
-      index: await this._getESIndexFromAlias(index, collection)
+      index: await this._getIndice(index, collection)
     };
 
     // If either the putMappings or the putSettings operation fail, we need to
     // rollback the whole operation. Since mappings can't be rollback, we try to
     // update the settings first, then the mappings and we rollback the settings
     // if putMappings fail.
-    let esIndexSettings;
+    let indiceSettings;
     try {
       const response = await this._client.indices.getSettings(esRequest);
-      esIndexSettings = response.body[esRequest.index].settings;
+      indiceSettings = response.body[esRequest.index].settings;
     }
     catch (error) {
       throw this._esWrapper.formatESError(error);
@@ -1359,7 +1357,7 @@ class ElasticSearch extends Service {
     catch (error) {
       const allowedSettings = {
         index: _.omit(
-          esIndexSettings.index,
+          indiceSettings.index,
           ['creation_date', 'provided_name', 'uuid', 'version'])
       };
 
@@ -1386,7 +1384,7 @@ class ElasticSearch extends Service {
       body: {},
       // @cluster: conflicts when two nodes start at the same time
       conflicts: 'proceed',
-      index: this._getESIndex(index, collection),
+      index: this._getAlias(index, collection),
       refresh: true,
       // This operation can take some time: this should be an ES
       // background task. And it's preferable to a request timeout when
@@ -1415,7 +1413,7 @@ class ElasticSearch extends Service {
    */
   async updateMapping (index, collection, mappings = {}) {
     const esRequest = {
-      index: this._getESIndex(index, collection)
+      index: this._getAlias(index, collection)
     };
 
     this._checkDynamicProperty(mappings);
@@ -1461,7 +1459,7 @@ class ElasticSearch extends Service {
    */
   async updateSettings (index, collection, settings = {}) {
     const esRequest = {
-      index: this._getESIndex(index, collection)
+      index: this._getAlias(index, collection)
     };
 
     await this._client.indices.close(esRequest);
@@ -1491,7 +1489,7 @@ class ElasticSearch extends Service {
     let mappings;
 
     const esRequest = {
-      index: await this._getESIndexFromAlias(index, collection)
+      index: await this._getIndice(index, collection)
     };
 
     try {
@@ -1503,7 +1501,7 @@ class ElasticSearch extends Service {
         ...esRequest,
         body: {
           aliases: {
-            [this._getESIndex(index, collection)]: {}
+            [this._getAlias(index, collection)]: {}
           },
           mappings
         }
@@ -1512,7 +1510,7 @@ class ElasticSearch extends Service {
       return null;
     }
     catch (error) {
-      return this._esWrapper.reject(error);
+      throw this._esWrapper.formatESError(error);
     }
   }
 
@@ -1532,7 +1530,7 @@ class ElasticSearch extends Service {
     documents,
     { refresh, timeout, userId=null } = {})
   {
-    const esIndex = this._getESIndex(index, collection);
+    const alias = this._getAlias(index, collection);
     const actionNames = ['index', 'create', 'update', 'delete'];
     const dateNow = Date.now();
     const esRequest = {
@@ -1570,7 +1568,7 @@ class ElasticSearch extends Service {
       if (actionNames.indexOf(action) !== -1) {
         lastAction = action;
 
-        item[action]._index = esIndex;
+        item[action]._index = alias;
 
         if (item[action]._type) {
           item[action]._type = undefined;
@@ -1682,9 +1680,9 @@ class ElasticSearch extends Service {
       throw this._esWrapper.formatESError(error);
     }
 
-    const esIndexes = body.map(({ alias: esIndex }) => esIndex);
+    const aliases = body.map(({ alias }) => alias);
 
-    const schema = this._extractSchema(esIndexes, { includeHidden });
+    const schema = this._extractSchema(aliases, { includeHidden });
 
     return schema[index] || [];
   }
@@ -1704,9 +1702,9 @@ class ElasticSearch extends Service {
       throw this._esWrapper.formatESError(error);
     }
 
-    const esIndexes = body.map(({ alias: index }) => index);
+    const aliases = body.map(({ alias }) => alias);
 
-    const schema = this._extractSchema(esIndexes);
+    const schema = this._extractSchema(aliases);
 
     return Object.keys(schema);
   }
@@ -1718,7 +1716,7 @@ class ElasticSearch extends Service {
    */
   async getSchema () {
     // This check avoids a breaking change for those who were using Kuzzle before
-    // alias attribution for each ES index was the standard ('auto-version')
+    // alias attribution for each indice was the standard ('auto-version')
     await this._ensureAliasConsistency();
 
     let body;
@@ -1729,9 +1727,9 @@ class ElasticSearch extends Service {
       throw this._esWrapper.formatESError(error);
     }
 
-    const esIndexes = body.map(({ alias: index }) => index);
+    const aliases = body.map(({ alias }) => alias);
 
-    const schema = this._extractSchema(esIndexes, { includeHidden: true });
+    const schema = this._extractSchema(aliases, { includeHidden: true });
 
     for (const [index, collections] of Object.entries(schema)) {
       schema[index] = collections.filter(c => c !== HIDDEN_COLLECTION);
@@ -1743,7 +1741,7 @@ class ElasticSearch extends Service {
   /**
    * Retrieves the complete list of aliases
    *
-   * @returns {Promise.<Object[]>} [ { name, index, collection } ]
+   * @returns {Promise.<Object[]>} [ { alias, index, collection, indice } ]
    */
   async listAliases () {
     let body;
@@ -1757,12 +1755,13 @@ class ElasticSearch extends Service {
 
     const aliases = [];
 
-    for (const { alias, index: esIndex } of body) {
-      if (alias[INDEX_PREFIX_POSITON_IN_ALIAS] === this._indexPrefix) {
+    for (const { alias, index: indice } of body) {
+      if (alias[INDEX_PREFIX_POSITION_IN_ALIAS] === this._indexPrefix) {
         aliases.push({
+          alias,
           collection: this._extractCollection(alias),
           index: this._extractIndex(alias),
-          name: esIndex,
+          indice,
         });
       }
     }
@@ -1779,7 +1778,7 @@ class ElasticSearch extends Service {
    */
   async deleteCollection (index, collection) {
     const esRequest = {
-      index: await this._getESIndexFromAlias(index, collection)
+      index: await this._getIndice(index, collection)
     };
 
     const mutex = new Mutex(`hiddenCollection/delete/${index}`);
@@ -1818,15 +1817,15 @@ class ElasticSearch extends Service {
     try {
       const { body } = await this._client.cat.aliases({ format: 'json' });
 
-      const esRequest = body.reduce((request, { alias, index: esIndex }) => {
+      const esRequest = body.reduce((request, { alias, index: indice }) => {
         const index = this._extractIndex(alias);
 
-        if (alias[INDEX_PREFIX_POSITON_IN_ALIAS] !== this._indexPrefix || ! indexes.includes(index)) {
+        if (alias[INDEX_PREFIX_POSITION_IN_ALIAS] !== this._indexPrefix || ! indexes.includes(index)) {
           return request;
         }
 
         deleted.add(index);
-        request.index.push(esIndex);
+        request.index.push(indice);
 
         return request;
       }, { index: [] });
@@ -1836,7 +1835,7 @@ class ElasticSearch extends Service {
       await this._client.indices.delete(esRequest);
     }
     catch (error) {
-      return this._esWrapper.reject(error);
+      throw this._esWrapper.formatESError(error);
     }
 
     return Array.from(deleted);
@@ -1867,7 +1866,7 @@ class ElasticSearch extends Service {
    */
   async refreshCollection (index, collection) {
     const esRequest = {
-      index: this._getESIndex(index, collection),
+      index: this._getAlias(index, collection),
     };
 
     let _shards;
@@ -1894,7 +1893,7 @@ class ElasticSearch extends Service {
   async exists (index, collection, id) {
     const esRequest = {
       id,
-      index: this._getESIndex(index, collection)
+      index: this._getAlias(index, collection)
     };
 
     try {
@@ -1903,7 +1902,7 @@ class ElasticSearch extends Service {
       return exists;
     }
     catch (error) {
-      return this._esWrapper.reject(error);
+      throw this._esWrapper.formatESError(error);
     }
   }
 
@@ -1966,7 +1965,7 @@ class ElasticSearch extends Service {
     { refresh, timeout, userId=null } = {})
   {
     const
-      esIndex = this._getESIndex(index, collection),
+      alias = this._getAlias(index, collection),
       kuzzleMeta = {
         _kuzzle_info: {
           author: getKuid(userId),
@@ -1983,14 +1982,14 @@ class ElasticSearch extends Service {
 
     // prepare the mget request, but only for document having a specified id
     const {body} = documentsToGet.length > 0
-      ? await this._client.mget({body: {docs: documentsToGet}, index: esIndex})
+      ? await this._client.mget({body: {docs: documentsToGet}, index: alias})
       : {body: {docs: []}};
 
     const
       existingDocuments = body.docs,
       esRequest = {
         body: [],
-        index: esIndex,
+        index: alias,
         refresh,
         timeout
       },
@@ -2024,7 +2023,7 @@ class ElasticSearch extends Service {
           esRequest.body.push({
             index: {
               _id: document._id,
-              _index: esIndex
+              _index: alias
             }
           });
           esRequest.body.push(document._source);
@@ -2033,7 +2032,7 @@ class ElasticSearch extends Service {
         }
       }
       else {
-        esRequest.body.push({ index: { _index: esIndex } });
+        esRequest.body.push({ index: { _index: alias } });
         esRequest.body.push(document._source);
 
         toImport.push(document);
@@ -2073,10 +2072,10 @@ class ElasticSearch extends Service {
       };
     }
 
-    const esIndex = this._getESIndex(index, collection);
+    const alias = this._getAlias(index, collection);
     const esRequest = {
       body: [],
-      index: esIndex,
+      index: alias,
       refresh,
       timeout
     };
@@ -2096,7 +2095,7 @@ class ElasticSearch extends Service {
       esRequest.body.push({
         index: {
           _id: extractedDocuments[i]._id,
-          _index: esIndex
+          _index: alias
         }
       });
       esRequest.body.push(extractedDocuments[i]._source);
@@ -2125,11 +2124,11 @@ class ElasticSearch extends Service {
     { refresh, retryOnConflict = 0, timeout, userId=null } = {})
   {
     const
-      esIndex = this._getESIndex(index, collection),
+      alias = this._getAlias(index, collection),
       toImport = [],
       esRequest = {
         body: [],
-        index: esIndex,
+        index: alias,
         refresh,
         timeout
       },
@@ -2156,7 +2155,7 @@ class ElasticSearch extends Service {
         esRequest.body.push({
           update: {
             _id: extractedDocument._id,
-            _index: esIndex,
+            _index: alias,
             retry_on_conflict: retryOnConflict || this._config.defaults.onUpdateConflictRetries
           }
         });
@@ -2216,7 +2215,7 @@ class ElasticSearch extends Service {
     documents,
     { refresh, retryOnConflict = 0, timeout, userId=null } = {})
   {
-    const esIndex = this._getESIndex(index, collection);
+    const alias = this._getAlias(index, collection);
     const esRequest = {
       body: [],
       refresh,
@@ -2259,7 +2258,7 @@ class ElasticSearch extends Service {
         {
           update: {
             _id: extractedDocuments[i]._id,
-            _index: esIndex,
+            _index: alias,
             _source: true,
             retry_on_conflict: retryOnConflict || this._config.defaults.onUpdateConflictRetries
           }
@@ -2311,7 +2310,7 @@ class ElasticSearch extends Service {
     { refresh, timeout, userId=null } = {})
   {
     const
-      esIndex = this._getESIndex(index, collection),
+      alias = this._getAlias(index, collection),
       kuzzleMeta = {
         _kuzzle_info: {
           author: getKuid(userId),
@@ -2335,7 +2334,7 @@ class ElasticSearch extends Service {
 
     const {body} = await this._client.mget({
       body: { docs: documentsToGet },
-      index: esIndex
+      index: alias
     });
 
     const
@@ -2360,7 +2359,7 @@ class ElasticSearch extends Service {
         esRequest.body.push({
           index: {
             _id: document._id,
-            _index: esIndex
+            _index: alias
           }
         });
         esRequest.body.push(document._source);
@@ -2677,27 +2676,29 @@ class ElasticSearch extends Service {
   }
 
   /**
-   * Given index + collection, returns the well formatted esIndex alias name
+   * Given index + collection, returns the associated alias name.
+   * Prefer this function to `_getIndice` and `_getAvailableIndice` whenever it is possible.
    *
    * @param {String} index
    * @param {String} collection
    *
-   * @returns {String} esIndex name (eg: '@&nepali.liia')
+   * @returns {String} Alias name (eg: '@&nepali.liia')
    */
-  _getESIndex (index, collection) {
+  _getAlias (index, collection) {
     return `${ALIAS_PREFIX}${this._indexPrefix}${index}${NAME_SEPARATOR}${collection}`;
   }
 
   /**
-   * Gets the concrete esIndex name from an alias (index + collection)
+   * Given index + collection, returns the associated indice name.
+   * Use this function if ES does not accept aliases in the request. Otherwise use `_getAlias`.
    *
    * @param {String} index
    * @param {String} collection
    *
-   * @returns {String} esIndex name (eg: '&nepali.liia')
-   * @throws If there is not exactly one esIndex related to this alias (index + collection)
+   * @returns {String} Indice name (eg: '&nepali.liia')
+   * @throws If there is not exactly one indice associated
    */
-  async _getESIndexFromAlias (index, collection) {
+  async _getIndice (index, collection) {
     const alias = `${ALIAS_PREFIX}${this._indexPrefix}${index}${NAME_SEPARATOR}${collection}`;
     const { body } = await this._client.cat.aliases({ format: 'json', name: alias });
 
@@ -2705,87 +2706,88 @@ class ElasticSearch extends Service {
       throw kerror.get('unknown_index_collection');
     }
     else if (body.length > 1) {
-      throw kerror.get('multiple_index_alias', 'alias', 'index');
+      throw kerror.get('multiple_indice_alias', 'alias', 'indices');
     }
 
     return body[0].index;
   }
 
   /**
-   * Gets the alias name from a concrete esIndex
+   * Given index + collection, returns an available indice name.
+   * Use this function when creating the associated indice. Otherwise use `_getAlias`.
    *
-   * @param {String} esIndex
+   * @param {String} index
+   * @param {String} collection
    *
-   * @returns {String} alias name (eg: '@&nepali.liia')
-   * @throws If there is not exactly one alias related to this esIndex
+   * @returns {String} Available indice name (eg: '&nepali.liia2')
    */
-  async _getAliasFromESIndex (esIndex) {
-    const { body } = await this._client.indices.getAlias({ index: esIndex});
-    const aliases = Object.keys(body[esIndex].aliases);
+  async _getAvailableIndice (index, collection) {
+    let indice = this._getAlias(index, collection).substr(INDEX_PREFIX_POSITION_IN_ALIAS);
+
+    if (! (await this._client.indices.exists({ index: indice })).body) {
+      return indice;
+    }
+
+    let notAvailable;
+    let suffix;
+    do {
+      suffix = `.${randomNumber(100000)}`;
+
+      const overflow = Buffer.from(indice + suffix).length - 255;
+      if ( overflow > 0) {
+        const indiceBuffer = Buffer.from(indice);
+        indice = indiceBuffer.slice(0, indiceBuffer.length - overflow).toString();
+      }
+
+      notAvailable = await this._client.indices.exists({ index: indice + suffix }).body;
+    }
+    while (notAvailable);
+
+    return indice + suffix;
+  }
+
+  /**
+   * Given an indice, returns the associated alias name.
+   *
+   * @param {String} indice
+   *
+   * @returns {String} Alias name (eg: '@&nepali.liia')
+   * @throws If there is not exactly one alias associated
+   */
+  async _getAliasFromIndice (indice) {
+    const { body } = await this._client.indices.getAlias({ index: indice});
+    const aliases = Object.keys(body[indice].aliases);
 
     if (aliases.length < 1) {
       throw kerror.get('unknown_index_collection');
     }
     else if (aliases.length > 1) {
-      throw kerror.get('multiple_index_alias', 'index', 'alias');
+      throw kerror.get('multiple_indice_alias', 'indice', 'aliases');
     }
 
     return aliases[0];
   }
 
   /**
-   * Gets the concrete esIndex name from an alias (index + collection)
-   *
-   * @param {String} esIndex
-   *
-   * @returns {boolean} `true` if the raw ES index name is available, `false` otherwise
-   */
-  async _isESIndexAvailable (esIndex) {
-    return ! await this._client.indices.exists({ index: esIndex }).body;
-  }
-
-  /**
-   * Gets the concrete esIndex name from an alias (index + collection)
-   *
-   * @param {String} index
-   * @param {String} collection Default to `HIDDEN_COLLECTION`
-   *
-   * @returns {String} Available esIndex name (eg: '&nepali.liia')
-   */
-  async _getSafeESIndex (index, collection = HIDDEN_COLLECTION) {
-    let esIndex = this._getESIndex(index, collection).substr(INDEX_PREFIX_POSITON_IN_ALIAS);
-    let available = await this._isESIndexAvailable(esIndex);
-
-    while (! available) {
-      esIndex = generateRandomCustom(
-        (adjective, name) => `${this._indexPrefix}${adjective}${NAME_SEPARATOR}${name}`);
-
-      available = Buffer.from(esIndex).length < 255 && await this._isESIndexAvailable(esIndex);
-    }
-
-    return esIndex;
-  }
-
-  /**
-   * Check for each ES index whether it has an alias or not.
-   * When the latter is missing, create one based on the actual index name.
+   * Check for each indice whether it has an alias or not.
+   * When the latter is missing, create one based on the indice name.
    *
    * This check avoids a breaking change for those who were using Kuzzle before
-   * alias attribution for each ES index turned into a standard ('auto-version').
+   * alias attribution for each indice turned into a standard ('auto-version').
    */
   async _ensureAliasConsistency () {
     try {
       const { body } = await this._client.cat.indices({ format: 'json' });
-      const esIndexes = body.map(({ index }) => index);
+      const indices = body.map(({ index: indice }) => indice);
       const aliases = await this.listAliases();
 
-      const indexesWithoutAlias = esIndexes.filter(index =>
-              index[INDEX_PREFIX_POSITON_IN_INDEX] === this._indexPrefix
-        && ! aliases.some(alias => alias.name === index));
+      const indicesWithoutAlias = indices.filter(indice =>
+        indice[INDEX_PREFIX_POSITION_IN_INDICE] === this._indexPrefix
+        && ! aliases.some(alias => alias.indice === indice));
 
-      const esRequest = { body:{ actions : [] } };
-      for (const index of indexesWithoutAlias) {
-        esRequest.body.actions.push({ add : { alias: `${ALIAS_PREFIX}${index}`, index } });
+      const esRequest = { body: { actions : [] } };
+      for (const indice of indicesWithoutAlias) {
+        esRequest.body.actions.push({ add : { alias: `${ALIAS_PREFIX}${indice}`, index: indice } });
       }
 
       if (esRequest.body.actions.length > 0) {
@@ -2814,53 +2816,48 @@ class ElasticSearch extends Service {
   }
 
   /**
-   * Extracts the index name from esIndex name
+   * Given an alias, extract the associated index.
    *
-   * @param {String} esIndex
+   * @param {String} alias
    *
-   * @returns {String} index name
+   * @returns {String} Index name
    */
-  _extractIndex (esIndex) {
-    const prefixPosition = esIndex.search(ALIAS_PREFIX) === -1
-      ? INDEX_PREFIX_POSITON_IN_INDEX
-      : INDEX_PREFIX_POSITON_IN_ALIAS;
-
-    return esIndex.substr(
-      prefixPosition + 1,
-      esIndex.indexOf(NAME_SEPARATOR) - prefixPosition -1 );
+  _extractIndex (alias) {
+    return alias.substr(
+      INDEX_PREFIX_POSITION_IN_ALIAS + 1,
+      alias.indexOf(NAME_SEPARATOR) - INDEX_PREFIX_POSITION_IN_ALIAS -1 );
   }
 
   /**
-   * Extracts the collection name from esIndex name
+   * Given an alias, extract the associated collection.
    *
-   * @param {String} esIndex
+   * @param {String} alias
    *
-   * @returns {String} collection name
+   * @returns {String} Collection name
    */
-  _extractCollection (esIndex) {
-    const separatorPos = esIndex.indexOf(NAME_SEPARATOR);
+  _extractCollection (alias) {
+    const separatorPos = alias.indexOf(NAME_SEPARATOR);
 
-    return esIndex.substr(separatorPos + 1, esIndex.length);
+    return alias.substr(separatorPos + 1, alias.length);
   }
 
   /**
-   * Returns an object containing index names as keys and their collections
-   * as value.
+   * Given aliases, extract indexes and collections.
    *
-   * @param {Array.<String>} esIndexes
-   * @param {Object.Boolean} includeHidden
+   * @param {Array.<String>} aliases
+   * @param {Object.Boolean} includeHidden Only refers to `HIDDEN_COLLECTION` occurences. An empty index will still be listed. Default to `false`.
    *
-   * @returns {Object.<String, String[]>} indexes and their collections
+   * @returns {Object.<String, String[]>} Indexes as key and an array of their collections as value
    */
-  _extractSchema (esIndexes, { includeHidden = false } = {}) {
+  _extractSchema (aliases, { includeHidden = false } = {}) {
     const schema = {};
 
-    for (const esIndex of esIndexes) {
-      const [ indexName, collectionName ] = esIndex
-        .substr(esIndex.indexOf(this._indexPrefix) + 1, esIndex.length)
+    for (const alias of aliases) {
+      const [ indexName, collectionName ] = alias
+        .substr(INDEX_PREFIX_POSITION_IN_ALIAS + 1, alias.length)
         .split(NAME_SEPARATOR);
 
-      if ( esIndex[INDEX_PREFIX_POSITON_IN_ALIAS] === this._indexPrefix
+      if ( alias[INDEX_PREFIX_POSITION_IN_ALIAS] === this._indexPrefix
         && (collectionName !== HIDDEN_COLLECTION || includeHidden)
       ) {
         if (! schema[indexName]) {
@@ -2887,14 +2884,14 @@ class ElasticSearch extends Service {
       await this._client.indices.create({
         body: {
           aliases: {
-            [this._getESIndex(index, HIDDEN_COLLECTION)]: {}
+            [this._getAlias(index, HIDDEN_COLLECTION)]: {}
           },
           settings: {
             number_of_replicas: 1,
             number_of_shards: 1,
           }
         },
-        index: await this._getSafeESIndex(index),
+        index: await this._getAvailableIndice(index, HIDDEN_COLLECTION),
       });
     }
     catch (e) {
@@ -2903,9 +2900,9 @@ class ElasticSearch extends Service {
   }
 
   /**
-   * Scroll index in elasticsearch and return all document that match the filter
+   * Scroll indice in elasticsearch and return all document that match the filter
    * /!\ throws a write_limit_exceed error: this method is intended to be used
-   * by deleteByQuery
+   * by deleteByQuery and updateByQuery
    *
    * @param {Object} esRequest - Search request body
    *
@@ -3182,8 +3179,8 @@ function getKuid (userId) {
  *
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/7.4/indices-create-index.html
  *
- * Beware of the length check: ES allows index names up to 255 bytes, but since
- * in Kuzzle we emulate collections as indexes, we have to make sure
+ * Beware of the length check: ES allows indice names up to 255 bytes, but since
+ * in Kuzzle we emulate collections as indices, we have to make sure
  * that the privacy prefix, the index name, the separator and the collection
  * name ALL fit within the 255-bytes limit of Elasticsearch. The simplest way
  * is to limit index and collection names to 126 bytes and document that

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -239,7 +239,7 @@ class ElasticSearch extends Service {
     let size = 0;
 
     for (const [esIndex, esIndexInfo] of Object.entries(body.indices)) {
-      const alias = this._getAliasFromESIndex(esIndex);
+      const alias = await this._getAliasFromESIndex(esIndex);
       const indexName = this._extractIndex(alias);
       const collectionName = this._extractCollection(alias);
 
@@ -445,7 +445,7 @@ class ElasticSearch extends Service {
       };
     }
     catch (error) {
-      this._esWrapper.reject(error);
+      return this._esWrapper.reject(error);
     }
   }
 
@@ -528,7 +528,7 @@ class ElasticSearch extends Service {
       return body.count;
     }
     catch (error) {
-      this._esWrapper.reject(error);
+      return this._esWrapper.reject(error);
     }
   }
 
@@ -637,7 +637,7 @@ class ElasticSearch extends Service {
       };
     }
     catch (error) {
-      this._esWrapper.reject(error);
+      return this._esWrapper.reject(error);
     }
   }
 
@@ -688,7 +688,7 @@ class ElasticSearch extends Service {
       };
     }
     catch (error) {
-      this._esWrapper.reject(error);
+      return this._esWrapper.reject(error);
     }
   }
 
@@ -812,7 +812,7 @@ class ElasticSearch extends Service {
       };
     }
     catch (error) {
-      this._esWrapper.reject(error);
+      return this._esWrapper.reject(error);
     }
   }
 
@@ -846,8 +846,9 @@ class ElasticSearch extends Service {
       await this._client.delete(esRequest);
     }
     catch (error) {
-      this._esWrapper.reject(error);
+      return this._esWrapper.reject(error);
     }
+    return null;
   }
 
   /**
@@ -1241,7 +1242,7 @@ class ElasticSearch extends Service {
         mappings: {},
         settings
       },
-      index: this._getSafeESIndex(index, collection),
+      index: await this._getSafeESIndex(index, collection),
     };
 
     this._checkDynamicProperty(mappings);
@@ -1309,7 +1310,7 @@ class ElasticSearch extends Service {
       };
     }
     catch (error) {
-      this._esWrapper.reject(error);
+      return this._esWrapper.reject(error);
     }
   }
 
@@ -1490,7 +1491,7 @@ class ElasticSearch extends Service {
     let mappings;
 
     const esRequest = {
-      index: this._getESIndexFromAlias(index, collection)
+      index: await this._getESIndexFromAlias(index, collection)
     };
 
     try {
@@ -1505,9 +1506,11 @@ class ElasticSearch extends Service {
         },
         body: { mappings },
       });
+
+      return null;
     }
     catch (error) {
-      this._esWrapper.reject(error);
+      return this._esWrapper.reject(error);
     }
   }
 
@@ -1714,7 +1717,7 @@ class ElasticSearch extends Service {
   async getSchema () {
     // This check avoids a breaking change for those who were using Kuzzle before
     // alias attribution for each ES index was the standard ('auto-version')
-    this._ensureAliasConsistency();
+    await this._ensureAliasConsistency();
 
     let body;
     try {
@@ -1774,7 +1777,7 @@ class ElasticSearch extends Service {
    */
   async deleteCollection (index, collection) {
     const esRequest = {
-      index: this._getESIndexFromAlias(index, collection)
+      index: await this._getESIndexFromAlias(index, collection)
     };
 
     const mutex = new Mutex(`hiddenCollection/delete/${index}`);
@@ -1831,7 +1834,7 @@ class ElasticSearch extends Service {
       await this._client.indices.delete(esRequest);
     }
     catch (error) {
-      this._esWrapper.reject(error);
+      return this._esWrapper.reject(error);
     }
 
     return Array.from(deleted);
@@ -1898,8 +1901,21 @@ class ElasticSearch extends Service {
       return exists;
     }
     catch (error) {
-      this._esWrapper.reject(error);
+      return this._esWrapper.reject(error);
     }
+  }
+
+  /**
+   * Returns true if the index exists
+   *
+   * @param {String} index - Index name
+   *
+   * @returns {Promise.<boolean>}
+   */
+  async hasIndex (index) {
+    const indexes = await this.listIndexes();
+
+    return indexes.some(idx => idx === index);
   }
 
   /**
@@ -2683,10 +2699,10 @@ class ElasticSearch extends Service {
     const alias = `${ALIAS_PREFIX}${this._indexPrefix}${index}${NAME_SEPARATOR}${collection}`;
     const { body } = await this._client.cat.aliases({ format: 'json', name: alias });
 
-    if (body.length() < 1) {
+    if (body.length < 1) {
       throw kerror.get('unknown_index_collection');
     }
-    else if (body.length() > 1) {
+    else if (body.length > 1) {
       throw kerror.get('multiple_index_alias', 'alias', 'index');
     }
 
@@ -2705,10 +2721,10 @@ class ElasticSearch extends Service {
     const { body } = await this._client.indices.getAlias({ index: esIndex});
     const aliases = Object.keys(body[esIndex].aliases);
 
-    if (aliases.length() < 1) {
+    if (aliases.length < 1) {
       throw kerror.get('unknown_index_collection');
     }
-    else if (body.length() > 1) {
+    else if (aliases.length > 1) {
       throw kerror.get('multiple_index_alias', 'index', 'alias');
     }
 
@@ -2725,7 +2741,7 @@ class ElasticSearch extends Service {
   async _isESIndexAvailable (esIndex) {
     const { body } = await this._client.indices.get({ index: esIndex });
 
-    return body.length() === 0;
+    return body.length === 0;
   }
 
   /**
@@ -2764,7 +2780,7 @@ class ElasticSearch extends Service {
       const aliases = await this.listAliases();
 
       const indexesWithoutAlias = esIndexes.filter((index) =>
-        index[INDEX_PREFIX_POSITON_IN_INDEX] !== this._indexPrefix
+        index[INDEX_PREFIX_POSITON_IN_INDEX] === this._indexPrefix
         && ! aliases.some((alias) => alias.name === index));
 
       let esRequest = { actions : [] };
@@ -2803,9 +2819,13 @@ class ElasticSearch extends Service {
    * @returns {String} index name
    */
   _extractIndex (esIndex) {
+    let prefixPosition = esIndex.search(ALIAS_PREFIX) === -1
+      ? INDEX_PREFIX_POSITON_IN_INDEX
+      : INDEX_PREFIX_POSITON_IN_ALIAS;
+
     return esIndex.substr(
-      esIndex.indexOf(this._indexPrefix) + 1,
-      esIndex.indexOf(NAME_SEPARATOR) - 1 );
+      prefixPosition + 1,
+      esIndex.indexOf(NAME_SEPARATOR) - prefixPosition -1 );
   }
 
   /**
@@ -2872,7 +2892,7 @@ class ElasticSearch extends Service {
             number_of_shards: 1,
           }
         },
-        index: this._getSafeESIndex(index),
+        index: await this._getSafeESIndex(index),
       });
     }
     catch (e) {

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -2677,7 +2677,7 @@ class ElasticSearch extends Service {
   }
 
   /**
-   * Given index + collection, returns the well formated esIndex alias name
+   * Given index + collection, returns the well formatted esIndex alias name
    *
    * @param {String} index
    * @param {String} collection

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -2779,13 +2779,13 @@ class ElasticSearch extends Service {
       const esIndexes = body.map(({ index }) => index);
       const aliases = await this.listAliases();
 
-      const indexesWithoutAlias = esIndexes.filter((index) =>
-        index[INDEX_PREFIX_POSITON_IN_INDEX] === this._indexPrefix
-        && ! aliases.some((alias) => alias.name === index));
+      const indexesWithoutAlias = esIndexes.filter(index =>
+              index[INDEX_PREFIX_POSITON_IN_INDEX] === this._indexPrefix
+        && ! aliases.some(alias => alias.name === index));
 
       const esRequest = { body:{ actions : [] } };
       for (const index of indexesWithoutAlias) {
-        esRequest.body.actions.push({ add : { alias: `@${index}`, index } });
+        esRequest.body.actions.push({ add : { alias: `${ALIAS_PREFIX}${index}`, index } });
       }
 
       if (esRequest.body.actions.length > 0) {

--- a/lib/util/name-generator.js
+++ b/lib/util/name-generator.js
@@ -25,13 +25,20 @@ function randomNumber (max) {
   return Math.floor(Math.random() * Math.floor(max));
 }
 
-module.exports = function generateRandomName (prefix) {
+function generateRandomName (prefix) {
+  return generateRandomCustom(
+    (adjective, name, number) => `${prefix}-${adjective}-${name}-${number}`);
+}
+
+function generateRandomCustom (callback) {
   const adjective = adjectives[randomNumber(adjectives.length)];
   const name = names[randomNumber(names.length)];
   const number = randomNumber(100000);
 
-  return `${prefix}-${adjective}-${name}-${number}`;
-};
+  return callback(adjective, name, number);
+}
+
+module.exports = { generateRandomCustom, generateRandomName };
 
 const adjectives = [
   'aback',

--- a/lib/util/name-generator.js
+++ b/lib/util/name-generator.js
@@ -26,19 +26,14 @@ function randomNumber (max) {
 }
 
 function generateRandomName (prefix) {
-  return generateRandomCustom(
-    (adjective, name, number) => `${prefix}-${adjective}-${name}-${number}`);
-}
-
-function generateRandomCustom (callback) {
   const adjective = adjectives[randomNumber(adjectives.length)];
   const name = names[randomNumber(names.length)];
   const number = randomNumber(100000);
 
-  return callback(adjective, name, number);
+  return `${prefix}-${adjective}-${name}-${number}`;
 }
 
-module.exports = { generateRandomCustom, generateRandomName };
+module.exports = { generateRandomName, randomNumber };
 
 const adjectives = [
   'aback',

--- a/test/core/storage/clientAdapter.test.js
+++ b/test/core/storage/clientAdapter.test.js
@@ -89,15 +89,11 @@ describe('#core/storage/ClientAdapter', () => {
       sinon.stub(kuzzle, 'onAsk');
     });
 
-    it('should populate the cache with index, collections and aliases', async () => {
+    it('should populate the cache with index and collections', async () => {
       uninitializedAdapter.client.getSchema.resolves({
         foo: ['foo1', 'foo2'],
         bar: ['bar1', 'bar2']
       });
-      uninitializedAdapter.client.listAliases.resolves([
-        { index: 'alias1', collection: 'qux' },
-        { index: 'alias2', collection: 'qux' },
-      ]);
 
       sinon.stub(uninitializedAdapter.cache, 'addCollection');
 
@@ -107,8 +103,6 @@ describe('#core/storage/ClientAdapter', () => {
       should(uninitializedAdapter.cache.addCollection).calledWith('foo', 'foo2');
       should(uninitializedAdapter.cache.addCollection).calledWith('bar', 'bar1');
       should(uninitializedAdapter.cache.addCollection).calledWith('bar', 'bar2');
-      should(uninitializedAdapter.cache.addCollection).calledWith('alias1', 'qux');
-      should(uninitializedAdapter.cache.addCollection).calledWith('alias2', 'qux');
     });
   });
 

--- a/test/mocks/name-generator.mock.js
+++ b/test/mocks/name-generator.mock.js
@@ -1,0 +1,11 @@
+'use strict';
+
+function randomNumberMock (max) {
+  return max;
+}
+
+function generateRandomNameMock (prefix) {
+  return `${prefix}-adjective-name-123456`;
+}
+
+module.exports = { generateRandomNameMock, randomNumberMock };

--- a/test/mocks/service/elasticsearchClient.mock.js
+++ b/test/mocks/service/elasticsearchClient.mock.js
@@ -56,7 +56,10 @@ class ElasticsearchClientMock {
       getMapping: sinon.stub().resolves(),
       putMapping: sinon.stub().resolves(),
       refresh: sinon.stub().resolves(),
-      stats: sinon.stub().resolves()
+      stats: sinon.stub().resolves(),
+      get: sinon.stub().resolves(),
+      getAlias: sinon.stub().resolves(),
+      updateAliases: sinon.stub().resolves(),
     };
 
     this.mcreate = sinon.stub().resolves();

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -3,6 +3,7 @@
 const should = require('should');
 const sinon = require('sinon');
 const ms = require('ms');
+const mockRequire = require('mock-require');
 
 const {
   BadRequestError,
@@ -12,8 +13,8 @@ const {
 } = require('../../../index');
 const KuzzleMock = require('../../mocks/kuzzle.mock');
 const ESClientMock = require('../../mocks/service/elasticsearchClient.mock');
+const { randomNumberMock } = require('../../mocks/name-generator.mock');
 
-const ES = require('../../../lib/service/storage/elasticsearch');
 const scopeEnum = require('../../../lib/core/storage/storeScopeEnum');
 const { Mutex } = require('../../../lib/util/mutex');
 
@@ -21,19 +22,29 @@ describe('Test: ElasticSearch service', () => {
   let kuzzle;
   let index;
   let collection;
-  let aliasIndexName;
-  let esIndexName;
+  let alias;
+  let indice;
   let elasticsearch;
   let timestamp;
   let esClientError;
+  let ES;
+
+  before(() => {
+    mockRequire('../../../lib/util/name-generator', { randomNumber: randomNumberMock });
+    ES = mockRequire.reRequire('../../../lib/service/storage/elasticsearch');
+  });
+
+  after(() => {
+    mockRequire.stopAll();
+  });
 
   beforeEach(async () => {
     kuzzle = new KuzzleMock();
 
     index = 'nyc-open-data';
     collection = 'yellow-taxi';
-    aliasIndexName = '@&nyc-open-data.yellow-taxi';
-    esIndexName = '&nyc-open-data.yellow-taxi';
+    alias = '@&nyc-open-data.yellow-taxi';
+    indice = '&nyc-open-data.yellow-taxi';
     timestamp = Date.now();
 
     esClientError = new Error('es client fail');
@@ -104,12 +115,12 @@ describe('Test: ElasticSearch service', () => {
           }
         }
       });
-      sinon.stub(elasticsearch, '_getAliasFromESIndex')
-        .callsFake((esIndex) => `@${esIndex}`);
+      sinon.stub(elasticsearch, '_getAliasFromIndice')
+        .callsFake((indiceArg) => `@${indiceArg}`);
     });
 
     afterEach(() => {
-      elasticsearch._getAliasFromESIndex.restore();
+      elasticsearch._getAliasFromIndice.restore();
     });
 
     it('should only request required stats from underlying client', async () => {
@@ -333,7 +344,7 @@ describe('Test: ElasticSearch service', () => {
       const result = await elasticsearch.search(index, collection, searchBody);
 
       should(elasticsearch._client.search.firstCall.args[0]).match({
-        index: aliasIndexName,
+        index: alias,
         body: { query: { match_all: {} } },
         from: undefined,
         size: undefined,
@@ -380,7 +391,7 @@ describe('Test: ElasticSearch service', () => {
       should(elasticsearch._client.search.firstCall.args[0]).match({
         body: searchBody,
         from: 0,
-        index: aliasIndexName,
+        index: alias,
         scroll: '30s',
         size: 1,
         trackTotalHits: true,
@@ -470,7 +481,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.get).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             id: 'liia'
           });
 
@@ -497,7 +508,8 @@ describe('Test: ElasticSearch service', () => {
 
       return should(promise).be.rejected()
         .then(() => {
-          should(elasticsearch._esWrapper.reject).be.calledWith(esClientError);
+          should(elasticsearch._esWrapper.formatESError)
+            .be.calledWith(esClientError);
         });
     });
   });
@@ -520,8 +532,8 @@ describe('Test: ElasticSearch service', () => {
           should(elasticsearch._client.mget).be.calledWithMatch({
             body: {
               docs: [
-                { _id: 'liia', _index: aliasIndexName },
-                { _id: 'mhery', _index: aliasIndexName },
+                { _id: 'liia', _index: alias },
+                { _id: 'mhery', _index: alias },
               ]
             }
           });
@@ -564,7 +576,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.count).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             body: filter
           });
 
@@ -579,7 +591,8 @@ describe('Test: ElasticSearch service', () => {
 
       return should(promise).be.rejected()
         .then(() => {
-          should(elasticsearch._esWrapper.reject).be.calledWith(esClientError);
+          should(elasticsearch._esWrapper.formatESError)
+            .be.calledWith(esClientError);
         });
     });
   });
@@ -603,7 +616,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.index).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             body: {
               city: 'Kathmandu',
               _kuzzle_info: {
@@ -641,7 +654,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.index).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             body: {
               city: 'Panipokari',
               _kuzzle_info: {
@@ -683,7 +696,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.index).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             body: {
               city: 'Kathmandu',
               _kuzzle_info: {
@@ -717,7 +730,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.index).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             body: {
               city: 'Kathmandu',
               _kuzzle_info: undefined
@@ -745,7 +758,8 @@ describe('Test: ElasticSearch service', () => {
 
       return should(promise).be.rejected()
         .then(() => {
-          should(elasticsearch._esWrapper.reject).be.calledWith(esClientError);
+          should(elasticsearch._esWrapper.formatESError)
+            .be.calledWith(esClientError);
         });
     });
   });
@@ -773,7 +787,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.update).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             body: {
               doc: {
                 city: 'Panipokari',
@@ -809,7 +823,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.update).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             body: {
               doc: {
                 city: 'Panipokari',
@@ -846,7 +860,8 @@ describe('Test: ElasticSearch service', () => {
 
       return should(promise).be.rejected()
         .then(() => {
-          should(elasticsearch._esWrapper.reject).be.calledWith(esClientError);
+          should(elasticsearch._esWrapper.formatESError)
+            .be.calledWith(esClientError);
         });
     });
 
@@ -859,7 +874,7 @@ describe('Test: ElasticSearch service', () => {
         { refresh: 'wait_for', userId: 'oh noes', retryOnConflict: null });
 
       should(elasticsearch._client.update).be.calledWithMatch({
-        index: aliasIndexName,
+        index: alias,
         body: {
           doc: {
             city: 'Panipokari',
@@ -899,7 +914,7 @@ describe('Test: ElasticSearch service', () => {
         { city: 'Panipokari' });
 
       should(elasticsearch._client.update).be.calledWithMatch({
-        index: aliasIndexName,
+        index: alias,
         body: {
           doc: {
             city: 'Panipokari',
@@ -941,7 +956,7 @@ describe('Test: ElasticSearch service', () => {
         });
 
       should(elasticsearch._client.update).be.calledWithMatch({
-        index: aliasIndexName,
+        index: alias,
         body: {
           doc: {
             city: 'Panipokari',
@@ -995,7 +1010,7 @@ describe('Test: ElasticSearch service', () => {
         });
 
       should(elasticsearch._client.update).be.calledWithMatch({
-        index: aliasIndexName,
+        index: alias,
         body: {
           doc: {
             city: 'Panipokari',
@@ -1036,7 +1051,7 @@ describe('Test: ElasticSearch service', () => {
         { refresh: 'wait_for', userId: 'aschen', retryOnConflict: 42 });
 
       should(elasticsearch._client.update).be.calledWithMatch({
-        index: aliasIndexName,
+        index: alias,
         body: {
           doc: {
             city: 'Panipokari',
@@ -1087,7 +1102,7 @@ describe('Test: ElasticSearch service', () => {
         { refresh: 'wait_for', userId: 'oh noes', retryOnConflict: null });
 
       should(elasticsearch._client.update).be.calledWithMatch({
-        index: aliasIndexName,
+        index: alias,
         body: {
           doc: {
             city: 'Panipokari',
@@ -1133,7 +1148,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.index).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             id: 'liia',
             body: {
               city: 'Kathmandu',
@@ -1166,7 +1181,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.index).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             id: 'liia',
             body: {
               city: 'Kathmandu',
@@ -1199,9 +1214,8 @@ describe('Test: ElasticSearch service', () => {
 
       return should(promise).be.rejected()
         .then(() => {
-          should(elasticsearch._esWrapper.reject).be.calledWithMatch({
-            id: 'services.storage.not_found'
-          });
+          should(elasticsearch._esWrapper.formatESError)
+            .be.calledWithMatch({ id: 'services.storage.not_found' });
           should(elasticsearch._client.index).not.be.called();
         });
     });
@@ -1217,7 +1231,8 @@ describe('Test: ElasticSearch service', () => {
 
       return should(promise).be.rejected()
         .then(() => {
-          should(elasticsearch._esWrapper.reject).be.calledWith(esClientError);
+          should(elasticsearch._esWrapper.formatESError)
+            .be.calledWith(esClientError);
         });
     });
   });
@@ -1240,7 +1255,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.delete).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             id: 'liia',
             refresh: undefined
           });
@@ -1259,7 +1274,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.delete).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             id: 'liia',
             refresh: 'wait_for'
           });
@@ -1278,7 +1293,8 @@ describe('Test: ElasticSearch service', () => {
 
       return should(promise).be.rejected()
         .then(() => {
-          should(elasticsearch._esWrapper.reject).be.calledWith(esClientError);
+          should(elasticsearch._esWrapper.formatESError)
+            .be.calledWith(esClientError);
         });
     });
   });
@@ -1372,7 +1388,7 @@ describe('Test: ElasticSearch service', () => {
         { refresh: 'wait_for', size: 3, userId: 'aschen' });
 
       should(elasticsearch._getAllDocumentsFromQuery).be.calledWithMatch({
-        index: aliasIndexName,
+        index: alias,
         body: { query: { filter: 'term'} },
         scroll: '5s',
         size: 3
@@ -1441,7 +1457,7 @@ describe('Test: ElasticSearch service', () => {
             source: 'ctx._source.bar = params[\'bar\'];'
           }
         },
-        index: aliasIndexName,
+        index: alias,
         refresh: 'false'
       };
 
@@ -1547,7 +1563,7 @@ describe('Test: ElasticSearch service', () => {
         { filter: 'term' });
 
       should(elasticsearch._client.deleteByQuery).be.calledWithMatch({
-        index: aliasIndexName,
+        index: alias,
         body: { query: { filter: 'term' } },
         scroll: '5s',
         from: undefined,
@@ -1556,7 +1572,7 @@ describe('Test: ElasticSearch service', () => {
       });
 
       should(elasticsearch._getAllDocumentsFromQuery).be.calledWithMatch({
-        index: aliasIndexName,
+        index: alias,
         body: { query: { filter: 'term' } },
         scroll: '5s',
         from: undefined,
@@ -1585,7 +1601,7 @@ describe('Test: ElasticSearch service', () => {
         { refresh: 'wait_for', from: 1, size: 3 });
 
       should(elasticsearch._client.deleteByQuery).be.calledWithMatch({
-        index: aliasIndexName,
+        index: alias,
         body: { query: { filter: 'term' } },
         size: 3,
         refresh: true
@@ -1608,7 +1624,7 @@ describe('Test: ElasticSearch service', () => {
         { fetch: false });
 
       should(elasticsearch._client.deleteByQuery).be.calledWithMatch({
-        index: aliasIndexName,
+        index: alias,
         body: { query: { filter: 'term' } },
         scroll: '5s',
         from: undefined,
@@ -1706,12 +1722,12 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.get).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             id: 'liia',
           });
 
           should(elasticsearch._client.index).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             id: 'liia',
             body: {
               city: 'Kathmandu',
@@ -1742,12 +1758,12 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.get).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             id: 'liia',
           });
 
           should(elasticsearch._client.index).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             id: 'liia',
             body: {
               city: 'Kathmandu',
@@ -1837,7 +1853,7 @@ describe('Test: ElasticSearch service', () => {
       should(result).match([1, 2]);
 
       should(elasticsearch._client.search.getCall(0).args[0]).match({
-        index: aliasIndexName,
+        index: alias,
         body: { query: { match: 21 } },
         scroll: '5s',
         from: 0,
@@ -1866,19 +1882,20 @@ describe('Test: ElasticSearch service', () => {
     beforeEach(() => {
       elasticsearch._client.cat.aliases.resolves({
         body: [
-          { alias: aliasIndexName }, { alias: '@%nepali.liia' }
+          { alias: alias }, { alias: '@%nepali.liia' }
         ]
       });
-      elasticsearch._client.indices.get.resolves({ body: [] });
+      sinon.stub(elasticsearch, '_createHiddenCollection').resolves();
+    });
+
+    afterEach(() => {
+      elasticsearch._createHiddenCollection.restore();
     });
 
     it('should resolve and create a hidden collection if the index does not exist', async () => {
       await elasticsearch.createIndex('lfiduras');
 
-      should(elasticsearch._client.indices.create).be.calledWithMatch({
-        index: '&lfiduras._kuzzle_keep',
-        body: {}
-      });
+      should(elasticsearch._createHiddenCollection).be.calledWithMatch('lfiduras');
     });
 
     it('should reject if the index already exists', () => {
@@ -1897,7 +1914,8 @@ describe('Test: ElasticSearch service', () => {
 
       return should(promise).be.rejected()
         .then(() => {
-          should(elasticsearch._esWrapper.reject).be.calledWith(esClientError);
+          should(elasticsearch._esWrapper.formatESError)
+            .be.calledWith(esClientError);
         });
     });
 
@@ -1923,11 +1941,11 @@ describe('Test: ElasticSearch service', () => {
       sinon.stub(elasticsearch, '_createHiddenCollection').resolves();
       sinon.stub(elasticsearch, '_hasHiddenCollection').resolves(false);
       sinon.stub(elasticsearch, 'deleteCollection').resolves();
-      sinon.stub(elasticsearch, '_isESIndexAvailable').resolves(true);
+      sinon.stub(elasticsearch, '_getAvailableIndice').resolves(indice);
     });
 
     afterEach(() => {
-      elasticsearch._isESIndexAvailable.restore();
+      elasticsearch._getAvailableIndice.restore();
     });
 
     it('should allow creating a new collection and inject commonMappings', async () => {
@@ -1944,9 +1962,9 @@ describe('Test: ElasticSearch service', () => {
         properties: mappings.properties
       });
       should(elasticsearch._client.indices.create).be.calledWithMatch({
-        index: esIndexName,
+        index: indice,
         body: {
-          aliases: { [aliasIndexName]: {} },
+          aliases: { [alias]: {} },
           mappings: {
             dynamic: elasticsearch.config.commonMapping.dynamic,
             _meta: elasticsearch.config.commonMapping._meta,
@@ -1981,9 +1999,9 @@ describe('Test: ElasticSearch service', () => {
         { mappings });
 
       should(elasticsearch._client.indices.create).be.calledWithMatch({
-        index: esIndexName,
+        index: indice,
         body: {
-          aliases: { [aliasIndexName]: {} },
+          aliases: { [alias]: {} },
           mappings: {
             dynamic: 'true',
             _meta: { some: 'meta' },
@@ -2192,7 +2210,7 @@ describe('Test: ElasticSearch service', () => {
     beforeEach(() => {
       elasticsearch._client.indices.getMapping.resolves({
         body: {
-          [esIndexName]: {
+          [indice]: {
             mappings: {
               dynamic: true,
               _meta: { lang: 'npl' },
@@ -2206,11 +2224,11 @@ describe('Test: ElasticSearch service', () => {
       });
 
       elasticsearch._esWrapper.getMapping = sinon.stub().resolves({foo: 'bar'});
-      sinon.stub(elasticsearch, '_getESIndexFromAlias').resolves(esIndexName);
+      sinon.stub(elasticsearch, '_getIndice').resolves(indice);
     });
 
     afterEach(() => {
-      elasticsearch._getESIndexFromAlias.restore();
+      elasticsearch._getIndice.restore();
     });
 
     it('should have getMapping capabilities', () => {
@@ -2219,7 +2237,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.indices.getMapping).be.calledWithMatch({
-            index: esIndexName
+            index: indice
           });
 
           should(result).match({
@@ -2241,7 +2259,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.indices.getMapping).be.calledWithMatch({
-            index: esIndexName
+            index: indice
           });
 
           should(result).match({
@@ -2262,7 +2280,8 @@ describe('Test: ElasticSearch service', () => {
 
       return should(promise).be.rejected()
         .then(() => {
-          should(elasticsearch._esWrapper.reject).be.calledWith(esClientError);
+          should(elasticsearch._esWrapper.formatESError)
+            .be.calledWith(esClientError);
         });
     });
   });
@@ -2276,7 +2295,7 @@ describe('Test: ElasticSearch service', () => {
     beforeEach(() => {
       oldSettings = {
         body: {
-          [esIndexName]: {
+          [indice]: {
             settings: {
               index: {
                 creation_date: Date.now(),
@@ -2296,11 +2315,11 @@ describe('Test: ElasticSearch service', () => {
       elasticsearch.updateMapping = sinon.stub().resolves();
       elasticsearch.updateSettings = sinon.stub().resolves();
       elasticsearch.updateSearchIndex = sinon.stub().resolves();
-      sinon.stub(elasticsearch, '_getESIndexFromAlias').resolves(esIndexName);
+      sinon.stub(elasticsearch, '_getIndice').resolves(indice);
     });
 
     afterEach(() => {
-      elasticsearch._getESIndexFromAlias.restore();
+      elasticsearch._getIndice.restore();
     });
 
     it('should call updateSettings, updateMapping', async () => {
@@ -2329,7 +2348,7 @@ describe('Test: ElasticSearch service', () => {
       return should(promise).be.rejected()
         .then(() => {
           should(elasticsearch._client.indices.getSettings).be.calledWithMatch({
-            index: esIndexName
+            index: indice
           });
           should(elasticsearch.updateSettings).be.calledTwice();
           should(elasticsearch.updateMapping).be.calledOnce();
@@ -2399,7 +2418,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.indices.putMapping).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             body: {
               dynamic: 'strict',
               _meta: { meta: 'data' },
@@ -2464,7 +2483,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.indices.putMapping).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             body: {
               dynamic: 'false',
               _meta: { other: 'meta' }
@@ -2503,14 +2522,14 @@ describe('Test: ElasticSearch service', () => {
       };
     });
 
-    it('should allow to change esindex settings', async () => {
+    it('should allow to change indice settings', async () => {
       const result = await elasticsearch.updateSettings(
         index,
         collection,
         newSettings);
 
       should(elasticsearch._client.indices.putSettings).be.calledWithMatch({
-        index: aliasIndexName,
+        index: alias,
         body: {
           index: {
             blocks: {
@@ -2531,10 +2550,10 @@ describe('Test: ElasticSearch service', () => {
       await elasticsearch.updateSettings(index, collection, newSettings);
 
       should(elasticsearch._client.indices.close).be.calledWithMatch({
-        index: aliasIndexName
+        index: alias
       });
       should(elasticsearch._client.indices.open).be.calledWithMatch({
-        index: aliasIndexName
+        index: alias
       });
     });
 
@@ -2559,7 +2578,7 @@ describe('Test: ElasticSearch service', () => {
       should(elasticsearch._client.updateByQuery).be.calledWithMatch({
         body: {},
         conflicts: 'proceed',
-        index: aliasIndexName,
+        index: alias,
         refresh: true,
         waitForCompletion: false,
       });
@@ -2578,12 +2597,11 @@ describe('Test: ElasticSearch service', () => {
       };
 
       elasticsearch.getMapping = sinon.stub().resolves(existingMapping);
-      sinon.stub(elasticsearch, '_getESIndexFromAlias')
-        .resolves(`${elasticsearch._indexPrefix}${index}.${collection}`);
+      sinon.stub(elasticsearch, '_getIndice').resolves(indice);
     });
 
     afterEach(() => {
-      elasticsearch._getESIndexFromAlias.restore();
+      elasticsearch._getIndice.restore();
     });
 
     it('should delete and then create the collection with the same mapping', () => {
@@ -2593,12 +2611,12 @@ describe('Test: ElasticSearch service', () => {
         .then(result => {
           should(elasticsearch.getMapping).be.calledWith(index, collection);
           should(elasticsearch._client.indices.delete).be.calledWithMatch({
-            index: esIndexName
+            index: indice
           });
           should(elasticsearch._client.indices.create).be.calledWithMatch({
-            index: esIndexName,
+            index: indice,
             body: {
-              aliases: { [aliasIndexName]: {} },
+              aliases: { [alias]: {} },
               mappings: {
                 dynamic: 'false',
                 properties: {
@@ -2619,7 +2637,8 @@ describe('Test: ElasticSearch service', () => {
 
       return should(promise).be.rejected()
         .then(() => {
-          should(elasticsearch._esWrapper.reject).be.calledWith(esClientError);
+          should(elasticsearch._esWrapper.formatESError)
+            .be.calledWith(esClientError);
         });
     });
   });
@@ -2634,7 +2653,7 @@ describe('Test: ElasticSearch service', () => {
     beforeEach(() => {
       getExpectedEsRequest = ({ userId=null, refresh, timeout } = {}) => ({
         body: [
-          { index: { _id: 1, _index: aliasIndexName } },
+          { index: { _id: 1, _index: alias } },
           {
             firstName: 'foo',
             _kuzzle_info: {
@@ -2645,7 +2664,7 @@ describe('Test: ElasticSearch service', () => {
             }
           },
 
-          { index: { _id: 2, _index: aliasIndexName, _type: undefined } },
+          { index: { _id: 2, _index: alias, _type: undefined } },
           {
             firstName: 'bar',
             _kuzzle_info: {
@@ -2656,7 +2675,7 @@ describe('Test: ElasticSearch service', () => {
             }
           },
 
-          { update: { _id: 3, _index: aliasIndexName } },
+          { update: { _id: 3, _index: alias } },
           {
             doc: {
               firstName: 'foobar',
@@ -2667,7 +2686,7 @@ describe('Test: ElasticSearch service', () => {
             }
           },
 
-          { delete: { _id: 4, _index: aliasIndexName } }
+          { delete: { _id: 4, _index: alias } }
         ],
         refresh,
         timeout
@@ -2894,9 +2913,9 @@ describe('Test: ElasticSearch service', () => {
     beforeEach(() => {
       elasticsearch._client.cat.aliases.resolves({
         body: [
-          { index: 'mehry', alias: '@&nepali.mehry' },
-          { index: 'liia', alias: '@&nepali.liia' },
-          { index: 'taxi', alias: '@&nyc-open-data.taxi' }
+          { index: '&nepalu.mehry', alias: '@&nepali.mehry' },
+          { index: '&nepali.lia', alias: '@&nepali.liia' },
+          { index: '&nyc-open-data.taxi', alias: '@&nyc-open-data.taxi' }
         ]
       });
     });
@@ -2909,26 +2928,26 @@ describe('Test: ElasticSearch service', () => {
       });
 
       should(result).match([
-        { name: 'mehry', index: 'nepali', collection: 'mehry' },
-        { name: 'liia', index: 'nepali', collection: 'liia' },
-        { name: 'taxi', index: 'nyc-open-data', collection: 'taxi' },
+        { alias: '@&nepali.mehry', index: 'nepali', collection: 'mehry', indice: '&nepalu.mehry' },
+        { alias: '@&nepali.liia', index: 'nepali', collection: 'liia', indice: '&nepali.lia' },
+        { alias: '@&nyc-open-data.taxi', index: 'nyc-open-data', collection: 'taxi', indice: '&nyc-open-data.taxi' },
       ]);
     });
 
     it('should not list unauthorized aliases', async () => {
       elasticsearch._client.cat.aliases.resolves({
         body: [
-          { index: 'alias-mehry', alias: '@%nepali.mehry' },
-          { index: 'alias-liia', alias: '@%nepali.liia' },
-          { index: 'alias-taxi', alias: '@%nyc-open-data.taxi' },
-          { index: 'alias-lfiduras', alias: '@&vietnam.lfiduras' }
+          { index: '%nepalu.mehry', alias: '@%nepali.mehry' },
+          { index: '%nepali.lia', alias: '@%nepali.liia' },
+          { index: '%nyc-open-data.taxi', alias: '@%nyc-open-data.taxi' },
+          { index: '&vietnam.lfiduras', alias: '@&vietnam.lfiduras' }
         ]
       });
 
       const result = await elasticsearch.listAliases();
 
       should(result).match([
-        { name: 'alias-lfiduras', index: 'vietnam', collection: 'lfiduras' },
+        { alias: '@&vietnam.lfiduras', index: 'vietnam', collection: 'lfiduras', indice: '&vietnam.lfiduras' },
       ]);
     });
 
@@ -3015,19 +3034,18 @@ describe('Test: ElasticSearch service', () => {
     beforeEach(() => {
       sinon.stub(elasticsearch, '_hasHiddenCollection').resolves(true);
       sinon.stub(elasticsearch, '_createHiddenCollection').resolves();
-      sinon.stub(elasticsearch, '_getESIndexFromAlias')
-        .resolves(`${elasticsearch._indexPrefix}${index}.${collection}`);
+      sinon.stub(elasticsearch, '_getIndice').resolves(indice);
     });
 
     afterEach(() => {
-      elasticsearch._getESIndexFromAlias.restore();
+      elasticsearch._getIndice.restore();
     });
 
     it('should allow to delete a collection', async () => {
       const result = await elasticsearch.deleteCollection(index, collection);
 
       should(elasticsearch._client.indices.delete).be.calledWithMatch({
-        index: esIndexName
+        index: indice
       });
 
       should(result).be.null();
@@ -3057,7 +3075,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.indices.refresh).be.calledWithMatch({
-            index: aliasIndexName
+            index: alias
           });
 
           should(result).match({
@@ -3086,7 +3104,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.exists).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             id: 'liia'
           });
 
@@ -3101,7 +3119,8 @@ describe('Test: ElasticSearch service', () => {
 
       return should(promise).be.rejected()
         .then(() => {
-          should(elasticsearch._esWrapper.reject).be.calledWith(esClientError);
+          should(elasticsearch._esWrapper.formatESError)
+            .be.calledWith(esClientError);
         });
     });
   });
@@ -3208,16 +3227,16 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.mget).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             body: { docs: [ { _id: 'liia', _source: false } ] }
           });
 
           const esRequest = {
-            index: aliasIndexName,
+            index: alias,
             body: [
-              { index: { _index: aliasIndexName } },
+              { index: { _index: alias } },
               { city: 'Kathmandu', ...kuzzleMeta },
-              { index: { _index: aliasIndexName } },
+              { index: { _index: alias } },
               { city: 'Ho Chi Minh City', ...kuzzleMeta }
             ],
             refresh: undefined,
@@ -3248,14 +3267,14 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.mget).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             body: { docs: [ { _id: 'liia', _source: false } ] }
           });
 
           const esRequest = {
-            index: aliasIndexName,
+            index: alias,
             body: [
-              { index: { _index: aliasIndexName } },
+              { index: { _index: alias } },
               { city: 'Kathmandu', ...kuzzleMeta }
             ],
             refresh: undefined,
@@ -3295,11 +3314,11 @@ describe('Test: ElasticSearch service', () => {
           should(elasticsearch._client.mget).not.be.called();
 
           const esRequest = {
-            index: aliasIndexName,
+            index: alias,
             body: [
-              { index: { _index: aliasIndexName } },
+              { index: { _index: alias } },
               { city: 'Kathmandu', ...kuzzleMeta },
-              { index: { _index: aliasIndexName } },
+              { index: { _index: alias } },
               { city: 'Ho Chi Minh City', ...kuzzleMeta }
             ],
             refresh: undefined,
@@ -3331,11 +3350,11 @@ describe('Test: ElasticSearch service', () => {
           should(elasticsearch._client.mget).not.be.called();
 
           const esRequest = {
-            index: aliasIndexName,
+            index: alias,
             body: [
-              { index: { _index: aliasIndexName } },
+              { index: { _index: alias } },
               { city: 'Kathmandu', ...kuzzleMeta },
-              { index: { _index: aliasIndexName } },
+              { index: { _index: alias } },
               { city: 'Ho Chi Minh City', ...kuzzleMeta }
             ],
             refresh: 'wait_for',
@@ -3387,11 +3406,11 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           const esRequest = {
-            index: aliasIndexName,
+            index: alias,
             body: [
-              { index: { _index: aliasIndexName, _id: 'mehry' } },
+              { index: { _index: alias, _id: 'mehry' } },
               { city: 'Kathmandu', ...kuzzleMeta },
-              { index: { _index: aliasIndexName, _id: 'liia' } },
+              { index: { _index: alias, _id: 'liia' } },
               { city: 'Ho Chi Minh City', ...kuzzleMeta }
             ],
             refresh: undefined,
@@ -3422,11 +3441,11 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           const esRequest = {
-            index: aliasIndexName,
+            index: alias,
             body: [
-              { index: { _index: aliasIndexName, _id: 'mehry' } },
+              { index: { _index: alias, _id: 'mehry' } },
               { city: 'Kathmandu', ...kuzzleMeta },
-              { index: { _index: aliasIndexName, _id: 'liia' } },
+              { index: { _index: alias, _id: 'liia' } },
               { city: 'Ho Chi Minh City', ...kuzzleMeta }
             ],
             refresh: 'wait_for',
@@ -3455,11 +3474,11 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           const esRequest = {
-            index: aliasIndexName,
+            index: alias,
             body: [
-              { index: { _index: aliasIndexName, _id: 'mehry' } },
+              { index: { _index: alias, _id: 'mehry' } },
               { city: 'Kathmandu' },
-              { index: { _index: aliasIndexName, _id: 'liia' } },
+              { index: { _index: alias, _id: 'liia' } },
               { city: 'Ho Chi Minh City' }
             ],
             refresh: undefined,
@@ -3534,11 +3553,11 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           const esRequest = {
-            index: aliasIndexName,
+            index: alias,
             body: [
-              { update: { _index: aliasIndexName, _id: 'mehry', retry_on_conflict: elasticsearch.config.defaults.onUpdateConflictRetries } },
+              { update: { _index: alias, _id: 'mehry', retry_on_conflict: elasticsearch.config.defaults.onUpdateConflictRetries } },
               { doc: { city: 'Kathmandu', ...kuzzleMeta }, _source: true },
-              { update: { _index: aliasIndexName, _id: 'liia', retry_on_conflict: elasticsearch.config.defaults.onUpdateConflictRetries } },
+              { update: { _index: alias, _id: 'liia', retry_on_conflict: elasticsearch.config.defaults.onUpdateConflictRetries } },
               { doc: { city: 'Ho Chi Minh City', ...kuzzleMeta }, _source: true }
             ],
             refresh: undefined,
@@ -3581,11 +3600,11 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(() => {
           const esRequest = {
-            index: aliasIndexName,
+            index: alias,
             body: [
-              { update: { _index: aliasIndexName, _id: 'mehry', retry_on_conflict: 2 } },
+              { update: { _index: alias, _id: 'mehry', retry_on_conflict: 2 } },
               { doc: { city: 'Kathmandu', ...kuzzleMeta }, _source: true },
-              { update: { _index: aliasIndexName, _id: 'liia', retry_on_conflict: 2 } },
+              { update: { _index: alias, _id: 'liia', retry_on_conflict: 2 } },
               { doc: { city: 'Ho Chi Minh City', ...kuzzleMeta }, _source: true }
             ],
             refresh: 'wait_for',
@@ -3614,9 +3633,9 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(() => {
           const esRequest = {
-            index: aliasIndexName,
+            index: alias,
             body: [
-              { update: { _index: aliasIndexName, _id: 'mehry', retry_on_conflict: elasticsearch.config.defaults.onUpdateConflictRetries } },
+              { update: { _index: alias, _id: 'mehry', retry_on_conflict: elasticsearch.config.defaults.onUpdateConflictRetries } },
               { doc: { city: 'Kathmandu', ...kuzzleMeta }, _source: true }
             ],
             refresh: undefined,
@@ -3670,9 +3689,9 @@ describe('Test: ElasticSearch service', () => {
 
       esRequest = {
         body: [
-          { update: { _index: aliasIndexName, _id: 'mehry', _source: true, retry_on_conflict: elasticsearch.config.defaults.onUpdateConflictRetries } },
+          { update: { _index: alias, _id: 'mehry', _source: true, retry_on_conflict: elasticsearch.config.defaults.onUpdateConflictRetries } },
           { doc: { city: 'Kathmandu', ...kuzzleUpdateMeta }, upsert: { city: 'Kathmandu', ...kuzzleCreateMeta } },
-          { update: { _index: aliasIndexName, _id: 'liia', _source: true, retry_on_conflict: elasticsearch.config.defaults.onUpdateConflictRetries } },
+          { update: { _index: alias, _id: 'liia', _source: true, retry_on_conflict: elasticsearch.config.defaults.onUpdateConflictRetries } },
           { doc: { city: 'Ho Chi Minh City', ...kuzzleUpdateMeta }, upsert: { city: 'Ho Chi Minh City', ...kuzzleCreateMeta } }
         ],
         refresh: undefined,
@@ -3870,7 +3889,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.mget).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             body: {
               docs: [
                 { _id: 'mehry', _source: false },
@@ -3883,9 +3902,9 @@ describe('Test: ElasticSearch service', () => {
             refresh: undefined,
             timeout: undefined,
             body: [
-              { index: { _id: 'mehry', _index: aliasIndexName } },
+              { index: { _id: 'mehry', _index: alias } },
               { city: 'Kathmandu', ...kuzzleMeta },
-              { index: { _id: 'liia', _index: aliasIndexName } },
+              { index: { _id: 'liia', _index: alias } },
               { city: 'Ho Chi Minh City', ...kuzzleMeta }
             ]
           };
@@ -3914,7 +3933,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.mget).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             body: {
               docs: [
                 { _id: 'mehry', _source: false },
@@ -3927,7 +3946,7 @@ describe('Test: ElasticSearch service', () => {
             refresh: undefined,
             timeout: undefined,
             body: [
-              { index: { _id: 'mehry', _index: aliasIndexName } },
+              { index: { _id: 'mehry', _index: alias } },
               { city: 'Kathmandu', ...kuzzleMeta }
             ]
           };
@@ -3966,7 +3985,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.mget).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             body: {
               docs: [ { _id: 'mehry', _source: false } ]
             }
@@ -3976,7 +3995,7 @@ describe('Test: ElasticSearch service', () => {
             refresh: undefined,
             timeout: undefined,
             body: [
-              { index: { _id: 'mehry', _index: aliasIndexName } },
+              { index: { _id: 'mehry', _index: alias } },
               { city: 'Kathmandu', ...kuzzleMeta }
             ]
           };
@@ -4014,9 +4033,9 @@ describe('Test: ElasticSearch service', () => {
             refresh: 'wait_for',
             timeout: '10m',
             body: [
-              { index: { _id: 'mehry', _index: aliasIndexName } },
+              { index: { _id: 'mehry', _index: alias } },
               { city: 'Kathmandu', ...kuzzleMeta },
-              { index: { _id: 'liia', _index: aliasIndexName } },
+              { index: { _id: 'liia', _index: alias } },
               { city: 'Ho Chi Minh City', ...kuzzleMeta }
             ]
           };
@@ -4078,7 +4097,7 @@ describe('Test: ElasticSearch service', () => {
         ['mehry', 'liia']);
 
       should(elasticsearch._client.deleteByQuery).be.calledWithMatch({
-        index: aliasIndexName,
+        index: alias,
         body: { query: { ids: { values: ['mehry', 'liia'] } } },
         scroll: '5s'
       });
@@ -4107,7 +4126,7 @@ describe('Test: ElasticSearch service', () => {
             ['mehry', 'liia']);
 
           should(elasticsearch._client.deleteByQuery).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             body: { query: { ids: { values: ['mehry'] } } },
             scroll: '5s'
           });
@@ -4138,7 +4157,7 @@ describe('Test: ElasticSearch service', () => {
             ['mehry']);
 
           should(elasticsearch._client.deleteByQuery).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             body: { query: { ids: { values: ['mehry'] } } },
             scroll: '5s'
           });
@@ -4164,7 +4183,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(() => {
           should(elasticsearch._client.deleteByQuery).be.calledWithMatch({
-            index: aliasIndexName,
+            index: alias,
             body: { query: { ids: { values: ['mehry', 'liia'] } } },
             scroll: '5s',
             refresh: true
@@ -4183,9 +4202,9 @@ describe('Test: ElasticSearch service', () => {
       esRequest = {
         refresh: undefined,
         body: [
-          { index: { _index: aliasIndexName, _id: 'liia' } },
+          { index: { _index: alias, _id: 'liia' } },
           { city: 'Kathmandu' },
-          { update: { _index: aliasIndexName, _id: 'mehry' } },
+          { update: { _index: alias, _id: 'mehry' } },
           { doc: { city: 'Kathmandu' } }
         ]
       };
@@ -4437,12 +4456,15 @@ describe('Test: ElasticSearch service', () => {
   });
 
   describe('#_createHiddenCollection', () => {
+    const hiddenIndice = '&nisantasi._kuzzle_keep';
+    const hiddenAlias = `@${hiddenIndice}`;
+
     beforeEach(() => {
-      sinon.stub(elasticsearch, '_isESIndexAvailable').resolves(true);
+      sinon.stub(elasticsearch, '_getAvailableIndice').resolves(hiddenIndice);
     });
 
     afterEach(() => {
-      elasticsearch._isESIndexAvailable.restore();
+      elasticsearch._getAvailableIndice.restore();
     });
 
     it('creates the hidden collection', async () => {
@@ -4451,9 +4473,9 @@ describe('Test: ElasticSearch service', () => {
       await elasticsearch._createHiddenCollection('nisantasi');
 
       should(elasticsearch._client.indices.create).be.calledWithMatch({
-        index: '&nisantasi._kuzzle_keep',
+        index: hiddenIndice,
         body: {
-          aliases: { '@&nisantasi._kuzzle_keep': {} },
+          aliases: { [hiddenAlias]: {} },
           settings: {
             number_of_shards: 1,
             number_of_replicas: 1,
@@ -4552,45 +4574,45 @@ describe('Test: ElasticSearch service', () => {
       await internalES.init();
     });
 
-    describe('#_getESIndex', () => {
-      it('return esIndex name for a collection', () => {
-        const publicESIndex = publicES._getESIndex('nepali', 'liia');
-        const internalESIndex = internalES._getESIndex('nepali', 'mehry');
+    describe('#_getAlias', () => {
+      it('return alias name for a collection', () => {
+        const publicAlias = publicES._getAlias('nepali', 'liia');
+        const internalAlias = internalES._getAlias('nepali', 'mehry');
 
-        should(publicESIndex).be.eql('@&nepali.liia');
-        should(internalESIndex).be.eql('@%nepali.mehry');
+        should(publicAlias).be.eql('@&nepali.liia');
+        should(internalAlias).be.eql('@%nepali.mehry');
       });
     });
 
-    describe('#_getESIndexFromAlias', () => {
+    describe('#_getIndice', () => {
       let publicBody;
       let privateBody;
 
-      it('return the esIndex name associated to an alias (index+collection)', async () => {
+      it('return the indice name associated to an alias (index+collection)', async () => {
         publicBody = [{ alias: '@&nepali.liia', index: '&nepali.lia', filter: 0 }];
         privateBody = [{ alias: '@%nepali.mehry', index: '%nepalu.mehry', filter: 0 }];
         publicES._client.cat.aliases.resolves({ body: publicBody });
         internalES._client.cat.aliases.resolves({ body: privateBody });
 
-        const publicESIndex = await publicES._getESIndexFromAlias('nepali', 'liia');
-        const internalESIndex = await internalES._getESIndexFromAlias('nepali', 'mehry');
+        const publicIndice = await publicES._getIndice('nepali', 'liia');
+        const internalIndice = await internalES._getIndice('nepali', 'mehry');
 
-        should(publicESIndex).be.eql('&nepali.lia');
-        should(internalESIndex).be.eql('%nepalu.mehry');
+        should(publicIndice).be.eql('&nepali.lia');
+        should(internalIndice).be.eql('%nepalu.mehry');
       });
 
-      it('throw if there is no ES index associated with the alias', async () => {
+      it('throw if there is no indice associated with the alias', async () => {
         publicES._client.cat.aliases.resolves({ body: [] });
         internalES._client.cat.aliases.resolves({ body: [] });
 
-        await should(publicES._getESIndexFromAlias('nepali', 'liia'))
+        await should(publicES._getIndice('nepali', 'liia'))
           .be.rejectedWith({ id: 'services.storage.unknown_index_collection'});
 
-        await should(internalES._getESIndexFromAlias('nepali', 'mehry'))
+        await should(internalES._getIndice('nepali', 'mehry'))
           .be.rejectedWith({ id: 'services.storage.unknown_index_collection'});
       });
 
-      it('throw if there is more than one ES index associated with the alias', async () => {
+      it('throw if there is more than one indice associated with the alias', async () => {
         publicBody = [
           { alias: '@&nepali.liia', index: '&nepali.lia', filter: 0 },
           { alias: '@&nepali.liia', index: '&nepali.liia', filter: 0 },
@@ -4603,19 +4625,69 @@ describe('Test: ElasticSearch service', () => {
         internalES._client.cat.aliases.resolves({ body: privateBody });
 
 
-        await should(publicES._getESIndexFromAlias('nepali', 'liia'))
-          .be.rejectedWith({ id: 'services.storage.multiple_index_alias'});
+        await should(publicES._getIndice('nepali', 'liia'))
+          .be.rejectedWith({ id: 'services.storage.multiple_indice_alias'});
 
-        await should(internalES._getESIndexFromAlias('nepali', 'mehry'))
-          .be.rejectedWith({ id: 'services.storage.multiple_index_alias'});
+        await should(internalES._getIndice('nepali', 'mehry'))
+          .be.rejectedWith({ id: 'services.storage.multiple_indice_alias'});
       });
     });
 
-    describe('#_getAliasFromESIndex', () => {
+    describe('#_getAvailableIndice', () => {
+      it('return simple indice whenever it is possible', async () => {
+        publicES._client.indices.exists.resolves({ body: false });
+        internalES._client.indices.exists.resolves({ body: false });
+
+        const publicIndice = await publicES._getAvailableIndice('nepali', 'liia');
+        const internalIndice = await internalES._getAvailableIndice('nepali', '_kuzzle_keep');
+
+        should(publicIndice).be.eql('&nepali.liia');
+        should(internalIndice).be.eql('%nepali._kuzzle_keep');
+      });
+
+      it('return a suffixed indice if necessary (indice already taken)', async () => {
+        publicES._client.indices.exists
+          .onFirstCall().resolves({ body: true })
+          .resolves({ body: false });
+        internalES._client.indices.exists
+          .onFirstCall().resolves({ body: true })
+          .resolves({ body: false });
+
+        const publicIndice = await publicES._getAvailableIndice('nepali', 'liia');
+        const internalIndice = await internalES._getAvailableIndice('nepali', 'mehry');
+
+        // Random suffix = 100000 because randomNumber has been mocked
+        should(publicIndice).match('&nepali.liia.100000');
+        should(internalIndice).match('%nepali.mehry.100000');
+      });
+
+      it('return a truncated and suffixed indice if necessary (indice + suffix too long)', async () => {
+        const longIndex = 'averyveryverylongindexwhichhasexactlythemaximumlengthacceptedofonehundredandtwentysixcharactersandthatiswaytoolongdontyouthink';
+        const longCollection = 'averyverylongcollectionwhichhasexactlythemaximumlengthacceptedofonehundredandtwentysixcharactersandthatswaytoolongdontyouthink';
+        publicES._client.indices.exists
+          .onFirstCall().resolves({ body: true })
+          .resolves({ body: false });
+        internalES._client.indices.exists
+          .onFirstCall().resolves({ body: true })
+          .resolves({ body: false });
+
+        const publicIndice = await publicES._getAvailableIndice(longIndex, longCollection);
+        const internalIndice = await internalES._getAvailableIndice(longIndex, longCollection);
+
+        // Random suffix = 100000 because randomNumber has been mocked
+        should(publicIndice).match(`&${longIndex}.${longCollection.substr(0, 120)}.100000`);
+        should(internalIndice).match(`%${longIndex}.${longCollection.substr(0, 120)}.100000`);
+        // The indice should be truncated just enough, not more not less
+        should(publicIndice).match((value) => Buffer.from(value).length === 255);
+        should(internalIndice).match((value) => Buffer.from(value).length === 255);
+      });
+    });
+
+    describe('#_getAliasFromIndice', () => {
       let publicBody;
       let privateBody;
 
-      it('return the alias associated with an esIndex', async () => {
+      it('return the alias associated with an indice', async () => {
         publicBody = {
           ['&nepali.lia']: {
             aliases: {
@@ -4633,14 +4705,14 @@ describe('Test: ElasticSearch service', () => {
         publicES._client.indices.getAlias.resolves({ body: publicBody });
         internalES._client.indices.getAlias.resolves({ body: privateBody });
 
-        const publicESIndex = await publicES._getAliasFromESIndex('&nepali.lia');
-        const internalESIndex = await internalES._getAliasFromESIndex('%nepalu.mehry');
+        const publicIndice = await publicES._getAliasFromIndice('&nepali.lia');
+        const internalIndice = await internalES._getAliasFromIndice('%nepalu.mehry');
 
-        should(publicESIndex).be.eql('@&nepali.liia');
-        should(internalESIndex).be.eql('@%nepali.mehry');
+        should(publicIndice).be.eql('@&nepali.liia');
+        should(internalIndice).be.eql('@%nepali.mehry');
       });
 
-      it('throw if there is no alias associated with the ES index', async () => {
+      it('throw if there is no alias associated with the indice', async () => {
         publicBody = {
           ['&nepali.lia']: {
             aliases: {}
@@ -4654,14 +4726,14 @@ describe('Test: ElasticSearch service', () => {
         publicES._client.indices.getAlias.resolves({ body: publicBody });
         internalES._client.indices.getAlias.resolves({ body: privateBody });
 
-        await should(publicES._getAliasFromESIndex('&nepali.lia'))
+        await should(publicES._getAliasFromIndice('&nepali.lia'))
           .be.rejectedWith({ id: 'services.storage.unknown_index_collection'});
 
-        await should(internalES._getAliasFromESIndex('%nepalu.mehry'))
+        await should(internalES._getAliasFromIndice('%nepalu.mehry'))
           .be.rejectedWith({ id: 'services.storage.unknown_index_collection'});
       });
 
-      it('throw if there is more than one alias associated with the ES index', async () => {
+      it('throw if there is more than one alias associated with the indice', async () => {
         publicBody = {
           ['&nepali.lia']: {
             aliases: {
@@ -4681,39 +4753,11 @@ describe('Test: ElasticSearch service', () => {
         publicES._client.indices.getAlias.resolves({ body: publicBody });
         internalES._client.indices.getAlias.resolves({ body: privateBody });
 
-        await should(publicES._getAliasFromESIndex('&nepali.lia'))
-          .be.rejectedWith({ id: 'services.storage.multiple_index_alias'});
+        await should(publicES._getAliasFromIndice('&nepali.lia'))
+          .be.rejectedWith({ id: 'services.storage.multiple_indice_alias'});
 
-        await should(internalES._getAliasFromESIndex('%nepalu.mehry'))
-          .be.rejectedWith({ id: 'services.storage.multiple_index_alias'});
-      });
-    });
-
-    describe('#_getSafeESIndex and _isESIndexAvailable', () => {
-      it('return raw ES index whenever it is possible', async () => {
-        publicES._client.indices.exists.resolves({ body: false });
-        internalES._client.indices.exists.resolves({ body: false });
-
-        const publicESIndex = await publicES._getSafeESIndex('nepali', 'liia');
-        const internalESIndex = await internalES._getSafeESIndex('nepali');
-
-        should(publicESIndex).be.eql('&nepali.liia');
-        should(internalESIndex).be.eql('%nepali._kuzzle_keep');
-      });
-
-      it('return random ES Index if necessary', async () => {
-        publicES._client.indices.exists
-          .onFirstCall().resolves({ body: true })
-          .resolves({ body: false });
-        internalES._client.indices.exists
-          .onFirstCall().resolves({ body: true })
-          .resolves({ body: false });
-
-        const publicESIndex = await publicES._getSafeESIndex('nepali', 'liia');
-        const internalESIndex = await internalES._getSafeESIndex('nepali', 'mehry');
-
-        should(publicESIndex).match(/&([a-z]*).([a-z]*)/);
-        should(internalESIndex).match(/%([a-z]*).([a-z]*)/);
+        await should(internalES._getAliasFromIndice('%nepalu.mehry'))
+          .be.rejectedWith({ id: 'services.storage.multiple_indice_alias'});
       });
     });
 
@@ -4726,11 +4770,12 @@ describe('Test: ElasticSearch service', () => {
           { index: '%nepali.mehry', status: 'open' },
         ]
       };
-      let aliasesBody = {
-        body: [
-          { alias: '@&nepali.lia', index: '&nepali.liia', filter: 0 },
-        ]
-      };
+      let aliasesList = [{
+        alias: '@&nepali.lia',
+        index: 'nepali',
+        collection: 'lia',
+        indice: '&nepali.liia',
+      }];
 
       beforeEach(() => {
         publicES._client.indices.updateAliases.resolves();
@@ -4739,11 +4784,16 @@ describe('Test: ElasticSearch service', () => {
         publicES._client.cat.indices.resolves(indicesBody);
         internalES._client.cat.indices.resolves(indicesBody);
 
-        publicES._client.cat.aliases.resolves(aliasesBody);
-        internalES._client.cat.aliases.resolves(aliasesBody);
+        sinon.stub(publicES, 'listAliases').resolves(aliasesList);
+        sinon.stub(internalES, 'listAliases').resolves(aliasesList);
       });
 
-      it('Find indexes without alias and create aliases accordingly', async () => {
+      afterEach(() => {
+        publicES.listAliases.restore();
+        internalES.listAliases.restore();
+      });
+
+      it('Find indices without associated aliases and create some accordingly', async () => {
         await publicES._ensureAliasConsistency();
         await internalES._ensureAliasConsistency();
 
@@ -4764,17 +4814,16 @@ describe('Test: ElasticSearch service', () => {
         });
       });
 
-      it('do nothing when every index is associated with an alias', async () => {
-        aliasesBody = {
-          body: [
-            { alias: '@&nepali.lia', index: '&nepali.liia', filter: 0 },
-            { alias: '@%nepali.lia', index: '%nepali.liia', filter: 0 },
-            { alias: '@&nepalu.mehry', index: '&nepali.mehry', filter: 0 },
-            { alias: '@%nepalu.mehry', index: '%nepali.mehry', filter: 0 },
-          ]
-        };
-        publicES._client.cat.aliases.resolves(aliasesBody);
-        internalES._client.cat.aliases.resolves(aliasesBody);
+      it('do nothing when every indice is associated with an alias', async () => {
+        aliasesList = [
+          { alias: '@&nepali.lia', index: 'nepali', collection: 'lia', indice: '&nepali.liia' },
+          { alias: '@%nepali.lia', index: 'nepali', collection: 'lia', indice: '%nepali.liia' },
+          { alias: '@&nepalu.mehry', index: 'nepalu', collection: 'mehry', indice: '&nepali.mehry' },
+          { alias: '@%nepalu.mehry', index: 'nepalu', collection: 'mehry', indice: '%nepali.mehry' },
+        ];
+
+        publicES.listAliases.resolves(aliasesList);
+        internalES.listAliases.resolves(aliasesList);
 
         await publicES._ensureAliasConsistency();
         await internalES._ensureAliasConsistency();
@@ -4785,17 +4834,9 @@ describe('Test: ElasticSearch service', () => {
     });
 
     describe('#_extractIndex', () => {
-      it('extract the index name from alias index name', () => {
+      it('extract the index from alias', () => {
         const publicIndex = publicES._extractIndex('@&nepali.liia');
         const internalIndex = internalES._extractIndex('@%nepali.liia');
-
-        should(publicIndex).be.eql('nepali');
-        should(internalIndex).be.eql('nepali');
-      });
-
-      it('extract the index name from raw esIndex name', () => {
-        const publicIndex = publicES._extractIndex('&nepali.liia');
-        const internalIndex = internalES._extractIndex('%nepali.liia');
 
         should(publicIndex).be.eql('nepali');
         should(internalIndex).be.eql('nepali');
@@ -4803,12 +4844,12 @@ describe('Test: ElasticSearch service', () => {
     });
 
     describe('#_extractCollection', () => {
-      it('extract the collection names from esIndex name', () => {
-        const publicCollection = publicES._extractCollection('&nepali.liia');
+      it('extract the collection from alias', () => {
+        const publicCollection = publicES._extractCollection('@&nepali.liia');
         const publicCollection2 = publicES._extractCollection('@&vietnam.lfiduras');
         const publicCollection3 = publicES._extractCollection('@&vietnam.l');
-        const publicCollection4 = publicES._extractCollection('&vietnam.iamaverylongcollectionnamebecauseiworthit');
-        const internalCollection = internalES._extractCollection('%nepali.liia');
+        const publicCollection4 = publicES._extractCollection('@&vietnam.iamaverylongcollectionnamebecauseiworthit');
+        const internalCollection = internalES._extractCollection('@%nepali.liia');
 
         should(publicCollection).be.eql('liia');
         should(publicCollection2).be.eql('lfiduras');
@@ -4820,15 +4861,15 @@ describe('Test: ElasticSearch service', () => {
 
     describe('#_extractSchema', () => {
       it('should extract the list of indexes and their collections', () => {
-        const esIndexes = [
+        const aliases = [
           '@%nepali.liia', '@%nepali.mehry',
 
           '@&nepali.panipokari', '@&nepali._kuzzle_keep',
           '@&vietnam.lfiduras', '@&vietnam._kuzzle_keep'
         ];
 
-        const publicSchema = publicES._extractSchema(esIndexes);
-        const internalSchema = internalES._extractSchema(esIndexes);
+        const publicSchema = publicES._extractSchema(aliases);
+        const internalSchema = internalES._extractSchema(aliases);
 
         should(internalSchema).be.eql({
           nepali: ['liia', 'mehry'],
@@ -4840,15 +4881,15 @@ describe('Test: ElasticSearch service', () => {
       });
 
       it('should include hidden collection with the option', () => {
-        const esIndexes = [
+        const aliases = [
           '@%nepali.liia', '@%nepali.mehry',
 
           '@&nepali.panipokari', '@&nepali._kuzzle_keep',
           '@&vietnam.lfiduras', '@&vietnam._kuzzle_keep'
         ];
 
-        const publicSchema = publicES._extractSchema(esIndexes, { includeHidden: true });
-        const internalSchema = internalES._extractSchema(esIndexes, { includeHidden: true });
+        const publicSchema = publicES._extractSchema(aliases, { includeHidden: true });
+        const internalSchema = internalES._extractSchema(aliases, { includeHidden: true });
 
         should(internalSchema).be.eql({
           nepali: ['liia', 'mehry'],

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -21,6 +21,7 @@ describe('Test: ElasticSearch service', () => {
   let kuzzle;
   let index;
   let collection;
+  let aliasIndexName;
   let esIndexName;
   let elasticsearch;
   let timestamp;
@@ -31,6 +32,7 @@ describe('Test: ElasticSearch service', () => {
 
     index = 'nyc-open-data';
     collection = 'yellow-taxi';
+    aliasIndexName = '@&nyc-open-data.yellow-taxi';
     esIndexName = '&nyc-open-data.yellow-taxi';
     timestamp = Date.now();
 
@@ -102,6 +104,12 @@ describe('Test: ElasticSearch service', () => {
           }
         }
       });
+      sinon.stub(elasticsearch, '_getAliasFromESIndex')
+        .callsFake((esIndex) => `@${esIndex}`);
+    });
+
+    afterEach(() => {
+      elasticsearch._getAliasFromESIndex.restore();
     });
 
     it('should only request required stats from underlying client', async () => {
@@ -325,7 +333,7 @@ describe('Test: ElasticSearch service', () => {
       const result = await elasticsearch.search(index, collection, searchBody);
 
       should(elasticsearch._client.search.firstCall.args[0]).match({
-        index: esIndexName,
+        index: aliasIndexName,
         body: { query: { match_all: {} } },
         from: undefined,
         size: undefined,
@@ -372,7 +380,7 @@ describe('Test: ElasticSearch service', () => {
       should(elasticsearch._client.search.firstCall.args[0]).match({
         body: searchBody,
         from: 0,
-        index: esIndexName,
+        index: aliasIndexName,
         scroll: '30s',
         size: 1,
         trackTotalHits: true,
@@ -396,7 +404,7 @@ describe('Test: ElasticSearch service', () => {
 
       should(elasticsearch._client.search.firstCall.args[0]).match({
         body: searchBody,
-        index: '&main.kuzzleData',
+        index: '@&main.kuzzleData',
         trackTotalHits: true,
       });
     });
@@ -462,7 +470,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.get).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             id: 'liia'
           });
 
@@ -512,8 +520,8 @@ describe('Test: ElasticSearch service', () => {
           should(elasticsearch._client.mget).be.calledWithMatch({
             body: {
               docs: [
-                { _id: 'liia', _index: esIndexName },
-                { _id: 'mhery', _index: esIndexName },
+                { _id: 'liia', _index: aliasIndexName },
+                { _id: 'mhery', _index: aliasIndexName },
               ]
             }
           });
@@ -556,7 +564,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.count).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             body: filter
           });
 
@@ -595,7 +603,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.index).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             body: {
               city: 'Kathmandu',
               _kuzzle_info: {
@@ -633,7 +641,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.index).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             body: {
               city: 'Panipokari',
               _kuzzle_info: {
@@ -675,7 +683,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.index).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             body: {
               city: 'Kathmandu',
               _kuzzle_info: {
@@ -709,7 +717,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.index).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             body: {
               city: 'Kathmandu',
               _kuzzle_info: undefined
@@ -765,7 +773,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.update).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             body: {
               doc: {
                 city: 'Panipokari',
@@ -801,7 +809,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.update).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             body: {
               doc: {
                 city: 'Panipokari',
@@ -851,7 +859,7 @@ describe('Test: ElasticSearch service', () => {
         { refresh: 'wait_for', userId: 'oh noes', retryOnConflict: null });
 
       should(elasticsearch._client.update).be.calledWithMatch({
-        index: esIndexName,
+        index: aliasIndexName,
         body: {
           doc: {
             city: 'Panipokari',
@@ -891,7 +899,7 @@ describe('Test: ElasticSearch service', () => {
         { city: 'Panipokari' });
 
       should(elasticsearch._client.update).be.calledWithMatch({
-        index: esIndexName,
+        index: aliasIndexName,
         body: {
           doc: {
             city: 'Panipokari',
@@ -933,7 +941,7 @@ describe('Test: ElasticSearch service', () => {
         });
 
       should(elasticsearch._client.update).be.calledWithMatch({
-        index: esIndexName,
+        index: aliasIndexName,
         body: {
           doc: {
             city: 'Panipokari',
@@ -987,7 +995,7 @@ describe('Test: ElasticSearch service', () => {
         });
 
       should(elasticsearch._client.update).be.calledWithMatch({
-        index: esIndexName,
+        index: aliasIndexName,
         body: {
           doc: {
             city: 'Panipokari',
@@ -1028,7 +1036,7 @@ describe('Test: ElasticSearch service', () => {
         { refresh: 'wait_for', userId: 'aschen', retryOnConflict: 42 });
 
       should(elasticsearch._client.update).be.calledWithMatch({
-        index: esIndexName,
+        index: aliasIndexName,
         body: {
           doc: {
             city: 'Panipokari',
@@ -1079,7 +1087,7 @@ describe('Test: ElasticSearch service', () => {
         { refresh: 'wait_for', userId: 'oh noes', retryOnConflict: null });
 
       should(elasticsearch._client.update).be.calledWithMatch({
-        index: esIndexName,
+        index: aliasIndexName,
         body: {
           doc: {
             city: 'Panipokari',
@@ -1125,7 +1133,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.index).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             id: 'liia',
             body: {
               city: 'Kathmandu',
@@ -1158,7 +1166,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.index).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             id: 'liia',
             body: {
               city: 'Kathmandu',
@@ -1232,7 +1240,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.delete).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             id: 'liia',
             refresh: undefined
           });
@@ -1251,7 +1259,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.delete).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             id: 'liia',
             refresh: 'wait_for'
           });
@@ -1364,7 +1372,7 @@ describe('Test: ElasticSearch service', () => {
         { refresh: 'wait_for', size: 3, userId: 'aschen' });
 
       should(elasticsearch._getAllDocumentsFromQuery).be.calledWithMatch({
-        index: esIndexName,
+        index: aliasIndexName,
         body: { query: { filter: 'term'} },
         scroll: '5s',
         size: 3
@@ -1433,7 +1441,7 @@ describe('Test: ElasticSearch service', () => {
             source: 'ctx._source.bar = params[\'bar\'];'
           }
         },
-        index: esIndexName,
+        index: aliasIndexName,
         refresh: 'false'
       };
 
@@ -1539,7 +1547,7 @@ describe('Test: ElasticSearch service', () => {
         { filter: 'term' });
 
       should(elasticsearch._client.deleteByQuery).be.calledWithMatch({
-        index: esIndexName,
+        index: aliasIndexName,
         body: { query: { filter: 'term' } },
         scroll: '5s',
         from: undefined,
@@ -1548,7 +1556,7 @@ describe('Test: ElasticSearch service', () => {
       });
 
       should(elasticsearch._getAllDocumentsFromQuery).be.calledWithMatch({
-        index: esIndexName,
+        index: aliasIndexName,
         body: { query: { filter: 'term' } },
         scroll: '5s',
         from: undefined,
@@ -1577,7 +1585,7 @@ describe('Test: ElasticSearch service', () => {
         { refresh: 'wait_for', from: 1, size: 3 });
 
       should(elasticsearch._client.deleteByQuery).be.calledWithMatch({
-        index: esIndexName,
+        index: aliasIndexName,
         body: { query: { filter: 'term' } },
         size: 3,
         refresh: true
@@ -1600,7 +1608,7 @@ describe('Test: ElasticSearch service', () => {
         { fetch: false });
 
       should(elasticsearch._client.deleteByQuery).be.calledWithMatch({
-        index: esIndexName,
+        index: aliasIndexName,
         body: { query: { filter: 'term' } },
         scroll: '5s',
         from: undefined,
@@ -1698,12 +1706,12 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.get).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             id: 'liia',
           });
 
           should(elasticsearch._client.index).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             id: 'liia',
             body: {
               city: 'Kathmandu',
@@ -1734,12 +1742,12 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.get).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             id: 'liia',
           });
 
           should(elasticsearch._client.index).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             id: 'liia',
             body: {
               city: 'Kathmandu',
@@ -1829,7 +1837,7 @@ describe('Test: ElasticSearch service', () => {
       should(result).match([1, 2]);
 
       should(elasticsearch._client.search.getCall(0).args[0]).match({
-        index: esIndexName,
+        index: aliasIndexName,
         body: { query: { match: 21 } },
         scroll: '5s',
         from: 0,
@@ -1856,11 +1864,12 @@ describe('Test: ElasticSearch service', () => {
 
   describe('#createIndex', () => {
     beforeEach(() => {
-      elasticsearch._client.cat.indices.resolves({
+      elasticsearch._client.cat.aliases.resolves({
         body: [
-          { index: esIndexName }, { index: '%nepali.liia' }
+          { alias: aliasIndexName }, { alias: '@%nepali.liia' }
         ]
       });
+      elasticsearch._client.indices.get.resolves({ body: [] });
     });
 
     it('should resolve and create a hidden collection if the index does not exist', async () => {
@@ -1879,7 +1888,7 @@ describe('Test: ElasticSearch service', () => {
     });
 
     it('should return a rejected promise if client.cat.indices fails', () => {
-      elasticsearch._client.cat.indices.rejects(esClientError);
+      elasticsearch._client.cat.aliases.rejects(esClientError);
 
       const promise = elasticsearch.createIndex(
         index,
@@ -1914,6 +1923,11 @@ describe('Test: ElasticSearch service', () => {
       sinon.stub(elasticsearch, '_createHiddenCollection').resolves();
       sinon.stub(elasticsearch, '_hasHiddenCollection').resolves(false);
       sinon.stub(elasticsearch, 'deleteCollection').resolves();
+      sinon.stub(elasticsearch, '_isESIndexAvailable').resolves(true);
+    });
+
+    afterEach(() => {
+      elasticsearch._isESIndexAvailable.restore();
     });
 
     it('should allow creating a new collection and inject commonMappings', async () => {
@@ -1930,6 +1944,7 @@ describe('Test: ElasticSearch service', () => {
         properties: mappings.properties
       });
       should(elasticsearch._client.indices.create).be.calledWithMatch({
+        aliases: { [aliasIndexName]: {} },
         index: esIndexName,
         body: {
           mappings: {
@@ -1966,6 +1981,7 @@ describe('Test: ElasticSearch service', () => {
         { mappings });
 
       should(elasticsearch._client.indices.create).be.calledWithMatch({
+        aliases: { [aliasIndexName]: {} },
         index: esIndexName,
         body: {
           mappings: {
@@ -2176,7 +2192,7 @@ describe('Test: ElasticSearch service', () => {
     beforeEach(() => {
       elasticsearch._client.indices.getMapping.resolves({
         body: {
-          [esIndexName]: {
+          [aliasIndexName]: {
             mappings: {
               dynamic: true,
               _meta: { lang: 'npl' },
@@ -2198,7 +2214,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.indices.getMapping).be.calledWithMatch({
-            index: esIndexName
+            index: aliasIndexName
           });
 
           should(result).match({
@@ -2220,7 +2236,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.indices.getMapping).be.calledWithMatch({
-            index: esIndexName
+            index: aliasIndexName
           });
 
           should(result).match({
@@ -2255,7 +2271,7 @@ describe('Test: ElasticSearch service', () => {
     beforeEach(() => {
       oldSettings = {
         body: {
-          [esIndexName]: {
+          [aliasIndexName]: {
             settings: {
               index: {
                 creation_date: Date.now(),
@@ -2302,7 +2318,7 @@ describe('Test: ElasticSearch service', () => {
       return should(promise).be.rejected()
         .then(() => {
           should(elasticsearch._client.indices.getSettings).be.calledWithMatch({
-            index: esIndexName
+            index: aliasIndexName
           });
           should(elasticsearch.updateSettings).be.calledTwice();
           should(elasticsearch.updateMapping).be.calledOnce();
@@ -2372,7 +2388,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.indices.putMapping).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             body: {
               dynamic: 'strict',
               _meta: { meta: 'data' },
@@ -2437,7 +2453,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.indices.putMapping).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             body: {
               dynamic: 'false',
               _meta: { other: 'meta' }
@@ -2483,7 +2499,7 @@ describe('Test: ElasticSearch service', () => {
         newSettings);
 
       should(elasticsearch._client.indices.putSettings).be.calledWithMatch({
-        index: esIndexName,
+        index: aliasIndexName,
         body: {
           index: {
             blocks: {
@@ -2504,10 +2520,10 @@ describe('Test: ElasticSearch service', () => {
       await elasticsearch.updateSettings(index, collection, newSettings);
 
       should(elasticsearch._client.indices.close).be.calledWithMatch({
-        index: esIndexName
+        index: aliasIndexName
       });
       should(elasticsearch._client.indices.open).be.calledWithMatch({
-        index: esIndexName
+        index: aliasIndexName
       });
     });
 
@@ -2532,7 +2548,7 @@ describe('Test: ElasticSearch service', () => {
       should(elasticsearch._client.updateByQuery).be.calledWithMatch({
         body: {},
         conflicts: 'proceed',
-        index: '&nyc-open-data.yellow-taxi',
+        index: aliasIndexName,
         refresh: true,
         waitForCompletion: false,
       });
@@ -2551,6 +2567,12 @@ describe('Test: ElasticSearch service', () => {
       };
 
       elasticsearch.getMapping = sinon.stub().resolves(existingMapping);
+      sinon.stub(elasticsearch, '_getESIndexFromAlias')
+        .resolves(`${elasticsearch._indexPrefix}${index}.${collection}`);
+    });
+
+    afterEach(() => {
+      elasticsearch._getESIndexFromAlias.restore();
     });
 
     it('should delete and then create the collection with the same mapping', () => {
@@ -2563,6 +2585,7 @@ describe('Test: ElasticSearch service', () => {
             index: esIndexName
           });
           should(elasticsearch._client.indices.create).be.calledWithMatch({
+            aliases: { [aliasIndexName]: {} },
             index: esIndexName,
             body: {
               mappings: {
@@ -2600,7 +2623,7 @@ describe('Test: ElasticSearch service', () => {
     beforeEach(() => {
       getExpectedEsRequest = ({ userId=null, refresh, timeout } = {}) => ({
         body: [
-          { index: { _id: 1, _index: esIndexName } },
+          { index: { _id: 1, _index: aliasIndexName } },
           {
             firstName: 'foo',
             _kuzzle_info: {
@@ -2611,7 +2634,7 @@ describe('Test: ElasticSearch service', () => {
             }
           },
 
-          { index: { _id: 2, _index: esIndexName, _type: undefined } },
+          { index: { _id: 2, _index: aliasIndexName, _type: undefined } },
           {
             firstName: 'bar',
             _kuzzle_info: {
@@ -2622,7 +2645,7 @@ describe('Test: ElasticSearch service', () => {
             }
           },
 
-          { update: { _id: 3, _index: esIndexName } },
+          { update: { _id: 3, _index: aliasIndexName } },
           {
             doc: {
               firstName: 'foobar',
@@ -2633,7 +2656,7 @@ describe('Test: ElasticSearch service', () => {
             }
           },
 
-          { delete: { _id: 4, _index: esIndexName } }
+          { delete: { _id: 4, _index: aliasIndexName } }
         ],
         refresh,
         timeout
@@ -2760,12 +2783,12 @@ describe('Test: ElasticSearch service', () => {
 
   describe('#listCollections', () => {
     beforeEach(() => {
-      elasticsearch._client.cat.indices.resolves({
+      elasticsearch._client.cat.aliases.resolves({
         body: [
-          { index: '&nepali.mehry' },
-          { index: '&nepali.liia' },
-          { index: '&nyc-open-data.taxi' },
-          { index: '&nepali._kuzzle_keep' }
+          { alias: '@&nepali.mehry' },
+          { alias: '@&nepali.liia' },
+          { alias: '@&nyc-open-data.taxi' },
+          { alias: '@&nepali._kuzzle_keep' }
         ]
       });
     });
@@ -2780,11 +2803,11 @@ describe('Test: ElasticSearch service', () => {
     });
 
     it('should not list unauthorized collections', () => {
-      elasticsearch._client.cat.indices.resolves({
+      elasticsearch._client.cat.aliases.resolves({
         body: [
-          { index: '%nepali.mehry' },
-          { index: '%nepali.liia' },
-          { index: '%nyc-open-data.taxi' }
+          { alias: '@%nepali.mehry' },
+          { alias: '@%nepali.liia' },
+          { alias: '@%nyc-open-data.taxi' }
         ]
       });
 
@@ -2797,7 +2820,7 @@ describe('Test: ElasticSearch service', () => {
     });
 
     it('should return a rejected promise if client fails', async () => {
-      elasticsearch._client.cat.indices.rejects(esClientError);
+      elasticsearch._client.cat.aliases.rejects(esClientError);
 
       await should(elasticsearch.listCollections(index)).be.rejected();
 
@@ -2807,11 +2830,11 @@ describe('Test: ElasticSearch service', () => {
 
   describe('#listIndexes', () => {
     beforeEach(() => {
-      elasticsearch._client.cat.indices.resolves({
+      elasticsearch._client.cat.aliases.resolves({
         body: [
-          { index: '&nepali.mehry' },
-          { index: '&nepali.liia' },
-          { index: '&nyc-open-data.taxi' }
+          { alias: '@&nepali.mehry' },
+          { alias: '@&nepali.liia' },
+          { alias: '@&nyc-open-data.taxi' }
         ]
       });
     });
@@ -2821,7 +2844,7 @@ describe('Test: ElasticSearch service', () => {
 
       return promise
         .then(result => {
-          should(elasticsearch._client.cat.indices).be.calledWithMatch({
+          should(elasticsearch._client.cat.aliases).be.calledWithMatch({
             format: 'json'
           });
 
@@ -2830,12 +2853,12 @@ describe('Test: ElasticSearch service', () => {
     });
 
     it('should not list unauthorized indexes', () => {
-      elasticsearch._client.cat.indices.resolves({
+      elasticsearch._client.cat.aliases.resolves({
         body: [
-          { index: '%nepali.mehry' },
-          { index: '%nepali.liia' },
-          { index: '%nyc-open-data.taxi' },
-          { index: '&vietnam.lfiduras' }
+          { alias: '@%nepali.mehry' },
+          { alias: '@%nepali.liia' },
+          { alias: '@%nyc-open-data.taxi' },
+          { alias: '@&vietnam.lfiduras' }
         ]
       });
 
@@ -2848,7 +2871,7 @@ describe('Test: ElasticSearch service', () => {
     });
 
     it('should return a rejected promise if client fails', async () => {
-      elasticsearch._client.cat.indices.rejects(esClientError);
+      elasticsearch._client.cat.aliases.rejects(esClientError);
 
       await should(elasticsearch.listIndexes()).be.rejected();
 
@@ -2860,9 +2883,9 @@ describe('Test: ElasticSearch service', () => {
     beforeEach(() => {
       elasticsearch._client.cat.aliases.resolves({
         body: [
-          { index: 'mehry', alias: '&nepali.mehry' },
-          { index: 'liia', alias: '&nepali.liia' },
-          { index: 'taxi', alias: '&nyc-open-data.taxi' }
+          { index: 'mehry', alias: '@&nepali.mehry' },
+          { index: 'liia', alias: '@&nepali.liia' },
+          { index: 'taxi', alias: '@&nyc-open-data.taxi' }
         ]
       });
     });
@@ -2884,10 +2907,10 @@ describe('Test: ElasticSearch service', () => {
     it('should not list unauthorized aliases', async () => {
       elasticsearch._client.cat.aliases.resolves({
         body: [
-          { index: 'alias-mehry', alias: '%nepali.mehry' },
-          { index: 'alias-liia', alias: '%nepali.liia' },
-          { index: 'alias-taxi', alias: '%nyc-open-data.taxi' },
-          { index: 'alias-lfiduras', alias: '&vietnam.lfiduras' }
+          { index: 'alias-mehry', alias: '@%nepali.mehry' },
+          { index: 'alias-liia', alias: '@%nepali.liia' },
+          { index: 'alias-taxi', alias: '@%nyc-open-data.taxi' },
+          { index: 'alias-lfiduras', alias: '@&vietnam.lfiduras' }
         ]
       });
 
@@ -2907,66 +2930,14 @@ describe('Test: ElasticSearch service', () => {
     });
   });
 
-  describe('#listAliases', () => {
-    beforeEach(() => {
-      elasticsearch._client.cat.aliases.resolves({
-        body: [
-          { index: 'mehry', alias: '&nepali.mehry' },
-          { index: 'liia', alias: '&nepali.liia' },
-          { index: 'taxi', alias: '&nyc-open-data.taxi' }
-        ]
-      });
-    });
-
-    it('should allow listing all available aliases', async () => {
-      const result = await elasticsearch.listAliases();
-
-      should(elasticsearch._client.cat.aliases).be.calledWithMatch({
-        format: 'json'
-      });
-
-      should(result).match([
-        { name: 'mehry', index: 'nepali', collection: 'mehry' },
-        { name: 'liia', index: 'nepali', collection: 'liia' },
-        { name: 'taxi', index: 'nyc-open-data', collection: 'taxi' },
-      ]);
-    });
-
-    it('should not list unauthorized aliases', async () => {
-      elasticsearch._client.cat.aliases.resolves({
-        body: [
-          { index: 'mehry', alias: '%nepali.mehry' },
-          { index: 'liia', alias: '%nepali.liia' },
-          { index: 'taxi', alias: '%nyc-open-data.taxi' },
-          { index: 'lfiduras', alias: '&vietnam.lfiduras' }
-        ]
-      });
-
-      const result = await elasticsearch.listAliases();
-
-      should(result).match([
-        { name: 'lfiduras', index: 'vietnam', collection: 'lfiduras' },
-      ]);
-    });
-
-    it('should return a rejected promise if client fails', async () => {
-      elasticsearch._client.cat.aliases.rejects(esClientError);
-
-      const promise = elasticsearch.listAliases();
-
-      await should(promise).be.rejected();
-      should(elasticsearch._esWrapper.formatESError).be.calledWith(esClientError);
-    });
-  });
-
   describe('#deleteIndexes', () => {
     beforeEach(() => {
-      elasticsearch._client.cat.indices.resolves({
+      elasticsearch._client.cat.aliases.resolves({
         body: [
-          { index: '&nepali.mehry' },
-          { index: '&nepali.liia' },
-          { index: '&do-not.delete' },
-          { index: '&nyc-open-data.taxi' }
+          { alias: '@&nepali.mehry', index: '&nepali.mehry' },
+          { alias: '@&nepali.liia', index: '&nepali.liia' },
+          { alias: '@&do-not.delete', index: '&do-not.delete' },
+          { alias: '@&nyc-open-data.taxi', index: '&nyc-open-data.taxi' }
         ]
       });
     });
@@ -2985,12 +2956,12 @@ describe('Test: ElasticSearch service', () => {
     });
 
     it('should not delete unauthorized indexes', () => {
-      elasticsearch._client.cat.indices.resolves({
+      elasticsearch._client.cat.aliases.resolves({
         body: [
-          { index: '&nepali.mehry' },
-          { index: '&nepali.liia' },
-          { index: '&do-not.delete' },
-          { index: '%nyc-open-data.taxi' }
+          { alias: '@&nepali.mehry', index: '&nepali.mehry' },
+          { alias: '@&nepali.liia', index: '&nepali.liia' },
+          { alias: '@&do-not.delete', index: '&do-not.delete' },
+          { alias: '@%nyc-open-data.taxi', index: '%nyc-open-data.taxi' }
         ]
       });
 
@@ -3007,7 +2978,7 @@ describe('Test: ElasticSearch service', () => {
     });
 
     it('should return a rejected promise if client fails', async () => {
-      elasticsearch._client.cat.indices.rejects(esClientError);
+      elasticsearch._client.cat.aliases.rejects(esClientError);
 
       await should(elasticsearch.listIndexes()).be.rejected();
       should(elasticsearch._esWrapper.formatESError).be.calledWith(esClientError);
@@ -3033,13 +3004,19 @@ describe('Test: ElasticSearch service', () => {
     beforeEach(() => {
       sinon.stub(elasticsearch, '_hasHiddenCollection').resolves(true);
       sinon.stub(elasticsearch, '_createHiddenCollection').resolves();
+      sinon.stub(elasticsearch, '_getESIndexFromAlias')
+        .resolves(`${elasticsearch._indexPrefix}${index}.${collection}`);
+    });
+
+    afterEach(() => {
+      elasticsearch._getESIndexFromAlias.restore();
     });
 
     it('should allow to delete a collection', async () => {
-      const result = await elasticsearch.deleteCollection('nepali', 'liia');
+      const result = await elasticsearch.deleteCollection(index, collection);
 
       should(elasticsearch._client.indices.delete).be.calledWithMatch({
-        index: '&nepali.liia'
+        index: esIndexName
       });
 
       should(result).be.null();
@@ -3050,7 +3027,7 @@ describe('Test: ElasticSearch service', () => {
     it('should create the hidden collection if the index is empty', async () => {
       elasticsearch._hasHiddenCollection.resolves(false);
 
-      await elasticsearch.deleteCollection('nepali', 'liia');
+      await elasticsearch.deleteCollection(index, collection);
 
       should(Mutex.prototype.lock).be.called();
       should(Mutex.prototype.unlock).be.called();
@@ -3069,7 +3046,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.indices.refresh).be.calledWithMatch({
-            index: esIndexName
+            index: aliasIndexName
           });
 
           should(result).match({
@@ -3098,7 +3075,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.exists).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             id: 'liia'
           });
 
@@ -3220,16 +3197,16 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.mget).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             body: { docs: [ { _id: 'liia', _source: false } ] }
           });
 
           const esRequest = {
-            index: esIndexName,
+            index: aliasIndexName,
             body: [
-              { index: { _index: esIndexName } },
+              { index: { _index: aliasIndexName } },
               { city: 'Kathmandu', ...kuzzleMeta },
-              { index: { _index: esIndexName } },
+              { index: { _index: aliasIndexName } },
               { city: 'Ho Chi Minh City', ...kuzzleMeta }
             ],
             refresh: undefined,
@@ -3260,14 +3237,14 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.mget).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             body: { docs: [ { _id: 'liia', _source: false } ] }
           });
 
           const esRequest = {
-            index: esIndexName,
+            index: aliasIndexName,
             body: [
-              { index: { _index: esIndexName } },
+              { index: { _index: aliasIndexName } },
               { city: 'Kathmandu', ...kuzzleMeta }
             ],
             refresh: undefined,
@@ -3307,11 +3284,11 @@ describe('Test: ElasticSearch service', () => {
           should(elasticsearch._client.mget).not.be.called();
 
           const esRequest = {
-            index: esIndexName,
+            index: aliasIndexName,
             body: [
-              { index: { _index: esIndexName } },
+              { index: { _index: aliasIndexName } },
               { city: 'Kathmandu', ...kuzzleMeta },
-              { index: { _index: esIndexName } },
+              { index: { _index: aliasIndexName } },
               { city: 'Ho Chi Minh City', ...kuzzleMeta }
             ],
             refresh: undefined,
@@ -3343,11 +3320,11 @@ describe('Test: ElasticSearch service', () => {
           should(elasticsearch._client.mget).not.be.called();
 
           const esRequest = {
-            index: esIndexName,
+            index: aliasIndexName,
             body: [
-              { index: { _index: esIndexName } },
+              { index: { _index: aliasIndexName } },
               { city: 'Kathmandu', ...kuzzleMeta },
-              { index: { _index: esIndexName } },
+              { index: { _index: aliasIndexName } },
               { city: 'Ho Chi Minh City', ...kuzzleMeta }
             ],
             refresh: 'wait_for',
@@ -3399,11 +3376,11 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           const esRequest = {
-            index: esIndexName,
+            index: aliasIndexName,
             body: [
-              { index: { _index: esIndexName, _id: 'mehry' } },
+              { index: { _index: aliasIndexName, _id: 'mehry' } },
               { city: 'Kathmandu', ...kuzzleMeta },
-              { index: { _index: esIndexName, _id: 'liia' } },
+              { index: { _index: aliasIndexName, _id: 'liia' } },
               { city: 'Ho Chi Minh City', ...kuzzleMeta }
             ],
             refresh: undefined,
@@ -3434,11 +3411,11 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           const esRequest = {
-            index: esIndexName,
+            index: aliasIndexName,
             body: [
-              { index: { _index: esIndexName, _id: 'mehry' } },
+              { index: { _index: aliasIndexName, _id: 'mehry' } },
               { city: 'Kathmandu', ...kuzzleMeta },
-              { index: { _index: esIndexName, _id: 'liia' } },
+              { index: { _index: aliasIndexName, _id: 'liia' } },
               { city: 'Ho Chi Minh City', ...kuzzleMeta }
             ],
             refresh: 'wait_for',
@@ -3467,11 +3444,11 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           const esRequest = {
-            index: esIndexName,
+            index: aliasIndexName,
             body: [
-              { index: { _index: esIndexName, _id: 'mehry' } },
+              { index: { _index: aliasIndexName, _id: 'mehry' } },
               { city: 'Kathmandu' },
-              { index: { _index: esIndexName, _id: 'liia' } },
+              { index: { _index: aliasIndexName, _id: 'liia' } },
               { city: 'Ho Chi Minh City' }
             ],
             refresh: undefined,
@@ -3546,11 +3523,11 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           const esRequest = {
-            index: esIndexName,
+            index: aliasIndexName,
             body: [
-              { update: { _index: esIndexName, _id: 'mehry', retry_on_conflict: elasticsearch.config.defaults.onUpdateConflictRetries } },
+              { update: { _index: aliasIndexName, _id: 'mehry', retry_on_conflict: elasticsearch.config.defaults.onUpdateConflictRetries } },
               { doc: { city: 'Kathmandu', ...kuzzleMeta }, _source: true },
-              { update: { _index: esIndexName, _id: 'liia', retry_on_conflict: elasticsearch.config.defaults.onUpdateConflictRetries } },
+              { update: { _index: aliasIndexName, _id: 'liia', retry_on_conflict: elasticsearch.config.defaults.onUpdateConflictRetries } },
               { doc: { city: 'Ho Chi Minh City', ...kuzzleMeta }, _source: true }
             ],
             refresh: undefined,
@@ -3593,11 +3570,11 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(() => {
           const esRequest = {
-            index: esIndexName,
+            index: aliasIndexName,
             body: [
-              { update: { _index: esIndexName, _id: 'mehry', retry_on_conflict: 2 } },
+              { update: { _index: aliasIndexName, _id: 'mehry', retry_on_conflict: 2 } },
               { doc: { city: 'Kathmandu', ...kuzzleMeta }, _source: true },
-              { update: { _index: esIndexName, _id: 'liia', retry_on_conflict: 2 } },
+              { update: { _index: aliasIndexName, _id: 'liia', retry_on_conflict: 2 } },
               { doc: { city: 'Ho Chi Minh City', ...kuzzleMeta }, _source: true }
             ],
             refresh: 'wait_for',
@@ -3626,9 +3603,9 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(() => {
           const esRequest = {
-            index: esIndexName,
+            index: aliasIndexName,
             body: [
-              { update: { _index: esIndexName, _id: 'mehry', retry_on_conflict: elasticsearch.config.defaults.onUpdateConflictRetries } },
+              { update: { _index: aliasIndexName, _id: 'mehry', retry_on_conflict: elasticsearch.config.defaults.onUpdateConflictRetries } },
               { doc: { city: 'Kathmandu', ...kuzzleMeta }, _source: true }
             ],
             refresh: undefined,
@@ -3682,9 +3659,9 @@ describe('Test: ElasticSearch service', () => {
 
       esRequest = {
         body: [
-          { update: { _index: esIndexName, _id: 'mehry', _source: true, retry_on_conflict: elasticsearch.config.defaults.onUpdateConflictRetries } },
+          { update: { _index: aliasIndexName, _id: 'mehry', _source: true, retry_on_conflict: elasticsearch.config.defaults.onUpdateConflictRetries } },
           { doc: { city: 'Kathmandu', ...kuzzleUpdateMeta }, upsert: { city: 'Kathmandu', ...kuzzleCreateMeta } },
-          { update: { _index: esIndexName, _id: 'liia', _source: true, retry_on_conflict: elasticsearch.config.defaults.onUpdateConflictRetries } },
+          { update: { _index: aliasIndexName, _id: 'liia', _source: true, retry_on_conflict: elasticsearch.config.defaults.onUpdateConflictRetries } },
           { doc: { city: 'Ho Chi Minh City', ...kuzzleUpdateMeta }, upsert: { city: 'Ho Chi Minh City', ...kuzzleCreateMeta } }
         ],
         refresh: undefined,
@@ -3882,7 +3859,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.mget).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             body: {
               docs: [
                 { _id: 'mehry', _source: false },
@@ -3895,9 +3872,9 @@ describe('Test: ElasticSearch service', () => {
             refresh: undefined,
             timeout: undefined,
             body: [
-              { index: { _id: 'mehry', _index: esIndexName } },
+              { index: { _id: 'mehry', _index: aliasIndexName } },
               { city: 'Kathmandu', ...kuzzleMeta },
-              { index: { _id: 'liia', _index: esIndexName } },
+              { index: { _id: 'liia', _index: aliasIndexName } },
               { city: 'Ho Chi Minh City', ...kuzzleMeta }
             ]
           };
@@ -3926,7 +3903,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.mget).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             body: {
               docs: [
                 { _id: 'mehry', _source: false },
@@ -3939,7 +3916,7 @@ describe('Test: ElasticSearch service', () => {
             refresh: undefined,
             timeout: undefined,
             body: [
-              { index: { _id: 'mehry', _index: esIndexName } },
+              { index: { _id: 'mehry', _index: aliasIndexName } },
               { city: 'Kathmandu', ...kuzzleMeta }
             ]
           };
@@ -3978,7 +3955,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(result => {
           should(elasticsearch._client.mget).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             body: {
               docs: [ { _id: 'mehry', _source: false } ]
             }
@@ -3988,7 +3965,7 @@ describe('Test: ElasticSearch service', () => {
             refresh: undefined,
             timeout: undefined,
             body: [
-              { index: { _id: 'mehry', _index: esIndexName } },
+              { index: { _id: 'mehry', _index: aliasIndexName } },
               { city: 'Kathmandu', ...kuzzleMeta }
             ]
           };
@@ -4026,9 +4003,9 @@ describe('Test: ElasticSearch service', () => {
             refresh: 'wait_for',
             timeout: '10m',
             body: [
-              { index: { _id: 'mehry', _index: esIndexName } },
+              { index: { _id: 'mehry', _index: aliasIndexName } },
               { city: 'Kathmandu', ...kuzzleMeta },
-              { index: { _id: 'liia', _index: esIndexName } },
+              { index: { _id: 'liia', _index: aliasIndexName } },
               { city: 'Ho Chi Minh City', ...kuzzleMeta }
             ]
           };
@@ -4081,7 +4058,7 @@ describe('Test: ElasticSearch service', () => {
       const result = await elasticsearch.mDelete(index, collection, documentIds);
 
       should(elasticsearch._client.indices.refresh).be.calledWith({
-        index: `&${index}.${collection}`
+        index: `@&${index}.${collection}`
       });
 
       should(elasticsearch.mGet).be.calledWithMatch(
@@ -4090,7 +4067,7 @@ describe('Test: ElasticSearch service', () => {
         ['mehry', 'liia']);
 
       should(elasticsearch._client.deleteByQuery).be.calledWithMatch({
-        index: esIndexName,
+        index: aliasIndexName,
         body: { query: { ids: { values: ['mehry', 'liia'] } } },
         scroll: '5s'
       });
@@ -4119,7 +4096,7 @@ describe('Test: ElasticSearch service', () => {
             ['mehry', 'liia']);
 
           should(elasticsearch._client.deleteByQuery).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             body: { query: { ids: { values: ['mehry'] } } },
             scroll: '5s'
           });
@@ -4150,7 +4127,7 @@ describe('Test: ElasticSearch service', () => {
             ['mehry']);
 
           should(elasticsearch._client.deleteByQuery).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             body: { query: { ids: { values: ['mehry'] } } },
             scroll: '5s'
           });
@@ -4176,7 +4153,7 @@ describe('Test: ElasticSearch service', () => {
       return promise
         .then(() => {
           should(elasticsearch._client.deleteByQuery).be.calledWithMatch({
-            index: esIndexName,
+            index: aliasIndexName,
             body: { query: { ids: { values: ['mehry', 'liia'] } } },
             scroll: '5s',
             refresh: true
@@ -4195,9 +4172,9 @@ describe('Test: ElasticSearch service', () => {
       esRequest = {
         refresh: undefined,
         body: [
-          { index: { _index: esIndexName, _id: 'liia' } },
+          { index: { _index: aliasIndexName, _id: 'liia' } },
           { city: 'Kathmandu' },
-          { update: { _index: esIndexName, _id: 'mehry' } },
+          { update: { _index: aliasIndexName, _id: 'mehry' } },
           { doc: { city: 'Kathmandu' } }
         ]
       };
@@ -4423,18 +4400,24 @@ describe('Test: ElasticSearch service', () => {
 
   describe('#getSchema', () => {
     beforeEach(() => {
-      elasticsearch._client.cat.indices.resolves({
+      elasticsearch._client.cat.aliases.resolves({
         body: [
-          { index: '&nepali.mehry' },
-          { index: '&nepali._kuzzle_keep' },
-          { index: '&istanbul._kuzzle_keep' }
+          { alias: '@&nepali.mehry' },
+          { alias: '@&nepali._kuzzle_keep' },
+          { alias: '@&istanbul._kuzzle_keep' }
         ]
       });
+      sinon.stub(elasticsearch, '_ensureAliasConsistency').resolves();
+    });
+
+    afterEach(() => {
+      elasticsearch._ensureAliasConsistency.restore();
     });
 
     it('should returns the DB schema without hidden collections', async () => {
       const schema = await elasticsearch.getSchema();
 
+      should(elasticsearch._ensureAliasConsistency).be.called();
       should(schema).be.eql({
         nepali: ['mehry'],
         istanbul: [],
@@ -4443,6 +4426,14 @@ describe('Test: ElasticSearch service', () => {
   });
 
   describe('#_createHiddenCollection', () => {
+    beforeEach(() => {
+      sinon.stub(elasticsearch, '_isESIndexAvailable').resolves(true);
+    });
+
+    afterEach(() => {
+      elasticsearch._isESIndexAvailable.restore();
+    });
+
     it('creates the hidden collection', async () => {
       elasticsearch._client.indices.create.resolves({});
 
@@ -4539,11 +4530,14 @@ describe('Test: ElasticSearch service', () => {
     let internalES;
     let publicES;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       publicES = new ES(kuzzle.config.services.storageEngine);
       internalES = new ES(
         kuzzle.config.services.storageEngine,
         scopeEnum.PRIVATE);
+
+      await publicES.init();
+      await internalES.init();
     });
 
     describe('#_getESIndex', () => {
@@ -4557,114 +4551,106 @@ describe('Test: ElasticSearch service', () => {
     });
 
     describe('#_getESIndexFromAlias', () => {
-      let body;
+      let publicBody;
+      let privateBody;
 
       it('return the esIndex name associated to an alias (index+collection)', async () => {
-        body = [{ alias: '@&nepali.liia', index: '&nepali.lia', filter: 0 }];
-        elasticsearch._client.cat.aliases.resolves({ body });
+        publicBody = [{ alias: '@&nepali.liia', index: '&nepali.lia', filter: 0 }];
+        privateBody = [{ alias: '@%nepali.mehry', index: '%nepalu.mehry', filter: 0 }];
+        publicES._client.cat.aliases.resolves({ body: publicBody });
+        internalES._client.cat.aliases.resolves({ body: privateBody });
 
         const publicESIndex = await publicES._getESIndexFromAlias('nepali', 'liia');
-
-        should(publicESIndex).be.eql('&nepali.lia');
-
-
-        body = [{ alias: '@%nepali.mehry', index: '%nepalu.mehry', filter: 0 }];
-        elasticsearch._client.cat.aliases.resolves({ body });
-
         const internalESIndex = await internalES._getESIndexFromAlias('nepali', 'mehry');
 
+        should(publicESIndex).be.eql('&nepali.lia');
         should(internalESIndex).be.eql('%nepalu.mehry');
       });
 
       it('throw if there is no ES index associated with the alias', async () => {
-        elasticsearch._client.cat.aliases.resolves({ body: [] });
+        publicES._client.cat.aliases.resolves({ body: [] });
+        internalES._client.cat.aliases.resolves({ body: [] });
 
         await should(publicES._getESIndexFromAlias('nepali', 'liia'))
-          .be.rejectedWith({ id: 'service.storage.unknown_index_collection'});
+          .be.rejectedWith({ id: 'services.storage.unknown_index_collection'});
 
         await should(internalES._getESIndexFromAlias('nepali', 'mehry'))
-          .be.rejectedWith({ id: 'service.storage.unknown_index_collection'});
+          .be.rejectedWith({ id: 'services.storage.unknown_index_collection'});
       });
 
       it('throw if there is more than one ES index associated with the alias', async () => {
-        body = [
+        publicBody = [
           { alias: '@&nepali.liia', index: '&nepali.lia', filter: 0 },
           { alias: '@&nepali.liia', index: '&nepali.liia', filter: 0 },
         ];
-        elasticsearch._client.cat.aliases.resolves({ body });
-
-        await should(publicES._getESIndexFromAlias('nepali', 'liia'))
-          .be.rejectedWith({ id: 'service.storage.multiple_index_alias'});
-
-
-        body = [
+        privateBody = [
           { alias: '@%nepali.mehry', index: '%nepalu.mehry', filter: 0 },
           { alias: '@%nepali.mehry', index: '%nepali.mehry', filter: 0 }
         ];
-        elasticsearch._client.cat.aliases.resolves({ body });
+        publicES._client.cat.aliases.resolves({ body: publicBody });
+        internalES._client.cat.aliases.resolves({ body: privateBody });
+
+
+        await should(publicES._getESIndexFromAlias('nepali', 'liia'))
+          .be.rejectedWith({ id: 'services.storage.multiple_index_alias'});
 
         await should(internalES._getESIndexFromAlias('nepali', 'mehry'))
-          .be.rejectedWith({ id: 'service.storage.multiple_index_alias'});
+          .be.rejectedWith({ id: 'services.storage.multiple_index_alias'});
       });
     });
 
     describe('#_getAliasFromESIndex', () => {
-      let body;
+      let publicBody;
+      let privateBody;
 
       it('return the alias associated with an esIndex', async () => {
-        body = {
+        publicBody = {
           ['&nepali.lia']: {
             aliases: {
               ['@&nepali.liia']: {}
             }
           }
         };
-        elasticsearch._client.indices.getAlias.resolves({ body });
-
-        const publicESIndex = await publicES._getAliasFromESIndex('&nepali.lia');
-
-        should(publicESIndex).be.eql('@&nepali.liia');
-
-
-        body = {
+        privateBody = {
           ['%nepalu.mehry']: {
             aliases: {
               ['@%nepali.mehry']: {}
             }
           }
         };
-        elasticsearch._client.indices.getAlias.resolves({ body });
+        publicES._client.indices.getAlias.resolves({ body: publicBody });
+        internalES._client.indices.getAlias.resolves({ body: privateBody });
 
+        const publicESIndex = await publicES._getAliasFromESIndex('&nepali.lia');
         const internalESIndex = await internalES._getAliasFromESIndex('%nepalu.mehry');
 
+        should(publicESIndex).be.eql('@&nepali.liia');
         should(internalESIndex).be.eql('@%nepali.mehry');
       });
 
       it('throw if there is no alias associated with the ES index', async () => {
-        body = {
+        publicBody = {
           ['&nepali.lia']: {
             aliases: {}
           }
         };
-        elasticsearch._client.indices.getAlias.resolves({ body });
-
-        await should(publicES._getAliasFromESIndex('&nepali.lia'))
-          .be.rejectedWith({ id: 'service.storage.unknown_index_collection'});
-
-
-        body = {
+        privateBody = {
           ['%nepalu.mehry']: {
             aliases: {}
           }
         };
-        elasticsearch._client.indices.getAlias.resolves({ body });
+        publicES._client.indices.getAlias.resolves({ body: publicBody });
+        internalES._client.indices.getAlias.resolves({ body: privateBody });
+
+        await should(publicES._getAliasFromESIndex('&nepali.lia'))
+          .be.rejectedWith({ id: 'services.storage.unknown_index_collection'});
 
         await should(internalES._getAliasFromESIndex('%nepalu.mehry'))
-          .be.rejectedWith({ id: 'service.storage.unknown_index_collection'});
+          .be.rejectedWith({ id: 'services.storage.unknown_index_collection'});
       });
 
       it('throw if there is more than one alias associated with the ES index', async () => {
-        body = {
+        publicBody = {
           ['&nepali.lia']: {
             aliases: {
               ['@&nepali.liia']: {},
@@ -4672,13 +4658,7 @@ describe('Test: ElasticSearch service', () => {
             }
           }
         };
-        elasticsearch._client.indices.getAlias.resolves({ body });
-
-        await should(publicES._getAliasFromESIndex('&nepali.lia'))
-          .be.rejectedWith({ id: 'service.storage.multiple_index_alias'});
-
-
-        body = {
+        privateBody = {
           ['%nepalu.mehry']: {
             aliases: {
               ['@%nepali.mehry']: {},
@@ -4686,16 +4666,21 @@ describe('Test: ElasticSearch service', () => {
             }
           }
         };
-        elasticsearch._client.indices.getAlias.resolves({ body });
+        publicES._client.indices.getAlias.resolves({ body: publicBody });
+        internalES._client.indices.getAlias.resolves({ body: privateBody });
+
+        await should(publicES._getAliasFromESIndex('&nepali.lia'))
+          .be.rejectedWith({ id: 'services.storage.multiple_index_alias'});
 
         await should(internalES._getAliasFromESIndex('%nepalu.mehry'))
-          .be.rejectedWith({ id: 'service.storage.multiple_index_alias'});
+          .be.rejectedWith({ id: 'services.storage.multiple_index_alias'});
       });
     });
 
     describe('#_getSafeESIndex and _isESIndexAvailable', () => {
       it('return raw ES index whenever it is possible', async () => {
-        elasticsearch._client.indices.get.resolves({ body: [] });
+        publicES._client.indices.get.resolves({ body: [] });
+        internalES._client.indices.get.resolves({ body: [] });
 
         const publicESIndex = await publicES._getSafeESIndex('nepali', 'liia');
         const internalESIndex = await internalES._getSafeESIndex('nepali');
@@ -4705,16 +4690,14 @@ describe('Test: ElasticSearch service', () => {
       });
 
       it('return random ES Index if necessary', async () => {
-        elasticsearch._client.indices.get
+        publicES._client.indices.get
           .onFirstCall().resolves({ body: [{index: '&nepali.liia'}] })
           .resolves({ body: [] });
-
-        const publicESIndex = await publicES._getSafeESIndex('nepali', 'liia');
-
-        elasticsearch._client.indices.get
+        internalES._client.indices.get
           .onFirstCall().resolves({ body: [{index: '%nepali.mehry'}] })
           .resolves({ body: [] });
 
+        const publicESIndex = await publicES._getSafeESIndex('nepali', 'liia');
         const internalESIndex = await internalES._getSafeESIndex('nepali', 'mehry');
 
         should(publicESIndex).match(/&([a-z]*).([a-z]*)/);
@@ -4723,31 +4706,37 @@ describe('Test: ElasticSearch service', () => {
     });
 
     describe('#_ensureAliasConsistency', () => {
+      const indicesBody = { body: [
+        { index: '&nepali.liia', status: 'open' },
+        { index: '%nepali.liia', status: 'open' },
+        { index: '&nepali.mehry', status: 'open' },
+        { index: '%nepali.mehry', status: 'open' },
+      ]};
+      const aliasesBody = { body: [
+        { alias: '@&nepali.lia', index: '&nepali.liia', filter: 0 },
+      ]};
+
       beforeEach(() => {
-        elasticsearch._client.indices.updateAliases.resolves();
-        elasticsearch._client.cat.indices.resolves({ body: [
-          { index: '&nepali.liia', status: 'open' },
-          { index: '%nepali.liia', status: 'open' },
-          { index: '&nepali.mehry', status: 'open' },
-          { index: '%nepali.mehry', status: 'open' },
-        ]});
-        elasticsearch._client.cat.aliases.resolves({ body: [
-          { alias: '@&nepali.lia', index: '&nepali.liia', filter: 0 },
-        ]});
+        publicES._client.indices.updateAliases.resolves();
+        internalES._client.indices.updateAliases.resolves();
+
+        publicES._client.cat.indices.resolves(indicesBody);
+        internalES._client.cat.indices.resolves(indicesBody);
+
+        publicES._client.cat.aliases.resolves(aliasesBody);
+        internalES._client.cat.aliases.resolves(aliasesBody);
       });
 
       it('Find indexes without alias and create aliases accordingly', async () => {
         await publicES._ensureAliasConsistency();
+        await internalES._ensureAliasConsistency();
 
-        should(elasticsearch._client.indices.updateAliases).be.calledWith({
+        should(publicES._client.indices.updateAliases).be.calledWith({
           actions : [
             { add : { alias: '@&nepali.mehry', index: '&nepali.mehry' } }
           ]
         });
-
-        await internalES._ensureAliasConsistency();
-
-        should(elasticsearch._client.indices.updateAliases).be.calledWith({
+        should(internalES._client.indices.updateAliases).be.calledWith({
           actions : [
             { add : { alias: '@%nepali.liia', index: '%nepali.liia' } },
             { add : { alias: '@%nepali.mehry', index: '%nepali.mehry' } },
@@ -4793,9 +4782,9 @@ describe('Test: ElasticSearch service', () => {
     describe('#_extractSchema', () => {
       it('should extract the list of indexes and their collections', () => {
         const esIndexes = [
-          '%nepali.liia', '@%nepali.mehry',
+          '@%nepali.liia', '@%nepali.mehry',
 
-          '&nepali.panipokari', '&nepali._kuzzle_keep',
+          '@&nepali.panipokari', '@&nepali._kuzzle_keep',
           '@&vietnam.lfiduras', '@&vietnam._kuzzle_keep'
         ];
 
@@ -4813,9 +4802,9 @@ describe('Test: ElasticSearch service', () => {
 
       it('should include hidden collection with the option', () => {
         const esIndexes = [
-          '%nepali.liia', '@%nepali.mehry',
+          '@%nepali.liia', '@%nepali.mehry',
 
-          '&nepali.panipokari', '&nepali._kuzzle_keep',
+          '@&nepali.panipokari', '@&nepali._kuzzle_keep',
           '@&vietnam.lfiduras', '@&vietnam._kuzzle_keep'
         ];
 


### PR DESCRIPTION
Closes #2065

## What does this PR do ?

Change default behavior with ElasticSearch indice. An alias is associated with each indice following the same pattern index + collection. From now, Kuzzle only use aliases instead of indices for each request allowing multiple use cases on indices (such as shrinking or renaming) and facilitating overall maintenance.

- Remove reference to aliases anywhere else than in elasticsearch file (indices are implicitely aliases and that must be invisible)
- Refacto `ES index` reference to `indice` for a better understanding and to be consistent with the doc
- ElasticSearch file uses almost always aliases and has new helpers (`_getAlias`, `_getIndice`, `_getAvailableIndice`, `_getAliasFromIndice`) to facilitate their usage in different use cases well described.
- New error to preserve alias/index unique relationship
- Main concepts doc updated
- New name-generator mock
- Boyscout: Refacto some functions of `lib/service/storage/elasticsearch` with `async`/`await` instead of `.then`/`.catch`

### ElasticSearch indice/alias concerns

Using only aliases instead of indices which can evolve independently require some precautions.

| Concern | Why? | Solution |
| --------------------------- | ------------ | ------------ |
| Using a name as an alias that also refers to a different indice name. | For each ES request, referring to an alias or an indice is equivalent. We have to use the same `index` field. | Add an `ALIAS_PREFIX` (currently @) to always differentiate an alias name from an indice name. |
| The `ALIAS_PREFIX` can be confused with an index or collection char. | The `ALIAS_PREFIX` can not be added to the `FORBIDDEN_CHARS` without making a breaking change | `INDEX_PREFIX` comes between `ALIAS_PREFIX` and `index.collection`. Since the `INDEX_PREFIX` is already forbidden and always there, the `ALIAS_PREFIX` can be distinguished from a char contained in an index or collection thanks to its position. |
| Unable to create an index because the indice name is already taken even though the alias name is not. | Aliases and indices should evolve independently. If an alias has changed but the indice did not, we could theoretically create a new independant indice with the "old" alias name but when removing the prefix to have the "raw" index name, we would be falling onto the existing index.| Instead of just removing the alias prefix, we use a new method `_getAvailableIndice` which is in charge of checking for this situation and generating a unique suffix if necessary.  |
| Actual Kuzzle users do not have aliases. | This breaking change would lead to multiple errors because Kuzzle would not consider their actual indexes/collections | Add a new method `_ensureAliasConsistency` which runs when Kuzzle starts. This function is in charge of checking for this situation and adding, if necessary, missing aliases based on their existing indices. |