### PR TITLE
remove js-yaml in favor of yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "cucumber": "^6.0.5",
     "ergol": "^1.0.1",
     "eslint": "^7.32.0",
-    "js-yaml": "^4.1.0",
     "mocha": "^9.1.2",
     "mock-require": "^3.0.3",
     "mqtt": "^4.2.8",
@@ -109,7 +108,8 @@
     "sinon": "^11.1.2",
     "strip-json-comments": "3.1.1",
     "ts-node": "^10.2.1",
-    "typescript": "^4.4.3"
+    "typescript": "^4.4.3",
+    "yaml": "^1.10.2"
   },
   "engines": {
     "node": ">= 12.13.0"

--- a/test/api/controllers/serverController.test.js
+++ b/test/api/controllers/serverController.test.js
@@ -2,7 +2,7 @@
 
 const should = require('should');
 const sinon = require('sinon');
-const yaml = require('js-yaml');
+const yaml = require('yaml');
 
 const {
   Request,
@@ -371,7 +371,7 @@ describe('ServerController', () => {
       request.input.args.format = 'yaml';
       return serverController.openapi(request)
         .then((response) => {
-          const parsedResponse = yaml.load(response);
+          const parsedResponse = yaml.parse(response);
           parsedResponse.should.be.an.Object();
           parsedResponse.openapi.should.be.a.String();
         });


### PR DESCRIPTION
<!--
  Thank you for submitting a Pull Request. Please:
    - Read our CONTRIBUTING guidelines.
      https://github.com/kuzzleio/kuzzle/blob/master/CONTRIBUTING.md
    - Associate an issue with the Pull Request.
    - IMPORTANT - Add the corresponding "changelog:xxx" label to your PR.
-->

<!--- This template is optional. -->

## What does this PR do ?

This PR address the issue where Kuzzle might not start when using from `kuzzleio/kuzzle:2` docker image and throwing an missing module `js-yaml` 

I removed the deps to js-yaml in favor of yaml package from npm

### How should this be manually tested?

To see the issue do

  - Step 1 : `docker rmi kuzzleio/kuzzle:2` 
  - Step 2 : `docker run -ti  kuzzleio/kuzzle:2 bash`
  - Step 3 : `kuzzle start`