### PR TITLE
Send tokens to every user with persistent connection

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -398,10 +398,13 @@
         //    allocate as many decoders to handle the incoming request.
         // * maxFormFileSize:
         //    Maximum size of requests sent via http forms
+        // * notifyTokenExpired:
+        //    Set to "true" to enable notification of expired tokens
         "allowCompression": true,
         "enabled": true,
         "maxEncodingLayers": 3,
-        "maxFormFileSize": "1mb"
+        "maxFormFileSize": "1mb",
+        "notifyTokenExpired": false
       },
       "mqtt": {
         // * enabled:
@@ -420,6 +423,8 @@
         // * server
         //    Constructor options passed to underlying MQTT server.
         //    See aedes documentation for further reference: https://github.com/moscajs/aedes
+        // * notifyTokenExpired:
+        //    Set to "true" to enable notification of expired tokens
         "enabled": false,
         "allowPubSub": false,
         "developmentMode": false,
@@ -428,7 +433,8 @@
         "responseTopic": "Kuzzle/response",
         "server": {
           "port": 1883
-        }
+        },
+        "notifyTokenExpired": true
       },
       "websocket": {
         // * compression:
@@ -448,10 +454,13 @@
         //    submit to the server.
         //    Requests exceeding that rate limit are rejected.
         //    Disabled if set to 0.
+        // * notifyTokenExpired:
+        //    Set to "true" to enable notification of expired tokens
         "compression": false,
         "enabled": true,
         "idleTimeout": 60000,
-        "rateLimit": 0
+        "rateLimit": 0,
+        "notifyTokenExpired": true
       }
     }
   },

--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -401,7 +401,7 @@
         "allowCompression": true,
         "enabled": true,
         "maxEncodingLayers": 3,
-        "maxFormFileSize": "1mb",
+        "maxFormFileSize": "1mb"
       },
       "mqtt": {
         // * enabled:

--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -398,13 +398,10 @@
         //    allocate as many decoders to handle the incoming request.
         // * maxFormFileSize:
         //    Maximum size of requests sent via http forms
-        // * notifyTokenExpired:
-        //    Set to "true" to enable notification of expired tokens
         "allowCompression": true,
         "enabled": true,
         "maxEncodingLayers": 3,
         "maxFormFileSize": "1mb",
-        "notifyTokenExpired": false
       },
       "mqtt": {
         // * enabled:
@@ -423,8 +420,8 @@
         // * server
         //    Constructor options passed to underlying MQTT server.
         //    See aedes documentation for further reference: https://github.com/moscajs/aedes
-        // * notifyTokenExpired:
-        //    Set to "true" to enable notification of expired tokens
+        // * realtimeNotifications:
+        //    Set to "true" to enable realtime notifications like "TokenExpired" notifications
         "enabled": false,
         "allowPubSub": false,
         "developmentMode": false,
@@ -434,7 +431,7 @@
         "server": {
           "port": 1883
         },
-        "notifyTokenExpired": true
+        "realtimeNotifications": true
       },
       "websocket": {
         // * compression:
@@ -454,13 +451,13 @@
         //    submit to the server.
         //    Requests exceeding that rate limit are rejected.
         //    Disabled if set to 0.
-        // * notifyTokenExpired:
-        //    Set to "true" to enable notification of expired tokens
+        // * realtimeNotifications:
+        //    Set to "true" to enable realtime notifications like "TokenExpired" notifications
         "compression": false,
         "enabled": true,
         "idleTimeout": 60000,
         "rateLimit": 0,
-        "notifyTokenExpired": true
+        "realtimeNotifications": true
       }
     }
   },

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -182,6 +182,13 @@ class AuthController extends NativeController {
       this.assertIsAuthenticated(request);
     }
 
