### PR TITLE
Add kuid to realtime events

### DIFF
--- a/doc/2/framework/events/realtime/index.md
+++ b/doc/2/framework/events/realtime/index.md
@@ -140,6 +140,7 @@ The provided `subscription` object has the following properties:
 | `index`        | <pre>string</pre>  | Index                                                                                                      |
 | `collection`   | <pre>string</pre>  | Collection                                                                                                 |
 | `filters`      | <pre>object</pre>  | Filters in [Koncorde's normalized format](https://www.npmjs.com/package/koncorde#filter-unique-identifier) |
+| `kuid`         | <pre>string</pre>  | ID of the user <SinceBadge version="auto-version" />                                                       |
 
 ---
 
@@ -153,10 +154,11 @@ Pipes cannot listen to this event, only hooks can.
 
 <SinceBadge version="2.5.0"/>
 
-| Arguments        | Type              | Description                                                                     |
-|------------------|-------------------|---------------------------------------------------------------------------------|
-| `RequestContest` | <pre>object</pre> | [requestContext](/core/2/guides/write-protocols/context/requestcontext/) object |
-| `room`           | <pre>object</pre> | Joined room information in Koncorde format                                      |
+| Arguments        | Type              | Description                                                                                                                |
+|------------------|-------------------|----------------------------------------------------------------------------------------------------------------------------|
+| `RequestContest` | <pre>object</pre> | [RequestContext](/core/2/guides/write-protocols/context/requestcontext/) object <DeprecatedBadge version="auto-version" /> |
+| `room`           | <pre>object</pre> | Joined room information in Koncorde format <DeprecatedBadge version="auto-version" />                                      |
+| `subscription`   | <pre>object</pre> | Contains information about the removed subscription <SinceBadge version="auto-version" />                                  |
 
 ### room
 
@@ -167,6 +169,18 @@ The provided `room` object has the following properties:
 | `id`         | <pre>string</pre> | Room unique identifier |
 | `index`      | <pre>string</pre> | Index                  |
 | `collection` | <pre>string</pre> | Collection             |
+
+### subscription
+
+The provided `subscription` object has the following properties:
+
+| Properties     | Type               | Description                                                                                   |
+|----------------|--------------------|-----------------------------------------------------------------------------------------------|
+| `roomId`       | <pre>string</pre>  | Room unique identifier                                                                        |
+| `connectionId` | <pre>integer</pre> | [ClientConnection](/core/2/guides/write-protocols/context/clientconnection) unique identifier |
+| `index`        | <pre>string</pre>  | Index                                                                                         |
+| `collection`   | <pre>string</pre>  | Collection                                                                                    |
+| `kuid`         | <pre>string</pre>  | ID of the user                                                                                |
 
 ---
 

--- a/lib/api/controllers/realtimeController.js
+++ b/lib/api/controllers/realtimeController.js
@@ -92,7 +92,8 @@ class RealtimeController extends NativeController {
     await global.kuzzle.ask(
       'core:realtime:unsubscribe',
       request.context.connection.id,
-      roomId);
+      roomId,
+      request.getKuid());
 
     return { roomId };
   }

