### PR TITLE
Wait index cache propagation before allowing nodes to process requests

### DIFF
--- a/lib/cluster/node.js
+++ b/lib/cluster/node.js
@@ -554,7 +554,7 @@ class ClusterNode {
     }
     finally {
       clearTimeout(handshakeTimeout);
-      mutex.unlock();
+      await mutex.unlock();
     }
   }
 

--- a/lib/core/backend/backend.ts
+++ b/lib/core/backend/backend.ts
@@ -21,7 +21,7 @@
 
 import fs from 'fs';
 
-import Kuzzle from '../../kuzzle';
+import { Kuzzle } from '../../kuzzle';
 import { EmbeddedSDK } from '../shared/sdk/embeddedSdk';
 import kerror from '../../kerror';
 import { JSONObject } from '../../../index';

--- a/lib/core/plugin/pluginContext.ts
+++ b/lib/core/plugin/pluginContext.ts
@@ -521,7 +521,7 @@ function curryAddStrategy(pluginName) {
       });
     }
     finally {
-      mutex.unlock();
+      await mutex.unlock();
     }
   };
 }
@@ -547,7 +547,7 @@ function curryRemoveStrategy(pluginName) {
       return await global.kuzzle.pipe('core:auth:strategyRemoved', {name, pluginName});
     }
     finally {
-      mutex.unlock();
+      await mutex.unlock();
     }
   };
 }

--- a/lib/core/security/tokenRepository.js
+++ b/lib/core/security/tokenRepository.js
@@ -433,7 +433,7 @@ class TokenRepository extends Repository {
       await global.kuzzle.ask('core:cache:internal:store', BOOTSTRAP_DONE_KEY, 1);
     }
     finally {
-      mutex.unlock();
+      await mutex.unlock();
     }
   }
 

--- a/lib/core/storage/clientAdapter.js
+++ b/lib/core/storage/clientAdapter.js
@@ -875,7 +875,7 @@ class ClientAdapter {
       }
     }
     finally {
-      mutex.unlock();
+      await mutex.unlock();
     }
   }
 }

--- a/lib/kuzzle/kuzzle.js
+++ b/lib/kuzzle/kuzzle.js
@@ -53,6 +53,8 @@ const SecurityModule = require('../core/security');
 const RealtimeModule = require('../core/realtime');
 const Cluster = require('../cluster');
 
