### PR TITLE
[Hotfix] Add lastMessageId of the node sending the fullState

### DIFF
--- a/lib/cluster/command.js
+++ b/lib/cluster/command.js
@@ -124,6 +124,10 @@ class ClusterCommand {
         lastMessageId: subscriber.lastMessageId
       });
     }
+    fullState.nodesState.push({
+      id: this.node.nodeId,
+      lastMessageId: this.node.publisher.lastMessageId
+    });
     const protoEncode = this.protoroot.lookupType('FullStateResponse');
     const buffer = protoEncode.encode(protoEncode.create(fullState)).finish();
 


### PR DESCRIPTION
<!--
  Thank you for submitting a Pull Request. Please:
    - Read our CONTRIBUTING guidelines.
      https://github.com/kuzzleio/kuzzle/blob/master/CONTRIBUTING.md
    - Associate an issue with the Pull Request.
    - IMPORTANT - Add the corresponding "changelog:xxx" label to your PR.
-->

<!--- This template is optional. -->

## What does this PR do ?

Add the lastMessageId of the node sending the fullstate

### How should this be manually tested?

`npm run test`