--- a/lib/core/plugin/pluginContext.ts
+++ b/lib/core/plugin/pluginContext.ts
@@ -354,14 +354,12 @@ export class PluginContext {
             });
           return global.kuzzle.ask(
             'core:realtime:subscribe',
-            request
-          );
+            request);
         },
         unregister: (connectionId, roomId, notify) =>
           global.kuzzle.ask(
             'core:realtime:unsubscribe',
-            connectionId, roomId, notify
-          )
+            connectionId, roomId, null, notify)
       },
       trigger: (eventName, payload) => (
         global.kuzzle.pipe(`plugin-${pluginName}:${eventName}`, payload)

--- a/lib/core/realtime/hotelClerk.js
+++ b/lib/core/realtime/hotelClerk.js
@@ -54,12 +54,13 @@ class Channel {
 }
 
 class Subscription {
-  constructor (index, collection, filters, roomId, connectionId) {
+  constructor (index, collection, filters, roomId, connectionId, kuid) {
     this.index = index;
     this.collection = collection;
     this.filters = filters;
     this.roomId = roomId;
     this.connectionId = connectionId;
+    this.kuid = kuid;
   }
 }
 
@@ -186,12 +187,13 @@ class HotelClerk {
      * Unsubscribes a user from a room
      * @param {string} connectionId
      * @param {string} roomId
+     * @param {string} kuid
      * @param {boolean} [notify]
      */
     global.kuzzle.onAsk(
       'core:realtime:unsubscribe',
-      (connectionId, roomId, notify) => {
-        return this.unsubscribe(connectionId, roomId, notify);
+      (connectionId, roomId, kuid, notify) => {
+        return this.unsubscribe(connectionId, roomId, kuid, notify);
       });
   }
 
@@ -271,7 +273,8 @@ class HotelClerk {
       collection,
       request.input.body,
       normalized.id,
-      request.context.connection.id);
+      request.context.connection.id,
+      request.context.user._id);
 
     global.kuzzle.emit('core:realtime:user:subscribe:after', subscription);
 
@@ -467,10 +470,11 @@ class HotelClerk {
    * @this HotelClerk
    * @param {string} connectionId
    * @param {string} roomId
+   * @param {string} kuid
    * @param {Boolean} [notify]
    * @returns {Promise}
    */
-  async unsubscribe (connectionId, roomId, notify = true) {
+  async unsubscribe (connectionId, roomId, kuid, notify = true) {
     const customer = this.customers.get(connectionId);
     const requestContext = new RequestContext({
       connection: { id: connectionId }
@@ -550,13 +554,24 @@ class HotelClerk {
       });
     }
 
+    const subscription = new Subscription(
+      room.index,
+      room.collection,
+      undefined,
+      roomId,
+      connectionId,
+      kuid);
+
     global.kuzzle.emit('core:realtime:user:unsubscribe:after', {
+      /* @deprecated */
       requestContext,
+      /* @deprecated */
       room: {
         collection: room.collection,
         id: roomId,
         index: room.index,
-      }
+      },
+      subscription,
     });
   }
 

--- a/lib/core/realtime/hotelClerk.js
+++ b/lib/core/realtime/hotelClerk.js
@@ -54,13 +54,13 @@ class Channel {
 }
 
 class Subscription {
-  constructor (index, collection, filters, roomId, connectionId, kuid) {
+  constructor (index, collection, filters, roomId, connectionId, user) {
     this.index = index;
     this.collection = collection;
     this.filters = filters;
     this.roomId = roomId;
     this.connectionId = connectionId;
-    this.kuid = kuid;
+    this.kuid = user && user._id || null;
   }
 }
 
@@ -274,7 +274,7 @@ class HotelClerk {
       request.input.body,
       normalized.id,
       request.context.connection.id,
-      request.context.user._id);
+      request.context.user);
 
     global.kuzzle.emit('core:realtime:user:subscribe:after', subscription);
 
@@ -560,7 +560,7 @@ class HotelClerk {
       undefined,
       roomId,
       connectionId,
-      kuid);
+      { _id: kuid });
 
     global.kuzzle.emit('core:realtime:user:unsubscribe:after', {
       /* @deprecated */

--- a/test/core/plugin/context/context.test.js
+++ b/test/core/plugin/context/context.test.js
@@ -359,7 +359,7 @@ describe('Plugin Context', () => {
 
       it('should call unregister with the right ask and argument', async () => {
         await context.accessors.subscription.unregister('connectionId', 'roomId', false);
-        should(kuzzle.ask).be.calledWithExactly('core:realtime:unsubscribe', 'connectionId', 'roomId', false);
+        should(kuzzle.ask).be.calledWithExactly('core:realtime:unsubscribe', 'connectionId', 'roomId', null,false);
       });
     });
 

--- a/test/core/realtime/hotelClerk/subscribe.test.js
+++ b/test/core/realtime/hotelClerk/subscribe.test.js
@@ -64,6 +64,7 @@ describe('Test: hotelClerk.subscribe', () => {
   });
 
   it('should register a new room and customer', async () => {
+    request['context\u200b'].user = { _id: 'Umraniye' };
     kuzzle.koncorde.normalize
       .onFirstCall().returns({id: 'foobar', index: 'foo/bar', filter: []})
       .onSecondCall().returns({id: 'barfoo', index: 'foo/bar', filter: []});
@@ -122,6 +123,7 @@ describe('Test: hotelClerk.subscribe', () => {
       filters: request.input.body,
       roomId,
       connectionId,
+      kuid: 'Umraniye',
     });
   });
 

--- a/test/core/realtime/hotelClerk/unsubscribe.test.js
+++ b/test/core/realtime/hotelClerk/unsubscribe.test.js
@@ -52,13 +52,13 @@ describe('Test: hotelClerk.unsubscribe', () => {
     sinon.stub(hotelClerk, 'unsubscribe');
 
     kuzzle.ask.restore();
-    await kuzzle.ask('core:realtime:unsubscribe', 'cnx', 'room', 'notify');
+    await kuzzle.ask('core:realtime:unsubscribe', 'cnx', 'room', null, 'notify');
 
-    should(hotelClerk.unsubscribe).calledWith('cnx', 'room', 'notify');
+    should(hotelClerk.unsubscribe).calledWith('cnx', 'room', null, 'notify');
   });
 
   it('should reject if the customer cannot be found', () => {
-    return hotelClerk.unsubscribe('connectionId', 'idontexist')
+    return hotelClerk.unsubscribe('connectionId', 'idontexist', null)
       .should.be.rejectedWith(PreconditionError, {
         id: 'core.realtime.not_subscribed',
       });
@@ -67,7 +67,7 @@ describe('Test: hotelClerk.unsubscribe', () => {
   it('should reject if the customer did not subscribe to the room', async () => {
     hotelClerk.customers.set(connectionId, new Map([]));
 
-    await should(hotelClerk.unsubscribe(connectionId, roomId))
+    await should(hotelClerk.unsubscribe(connectionId, roomId, null))
       .rejectedWith(PreconditionError, { id: 'core.realtime.not_subscribed' });
 
     should(hotelClerk.rooms).have.key(roomId);
@@ -80,7 +80,7 @@ describe('Test: hotelClerk.unsubscribe', () => {
       [ 'nowhere', null ]
     ]));
 
-    return hotelClerk.unsubscribe(connectionId, 'nowhere')
+    return hotelClerk.unsubscribe(connectionId, 'nowhere', null)
       .should.be.rejectedWith(NotFoundError, {
         id: 'core.realtime.room_not_found',
       });
@@ -91,7 +91,7 @@ describe('Test: hotelClerk.unsubscribe', () => {
       [ roomId, null ]
     ]));
 
-    await hotelClerk.unsubscribe(connectionId, roomId);
+    await hotelClerk.unsubscribe(connectionId, roomId, 'Umraniye');
 
     should(hotelClerk.customers).be.empty();
 
@@ -125,6 +125,14 @@ describe('Test: hotelClerk.unsubscribe', () => {
         collection: 'collection',
         id: roomId,
         index: 'index',
+      },
+      subscription: {
+        index: 'index',
+        collection: 'collection',
+        filters: undefined,
+        roomId,
+        connectionId,
+        kuid: 'Umraniye',
       }
     });
   });
@@ -138,7 +146,7 @@ describe('Test: hotelClerk.unsubscribe', () => {
     hotelClerk.rooms.set('anotherRoom', {});
     hotelClerk.roomsCount = 2;
 
-    await hotelClerk.unsubscribe(connectionId, roomId);
+    await hotelClerk.unsubscribe(connectionId, roomId, null);
 
     should(hotelClerk.customers.get('connectionId')).have.value(
       'anotherRoom',
@@ -172,7 +180,7 @@ describe('Test: hotelClerk.unsubscribe', () => {
     ]));
     hotelClerk.rooms.get(roomId).customers.add('foobar');
 
-    await hotelClerk.unsubscribe(connectionId, roomId);
+    await hotelClerk.unsubscribe(connectionId, roomId, null);
 
     should(hotelClerk.rooms).have.key(roomId);
     should(hotelClerk.rooms.get(roomId).customers).have.size(1);


### PR DESCRIPTION
## What does this PR do ?

Add the `kuid` into the payload of the `core:realtime:user:subscribe:after`.
Add the whole `Subscription` object to the payload of `core:realtime:user:unsubscribe:after`