+const BACKEND_IMPORT_KEY = 'backend:init:import';
+
 let _kuzzle = null;
 
 Reflect.defineProperty(global, 'kuzzle', {
@@ -127,6 +129,14 @@ class Kuzzle extends KuzzleEventEmitter {
 
     // Kuzzle version
     this.version = require('../../package.json').version;
+
+    // List of differents imports types and their associated method;
+    this.importTypes = {
+      userMappings: this._importUserMappings.bind(this),
+      mappings: this._importMappings.bind(this),
+      fixtures: this._importFixtures.bind(this),
+      permissions: this._importPermissions.bind(this),
+    };
   }
 
   /**
@@ -299,6 +309,92 @@ class Kuzzle extends KuzzleEventEmitter {
     }
   }
 
+  async _importUserMappings({ toImport } = { toImport: {} }) {
+    if (! _.isEmpty(toImport.userMappings)) {
+      await this.internalIndex.updateMapping('users', toImport.userMappings);
+      await this.internalIndex.refreshCollection('users');
+      this.log.info('[✔] User mappings import successful');
+    }
+  }
+
+  async _importMappings({ toImport, toSupport } = { toImport: {}, toSupport: {} }) {
+    if (! _.isEmpty(toSupport.mappings) && ! _.isEmpty(toImport.mappings)) {
+      throw kerror.get(
+        'plugin',
+        'runtime',
+        'incompatible',
+        '_support.mappings',
+        'import.mappings');
+    }
+    else if (! _.isEmpty(toSupport.mappings)) {
+      await this.ask(
+        'core:storage:public:mappings:import',
+        toSupport.mappings,
+        {
+          rawMappings: true,
+          refresh: true
+        });
+      this.log.info('[✔] Mappings import successful');
+    }
+    else if (! _.isEmpty(toImport.mappings)) {
+      await this.ask('core:storage:public:mappings:import',
+        toImport.mappings,
+        { refresh: true });
+      this.log.info('[✔] Mappings import successful');
+    }
+  }
+
+  async _importFixtures({ toSupport } = { toSupport: {} }) {
+    if (! _.isEmpty(toSupport.fixtures)) {
+      await this.ask('core:storage:public:document:import', toSupport.fixtures);
+      this.log.info('[✔] Fixtures import successful');
+    }
+  }
+
+  async _importPermissions({ toImport, toSupport } = { toImport: {}, toSupport: {} }) {
+    const isPermissionsToImport = !(
+      _.isEmpty(toImport.profiles)
+      && _.isEmpty(toImport.roles)
+      && _.isEmpty(toImport.users)
+    );
+    const isPermissionsToSupport = toSupport.securities
+      && !(
+        _.isEmpty(toSupport.securities.profiles)
+        && _.isEmpty(toSupport.securities.roles)
+        && _.isEmpty(toSupport.securities.users)
+      );
+    if (isPermissionsToSupport && isPermissionsToImport) {
+      throw kerror.get(
+        'plugin',
+        'runtime',
+        'incompatible',
+        '_support.securities',
+        'import profiles roles or users');
+    }
+    else if (isPermissionsToSupport) {
+      await this.ask('core:security:load', toSupport.securities,
+        {
+          force: true,
+          refresh: 'wait_for'
+        });
+      this.log.info('[✔] Securities import successful');
+    }
+    else if (isPermissionsToImport) {
+      await this.ask('core:security:load',
+        {
+          profiles: toImport.profiles,
+          roles: toImport.roles,
+          users: toImport.users,
+        },
+        {
+          onExistingUsers: toImport.onExistingUsers,
+          onExistingUsersWarning: true,
+          refresh: 'wait_for',
+        });
+      this.log.info('[✔] Permissions import successful');
+    }
+  }
+
   /**
    * Load into the app several imports
    *
@@ -308,109 +404,44 @@ class Kuzzle extends KuzzleEventEmitter {
    * @returns {Promise<void>}
    */
   async import (toImport = {}, toSupport = {}) {
-    const types = ['userMappings', 'mappings', 'fixtures', 'permissions'];
-    // If a mutex fail to acquire the lock on the first attempt,
-    // it means that another node has taken care of doing so...
-    // Therefore, there is no need to do the same import twice.
-    const mutexes = types.reduce((result, type) => {
-      result[type] = new Mutex(`backend:import:${type}`, { timeout: 0 });
-      return result;
-    }, {});
-    // Following the same logic as before, mutexes are locked longer
-    // than necessary in order to rarely execute the same import
-    const lockedMutexes = [];
-
-    this.log.info('[ℹ] Imports in progress: This can take some time.');
+    const lockedMutex = [];
 
     try {
-      if (! _.isEmpty(toImport.userMappings) && await mutexes.userMappings.lock()) {
-        lockedMutexes.push(mutexes.userMappings);
-        await this.internalIndex.updateMapping('users', toImport.userMappings);
-        await this.internalIndex.refreshCollection('users');
-        this.log.info('[✔] User mappings import successful');
-      }
-
-      if (await mutexes.mappings.lock()) {
-        lockedMutexes.push(mutexes.mappings);
-        if (! _.isEmpty(toSupport.mappings) && ! _.isEmpty(toImport.mappings)) {
-          throw kerror.get(
-            'plugin',
-            'runtime',
-            'incompatible',
-            '_support.mappings',
-            'import.mappings');
-        }
-        else if (! _.isEmpty(toSupport.mappings)) {
-          await this.ask(
-            'core:storage:public:mappings:import',
-            toSupport.mappings,
-            {
-              rawMappings: true,
-              refresh: true
-            });
-          this.log.info('[✔] Mappings import successful');
-        }
-        else if (! _.isEmpty(toImport.mappings)) {
-          await this.ask('core:storage:public:mappings:import',
-            toImport.mappings,
-            { refresh: true });
-          this.log.info('[✔] Mappings import successful');
+      for (const [type, importMethod] of Object.entries(this.importTypes)) {
+        const mutex = new Mutex(`backend:import:${type}`, { timeout: 0 });
+        if (! await this.ask('core:cache:internal:get', `${BACKEND_IMPORT_KEY}:${type}`)
+          && await mutex.lock()
+        ) {
+          lockedMutex.push(mutex);
+          await importMethod({ toImport, toSupport });
+          await this.ask('core:cache:internal:store', `${BACKEND_IMPORT_KEY}:${type}`, 1);
         }
       }
 
-      if (! _.isEmpty(toSupport.fixtures) && await mutexes.fixtures.lock()) {
-        lockedMutexes.push(mutexes.fixtures);
-        await this.ask('core:storage:public:document:import', toSupport.fixtures);
-        this.log.info('[✔] Fixtures import successful');
+      
+      this.log.info('[✔] Waiting for imports to be finished');
+      /**
+       * Check if every import has been done, if one of them is not finished yet, wait for it
+       */
+      let initialized = false;
+      while (! initialized) {
+        initialized = true;
+
+        for (const type of Object.keys(this.importTypes)) {
+          if (! await this.ask('core:cache:internal:get', `${BACKEND_IMPORT_KEY}:${type}`)) {
+            initialized = false;
+            break;
+          }
+        }
+
+        if (! initialized) {
+          await Bluebird.delay(1000);
+        }
       }
 
-      if (await mutexes.permissions.lock()) {
-        lockedMutexes.push(mutexes.permissions);
-        const isPermissionsToImport = ! (
-          _.isEmpty(toImport.profiles)
-          && _.isEmpty(toImport.roles)
-          && _.isEmpty(toImport.users)
-        );
-        const isPermissionsToSupport = toSupport.securities
-          && ! (
-            _.isEmpty(toSupport.securities.profiles)
-            && _.isEmpty(toSupport.securities.roles)
-            && _.isEmpty(toSupport.securities.users)
-          );
-        if (isPermissionsToSupport && isPermissionsToImport) {
-          throw kerror.get(
-            'plugin',
-            'runtime',
-            'incompatible',
-            '_support.securities',
-            'import profiles roles or users');
-        }
-        else if (isPermissionsToSupport) {
-          await this.ask('core:security:load', toSupport.securities,
-            {
-              force: true,
-              refresh: 'wait_for'
-            });
-          this.log.info('[✔] Securities import successful');
-        }
-        else if (isPermissionsToImport) {
-          await this.ask('core:security:load',
-            {
-              profiles: toImport.profiles,
-              roles: toImport.roles,
-              users: toImport.users,
-            },
-            {
-              onExistingUsers: toImport.onExistingUsers,
-              onExistingUsersWarning: true,
-              refresh: 'wait_for',
-            });
-          this.log.info('[✔] Permissions import successful');
-        }
-      }
-    }
-    finally {
-      Promise.all(lockedMutexes.map(mutex => mutex.unlock()));
+      this.log.info('[✔] Import successful');
+    } finally {
+      await Promise.all(lockedMutex.map(mutex => mutex.unlock()));
     }
   }
 

--- a/lib/types/Kuzzle.ts
+++ b/lib/types/Kuzzle.ts
@@ -1,0 +1,37 @@
+import { JSONObject } from "../../index";
+
+export namespace KuzzleTypes {
+
+  export type StartOptions = {
+    import?: JSONObject;
+    plugins?: JSONObject;
+    secretsFile?: JSONObject;
+    support?: JSONObject;
+    vaultKey?: JSONObject;
+    installations?: Array<{
+      id: string,
+      handler: Function,
+      description?: string
+    }>;
+  };
+
+  export type ImportConfig = {
+    mappings?: JSONObject;
+    onExistingUsers?: string;
+    profiles?: JSONObject; 
+    roles?: JSONObject; 
+    userMappings?: JSONObject;
+    users?: JSONObject;
+  };
+
+  export type SupportConfig = {
+    fixtures?: JSONObject;
+    mappings?: JSONObject;
+    securities?: {
+      profiles?: JSONObject;
+      roles?: JSONObject;
+      users?: JSONObject;
+    };
+  };
+
+};


### PR DESCRIPTION

## What does this PR do ?

This PR forces the Kuzzle Nodes to wait for the index cache propagation to be finished before accepting requests.

### Why ?

Before the different nodes were checking if specific mutexes could be acquired and the node that acquired the mutex will do the import of either `user mappings`, `mappings`, `fixtures` or `permissions`.

If all mutexes were acquired during the boot time of one node, the node will then skip the imports since another node was doing the work to import the data inside the index cache, but the issue was that the node were not waiting for other nodes to have finished importing the data inside the index cache and were accepting requests before everything was initialized.

### Other changes

Convert Kuzzle class to TypeScript