+    if (request.context.connection.protocol === 'websocket') {
+      // Unlink connection so the connection will not be notified when the token expires.
+      global.kuzzle.tokenManager.unlink(
+        request.context.token,
+        request.context.connection.id);
+    }
+
     if (request.context.user._id !== this.anonymousId) {
 
       if (request.getBoolean('global')) {
@@ -333,6 +340,13 @@ class AuthController extends NativeController {
 
     if (existingToken) {
       global.kuzzle.tokenManager.refresh(existingToken, token);
+    }
+
+    if (request.context.connection.protocol === 'websocket') {
+      // Link the connection with the token, this way the connection can be notified when the token has expired.
+      global.kuzzle.tokenManager.link(
+        token,
+        request.context.connection.id);
     }
 
     return this._sendToken(token, request);

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -182,7 +182,7 @@ class AuthController extends NativeController {
       this.assertIsAuthenticated(request);
     }
 
-    if (['websocket', 'mqtt'].includes(request.context.connection.protocol)) {
+    if (global.kuzzle.config.internal.notifiableProtocols.includes(request.context.connection.protocol)) {
       // Unlink connection so the connection will not be notified when the token expires.
       global.kuzzle.tokenManager.unlink(
         request.context.token,
@@ -342,7 +342,7 @@ class AuthController extends NativeController {
       global.kuzzle.tokenManager.refresh(existingToken, token);
     }
 
-    if (['websocket', 'mqtt'].includes(request.context.connection.protocol)) {
+    if (global.kuzzle.config.internal.notifiableProtocols.includes(request.context.connection.protocol)) {
       // Link the connection with the token, this way the connection can be notified when the token has expired.
       global.kuzzle.tokenManager.link(
         token,

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -182,7 +182,7 @@ class AuthController extends NativeController {
       this.assertIsAuthenticated(request);
     }
 
-    if (request.context.connection.protocol === 'websocket') {
+    if (['websocket', 'mqtt'].includes(request.context.connection.protocol)) {
       // Unlink connection so the connection will not be notified when the token expires.
       global.kuzzle.tokenManager.unlink(
         request.context.token,
@@ -342,7 +342,7 @@ class AuthController extends NativeController {
       global.kuzzle.tokenManager.refresh(existingToken, token);
     }
 
-    if (request.context.connection.protocol === 'websocket') {
+    if (['websocket', 'mqtt'].includes(request.context.connection.protocol)) {
       // Link the connection with the token, this way the connection can be notified when the token has expired.
       global.kuzzle.tokenManager.link(
         token,

--- a/lib/api/controllers/realtimeController.js
+++ b/lib/api/controllers/realtimeController.js
@@ -68,11 +68,6 @@ class RealtimeController extends NativeController {
       return null;
     }
 
-    global.kuzzle.tokenManager.link(
-      request.context.token,
-      request.context.connection.id,
-      result.roomId);
-
     return result;
   }
 
@@ -81,15 +76,10 @@ class RealtimeController extends NativeController {
    * @returns {Promise<Object>}
    */
   async join (request) {
-    const roomId = request.getBodyString('roomId');
-    const result = await global.kuzzle.ask('core:realtime:join', request);
+    // assertion checks
+    request.getBodyString('roomId');
 
-    global.kuzzle.tokenManager.link(
-      request.context.token,
-      request.context.connection.id,
-      roomId);
-
-    return result;
+    return await global.kuzzle.ask('core:realtime:join', request);
   }
 
   /**
@@ -103,8 +93,6 @@ class RealtimeController extends NativeController {
       'core:realtime:unsubscribe',
       request.context.connection.id,
       roomId);
-
-    global.kuzzle.tokenManager.unlink(request.context.token, roomId);
 
     return { roomId };
   }

--- a/lib/api/controllers/realtimeController.js
+++ b/lib/api/controllers/realtimeController.js
@@ -79,7 +79,7 @@ class RealtimeController extends NativeController {
     // assertion checks
     request.getBodyString('roomId');
 
-    return await global.kuzzle.ask('core:realtime:join', request);
+    return global.kuzzle.ask('core:realtime:join', request);
   }
 
   /**

--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -471,7 +471,7 @@ class Funnel {
       'core:security:user:get',
       userId);
 
-    if (request.context.connection.protocol === 'websocket') {
+    if (['websocket', 'mqtt'].includes(request.context.connection.protocol)) {
       // Link the connection with the token, this way the connection can be notified when the token has expired.
       global.kuzzle.tokenManager.link(
         request.context.token,

--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -471,6 +471,13 @@ class Funnel {
       'core:security:user:get',
       userId);
 
+    if (request.context.connection.protocol === 'websocket') {
+      // Link the connection with the token, this way the connection can be notified when the token has expired.
+      global.kuzzle.tokenManager.link(
+        request.context.token,
+        request.context.connection.id);
+    }
+
     if (! await request.context.user.isActionAllowed(request)) {
       // anonymous user => 401 (Unauthorized) error
       // logged-in user with insufficient permissions => 403 (Forbidden) error

--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -471,7 +471,7 @@ class Funnel {
       'core:security:user:get',
       userId);
 
-    if (['websocket', 'mqtt'].includes(request.context.connection.protocol)) {
+    if (global.kuzzle.config.internal.notifiableProtocols.includes(request.context.connection.protocol)) {
       // Link the connection with the token, this way the connection can be notified when the token has expired.
       global.kuzzle.tokenManager.link(
         request.context.token,

--- a/lib/config/default.config.js
+++ b/lib/config/default.config.js
@@ -212,7 +212,6 @@ module.exports = {
         enabled: true,
         maxEncodingLayers: 3,
         maxFormFileSize: '1MB',
-        notifyTokenExpired: false,
       },
       mqtt: {
         enabled: false,
@@ -224,14 +223,14 @@ module.exports = {
         server: {
           port: 1883
         },
-        notifyTokenExpired: true,
+        realtimeNotifications: true,
       },
       websocket: {
         enabled: true,
         idleTimeout: 60000,
         compression: false,
         rateLimit: 0,
-        notifyTokenExpired: true,
+        realtimeNotifications: true,
       }
     }
   },

--- a/lib/config/default.config.js
+++ b/lib/config/default.config.js
@@ -211,7 +211,8 @@ module.exports = {
         allowCompression: true,
         enabled: true,
         maxEncodingLayers: 3,
-        maxFormFileSize: '1MB'
+        maxFormFileSize: '1MB',
+        notifyTokenExpired: false,
       },
       mqtt: {
         enabled: false,
@@ -222,13 +223,15 @@ module.exports = {
         responseTopic: 'Kuzzle/response',
         server: {
           port: 1883
-        }
+        },
+        notifyTokenExpired: true,
       },
       websocket: {
         enabled: true,
         idleTimeout: 60000,
         compression: false,
         rateLimit: 0,
+        notifyTokenExpired: true,
       }
     }
   },

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -58,6 +58,7 @@ function load () {
   };
 
   preprocessHttpOptions(config);
+  preprocessProtocolsOptions(config);
   // Injects the current Kuzzle version
   config.version = packageJson.version;
 
@@ -230,6 +231,16 @@ function preprocessHttpOptions (config) {
 
   // Stored to avoid doing includes multiple times later
   config.internal.allowAllOrigins = httpConfig.accessControlAllowOrigin.includes('*');
+}
+
+function preprocessProtocolsOptions(config) {
+  const protocols = config.server.protocols;
+  config.internal.notifiableProtocols = [];
+  for (const [protocolName, protocolConfig] of Object.entries(protocols)) {
+    if (protocolConfig.enabled && protocolConfig.notifyTokenExpired) {
+      config.internal.notifiableProtocols.push(protocolName);
+    }
+  }
 }
 
 module.exports = { load };

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -237,7 +237,7 @@ function preprocessProtocolsOptions(config) {
   const protocols = config.server.protocols;
   config.internal.notifiableProtocols = [];
   for (const [protocolName, protocolConfig] of Object.entries(protocols)) {
-    if (protocolConfig.enabled && protocolConfig.notifyTokenExpired) {
+    if (protocolConfig.enabled && protocolConfig.realtimeNotifications) {
       config.internal.notifiableProtocols.push(protocolName);
     }
   }

--- a/lib/core/auth/tokenManager.js
+++ b/lib/core/auth/tokenManager.js
@@ -60,7 +60,7 @@ class TokenManager {
 
       return a.idx < b.idx ? -1 : 1;
     });
-    this.tokensByConnectedUser = new Map();
+    this.tokensByConnection = new Map();
 
     this.timer = null;
   }
@@ -83,51 +83,62 @@ class TokenManager {
   }
 
   /**
-   * Link a real-time room identifier with a connection and its associated
-   * token. If one or another expires, associated subscriptions are cleaned up
-   *
+   * Link a connection and a token.
+   * If one or another expires, associated subscriptions are cleaned up
    * @param {Token} token
    * @param {String} connectionId
-   * @param {String} roomId
    */
-  link (token, connectionId, roomId) {
+  link (token, connectionId) {
     // Embedded SDK does not use tokens
     if (! token || token._id === this.anonymousUserId) {
       return;
     }
 
     const idx = getTokenIndex(token);
+    const currentToken = this.tokensByConnection.get(connectionId);
+    
+    if (currentToken) {
+      if (currentToken._id === token._id) {
+        return; // Connection and Token already linked
+      }
+      this._removeConnectionLinkedToToken(connectionId, currentToken);
+    }
     const pos = this.tokens.search({idx});
 
     if (pos === -1) {
-      this._add(token, connectionId, [roomId]);
+      this._add(token, [connectionId]);
     }
     else {
-      this.tokens.array[pos].rooms.add(roomId);
+      const data = this.tokens.array[pos];
+      data.connectionIds.add(connectionId);
+      this.tokensByConnection.set(connectionId, data);
     }
   }
 
   /**
-   * Unlink a real-time identifier from its associated token
+   * Unlink a connection from its associated token
    *
    * @param  {Token} token
-   * @param  {String} roomId
+   * @param  {String} connectionId
    */
-  unlink (token, roomId) {
+  unlink (token, connectionId) {
     // Embedded SDK does not use tokens
     if (! token || token._id === this.anonymousUserId) {
       return;
     }
 
     const idx = getTokenIndex(token);
-    const pos = this.tokens.search({idx});
+    const pos = this.tokens.search({ idx });
 
-    if (pos > -1) {
-      this.tokens.array[pos].rooms.delete(roomId);
+    if (pos === -1) {
+      return;
+    }
 
-      if (this.tokens.array[pos].rooms.size === 0) {
-        this._deleteByIndex(pos);
-      }
+    this._removeConnectionLinkedToToken(connectionId, this.tokens.array[pos]);
+
+    const currentToken = this.tokensByConnection.get(connectionId);
+    if (currentToken && currentToken._id === token._id) {
+      this.tokensByConnection.delete(connectionId);
     }
   }
 
@@ -148,9 +159,12 @@ class TokenManager {
     const searchResult = this.tokens.search({idx});
 
     if (searchResult > -1) {
-      const connectionId = this.tokens.array[searchResult].connectionId;
+      const data = this.tokens.array[searchResult];
 
-      await global.kuzzle.ask('core:realtime:user:remove', connectionId);
+      for (const connectionId of data.connectionIds) {
+        this.tokensByConnection.delete(connectionId);
+        await global.kuzzle.ask('core:realtime:user:remove', connectionId);
+      }
 
       this._deleteByIndex(searchResult);
     }
@@ -175,11 +189,12 @@ class TokenManager {
     // potentially very, very, very hard to debug random problem before it
     // occurs
     if (pos > -1 && oldToken._id !== newToken._id) {
-      this._add(
-        newToken,
-        this.tokens.array[pos].connectionId,
-        [...this.tokens.array[pos].rooms]);
+      const connectionIds = this.tokens.array[pos].connectionIds;
+      const idx = getTokenIndex(newToken);
 
+      this._add(newToken, connectionIds);
+
+      // Delete old token
       this._deleteByIndex(pos);
     }
   }
@@ -189,11 +204,13 @@ class TokenManager {
 
     // API key can never expire (-1)
     if (arr.length > 0 && (arr[0].expiresAt > 0 && arr[0].expiresAt < Date.now())) {
-      const connectionId = arr[0].connectionId;
+      const connectionIds = arr[0].connectionIds;
 
       arr.shift();
 
-      await global.kuzzle.ask('core:realtime:tokenExpired:notify', connectionId);
+      for (const connectionId of connectionIds) {
+        await global.kuzzle.ask('core:realtime:tokenExpired:notify', connectionId);
+      }
       setImmediate(() => this.checkTokensValidity());
       return;
     }
@@ -211,9 +228,15 @@ class TokenManager {
    * @returns {Token}
    */
   getConnectedUserToken(userId, connectionId) {
-    const data = this.tokensByConnectedUser.get(`${userId}#${connectionId}`);
+    const data = this.tokensByConnection.get(connectionId);
 
-    return data ? new Token(data) : null;
+    if (!data) {
+      return;
+    }
+
+    return data.userId === userId 
+      ? new Token({...data, connectionId})
+      : null;
   }
 
   /**
@@ -221,21 +244,30 @@ class TokenManager {
    *
    * @param {Token} token
    * @param {string} connectionId
-   * @param {Array<string>} roomIds
    * @private
    */
-  _add(token, connectionId, roomIds = []) {
+  _add(token, connectionIds) {
     const data = Object.assign({}, token, {
-      connectionId,
-      idx: getTokenIndex(token),
-      rooms: new Set(roomIds)
+      connectionIds: new Set(connectionIds),
+      idx: getTokenIndex(token)
     });
 
+    for (const connectionId of connectionIds) {
+      this.tokensByConnection.set(connectionId, data);
+    }
     this.tokens.insert(data);
-    this.tokensByConnectedUser.set(`${data.userId}#${data.connectionId}`, data);
 
     if (this.tokens.array[0].idx === data.idx) {
       this.runTimer();
+    }
+  }
+
+  _removeConnectionLinkedToToken(connectionId, token) {
+    token.connectionIds.delete(connectionId);
+
+    if (token.connectionIds.size === 0) {
+      const pos = this.tokens.search({ idx: token.idx });
+      this._deleteByIndex(pos);
     }
   }
 
@@ -246,7 +278,6 @@ class TokenManager {
       return;
     }
 
-    this.tokensByConnectedUser.delete(`${data.userId}#${data.connectionId}`);
     this.tokens.array.splice(index, 1);
   }
 }

--- a/lib/core/auth/tokenManager.js
+++ b/lib/core/auth/tokenManager.js
@@ -52,10 +52,25 @@ class TokenManager {
      * The token id is added to the key to handle
      * equality between different tokens sharing
      * the exact same expiration date
+     * 
+     * We should always put infinite duration token at the end of the array
+     * because the loop that checks if a token is expired is always verifiying the first element of the array.
+     * Since an infinite token cannot be expired, if there is an infinite duration token at the first element
+     * the loop will verify the same token over and over again because the token cannot be removed from the queue
+     * and the other tokens will never be verifier.
      */
     this.tokens = new SortedArray([], (a, b) => {
       if (a.idx === b.idx) {
         return 0;
+      }
+
+
+      if (a.idx[0] === '-') {
+        return 1;
+      }
+
+      if (b.idx[0] === '-') {
+        return -1;
       }
 
       return a.idx < b.idx ? -1 : 1;
@@ -190,7 +205,6 @@ class TokenManager {
     // occurs
     if (pos > -1 && oldToken._id !== newToken._id) {
       const connectionIds = this.tokens.array[pos].connectionIds;
-      const idx = getTokenIndex(newToken);
 
       this._add(newToken, connectionIds);
 

--- a/lib/core/auth/tokenManager.js
+++ b/lib/core/auth/tokenManager.js
@@ -243,11 +243,7 @@ class TokenManager {
   getConnectedUserToken(userId, connectionId) {
     const data = this.tokensByConnection.get(connectionId);
 
-    if (!data) {
-      return;
-    }
-
-    return data.userId === userId 
+    return data && data.userId === userId 
       ? new Token({...data, connectionId})
       : null;
   }

--- a/lib/core/auth/tokenManager.js
+++ b/lib/core/auth/tokenManager.js
@@ -64,12 +64,11 @@ class TokenManager {
         return 0;
       }
 
-
-      if (a.idx[0] === '-') {
+      if (a.idx && a.idx[0] === '-') {
         return 1;
       }
 
-      if (b.idx[0] === '-') {
+      if (b.idx && b.idx[0] === '-') {
         return -1;
       }
 

--- a/test/core/auth/tokenManager.test.js
+++ b/test/core/auth/tokenManager.test.js
@@ -309,8 +309,7 @@ describe('Test: token manager core component', () => {
 
       tokenManager.link(
         new Token({_id: 'api-key-1', expiresAt: -1 }),
-        'connectionId1',
-        'roomId1');
+        'connectionId1');
 
       runTimerStub.resetHistory();
 
@@ -384,14 +383,14 @@ describe('Test: token manager core component', () => {
       tokenManager.link(token, 'baz');
 
       should(tokenManager.tokens.array)
-      .be.an.Array()
-      .and.match([{
-        idx: `${token.expiresAt};${token._id}`,
-        connectionIds: new Set(['foo', 'bar', 'baz']),
-        expiresAt: token.expiresAt,
-        userId: token.userId,
-      }])
-      .and.have.length(1);
+        .be.an.Array()
+        .and.match([{
+          idx: `${token.expiresAt};${token._id}`,
+          connectionIds: new Set(['foo', 'bar', 'baz']),
+          expiresAt: token.expiresAt,
+          userId: token.userId,
+        }])
+        .and.have.length(1);
 
       tokenManager.unlink(token, 'bar');
       should(tokenManager.tokens.array)
@@ -411,14 +410,14 @@ describe('Test: token manager core component', () => {
       tokenManager.link(token, 'baz');
 
       should(tokenManager.tokens.array)
-      .be.an.Array()
-      .and.match([{
-        idx: `${token.expiresAt};${token._id}`,
-        connectionIds: new Set(['foo', 'bar', 'baz']),
-        expiresAt: token.expiresAt,
-        userId: token.userId,
-      }])
-      .and.have.length(1);
+        .be.an.Array()
+        .and.match([{
+          idx: `${token.expiresAt};${token._id}`,
+          connectionIds: new Set(['foo', 'bar', 'baz']),
+          expiresAt: token.expiresAt,
+          userId: token.userId,
+        }])
+        .and.have.length(1);
 
       tokenManager.unlink(token, 'bar');
       tokenManager.unlink(token, 'foo');

--- a/test/core/auth/tokenManager.test.js
+++ b/test/core/auth/tokenManager.test.js
@@ -234,6 +234,7 @@ describe('Test: token manager core component', () => {
         userId: 'foo2',
         jwt: 'bar2',
         expiresAt: Date.now()+1000,
+        _idx: `${Date.now()+1000}#foo2`,
       });
 
       tokenManager.tokens.array.push(token);


### PR DESCRIPTION
## What does this PR do ?

This PR changes the way we handle tokens used with persistent connection.
Connections can only be associated to one token, but tokens can now be associated to multiple connections, this way when a Token expires every connection using the token will be notified that the token as expired.

Prior to this feature token and connection were as linked or unlinked when connection were subscribing / unsubscribing to a room using the realtimeController.
Now connection and tokens are directly linked in the funnel when processing request that contains a Token, or when calling `auth:login`, and connection and tokens are unlinked on `auth:logout`

I added the option `notifyTokenExpired` that work per protocol and enable the sending of token expired notifications.