### PR TITLE
Fix error when enforcing cluster topology when a node topology contain an invalid node id

### DIFF
--- a/lib/cluster/node.js
+++ b/lib/cluster/node.js
@@ -345,7 +345,6 @@ class ClusterNode {
 
         if (topology.length !== idCards.length) {
           topology = topology.sort();
-
           const found = splits.some(split => {
             if (split.length !== topology.length) {
               return false;
@@ -364,7 +363,6 @@ class ClusterNode {
       if (splits.length === 0) {
         return;
       }
-
       // There is at least 1 cluster split detected.
       //
       // First we elect the smallest split possible.
@@ -377,6 +375,13 @@ class ClusterNode {
       // The goal of this process is to force at least 1 node to kill itself,
       // with all nodes concluding on their own on the same list of nodes to
       // shut down.
+      
+      // First remove every non existing node from topologies
+      splits = splits.map(
+        topology => topology.filter(
+          nodeId => idCards.find(card => card.id === nodeId)
+        ));
+
       splits = splits.sort((a, b) => a.length - b.length);
       const eligibleSplits = splits
         .filter(split => split.length === splits[0].length);


### PR DESCRIPTION
## What does this PR do ?

Remove non-existing node from topologies before comparing their length to determine which node should be evicted,
this way node with non-existing nodeId in their topology will become shorted and will increase their chance to be elected first.

### How should this be manually tested?

`npm run test`