### PR TITLE
Fix documentation: add missing trigger to generic:document:beforeGet

### DIFF
--- a/doc/2/framework/events/generic-document/index.md
+++ b/doc/2/framework/events/generic-document/index.md
@@ -303,6 +303,7 @@ class PipePlugin {
 
 - [document:get](/core/2/api/controllers/document/get)
 - [document:mGet](/core/2/api/controllers/document/m-get)
+- [document:search](/core/2/api/controllers/document/search)
 
 ---
 


### PR DESCRIPTION
## What does this PR do ?

Add missing trigger `document:search` in the triggers list of `generic:document:beforeGet`
