### PR TITLE
Add logs to cluster interfaces / ip adress selection in debug

### DIFF
--- a/.github/workflows/push_master.workflow.yml
+++ b/.github/workflows/push_master.workflow.yml
@@ -183,13 +183,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-<<<<<<< HEAD
           node-version: "14.x"
           registry-url: "https://registry.npmjs.org"
-=======
-          node-version: '12.x'
-          registry-url: 'https://registry.npmjs.org'
->>>>>>> master
       - run: npm install
       - run: npm publish
         env:

--- a/lib/cluster/node.js
+++ b/lib/cluster/node.js
@@ -107,6 +107,8 @@ function getIP ({ family = 'IPv4', interface: netInterface, ip } = {}) {
     }
   }
 
+  debug('Found interfaces %o', interfaces);
+
   interfaces = interfaces.filter(n => {
     return !n.internal
       && !isInternalIP(n.address)
@@ -156,6 +158,7 @@ class ClusterNode {
       ip: this.config.ip,
     });
 
+    debug('Found IP address: %s with config %o', this.ip, this.config);
     assert(this.ip !== null, `[CLUSTER] No suitable IP address found with the provided configuration (family: ${family}, interface: ${this.config.interface}, ip: ${this.config.ip})`);
 
     this.nodeId = null;

--- a/lib/cluster/node.js
+++ b/lib/cluster/node.js
@@ -116,6 +116,8 @@ function getIP ({ family = 'IPv4', interface: netInterface, ip } = {}) {
       && (!ip || mustBePrivate === isPrivateIP(n.address));
   });
 
+  debug('Filtered interfaces %o', interfaces);
+
   if (interfaces.length === 0) {
     return null;
   }


### PR DESCRIPTION
## What does this PR do ?

Add to more debug() while kuzzle is making the interfaces selection and ip selection

### How should this be manually tested?

<!--
  Please describe your test configuration, the tests ran to verify your changes
  And give us instructions on how to reproduce them.
-->
  - Step 1 : start kuzzle
  - Step 2 : add kuzzle__cluster_ip or kuzzle__cluster_interfaces
  - Step 3 : see log appear in debug

### Other changes

<!--
  Please outline any changes not directly linked to the main issue, but made because of it.
  For instance: on-the-fly fixes, dependencies updates and so on.
-->

### Boyscout

<!--
  Finally, describe any improvements in the code base like:
  Typo fixes, improved/new comments, debug messages and so on.
-->
