### PR TITLE
Freeze @elastic/elasticsearch at 7.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "2.14.4",
+  "version": "2.14.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -400,9 +400,9 @@
       }
     },
     "@elastic/elasticsearch": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.14.1.tgz",
-      "integrity": "sha512-pnbh8ddXdxlQdZZfMCwxIIv8KscdhJysVI4ZAc9pBl/cUrLinAj+0gIyTgWA30cOFoKZSLlB9ZXGx6R0SJkIwg==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.13.0.tgz",
+      "integrity": "sha512-WgwLWo2p9P2tdqzBGX9fHeG8p5IOTXprXNTECQG2mJ7z9n93N5AFBJpEw4d35tWWeCWi9jI13A2wzQZH7XZ/xw==",
       "requires": {
         "debug": "^4.3.1",
         "hpagent": "^0.1.1",
@@ -7593,6 +7593,17 @@
         "winston-transport": "^4.4.0"
       },
       "dependencies": {
+        "@elastic/elasticsearch": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.15.0.tgz",
+          "integrity": "sha512-FUKvjV2IKtIiWsvBy7D+wLbSEONsmNR15RRN7P/Sb30g4ObZRHH2qGOP5PPnzxdntEkzZ8HzY7nKKXFS+3Du1g==",
+          "requires": {
+            "debug": "^4.3.1",
+            "hpagent": "^0.1.1",
+            "ms": "^2.1.3",
+            "secure-json-parse": "^2.4.0"
+          }
+        },
         "retry": {
           "version": "0.13.1",
           "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "2.14.3",
+  "version": "2.14.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.14.4",
+  "version": "2.14.5",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "bin": {
     "kuzzle": "bin/start-kuzzle-server"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.14.3",
+  "version": "2.14.4",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "bin": {
     "kuzzle": "bin/start-kuzzle-server"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lib": "lib"
   },
   "dependencies": {
-    "@elastic/elasticsearch": "^7.14.1",
+    "@elastic/elasticsearch": "7.13.0",
     "aedes": "^0.46.1",
     "bluebird": "^3.7.2",
     "cli-color": "^2.0.0",


### PR DESCRIPTION
## What does this PR do ?
Because of a Breaking Change introduced in the version `7.14.0` of  the package `@elastic/elasticsearch`, see the Issue [OSS Distrubtion rejected](https://github.com/elastic/elasticsearch-js/issues/1519), we have to freeze the version of the `@elastic/elasticsearch` package at version `7.13.0`

### How should this be manually tested?

With that fix you should be able to run Kuzzle on AWS using the managed Elasticsearch service
