### PR TITLE
Fix kuid in realtime events

### DIFF
--- a/lib/api/controllers/realtimeController.js
+++ b/lib/api/controllers/realtimeController.js
@@ -92,8 +92,7 @@ class RealtimeController extends NativeController {
     await global.kuzzle.ask(
       'core:realtime:unsubscribe',
       request.context.connection.id,
-      roomId,
-      request.getKuid());
+      roomId);
 
     return { roomId };
   }

--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -289,7 +289,7 @@ class Funnel {
         debug('Starting request %s:%s [%s]: %j', req.input.controller, req.input.action, req.id, req.input);
 
         global.kuzzle.asyncStore.run(() => {
-          
+
           global.kuzzle.asyncStore.set('REQUEST', req);
           global.kuzzle.pipe('request:beforeExecution', req)
             .then(modifiedRequest => {
@@ -326,7 +326,7 @@ class Funnel {
             .catch(err => {
               debug('Error processing request %s: %a', req.id, err);
               return this._executeError(err, req, true, callback);
-            });  
+            });
         });
       }, this, request);
 
@@ -411,31 +411,19 @@ class Funnel {
     // When a request is made with cookieAuth set to true
     // We try to use the auth token cookie if present as auth token
     // otherwise check for auth token as input
-    if (request.input.headers
-      && has(request.input.headers, 'cookie')
-    ) {
+    if (request.input.headers && has(request.input.headers, 'cookie')) {
       let cookie;
       try {
         cookie = Cookie.parse(request.input.headers.cookie);
       }
       catch (error) {
-        throw kerror.get(
-          'security',
-          'cookie',
-          'invalid'
-        );
+        throw kerror.get('security','cookie', 'invalid');
       }
 
       // if cookie is present and not null, and a token is present we should throw because we don't know which one to use
-      if (cookie.authToken
-        && cookie.authToken !== 'null'
-      ) {
-        if (!global.kuzzle.config.http.cookieAuthentication) {
-          throw kerror.get(
-            'security',
-            'cookie',
-            'unsupported'
-          );
+      if (cookie.authToken && cookie.authToken !== 'null') {
+        if (! global.kuzzle.config.http.cookieAuthentication) {
+          throw kerror.get('security', 'cookie', 'unsupported');
         }
 
         if (request.input.jwt) {
@@ -841,8 +829,8 @@ class Funnel {
 
   /**
    * Verifies if requests sent from a specific origin are allowed
-   * @param {string} origin 
-   * @returns 
+   * @param {string} origin
+   * @returns
    */
   _isOriginAuthorized (origin) {
     const httpConfig = global.kuzzle.config.http;

--- a/lib/core/auth/tokenManager.js
+++ b/lib/core/auth/tokenManager.js
@@ -52,7 +52,7 @@ class TokenManager {
      * The token id is added to the key to handle
      * equality between different tokens sharing
      * the exact same expiration date
-     * 
+     *
      * We should always put infinite duration token at the end of the array
      * because the loop that checks if a token is expired is always verifiying the first element of the array.
      * Since an infinite token cannot be expired, if there is an infinite duration token at the first element
@@ -110,7 +110,7 @@ class TokenManager {
 
     const idx = getTokenIndex(token);
     const currentToken = this.tokensByConnection.get(connectionId);
-    
+
     if (currentToken) {
       if (currentToken._id === token._id) {
         return; // Connection and Token already linked
@@ -243,9 +243,16 @@ class TokenManager {
   getConnectedUserToken(userId, connectionId) {
     const data = this.tokensByConnection.get(connectionId);
 
-    return data && data.userId === userId 
+    return data && data.userId === userId
       ? new Token({...data, connectionId})
       : null;
+  }
+
+  /**
+   * Returns the token associated to a connection
+   */
+  getToken (connectionId) {
+    return this.tokensByConnection.get(connectionId);
   }
 
   /**

--- a/lib/core/plugin/pluginContext.ts
+++ b/lib/core/plugin/pluginContext.ts
@@ -359,7 +359,7 @@ export class PluginContext {
         unregister: (connectionId, roomId, notify) =>
           global.kuzzle.ask(
             'core:realtime:unsubscribe',
-            connectionId, roomId, null, notify)
+            connectionId, roomId, notify)
       },
       trigger: (eventName, payload) => (
         global.kuzzle.pipe(`plugin-${pluginName}:${eventName}`, payload)

--- a/lib/core/realtime/hotelClerk.js
+++ b/lib/core/realtime/hotelClerk.js
@@ -192,8 +192,8 @@ class HotelClerk {
      */
     global.kuzzle.onAsk(
       'core:realtime:unsubscribe',
-      (connectionId, roomId, kuid, notify) => {
-        return this.unsubscribe(connectionId, roomId, kuid, notify);
+      (connectionId, roomId, notify) => {
+        return this.unsubscribe(connectionId, roomId, notify);
       });
   }
 
@@ -246,7 +246,7 @@ class HotelClerk {
       throw kerror.get('api', 'assert', 'koncorde_dsl_error', e.message);
     }
 
-    await this._createRoom(normalized);
+    this._createRoom(normalized);
 
     const { channel, subscribed } = await this._subscribeToRoom(
       normalized.id,
@@ -421,13 +421,15 @@ class HotelClerk {
    * Create new room if needed
    *
    * @this HotelClerk
+   *
    * @param {NormalizedFilter} normalized - Obtained with Koncorde.normalize
    * @param {Object} [options]
    *
    * @returns {void}
    */
   _createRoom (normalized) {
-    const { collection, index, id: roomId } = normalized;
+    const { index: koncordeIndex, id: roomId } = normalized;
+    const [index, collection] = koncordeIndex.split('/');
 
     if (this.rooms.has(normalized.id)) {
       return;
@@ -466,11 +468,10 @@ class HotelClerk {
    * @this HotelClerk
    * @param {string} connectionId
    * @param {string} roomId
-   * @param {string} kuid
    * @param {Boolean} [notify]
    * @returns {Promise}
    */
-  async unsubscribe (connectionId, roomId, kuid, notify = true) {
+  async unsubscribe (connectionId, roomId, notify = true) {
     const customer = this.customers.get(connectionId);
     const requestContext = new RequestContext({
       connection: { id: connectionId }
@@ -550,13 +551,15 @@ class HotelClerk {
       });
     }
 
+    const { userId } = global.kuzzle.tokenManager.getToken(connectionId);
+
     const subscription = new Subscription(
       room.index,
       room.collection,
       undefined,
       roomId,
       connectionId,
-      { _id: kuid });
+      { _id: userId });
 
     global.kuzzle.emit('core:realtime:user:unsubscribe:after', {
       /* @deprecated */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "2.14.2",
+  "version": "2.14.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.14.2",
+  "version": "2.14.3",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "bin": {
     "kuzzle": "bin/start-kuzzle-server"

--- a/test/core/plugin/context/context.test.js
+++ b/test/core/plugin/context/context.test.js
@@ -359,7 +359,8 @@ describe('Plugin Context', () => {
 
       it('should call unregister with the right ask and argument', async () => {
         await context.accessors.subscription.unregister('connectionId', 'roomId', false);
-        should(kuzzle.ask).be.calledWithExactly('core:realtime:unsubscribe', 'connectionId', 'roomId', null,false);
+
+        should(kuzzle.ask).be.calledWithExactly('core:realtime:unsubscribe', 'connectionId', 'roomId', false);
       });
     });
 

--- a/test/core/realtime/hotelClerk/join.test.js
+++ b/test/core/realtime/hotelClerk/join.test.js
@@ -43,6 +43,10 @@ describe('Test: hotelClerk.join', () => {
     }, {connectionId, token: null});
 
     kuzzle.config.limits.subscriptionMinterms = 0;
+
+    kuzzle.koncorde.normalize.returns({
+      id: 'foobar', index: 'foo/bar', filter: []
+    });
   });
 
   it('should register a "join" event', async () => {

--- a/test/core/realtime/hotelClerk/subscribe.test.js
+++ b/test/core/realtime/hotelClerk/subscribe.test.js
@@ -45,6 +45,10 @@ describe('Test: hotelClerk.subscribe', () => {
       }
     }, {connectionId, token: null});
 
+    kuzzle.koncorde.normalize.returns({
+      id: 'foobar', index: 'foo/bar', filter: []
+    });
+
     kuzzle.config.limits.subscriptionMinterms = 0;
   });
 

--- a/test/core/realtime/hotelClerk/unsubscribe.test.js
+++ b/test/core/realtime/hotelClerk/unsubscribe.test.js
@@ -45,6 +45,8 @@ describe('Test: hotelClerk.unsubscribe', () => {
 
     hotelClerk._removeRoomFromRealtimeEngine = sinon.spy();
 
+    kuzzle.tokenManager.getToken.returns({});
+
     return hotelClerk.init();
   });
 
@@ -58,7 +60,7 @@ describe('Test: hotelClerk.unsubscribe', () => {
   });
 
   it('should reject if the customer cannot be found', () => {
-    return hotelClerk.unsubscribe('connectionId', 'idontexist', null)
+    return hotelClerk.unsubscribe('connectionId', 'idontexist')
       .should.be.rejectedWith(PreconditionError, {
         id: 'core.realtime.not_subscribed',
       });
@@ -67,7 +69,7 @@ describe('Test: hotelClerk.unsubscribe', () => {
   it('should reject if the customer did not subscribe to the room', async () => {
     hotelClerk.customers.set(connectionId, new Map([]));
 
-    await should(hotelClerk.unsubscribe(connectionId, roomId, null))
+    await should(hotelClerk.unsubscribe(connectionId, roomId))
       .rejectedWith(PreconditionError, { id: 'core.realtime.not_subscribed' });
 
     should(hotelClerk.rooms).have.key(roomId);
@@ -80,18 +82,19 @@ describe('Test: hotelClerk.unsubscribe', () => {
       [ 'nowhere', null ]
     ]));
 
-    return hotelClerk.unsubscribe(connectionId, 'nowhere', null)
+    return hotelClerk.unsubscribe(connectionId, 'nowhere')
       .should.be.rejectedWith(NotFoundError, {
         id: 'core.realtime.room_not_found',
       });
   });
 
   it('should remove the room from the customer list and remove the connection entry if empty', async () => {
+    kuzzle.tokenManager.getToken.returns({ userId: 'Umraniye' });
     hotelClerk.customers.set(connectionId, new Map([
       [ roomId, null ]
     ]));
 
-    await hotelClerk.unsubscribe(connectionId, roomId, 'Umraniye');
+    await hotelClerk.unsubscribe(connectionId, roomId);
 
     should(hotelClerk.customers).be.empty();
 
@@ -146,7 +149,7 @@ describe('Test: hotelClerk.unsubscribe', () => {
     hotelClerk.rooms.set('anotherRoom', {});
     hotelClerk.roomsCount = 2;
 
-    await hotelClerk.unsubscribe(connectionId, roomId, null);
+    await hotelClerk.unsubscribe(connectionId, roomId);
 
     should(hotelClerk.customers.get('connectionId')).have.value(
       'anotherRoom',
@@ -180,7 +183,7 @@ describe('Test: hotelClerk.unsubscribe', () => {
     ]));
     hotelClerk.rooms.get(roomId).customers.add('foobar');
 
-    await hotelClerk.unsubscribe(connectionId, roomId, null);
+    await hotelClerk.unsubscribe(connectionId, roomId);
 
     should(hotelClerk.rooms).have.key(roomId);
     should(hotelClerk.rooms.get(roomId).customers).have.size(1);

--- a/test/core/realtime/hotelClerk/unsubscribe.test.js
+++ b/test/core/realtime/hotelClerk/unsubscribe.test.js
@@ -56,7 +56,7 @@ describe('Test: hotelClerk.unsubscribe', () => {
     kuzzle.ask.restore();
     await kuzzle.ask('core:realtime:unsubscribe', 'cnx', 'room', null, 'notify');
 
-    should(hotelClerk.unsubscribe).calledWith('cnx', 'room', null, 'notify');
+    should(hotelClerk.unsubscribe).calledWith('cnx', 'room', 'notify');
   });
 
   it('should reject if the customer cannot be found', () => {

--- a/test/core/realtime/hotelClerk/unsubscribe.test.js
+++ b/test/core/realtime/hotelClerk/unsubscribe.test.js
@@ -54,7 +54,7 @@ describe('Test: hotelClerk.unsubscribe', () => {
     sinon.stub(hotelClerk, 'unsubscribe');
 
     kuzzle.ask.restore();
-    await kuzzle.ask('core:realtime:unsubscribe', 'cnx', 'room', null, 'notify');
+    await kuzzle.ask('core:realtime:unsubscribe', 'cnx', 'room', 'notify');
 
     should(hotelClerk.unsubscribe).calledWith('cnx', 'room', 'notify');
   });

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -170,7 +170,8 @@ class KuzzleMock extends KuzzleEventEmitter {
       getConnectedUserToken: sinon.stub(),
       link: sinon.stub(),
       refresh: sinon.stub(),
-      unlink: sinon.stub()
+      unlink: sinon.stub(),
+      getToken: sinon.stub(),
     };
 
     this.validation = {


### PR DESCRIPTION
## What does this PR do ?

`kuid` was only available in the `core:realtime:user:unsubscribe:after` event if the unsubscription was made from the API.

Now it also handle unsubscription made when a connection is closed