### PR TITLE
Allows to use search queries for roles and profiles

### DIFF
--- a/doc/2/api/controllers/security/create-or-replace-profile/index.md
+++ b/doc/2/api/controllers/security/create-or-replace-profile/index.md
@@ -23,6 +23,7 @@ Body:
 ```js
 {
   "rateLimit": 50,
+  "tags": ["moderators"],
   "policies": [
     {
       "roleId": "<roleId>"
@@ -55,6 +56,7 @@ Body:
   "_id": "<profileId>",
   "body": {
     "rateLimit": 50,
+    "tags": ["moderators"],
     "policies": [
       {
         "roleId": "<anotherRoleId>"

--- a/doc/2/api/controllers/security/create-or-replace-role/index.md
+++ b/doc/2/api/controllers/security/create-or-replace-role/index.md
@@ -24,6 +24,7 @@ Body:
 
 ```js
 {
+  "tags": ["moderators"],
   "controllers": {
     "*": {
       "actions": {
@@ -42,6 +43,7 @@ Body:
   "action": "createOrReplaceRole",
   "_id": "<roleId>",
   "body": {
+    "tags": ["moderators"],
     "controllers": {
       "*": {
         "actions": {

--- a/doc/2/api/controllers/security/create-profile/index.md
+++ b/doc/2/api/controllers/security/create-profile/index.md
@@ -23,6 +23,7 @@ Body:
 ```js
 {
   "rateLimit": 50,
+  "tags": ["moderators"],
   "policies": [
     {
       "roleId": "<roleId>"
@@ -55,6 +56,7 @@ Body:
   "_id": "<profileId>",
   "body": {
     "rateLimit": 50,
+    "tags": ["moderators"],
     "policies": [
       {
         "roleId": "<roleId>"

--- a/doc/2/api/controllers/security/create-role/index.md
+++ b/doc/2/api/controllers/security/create-role/index.md
@@ -24,6 +24,7 @@ Body:
 
 ```js
 {
+  "tags": ["moderators"],
   "controllers": {
     "*": {
       "actions": {
@@ -42,6 +43,7 @@ Body:
   "action": "createRole",
   "_id": "<roleId>",
   "body": {
+    "tags": ["moderators"],
     "controllers": {
       "*": {
         "actions": {

--- a/doc/2/api/controllers/security/search-profiles/index.md
+++ b/doc/2/api/controllers/security/search-profiles/index.md
@@ -6,9 +6,7 @@ title: searchProfiles
 
 # searchProfiles
 
-
-
-Searches security profiles, returning only those linked to the provided list of security roles.
+Searches security profiles.
 
 <SinceBadge version="auto-version"/>
 
@@ -31,16 +29,16 @@ Body:
 
 ```js
 {
-  // list of roles
+  // list of roles (deprecated since auto-version)
   "roles": [
     "role1",
     "admin"
   ],
 
-  // OR use a search query 
+  // use a search query 
   "query": {
     "terms": {
-      "tags": "moderator"
+      "policies.roleId": ["role1", "admin"]
     }
   }
 }
@@ -53,16 +51,16 @@ Body:
   "controller": "security",
   "action": "searchProfiles",
   "body": {
-    // list of roles
+    // list of roles (deprecated since auto-version)
     "roles": [
       "role1",
       "admin"
     ],
 
-    // OR use a search query 
+    // use a search query 
     "query": {
       "terms": {
-        "tags": "moderator"
+        "policies.roleId": ["role1", "admin"]
       }
     }
   },
@@ -90,15 +88,11 @@ Body:
 
 ### Optional:
 
-- `roles`: an array of role identifiers. Restrict the search to profiles linked to the provided roles.
+- `roles`: an array of role identifiers. Restrict the search to profiles linked to the provided roles <DeprecatedBadge version="auto-version"/>.
 
 - `query`: search query using the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-dsl.html) or the [Koncorde Filters DSL](/core/2/api/koncorde-filters-syntax) syntax.
 
 If the body is left empty, the result will return all available profiles.
-
-::: warning
-You cannot use both `roles` and `query` properties at the same time.
-::: 
 
 ---
 

--- a/doc/2/api/controllers/security/search-profiles/index.md
+++ b/doc/2/api/controllers/security/search-profiles/index.md
@@ -8,7 +8,14 @@ title: searchProfiles
 
 
 
-Searches security profiles, optionally returning only those linked to the provided list of security roles.
+Searches security profiles, returning only those linked to the provided list of security roles.
+
+<SinceBadge version="auto-version"/>
+
+Support for search using a search query with the `query` property.
+
+This method also supports the [Koncorde Filters DSL](/core/2/api/koncorde-filters-syntax) to match documents by passing the `lang` argument with the value `koncorde`.  
+Koncorde filters will be translated into an Elasticsearch query.  
 
 ---
 
@@ -24,10 +31,18 @@ Body:
 
 ```js
 {
+  // list of roles
   "roles": [
     "role1",
     "admin"
-  ]
+  ],
+
+  // OR use a search query 
+  "query": {
+    "terms": {
+      "tags": "moderator"
+    }
+  }
 }
 ```
 
@@ -38,10 +53,18 @@ Body:
   "controller": "security",
   "action": "searchProfiles",
   "body": {
+    // list of roles
     "roles": [
       "role1",
       "admin"
-    ]
+    ],
+
+    // OR use a search query 
+    "query": {
+      "terms": {
+        "tags": "moderator"
+      }
+    }
   },
   // optional: result pagination configuration
   "from": 0,
@@ -59,6 +82,7 @@ Body:
 - `from`: the offset from the first result you want to fetch. Usually used with the `size` argument
 - `scroll`: create a new forward-only result cursor. This option must be set with a [time duration](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/common-options.html#time-units), at the end of which the cursor is destroyed. If set, a cursor identifier named `scrollId` will be returned in the results. This cursor can then be moved forward using the [scrollProfiles](/core/2/api/controllers/security/scroll-profiles) API action
 - `size`: the maximum number of profiles returned in one response page
+- `lang`: specify the query language to use. By default, it's `elasticsearch` but `koncorde` can also be used. <SinceBadge version="auto-version"/>
 
 ---
 
@@ -67,6 +91,14 @@ Body:
 ### Optional:
 
 - `roles`: an array of role identifiers. Restrict the search to profiles linked to the provided roles.
+
+- `query`: search query using the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-dsl.html) or the [Koncorde Filters DSL](/core/2/api/koncorde-filters-syntax) syntax.
+
+If the body is left empty, the result will return all available profiles.
+
+::: warning
+You cannot use both `roles` and `query` properties at the same time.
+::: 
 
 ---
 

--- a/doc/2/api/controllers/security/search-roles/index.md
+++ b/doc/2/api/controllers/security/search-roles/index.md
@@ -8,7 +8,14 @@ title: searchRoles
 
 
 
-Searches security roles, optionally returning only those allowing access to the provided controllers.
+Searches security roles, returning only those allowing access to the provided controllers.
+
+<SinceBadge version="auto-version"/>
+
+Support for search using a search query with the `query` property.
+
+This method also supports the [Koncorde Filters DSL](/core/2/api/koncorde-filters-syntax) to match documents by passing the `lang` argument with the value `koncorde`.  
+Koncorde filters will be translated into an Elasticsearch query.  
 
 ---
 
@@ -24,9 +31,16 @@ Body:
 
 ```js
 {
-  // optional: retrieve only roles giving access to the
+  // retrieve only roles giving access to the
   // provided controller names
-  "controllers": ["document", "security"]
+  "controllers": ["document", "security"],
+
+  // OR use a search query 
+  "query": {
+    "terms": {
+      "tags": "moderator"
+    }
+  }
 }
 ```
 
@@ -37,9 +51,17 @@ Body:
   "controller": "security",
   "action": "searchRoles",
   "body": {
-    // optional: search for roles allowing access to the provided
+    // search for roles allowing access to the provided
     // list of controllers
-    "controllers": ["document", "security"]
+    "controllers": ["document", "security"],
+
+    // OR use a search query 
+    "query": {
+      "terms": {
+        "tags": "moderator"
+      }
+    }
+
   },
   // optional: result pagination configuration
   "from": 0,
@@ -55,6 +77,7 @@ Body:
 
 - `from`: the offset from the first result you want to fetch. Usually used with the `size` argument
 - `size`: the maximum number of profiles returned in one response page
+- `lang`: specify the query language to use. By default, it's `elasticsearch` but `koncorde` can also be used. <SinceBadge version="auto-version"/>
 
 ---
 
@@ -63,6 +86,14 @@ Body:
 ### Optional:
 
 - `controllers`: an array of controller names. Restrict the search to roles linked to the provided controllers.
+
+- `query`: search query using the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-dsl.html) or the [Koncorde Filters DSL](/core/2/api/koncorde-filters-syntax) syntax.
+
+If the body is left empty, the result will return all available roles.
+
+::: warning
+You cannot use both `controllers` and `query` properties at the same time.
+::: 
 
 ---
 

--- a/doc/2/guides/main-concepts/permissions/index.md
+++ b/doc/2/guides/main-concepts/permissions/index.md
@@ -156,7 +156,7 @@ You can use the `onAssignedUsers` option of the [security:deleteProfile](/core/2
 A **profile definition is a JSON object** that contains an optional rate limit parameter, and an array of policies.
 
 ::: info
-Profiles also have a `tags` property who can contains a list of string.
+Profiles also have a `tags` property which can contains a list of string.
 
 ```js
 {

--- a/doc/2/guides/main-concepts/permissions/index.md
+++ b/doc/2/guides/main-concepts/permissions/index.md
@@ -76,7 +76,7 @@ The role definition is represented as a JSON object where each key at the root o
 ```
 
 ::: info
-Roles also have a `tags` property who can contains a list of string.
+Roles also have a `tags` property which can contains a list of string.
 
 ```js
 {

--- a/doc/2/guides/main-concepts/permissions/index.md
+++ b/doc/2/guides/main-concepts/permissions/index.md
@@ -75,6 +75,19 @@ The role definition is represented as a JSON object where each key at the root o
 }
 ```
 
+::: info
+Roles also have a `tags` property who can contains a list of string.
+
+```js
+{
+  "tags": ["moderator", "global"],
+  "controllers": {
+    // ...
+  }
+}
+```
+:::
+
 The `controllers` and `actions` properties can be set to a specific value or to the wildcard value "\*".
 
 When `controller` is declared within a Plugin, its name must be prefixed with the name of the Plugin, like `< plugin-name/controller-name >`.
@@ -141,6 +154,19 @@ You can use the `onAssignedUsers` option of the [security:deleteProfile](/core/2
 :::
 
 A **profile definition is a JSON object** that contains an optional rate limit parameter, and an array of policies.
+
+::: info
+Profiles also have a `tags` property who can contains a list of string.
+
+```js
+{
+  "tags": ["moderator", "global"],
+  "policies": [
+    // ...
+  ]
+}
+```
+:::
 
 ### Policies
 

--- a/docker/scripts/start-kuzzle-dev.ts
+++ b/docker/scripts/start-kuzzle-dev.ts
@@ -221,6 +221,15 @@ app.import.roles(functionalFixtures.roles)
 app.import.userMappings(functionalFixtures.userMappings)
 app.import.users(functionalFixtures.users, { onExistingUsers: 'overwrite' })
 
+
+app.hook.register('core:realtime:user:subscribe:after', sub => {
+  console.log('sub ', sub)
+});
+
+app.hook.register('core:realtime:user:unsubscribe:after', sub => {
+  console.log('unsub ', sub)
+});
+
 loadAdditionalPlugins()
   .then(() => app.start())
   .then(() => {

--- a/docker/scripts/start-kuzzle-dev.ts
+++ b/docker/scripts/start-kuzzle-dev.ts
@@ -221,15 +221,6 @@ app.import.roles(functionalFixtures.roles)
 app.import.userMappings(functionalFixtures.userMappings)
 app.import.users(functionalFixtures.users, { onExistingUsers: 'overwrite' })
 
-
-app.hook.register('core:realtime:user:subscribe:after', sub => {
-  console.log('sub ', sub)
-});
-
-app.hook.register('core:realtime:user:unsubscribe:after', sub => {
-  console.log('unsub ', sub)
-});
-
 loadAdditionalPlugins()
   .then(() => app.start())
   .then(() => {

--- a/features-legacy/step_definitions/profiles.js
+++ b/features-legacy/step_definitions/profiles.js
@@ -177,15 +177,15 @@ Then(/^I'm not able to delete profile (?:with id )?"([^"]*)"$/, function (id, ca
 });
 
 Then(/^I'm able to find "([\d]*)" profiles(?: containing the role with id "([^"]*)")?$/, function (profilesCount, roleId, callback) {
-  const body = {roles: []};
+  const roles = [];
 
   if (roleId) {
-    body.roles.push(this.idPrefix + roleId);
+   roles.push(this.idPrefix + roleId);
   }
 
   let main = function (callbackAsync) {
     setTimeout(() => {
-      this.api.searchProfiles(body)
+      this.api.searchProfiles(roles)
         .then(response => {
           if (response.error) {
             return callbackAsync(new Error(response.error.message));
@@ -280,7 +280,7 @@ Then(/^I'm able to do a multi get with "([^"]*)" and get "(\d*)" profiles$/, fun
 Given(/^A scrolled search on profiles$/, function () {
   this.scrollId = null;
 
-  return this.api.searchProfiles({roles: []}, {scroll: '2s'})
+  return this.api.searchProfiles([], {scroll: '2s'})
     .then(response => {
       if (response.error) {
         throw new Error(response.error.message);

--- a/features-legacy/step_definitions/profiles.js
+++ b/features-legacy/step_definitions/profiles.js
@@ -180,7 +180,7 @@ Then(/^I'm able to find "([\d]*)" profiles(?: containing the role with id "([^"]
   const roles = [];
 
   if (roleId) {
-   roles.push(this.idPrefix + roleId);
+    roles.push(this.idPrefix + roleId);
   }
 
   let main = function (callbackAsync) {

--- a/features-legacy/support/api/apiBase.js
+++ b/features-legacy/support/api/apiBase.js
@@ -1030,13 +1030,13 @@ class ApiBase {
     return this.send(msg);
   }
 
-  searchProfiles (query, args) {
+  searchProfiles (roles, args) {
     const
       msg = {
         controller: 'security',
         action: 'searchProfiles',
         body: {
-          query
+          roles
         }
       };
 

--- a/features-legacy/support/api/http.js
+++ b/features-legacy/support/api/http.js
@@ -1039,12 +1039,12 @@ class HttpApi {
     return this.callApi(options);
   }
 
-  searchProfiles (query, args) {
+  searchProfiles (roles, args) {
     const options = {
       url: this.apiPath('profiles/_search'),
       method: 'POST',
       body: {
-        query
+        roles
       }
     };
 

--- a/features/#BackendImport.feature
+++ b/features/#BackendImport.feature
@@ -9,23 +9,23 @@ Feature: Backend Import
   Scenario: Check if mappings have been correctly imported
     Given I have configured mappings in the app before startup
     When I successfully execute the action "collection":"getMapping" with args:
-      | index             | 'index1'                                                   |
-      | collection        | 'collection1'                                              |
-      | includeKuzzleMeta | true                                                       |
+      | index             | 'index1'      |
+      | collection        | 'collection1' |
+      | includeKuzzleMeta | true          |
     Then I should receive a result matching:
-      | dynamic           | 'strict'                                                   |
-      | _meta             | { field: 'value' }                                         |
-      | properties        | { fieldA: { type: 'keyword'}, fieldB: { type: 'integer'} } |
+      | dynamic    | 'strict'                                                   |
+      | _meta      | { field: 'value' }                                         |
+      | properties | { fieldA: { type: 'keyword'}, fieldB: { type: 'integer'} } |
     When I successfully execute the action "collection":"getMapping" with args:
-      | index             | 'index1'                                                   |
-      | collection        | 'collection2'                                              |
+      | index      | 'index1'      |
+      | collection | 'collection2' |
     Then I should receive a result matching:
-      | properties        | { fieldC: { type: 'keyword'} }                             |
+      | properties | { fieldC: { type: 'keyword'} } |
     When I successfully execute the action "collection":"getMapping" with args:
-      | index             | 'index2'                                                   |
-      | collection        | 'collection1'                                              |
+      | index      | 'index2'      |
+      | collection | 'collection1' |
     Then I should receive a result matching:
-      | properties        | { fieldD: { type: 'integer'} }                             |
+      | properties | { fieldD: { type: 'integer'} } |
 
   # import:profiles ===========================================================
 
@@ -48,7 +48,7 @@ Feature: Backend Import
       | document | { create: true, get: true } |
       | cluster  | { "*": true }               |
     And The role "roleB" should match:
-      | *        | { "*": true }               |
+      | * | { "*": true } |
 
   # import:userMappings =======================================================
 
@@ -65,7 +65,7 @@ Feature: Backend Import
   Scenario: Check if users have been correctly imported
     Given I have imported users in the app before startup
     When I successfully execute the action "security":"mGetUsers" with args:
-      | body    | { ids: [ 'userA', 'userB' ] }                     |
+      | body | { ids: [ 'userA', 'userB' ] } |
     Then I should receive a "hits" array of objects matching:
       | _id     | _source                                           |
       | "userA" | { profileIds: ['profileA', 'profileB'], age: 42 } |

--- a/features/SecurityController.feature
+++ b/features/SecurityController.feature
@@ -1,5 +1,39 @@
 Feature: Security Controller
 
+  # security:searchRole =====================================================
+
+  @security
+  Scenario: Search for profiles with a search query
+    Given I successfully execute the action "security":"createRole" with args:
+      | _id  | "kite-surf-1"                                                    |
+      | body | { "tags": ["kite-surf"], "controllers": { "*": { "actions": { "*": true } } } } |
+    And I successfully execute the action "security":"createRole" with args:
+      | _id  | "kite-surf-2"                                                    |
+      | body | { "tags": ["kite-surf"], "controllers": { "*": { "actions": { "*": true } } } } |
+    When I successfully execute the action "security":"searchRoles" with args:
+      | body | { "query": { "term": { "tags": "kite-surf" } } } |
+    Then I should receive a "hits" array of objects matching:
+      | _id           |
+      | "kite-surf-1" |
+      | "kite-surf-2" |
+
+  # security:searchProfile =====================================================
+
+  @security
+  Scenario: Search for profiles with a search query
+    Given I successfully execute the action "security":"createProfile" with args:
+      | _id  | "kite-surf-1"                                                    |
+      | body | { "tags": ["kite-surf"], "policies": [{ "roleId": "default" }] } |
+    And I successfully execute the action "security":"createProfile" with args:
+      | _id  | "kite-surf-2"                                                    |
+      | body | { "tags": ["kite-surf"], "policies": [{ "roleId": "default" }] } |
+    When I successfully execute the action "security":"searchProfiles" with args:
+      | body | { "query": { "term": { "tags": "kite-surf" } } } |
+    Then I should receive a "hits" array of objects matching:
+      | _id           |
+      | "kite-surf-1" |
+      | "kite-surf-2" |
+
   # security:updateRole ========================================================
 
   @security

--- a/features/step_definitions/controllers-steps.js
+++ b/features/step_definitions/controllers-steps.js
@@ -11,7 +11,7 @@ const Bluebird = require('bluebird');
 
 Then(/I (successfully )?execute the action "(.*?)":"(.*?)" with args:$/, async function (expectSuccess, controller, action, dataTable) {
   const args = this.parseObject(dataTable);
-  console.log({ controller, action, ...args })
+
   try {
     const response = await this.sdk.query({ controller, action, ...args });
 

--- a/features/step_definitions/controllers-steps.js
+++ b/features/step_definitions/controllers-steps.js
@@ -11,7 +11,7 @@ const Bluebird = require('bluebird');
 
 Then(/I (successfully )?execute the action "(.*?)":"(.*?)" with args:$/, async function (expectSuccess, controller, action, dataTable) {
   const args = this.parseObject(dataTable);
-
+  console.log({ controller, action, ...args })
   try {
     const response = await this.sdk.query({ controller, action, ...args });
 

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -535,6 +535,7 @@ class SecurityController extends NativeController {
    * @returns {Promise<Object>}
    */
   async searchProfiles (request) {
+    console.log(request.input)
     const size = this._getSearchPageSize(request);
     const { from, scrollTTL, searchBody } = request.getSearchParams();
     const lang = request.getLangParam();

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -25,7 +25,7 @@ const { isEmpty, isNil } = require('lodash');
 const Bluebird = require('bluebird');
 const { v4: uuidv4 } = require('uuid');
 
-const { KuzzleError } = require('../../kerror/errors');
+const { KuzzleError, BadRequestError } = require('../../kerror/errors');
 const { Request } = require('../request');
 const { NativeController } = require('./baseController');
 const formatProcessing = require('../../core/auth/formatProcessing');
@@ -33,6 +33,7 @@ const ApiKey = require('../../model/storage/apiKey');
 const kerror = require('../../kerror');
 const { has, get } = require('../../util/safeObject');
 const { generateRandomName } = require('../../util/name-generator');
+const { log } = require('winston');
 
 /**
  * @class SecurityController
@@ -320,19 +321,27 @@ class SecurityController extends NativeController {
   }
 
   /**
-   * Return a list of roles that specify a right for the given indexes
+   * Search for roles
    *
    * @param {Request} request
    * @returns {Promise<Object>}
    */
-  async searchRoles(request) {
+  async searchRoles (request) {
     const from = request.getInteger('from', 0);
     const size = this._getSearchPageSize(request);
-    const controllers = request.getBodyArray('controllers', []);
+    const body = request.getBody();
+
+    if (body.controllers && body.query) {
+      throw BadRequestError('You cannot specifify both "controllers" and "query". Prefer the usage of "query" property with a search query.');
+    }
+
+    if (body.controllers) {
+      request.addDeprecation('auto-version', 'Usage of the "controllers" property is deprecated. Prefer the usage of "query" property with a search query.');
+    }
 
     const response = await this.ask(
       'core:security:role:search',
-      controllers,
+      body,
       { from, size });
 
     response.hits = response.hits.map(formatProcessing.serializeRole);
@@ -367,7 +376,7 @@ class SecurityController extends NativeController {
    * @param {Request} request
    * @returns {Promise<Object>}
    */
-  async createRole(request) {
+  async createRole (request) {
     const id = request.getId();
     const body = request.getBody();
     const userId = request.getKuid();
@@ -515,20 +524,42 @@ class SecurityController extends NativeController {
   }
 
   /**
-   * Returns a list of profiles that contain a given set of roles
+   * Search for profiles
    *
    * @param {Request} request
    * @returns {Promise<Object>}
    */
-  async searchProfiles(request) {
-    const roles = request.getBodyArray('roles', []);
-    const from = request.getInteger('from', 0);
+  async searchProfiles (request) {
     const size = this._getSearchPageSize(request);
-    const scroll = request.getScrollTTLParam();
+    const { from, scrollTTL, searchBody } = request.getSearchParams();
+    const lang = request.getLangParam();
+    const body = request.getBody();
 
-    const response = await this.ask('core:security:profile:search', roles, {
+    if (body.roles && body.query) {
+      throw BadRequestError('You cannot specifify both "roles" and "query". Prefer the usage of "query" property with a search query.');
+    }
+
+    if (body.roles) {
+      const roles = request.getBodyArray('roles');
+
+      request.addDeprecation('auto-version', 'Usage of the "roles" property is deprecated. Prefer the usage of "query" property with a search query.');
+
+      if (roles.length > 0) {
+        searchBody.query = { terms: { 'policies.roleId': roles } };
+      }
+      else {
+        searchBody.query = { match_all: {} };
+      }
+      delete body.roles;
+    }
+
+    if (lang === 'koncorde') {
+      searchBody.query = await this.translateKoncorde(searchBody.query || {});
+    }
+
+    const response = await this.ask('core:security:profile:search', searchBody, {
       from,
-      scroll,
+      scroll: scrollTTL,
       size,
     });
 

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -329,14 +329,20 @@ class SecurityController extends NativeController {
   async searchRoles (request) {
     const from = request.getInteger('from', 0);
     const size = this._getSearchPageSize(request);
-    const body = request.getBody();
+    const lang = request.getLangParam();
+    const body = request.getBody({});
 
     if (body.controllers && body.query) {
       throw BadRequestError('You cannot specifify both "controllers" and "query". Prefer the usage of "query" property with a search query.');
     }
 
     if (body.controllers) {
-      request.addDeprecation('auto-version', 'Usage of the "controllers" property is deprecated. Prefer the usage of "query" property with a search query.');
+      // Type checking
+      request.getBodyArray('controllers');
+    }
+
+    if (lang === 'koncorde') {
+      body.query = await this.translateKoncorde(body.query || {});
     }
 
     const response = await this.ask(
@@ -533,7 +539,7 @@ class SecurityController extends NativeController {
     const size = this._getSearchPageSize(request);
     const { from, scrollTTL, searchBody } = request.getSearchParams();
     const lang = request.getLangParam();
-    const body = request.getBody();
+    const body = request.getBody({});
 
     if (body.roles && body.query) {
       throw BadRequestError('You cannot specifify both "roles" and "query". Prefer the usage of "query" property with a search query.');

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -33,7 +33,6 @@ const ApiKey = require('../../model/storage/apiKey');
 const kerror = require('../../kerror');
 const { has, get } = require('../../util/safeObject');
 const { generateRandomName } = require('../../util/name-generator');
-const { log } = require('winston');
 
 /**
  * @class SecurityController
@@ -333,7 +332,7 @@ class SecurityController extends NativeController {
     const body = request.getBody({});
 
     if (body.controllers && body.query) {
-      throw BadRequestError('You cannot specifify both "controllers" and "query". Prefer the usage of "query" property with a search query.');
+      throw new BadRequestError('You cannot specifify both "controllers" and "query". Prefer the usage of "query" property with a search query.');
     }
 
     if (body.controllers) {
@@ -542,7 +541,7 @@ class SecurityController extends NativeController {
     const body = request.getBody({});
 
     if (body.roles && body.query) {
-      throw BadRequestError('You cannot specifify both "roles" and "query". Prefer the usage of "query" property with a search query.');
+      throw new BadRequestError('You cannot specifify both "roles" and "query". Prefer the usage of "query" property with a search query.');
     }
 
     if (body.roles) {

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -535,7 +535,6 @@ class SecurityController extends NativeController {
    * @returns {Promise<Object>}
    */
   async searchProfiles (request) {
-    console.log(request.input)
     const size = this._getSearchPageSize(request);
     const { from, scrollTTL, searchBody } = request.getSearchParams();
     const lang = request.getLangParam();

--- a/lib/config/default.config.js
+++ b/lib/config/default.config.js
@@ -301,9 +301,17 @@ module.exports = {
           profiles: {
             dynamic: 'false',
             properties: {
+              tags: { type: 'keyword' },
               policies: {
                 properties:  {
-                  roleId: { type: 'keyword' }
+                  roleId: { type: 'keyword' },
+                  restrictedTo: {
+                    type: 'nested',
+                    properties: {
+                      index: { type: 'keyword' },
+                      collections: { type: 'keyword' }
+                    }
+                  }
                 }
               }
             }
@@ -311,6 +319,7 @@ module.exports = {
           roles: {
             dynamic: 'false',
             properties: {
+              tags: { type: 'keyword' },
               controllers: {
                 dynamic: 'false',
                 properties: {}

--- a/lib/core/security/profileRepository.js
+++ b/lib/core/security/profileRepository.js
@@ -124,14 +124,16 @@ class ProfileRepository extends Repository {
       (id, ttl) => this.scroll(id, ttl));
 
     /**
-     * Searches profiles associated to a provided list of roles
-     * @param  {Array.<String>} roles
+     * Searches profiles
+     *
+     * @param  {Object} searchBody - Search query (ES format)
      * @param  {Object} opts (from, size, scroll)
+     *
      * @returns {Object} Search results
      */
-    global.kuzzle.onAsk(
+     global.kuzzle.onAsk(
       'core:security:profile:search',
-      (roles, opts) => this.searchProfiles(roles, opts));
+      (searchBody, opts) => this.search(searchBody, opts));
 
     /**
      * Removes all existing profiles and invalidates the RAM cache
@@ -314,25 +316,6 @@ class ProfileRepository extends Repository {
       retryOnConflict,
       strict,
     });
-  }
-
-  /**
-   *
-   * @param {string[]} roles - array of role ids
-   * @param {object} [options] - optional search arguments (from, size, scroll)
-   * @returns {Promise}
-   */
-  searchProfiles (roles = [], {from=0, scroll, size=1000} = {}) {
-    const query = {query: {}};
-
-    if (roles && roles.length > 0) {
-      query.query = {terms: {'policies.roleId': roles}};
-    }
-    else {
-      query.query = {match_all: {}};
-    }
-
-    return this.search(query, {from, scroll, size});
   }
 
   /**

--- a/lib/core/security/profileRepository.js
+++ b/lib/core/security/profileRepository.js
@@ -131,7 +131,7 @@ class ProfileRepository extends Repository {
      *
      * @returns {Object} Search results
      */
-     global.kuzzle.onAsk(
+    global.kuzzle.onAsk(
       'core:security:profile:search',
       (searchBody, opts) => this.search(searchBody, opts));
 

--- a/lib/core/security/roleRepository.js
+++ b/lib/core/security/roleRepository.js
@@ -325,11 +325,11 @@ class RoleRepository extends Repository {
       total: searchResults.total
     };
 
-    if (controllers.length > 0) {
+    if (body.controllers.length > 0) {
       result.hits = searchResults.hits
         .filter(role => Object
           .keys(role.controllers)
-          .some(key => key === '*' || controllers.includes(key)));
+          .some(key => key === '*' || body.controllers.includes(key)));
 
       result.total = result.hits.length;
     }

--- a/lib/core/security/roleRepository.js
+++ b/lib/core/security/roleRepository.js
@@ -308,10 +308,14 @@ class RoleRepository extends Repository {
   }
 
   /**
-   * @param {Array} controllers
+   * @param {Object} body Search body containing either "query" or "controllers"
    * @param {Object} options
    */
-  async searchRole (controllers, {from = 0, size = 9999} = {}) {
+  async searchRole (body, { from = 0, size = 9999 } = {}) {
+    if (! body.controllers) {
+      return this.search(body, { from, size });
+    }
+
     const searchResults = await this.search(
       { query: {}, sort: [{ _id: { order: 'asc' } }]},
       { from: 0, size: 9999 }); // /!\ NOT the options values
@@ -488,7 +492,9 @@ class RoleRepository extends Repository {
       throw kerror.get('security', 'role', 'cannot_delete');
     }
 
-    const response = await this.module.profile.searchProfiles([role._id], {
+    const query = { term: { 'policies.roleId': role._id } };
+
+    const response = await this.module.profile.search({ query }, {
       from: 0,
       size: 1
     });

--- a/lib/core/security/userRepository.js
+++ b/lib/core/security/userRepository.js
@@ -122,13 +122,13 @@ class UserRepository extends Repository {
 
     /**
      * Searches users
-     * @param  {Object} query - Search query (ES format)
+     * @param  {Object} searchBody - Search body (ES format)
      * @param  {Object} opts (from, size, scroll)
      * @returns {Object} Search results
      */
     global.kuzzle.onAsk(
       'core:security:user:search',
-      (query, opts) => this.search(query, opts));
+      (searchBody, opts) => this.search(searchBody, opts));
 
     /**
      * Removes all existing users

--- a/lib/core/shared/repository.js
+++ b/lib/core/shared/repository.js
@@ -104,12 +104,12 @@ class Repository {
   /**
    * Search in database corresponding repository according to a query
    *
-   * @param {object} query
+   * @param {object} searchBody
    * @param {object} [options] - optional search arguments (from, size, scroll)
    * @returns {Promise}
    */
-  async search (query, options = {}) {
-    const response = await this.store.search(this.collection, query, options);
+  async search (searchBody, options = {}) {
+    const response = await this.store.search(this.collection, searchBody, options);
 
     return this._formatSearchResults(response);
   }

--- a/test/api/controllers/securityController/profiles.test.js
+++ b/test/api/controllers/securityController/profiles.test.js
@@ -455,11 +455,16 @@ describe('Test: security controller - profiles', () => {
 
       const response = await securityController.searchProfiles(request);
 
-      should(searchStub).calledWithMatch(searchEvent, request.input.body.roles, {
-        from: 13,
-        size: 42,
-        scroll: 'duration'
-      });
+      should(searchStub).calledWithMatch(
+        searchEvent,
+        {
+          query: { terms: { 'policies.roleId': 'roles'.split('') } }
+        },
+        {
+          from: 13,
+          size: 42,
+          scroll: 'duration'
+        });
 
       should(response).be.an.Object();
       should(response.hits).be.an.Array().and.have.length(3);
@@ -476,7 +481,7 @@ describe('Test: security controller - profiles', () => {
     it('should pass an empty array and default options on an empty request', async () => {
       await securityController.searchProfiles(request);
 
-      should(searchStub).calledWithMatch(searchEvent, [], {
+      should(searchStub).calledWithMatch(searchEvent, {}, {
         from: 0,
         size: kuzzle.config.limits.documentsFetchCount,
         scroll: undefined,
@@ -498,6 +503,7 @@ describe('Test: security controller - profiles', () => {
     });
 
     it('should reject if searching fails', () => {
+      request.input.body = {};
       const error = new Error('Mocked error');
       searchStub.rejects(error);
 

--- a/test/api/controllers/securityController/roles.test.js
+++ b/test/api/controllers/securityController/roles.test.js
@@ -394,7 +394,7 @@ describe('Test: security controller - roles', () => {
 
       should(searchStub).calledWithMatch(
         searchEvent,
-        request.input.body.controllers,
+        { controllers: request.input.body.controllers },
         { from: 0, size: kuzzle.config.limits.documentsFetchCount });
     });
 
@@ -449,17 +449,21 @@ describe('Test: security controller - roles', () => {
 
     it('should search for all controllers if none are provided', async () => {
       delete request.input.body.controllers;
+
       await securityController.searchRoles(request);
+
       should(searchStub).calledWithMatch(
         searchEvent,
-        [],
+        {},
         { from: 0, size: kuzzle.config.limits.documentsFetchCount });
 
       request.input.body = null;
+
       await securityController.searchRoles(request);
+
       should(searchStub).calledWithMatch(
         searchEvent,
-        [],
+        {},
         { from: 0, size: kuzzle.config.limits.documentsFetchCount });
     });
 

--- a/test/core/security/profileRepository.test.js
+++ b/test/core/security/profileRepository.test.js
@@ -329,32 +329,12 @@ describe('Test: security/profileRepository', () => {
 
   describe('#search', () => {
     it('should register a "search" event', async () => {
-      sinon.stub(profileRepository, 'searchProfiles');
+      sinon.stub(profileRepository, 'search');
 
       kuzzle.ask.restore();
       await kuzzle.ask('core:security:profile:search', 'foo', 'bar');
 
-      should(profileRepository.searchProfiles).calledWith('foo', 'bar');
-    });
-
-    it('should match all profiles on an empty request', async () => {
-      const opts = {from: 13, size: 42, scroll: 'foo'};
-      profileRepository.search = sinon.spy();
-
-      await profileRepository.searchProfiles(null, opts);
-
-      should(profileRepository.search)
-        .be.calledOnce()
-        .be.calledWith({query: {match_all: {}}}, opts);
-
-      await profileRepository.searchProfiles(['role1', 'role2']);
-      should(profileRepository.search)
-        .be.calledTwice()
-        .be.calledWith({
-          query: {
-            terms: {'policies.roleId': ['role1', 'role2']}
-          }
-        });
+      should(profileRepository.search).calledWith('foo', 'bar');
     });
   });
 

--- a/test/core/security/roleRepository.test.js
+++ b/test/core/security/roleRepository.test.js
@@ -28,7 +28,7 @@ describe('Test: security/roleRepository', () => {
     kuzzle = new KuzzleMock();
 
     profileRepositoryMock = {
-      searchProfiles: sinon.stub(),
+      search: sinon.stub(),
     };
 
     roleRepository = new RoleRepository({
@@ -241,39 +241,39 @@ describe('Test: security/roleRepository', () => {
 
       let result;
 
-      result = await roleRepository.searchRole(['foo']);
+      result = await roleRepository.searchRole({ controllers: ['foo'] });
       should(result.total).be.exactly(3);
       should(result.hits.length).be.exactly(3);
       should(result.hits).match([roles.default, roles.foo, roles.foobar]);
 
-      result = await roleRepository.searchRole(['bar']);
+      result = await roleRepository.searchRole({ controllers: ['bar'] });
       should(result.total).be.exactly(3);
       should(result.hits.length).be.exactly(3);
       should(result.hits).match([roles.default, roles.bar, roles.foobar]);
 
-      result = await roleRepository.searchRole(['foo', 'bar']);
+      result = await roleRepository.searchRole({ controllers: ['foo', 'bar'] });
       should(result.total).be.exactly(4);
       should(result.hits.length).be.exactly(4);
       should(result.hits).match([roles.default, roles.foo, roles.bar, roles.foobar]);
 
-      result = await roleRepository.searchRole(['baz']);
+      result = await roleRepository.searchRole({ controllers: ['baz'] });
       should(result.total).be.exactly(1);
       should(result.hits.length).be.exactly(1);
       should(result.hits).match([roles.default]);
 
-      result = await roleRepository.searchRole(['foo'], {from: 1});
+      result = await roleRepository.searchRole({ controllers: ['foo'] }, {from: 1});
       should(result.total).be.exactly(3);
       should(result.hits.length).be.exactly(2);
       should(result.hits).match([roles.foo, roles.foobar]);
       should(result.hits).not.match([roles.default]);
 
-      result = await roleRepository.searchRole(['foo'], {size: 2});
+      result = await roleRepository.searchRole({ controllers: ['foo'] }, {size: 2});
       should(result.total).be.exactly(3);
       should(result.hits.length).be.exactly(2);
       should(result.hits).match([roles.default, roles.foo]);
       should(result.hits).not.match([roles.foobar]);
 
-      result = await roleRepository.searchRole(['foo', 'bar'], {
+      result = await roleRepository.searchRole({ controllers: ['foo', 'bar'] }, {
         from: 1,
         size: 2
       });
@@ -282,6 +282,14 @@ describe('Test: security/roleRepository', () => {
       should(result.hits).match([roles.foo, roles.bar]);
       should(result.hits).not.match([roles.default]);
       should(result.hits).not.match([roles.foobar]);
+    });
+
+    it('should pass the query to the search method', async () => {
+      sinon.stub(roleRepository, 'search');
+
+      await roleRepository.searchRole({ query: { term: {} } });
+
+      should(roleRepository.search).be.calledWith({ query: { term: {} } });
     });
   });
 
@@ -318,7 +326,7 @@ describe('Test: security/roleRepository', () => {
     });
 
     it('should reject if a profile uses the role about to be deleted', async () => {
-      profileRepositoryMock.searchProfiles.resolves({
+      profileRepositoryMock.search.resolves({
         total: 1,
         hits: [fakeRole._id]
       });
@@ -331,7 +339,7 @@ describe('Test: security/roleRepository', () => {
     });
 
     it('should call thoroughly delete a role', async () => {
-      profileRepositoryMock.searchProfiles.resolves({total: 0});
+      profileRepositoryMock.search.resolves({total: 0});
       roleRepository.roles.set(fakeRole._id, fakeRole);
 
       await roleRepository.deleteById(fakeRole._id);


### PR DESCRIPTION
## What does this PR do ?

Allows to use search queries for `security:searchProfiles` and `security:searchRoles`.

### Other changes

  - Introduce the `tags` property to the profile and role definitions
