### PR TITLE
Support ES inner_hits keyword

### DIFF
--- a/doc/2/api/controllers/document/scroll/index.md
+++ b/doc/2/api/controllers/document/scroll/index.md
@@ -64,6 +64,8 @@ Returns a paginated search result set, with the following properties:
   - `_id`: document unique identifier
   - `_score`: [relevance score](https://www.elastic.co/guide/en/elasticsearch/guide/current/relevance-intro.html)
   - `_source`: new document content
+  - `highlight`: optional result from [highlight API](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/search-request-body.html#request-body-search-highlighting)
+  - `inner_hits`: optional result from [inner_hits API](https://www.elastic.co/guide/en/elasticsearch/reference/current/inner-hits.html) <SinceBadge version="auto-version"/>
 - `remaining`: remaining documents that can be fetched <SinceBadge version="2.4.0"/>
 - `scrollId`: identifier to the next page of result. Can be different than the previous one(s)
 - `total`: total number of found documents. Usually greater than the number of documents in a result page

--- a/doc/2/api/controllers/document/search/index.md
+++ b/doc/2/api/controllers/document/search/index.md
@@ -14,8 +14,8 @@ That limit is by default set at 10000 documents (see `limits.documentsFetchCount
 To handle larger result sets, you have to either create a cursor by providing a value to the `scroll` option or, if you sort the results, by using the Elasticsearch [search_after](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/search-request-body.html#request-body-search-search-after) command.
 
 ::: warning
-When using a cursor with the `scroll` option, Elasticsearch has to duplicate the transaction log to keep the same result during the entire scroll session.  
-It can lead to memory leaks if a scroll duration too large is provided, or if too many scroll sessions are open simultaneously.  
+When using a cursor with the `scroll` option, Elasticsearch has to duplicate the transaction log to keep the same result during the entire scroll session.
+It can lead to memory leaks if a scroll duration too large is provided, or if too many scroll sessions are open simultaneously.
 :::
 
 
@@ -26,8 +26,8 @@ You can restrict the scroll session maximum duration under the `services.storage
 
 <SinceBadge version="2.8.0"/>
 
-This method also supports the [Koncorde Filters DSL](/core/2/api/koncorde-filters-syntax) to match documents by passing the `lang` argument with the value `koncorde`.  
-Koncorde filters will be translated into an Elasticsearch query.  
+This method also supports the [Koncorde Filters DSL](/core/2/api/koncorde-filters-syntax) to match documents by passing the `lang` argument with the value `koncorde`.
+Koncorde filters will be translated into an Elasticsearch query.
 
 ::: warning
 Koncorde `bool` operator and `regexp` clause are not supported for search queries.
@@ -98,7 +98,7 @@ Method: GET
 
 ```bash
 kourou document:search <index> <collection> <query>
-kourou document:search <index> <collection> <query> --sort <sort> --size <size> 
+kourou document:search <index> <collection> <query> --sort <sort> --size <size>
 ```
 
 ---
@@ -143,6 +143,7 @@ Returns a paginated search result set, with the following properties:
   - `_score`: [relevance score](https://www.elastic.co/guide/en/elasticsearch/guide/current/relevance-intro.html)
   - `_source`: new document content
   - `highlight`: optional result from [highlight API](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/search-request-body.html#request-body-search-highlighting)
+  - `inner_hits`: optional result from [inner_hits API](https://www.elastic.co/guide/en/elasticsearch/reference/current/inner-hits.html) <SinceBadge version="auto-version"/>
 - `remaining`: remaining documents that can be fetched. Present only if the `scroll` argument has been supplied <SinceBadge version="2.4.0"/>
 - `scrollId`: identifier to the next page of result. Present only if the `scroll` argument has been supplied
 - `total`: total number of found documents. Can be greater than the number of documents in a result page, meaning that other matches than the one retrieved are available

--- a/doc/2/guides/main-concepts/querying/index.md
+++ b/doc/2/guides/main-concepts/querying/index.md
@@ -8,7 +8,7 @@ order: 300
 
 # Querying
 
-Kuzzle directly exposes [Elasticsearch's query language](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-dsl.html) in a secure way. 
+Kuzzle directly exposes [Elasticsearch's query language](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-dsl.html) in a secure way.
 
 It is possible for a client to send requests to **retrieve documents from any authorized collection**.
 
@@ -21,7 +21,6 @@ Elasticsearch supports many keywords in a search query root level. For security 
   - `explain`
   - `from`
   - `highlight`
-  - `inner_hits`
   - `query`
   - `search_after`
   - `search_timeout`
@@ -58,7 +57,7 @@ Most of the actions of the document controller accept an additional option that 
 
 When the value of this option is `wait_for`, then Elasticsearch (and thus Kuzzle) will **respond to the request only when the document has been indexed**.
 
-**Example:** _Create a document and wait for the collection to be refreshed_ 
+**Example:** _Create a document and wait for the collection to be refreshed_
 ```bash
 kourou sdk:execute '
   await sdk.document.createOrReplace(
@@ -67,10 +66,10 @@ kourou sdk:execute '
     "document-1",
     {
       age: 27,
-      city: "Tirana" 
+      city: "Tirana"
     },
     { refresh: "wait_for" });
-  
+
   return sdk.document.search("ktm-open-data", "thamel-taxi");
 '
 ```
@@ -86,7 +85,7 @@ It is possible to request a manual refresh of the documents of a collection with
 
 This action **can take up to a second** to refresh the underlying Elasticsearch indice.
 
-**Example:** _Create documents and then refresh the collection before searching it_ 
+**Example:** _Create documents and then refresh the collection before searching it_
 ```bash
 kourou sdk:execute '
   for (let i = 20; i--; ) {
@@ -96,12 +95,12 @@ kourou sdk:execute '
       "document-" + i,
       {
         age: 27 + i,
-        city: "Tirana" 
+        city: "Tirana"
       });
   }
 
   await sdk.collection.refresh("ktm-open-data", "thamel-taxi");
-  
+
   return sdk.document.search("ktm-open-data", "thamel-taxi");
 '
 ```
@@ -143,7 +142,7 @@ kourou collection:create ktm-open-data thamel-taxi '{
 
 kourou document:mCreate ktm-open-data thamel-taxi '{
   documents: [
-    { 
+    {
       _id: "aschen",
       body: {
         city: "Tirana",
@@ -152,7 +151,7 @@ kourou document:mCreate ktm-open-data thamel-taxi '{
         description: "Ruby is life"
       }
     },
-    { 
+    {
       _id: "jenow",
       body: {
         city: "Tirana",
@@ -161,7 +160,7 @@ kourou document:mCreate ktm-open-data thamel-taxi '{
         description: "Java is my only love"
       }
     },
-    { 
+    {
       _id: "liia",
       body: {
         city: "Kathmandu",
@@ -170,7 +169,7 @@ kourou document:mCreate ktm-open-data thamel-taxi '{
         description: "Little Princes is great"
       }
     },
-    { 
+    {
       _id: "domisol",
       body: {
         city: "Siccieu",
@@ -195,7 +194,7 @@ This clause should be used on fields with the [keyword](/core/2/guides/main-conc
 You can use the `term` clause to find documents based on a precise value such as a price, a product ID, or a username.
 :::
 
-**Example:** _Search for documents containing an exact field value_ 
+**Example:** _Search for documents containing an exact field value_
 ```bash
 kourou document:search ktm-open-data thamel-taxi '{
   term: { name: "Jenow" }
@@ -223,7 +222,7 @@ The match query is the standard query for **performing a full-text search**. As 
 The `match` clause as well as the content of a `text` fields are [analyzed](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/analysis-analyzers.html) by Elasticsearch before performing the query.
 :::
 
-**Example:** _Search for documents roughly matching the provided field value_ 
+**Example:** _Search for documents roughly matching the provided field value_
 ```bash
 kourou document:search ktm-open-data thamel-taxi '{
   match: { description: "java" }
@@ -238,7 +237,7 @@ It can be used with `number` or `date` fields (but not limited to).
 
 Range boundaries are defined using `gt` (greather than), `lt` (lower than), `gte` (greather than or equal) and `lte` (lower than or equal).
 
-**Example:** _Search for documents where the "age" field is between 30 and 42_ 
+**Example:** _Search for documents where the "age" field is between 30 and 42_
 ```bash
 kourou document:search ktm-open-data thamel-taxi '{
   range: {
@@ -254,7 +253,7 @@ kourou document:search ktm-open-data thamel-taxi '{
 
 The [ids](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-ids-query.html) clause allows to search documents **based on their IDs** (`_id` field).
 
-**Example:** _Search for documents by id_ 
+**Example:** _Search for documents by id_
 ```bash
 kourou document:search ktm-open-data thamel-taxi '{
   ids: {
@@ -305,7 +304,7 @@ kourou document:search ktm-open-data thamel-taxi '{
 
 <SinceBadge version="2.8.0"/>
 
-It is also possible to use [Koncorde Filters Syntax](/core/2/api/koncorde-filters-syntax) to search documents.  
+It is also possible to use [Koncorde Filters Syntax](/core/2/api/koncorde-filters-syntax) to search documents.
 
 To use a Koncorde filter instead of an Elasticsearch query, you have to pass the argument `lang` with the value `koncorde` to the API action.
 
@@ -360,9 +359,9 @@ kourou document:search ktm-open-data thamel-taxi --sort '[
 They allow to find all documents matching a search query.
 
 ::: info
-By default, the [document:search](/core/2/api/controllers/document/search) action returns only 10 documents.  
-The number of returned documents can be changed with the `size` option.  
-Elasticsearch does not allow a `search` request to return more than 10000 documents, no matter what pagination parameters are set.  
+By default, the [document:search](/core/2/api/controllers/document/search) action returns only 10 documents.
+The number of returned documents can be changed with the `size` option.
+Elasticsearch does not allow a `search` request to return more than 10000 documents, no matter what pagination parameters are set.
 See the available [Pagination](/core/2/guides/main-concepts/querying#pagination) action methods to get more results.
 :::
 
@@ -483,7 +482,7 @@ Pagination can be done by incrementing the `from` parameter value to retrieve fu
 It's the fastest pagination method available, but also the less consistent.
 
 ::: info
-Because this method does not freeze the search results between two calls, there can be missing or duplicated documents between two result pages.  
+Because this method does not freeze the search results between two calls, there can be missing or duplicated documents between two result pages.
 Also it's not possible to retrieve more than 10000 documents with this method.
 :::
 
@@ -560,15 +559,15 @@ kourou sdk:query document:search \
 ```
 
 ::: info
-Because this method does not freeze the search results between two calls, **there can be missing or duplicated documents between two result pages**.  
-This method efficiently mitigates the costs of scroll searches, but returns less consistent results: it's a middle ground, **ideal for real-time search requests**.  
+Because this method does not freeze the search results between two calls, **there can be missing or duplicated documents between two result pages**.
+This method efficiently mitigates the costs of scroll searches, but returns less consistent results: it's a middle ground, **ideal for real-time search requests**.
 :::
 
 ### Paginate with Scroll Cursor
 
 The `scroll` parameter can be specified in the search query to allow the usage of the [document:scroll](/core/2/api/controllers/document/scroll) action. This option creates **a forward-only cursor** to move through paginated results.
 
-The **results from a scroll request are frozen**, and reflect the state of the collection at the time the initial search request.  
+The **results from a scroll request are frozen**, and reflect the state of the collection at the time the initial search request.
 For that reason, this action is **guaranteed to return consistent results**, even if documents are updated or deleted in the database between two pages retrieval.
 
 This is the **most consistent way to paginate results**, however, this comes at a **higher computing cost** for the server.
@@ -576,7 +575,7 @@ This is the **most consistent way to paginate results**, however, this comes at 
 To use this pagination method, you need to pass a `scroll` parameter with a duration. This duration corresponds to the **time during which Elasticsearch will keep your results frozen**. This duration will be refreshed at each call of the [document:scroll](/core/2/api/controllers/document/scroll) action.
 
 ::: info
-The value of the `scroll` option should be the time needed to process one page of results.  
+The value of the `scroll` option should be the time needed to process one page of results.
 This value has a maximum value which can be modified under the `services.storage.maxScrollDuration` [configuration](/core/2/guides/advanced/configuration) key.
 :::
 
@@ -631,10 +630,10 @@ kourou sdk:query document:scroll -a scrollId=<scroll-id>
 
 ::: warning
 When using a cursor with the `scroll` option, Elasticsearch has to duplicate the transaction log to keep consistent results during the entire scroll session.
-It **can lead to memory issues** if a scroll duration too high is provided, or if too many scroll sessions are open simultaneously.  
+It **can lead to memory issues** if a scroll duration too high is provided, or if too many scroll sessions are open simultaneously.
 
 
-By default, Kuzzle sets a maximum scroll duration of 1 minute.  
+By default, Kuzzle sets a maximum scroll duration of 1 minute.
 This can be changed in the kuzzlerc configuration file under the key `services.storageEngine.maxScrollDuration`.
 :::
 

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -116,7 +116,6 @@ class ElasticSearch extends Service {
       'explain',
       'from',
       'highlight',
-      'inner_hits',
       'query',
       'search_after',
       'search_timeout',
@@ -395,11 +394,37 @@ class ElasticSearch extends Service {
   }
 
   _formatSearchResult (body) {
-    const hits = body.hits.hits.map(hit => ({
+    const formatHit = (hit) => ({
       _id: hit._id,
       _score: hit._score,
       _source: hit._source,
       highlight: hit.highlight,
+    });
+
+    const formatInnerHits = (innerHits) => {
+      let formattedInnerHits;
+
+      if (innerHits) {
+        formattedInnerHits = {};
+        for (const [name, innerHit] of Object.entries(innerHits)) {
+          formattedInnerHits[name] = innerHit.hits.hits.map(formatHit);
+        }
+      }
+
+      return formattedInnerHits;
+    };
+
+    let innerHits;
+    if (body.hits.inner_hits) {
+      innerHits = {};
+      for (const [name, innerHit] of Object.entries(body.hits.inner_hits)) {
+        innerHits[name] = innerHit.hits.hits.map(formatHit);
+      }
+    }
+
+    const hits = body.hits.hits.map(hit => ({
+      inner_hits: formatInnerHits(hit.inner_hits),
+      ...formatHit(hit)
     }));
 
     return {

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -405,7 +405,7 @@ class ElasticSearch extends Service {
 
     function formatInnerHits (innerHits) {
       if (! innerHits) {
-        return; // NOSONAR
+        return undefined;
       }
 
       const formattedInnerHits = {};

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -394,32 +394,25 @@ class ElasticSearch extends Service {
   }
 
   _formatSearchResult (body) {
-    const formatHit = (hit) => ({
-      _id: hit._id,
-      _score: hit._score,
-      _source: hit._source,
-      highlight: hit.highlight,
-    });
+    function formatHit (hit) {
+      return {
+        _id: hit._id,
+        _score: hit._score,
+        _source: hit._source,
+        highlight: hit.highlight,
+      };
+    }
 
-    const formatInnerHits = (innerHits) => {
-      let formattedInnerHits;
-
-      if (innerHits) {
-        formattedInnerHits = {};
-        for (const [name, innerHit] of Object.entries(innerHits)) {
-          formattedInnerHits[name] = innerHit.hits.hits.map(formatHit);
-        }
+    function formatInnerHits (innerHits) {
+      if (! innerHits) {
+        return undefined;
       }
 
+      const formattedInnerHits = {};
+      for (const [name, innerHit] of Object.entries(innerHits)) {
+        formattedInnerHits[name] = innerHit.hits.hits.map(formatHit);
+      }
       return formattedInnerHits;
-    };
-
-    let innerHits;
-    if (body.hits.inner_hits) {
-      innerHits = {};
-      for (const [name, innerHit] of Object.entries(body.hits.inner_hits)) {
-        innerHits[name] = innerHit.hits.hits.map(formatHit);
-      }
     }
 
     const hits = body.hits.hits.map(hit => ({

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -405,7 +405,7 @@ class ElasticSearch extends Service {
 
     function formatInnerHits (innerHits) {
       if (! innerHits) {
-        return;
+        return; // NOSONAR
       }
 
       const formattedInnerHits = {};

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -405,7 +405,7 @@ class ElasticSearch extends Service {
 
     function formatInnerHits (innerHits) {
       if (! innerHits) {
-        return undefined;
+        return;
       }
 
       const formattedInnerHits = {};

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -329,9 +329,20 @@ describe('Test: ElasticSearch service', () => {
             hits: [
               {
                 _id: 'liia',
-                _source: { city: 'Kathmandu' },
+                _source: { country: 'Nepal' },
+                _score: 42,
                 highlight: 'highlight',
-                other: 'thing'
+                inner_hits: {
+                  inner_name: {
+                    hits: {
+                      hits: [{
+                        _id: 'nestedLiia',
+                        _source: { city: 'Kathmandu' },
+                      }]
+                    }
+                  }
+                },
+                other: 'thing',
               }
             ],
             total: { value: 1 },
@@ -363,8 +374,15 @@ describe('Test: ElasticSearch service', () => {
         hits: [
           {
             _id: 'liia',
-            _source: { city: 'Kathmandu' },
+            _source: { country: 'Nepal' },
+            _score: 42,
             highlight: 'highlight',
+            inner_hits: {
+              inner_name: [{
+                _id: 'nestedLiia',
+                _source: { city: 'Kathmandu' },
+              }]
+            }
           },
         ],
         remaining: 0,


### PR DESCRIPTION
## What does this PR do ?

In this [PR](https://github.com/kuzzleio/kuzzle/pull/1957), Kuzzle allowed `inner_hits` keyword for search queries. However, this wasn't the good thing to do since `inner_hits` is not a root keyword and the issue was with the response format. This PR fix, once and for all, this issue allowing durably the use of [inner_hits API](https://www.elastic.co/guide/en/elasticsearch/reference/current/inner-hits.html) with Kuzzle.

### How should this be manually tested?

 - Clone and run kuzzle
 - Create index + collection with these mappings `{ "comments": { "type": "nested" } }` and `dynamic = true`
 - Add some nested documents:
```
{
  "title": "Test title",
  "comments": [
    {
      "author": "kimchy",
      "number": 1
    },
    {
      "author": "nik9000",
      "number": 2
    }
  ]
}
```
 - Use `document:search` with `inner_hits` keyword:
```
{
  "query": {
    "nested": {
      "path": "comments",
      "query": {
        "match": { "comments.number": 2 }
      },
      "inner_hits": {} 
    }
  }
}
```
 - You should see the result containing `inner_hits` as requested