### PR TITLE
Allows to deactivate stats module

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -820,11 +820,14 @@
   },
 
   // Configuration of the Kuzzle's internal statistics module
+  //   * enabled:
+  //      Enable or disable the stats module
   //   * ttl:
   //      Time to live (in seconds) of a statistics frame
   //   * statsInterval:
   //      Time (in seconds) between statistics snapshots
   "stats": {
+    "enabled": true,
     "ttl": 3600,
     "statsInterval": 10
   },

--- a/doc/2/api/errors/error-codes/services/index.md
+++ b/doc/2/api/errors/error-codes/services/index.md
@@ -75,3 +75,12 @@ description: Error codes definitions
 | services.cache.write_failed<br/><pre>0x01030004</pre>  | [InternalError](/core/2/api/errors/error-codes#internalerror) <pre>(500)</pre> | Cache write fail: %s | An attempt to write to the cache failed |
 
 ---
+
+
+### Subdomain: 0x0104: statistics
+
+| id / code | class / status | message | description |
+| --------- | -------------- | --------| ----------- |
+| services.statistics.not_available<br/><pre>0x01040001</pre>  | [InternalError](/core/2/api/errors/error-codes#internalerror) <pre>(500)</pre> | Statistics module is not available. | The statistics module is not enabled. See "config.stats.enabled". |
+
+---

--- a/lib/config/default.config.js
+++ b/lib/config/default.config.js
@@ -371,7 +371,7 @@ module.exports = {
   },
 
   stats: {
-    enabled: true,
+    enabled: false,
     ttl: 3600,
     statsInterval: 10
   },

--- a/lib/config/default.config.js
+++ b/lib/config/default.config.js
@@ -371,7 +371,7 @@ module.exports = {
   },
 
   stats: {
-    enabled: false,
+    enabled: true,
     ttl: 3600,
     statsInterval: 10
   },

--- a/lib/config/default.config.js
+++ b/lib/config/default.config.js
@@ -371,6 +371,7 @@ module.exports = {
   },
 
   stats: {
+    enabled: true,
     ttl: 3600,
     statsInterval: 10
   },

--- a/lib/core/statistics/statistics.js
+++ b/lib/core/statistics/statistics.js
@@ -28,12 +28,13 @@ const kerror = require('../../kerror').wrap('api', 'assert');
  * @param {Kuzzle} kuzzle
  */
 class Statistics {
-  constructor() {
+  constructor () {
     // uses '{' and '}' to force all statistics frames to be stored on 1 redis
     // node
     // (see https://redis.io/topics/cluster-spec#keys-distribution-model)
     this.cacheKeyPrefix = '{stats/}';
 
+    this.enabled = global.kuzzle.config.stats.enabled;
     this.ttl = global.kuzzle.config.stats.ttl * 1000;
     this.interval = global.kuzzle.config.stats.statsInterval * 1000;
     this.lastFrame = null;
@@ -53,6 +54,10 @@ class Statistics {
    * @param {Request} request
    */
   startRequest (request) {
+    if (! this.enabled) {
+      return;
+    }
+
     const protocol = request && request.context.connection.protocol;
 
     if (!protocol) {
@@ -75,6 +80,10 @@ class Statistics {
    * @param {Request} request
    */
   completedRequest (request) {
+    if (! this.enabled) {
+      return;
+    }
+
     const protocol = request && request.context.connection.protocol;
 
     if (!protocol) {
@@ -101,6 +110,10 @@ class Statistics {
    * @param {Request} request
    */
   failedRequest (request) {
+    if (! this.enabled) {
+      return;
+    }
+
     const protocol = request && request.context.connection.protocol;
 
     if (!protocol) {
@@ -127,6 +140,10 @@ class Statistics {
    * @param {RequestContext} requestContext
    */
   newConnection (requestContext) {
+    if (! this.enabled) {
+      return;
+    }
+
     if (!requestContext.connection.protocol) {
       return;
     }
@@ -147,6 +164,10 @@ class Statistics {
    * @param {RequestContext} requestContext
    */
   dropConnection (requestContext) {
+    if (! this.enabled) {
+      return;
+    }
+
     if (!requestContext.connection.protocol) {
       return;
     }
@@ -166,7 +187,11 @@ class Statistics {
    *
    * @returns {Promise}
    */
-  async getLastStats() {
+  async getLastStats () {
+    if (! this.enabled) {
+      throw new InternalError('Statistics module has been disabled.');
+    }
+
     const frame = Object.assign(
       {timestamp: (new Date()).getTime()},
       this.currentStats);
@@ -189,6 +214,10 @@ class Statistics {
    * @returns {Promise<Object>}
    */
   async getStats (request) {
+    if (! this.enabled) {
+      throw new InternalError('Statistics module has been disabled.');
+    }
+
     const response = {
       hits: [],
       total: null
@@ -286,6 +315,10 @@ class Statistics {
    * Init statistics component
    */
   init () {
+    if (! this.enabled) {
+      return;
+    }
+
     this.timer = setInterval(async () => {
       try {
         await this.writeStats();
@@ -301,6 +334,10 @@ class Statistics {
   }
 
   async writeStats () {
+    if (! this.enabled) {
+      return;
+    }
+
     const stats = JSON.stringify(this.currentStats);
 
     this.lastFrame = Date.now();

--- a/lib/core/statistics/statistics.js
+++ b/lib/core/statistics/statistics.js
@@ -21,7 +21,8 @@
 
 'use strict';
 
-const kerror = require('../../kerror').wrap('api', 'assert');
+const errorApiAssert = require('../../kerror').wrap('api', 'assert');
+const errorStats = require('../../kerror').wrap('services', 'stats');
 
 /**
  * @class Statistics
@@ -189,7 +190,7 @@ class Statistics {
    */
   async getLastStats () {
     if (! this.enabled) {
-      throw new InternalError('Statistics module has been disabled.');
+      throw errorStats.get('not_available');
     }
 
     const frame = Object.assign(
@@ -215,7 +216,7 @@ class Statistics {
    */
   async getStats (request) {
     if (! this.enabled) {
-      throw new InternalError('Statistics module has been disabled.');
+      throw errorStats.get('not_available');
     }
 
     const response = {
@@ -240,11 +241,11 @@ class Statistics {
     }
 
     if (startTime !== undefined && isNaN(startTime)) {
-      throw kerror.get('invalid_argument', 'startTime', 'number');
+      throw errorApiAssert.get('invalid_argument', 'startTime', 'number');
     }
 
     if (stopTime !== undefined && isNaN(stopTime)) {
-      throw kerror.get('invalid_argument', 'stopTime', 'number');
+      throw errorApiAssert.get('invalid_argument', 'stopTime', 'number');
     }
 
     if (startTime !== undefined && startTime >= currentDate) {

--- a/lib/kerror/codes/1-services.json
+++ b/lib/kerror/codes/1-services.json
@@ -306,6 +306,17 @@
           "class": "InternalError"
         }
       }
+    },
+    "statistics": {
+      "code": 4,
+      "errors": {
+        "not_available": {
+          "description": "The statistics module is not enabled. See \"config.stats.enabled\".",
+          "code": 1,
+          "message": "Statistics module is not available.",
+          "class": "InternalError"
+        }
+      }
     }
   }
 }

--- a/test/core/statistics/statistics.test.js
+++ b/test/core/statistics/statistics.test.js
@@ -41,6 +41,7 @@ describe('Test: statistics core component', () => {
 
     kuzzle = new Kuzzle();
     stats = new Statistics();
+    stats.enabled = true;
   });
 
   afterEach(() => {

--- a/test/core/statistics/statistics.test.js
+++ b/test/core/statistics/statistics.test.js
@@ -383,7 +383,7 @@ describe('Test: statistics core component', () => {
 
     await stats.writeStats();
 
-    should(kuzzle.ask).not.be.called()
+    should(kuzzle.ask).not.be.called();
   });
 
   it('should reject the promise if the cache returns an error', () => {

--- a/test/core/statistics/statistics.test.js
+++ b/test/core/statistics/statistics.test.js
@@ -76,6 +76,15 @@ describe('Test: statistics core component', () => {
     should(stats.currentStats.ongoingRequests).be.empty();
   });
 
+  it('should do nothing for startRequest if module is disabled', () => {
+    request.context.protocol = 'foobar';
+    stats.enabled = false;
+
+    stats.startRequest();
+
+    should(stats.currentStats.ongoingRequests).be.empty();
+  });
+
   it('should handle completed requests', () => {
     stats.currentStats.ongoingRequests.set('foobar', 2);
     request.context.protocol = 'foobar';
@@ -92,6 +101,16 @@ describe('Test: statistics core component', () => {
     should(stats.currentStats.completedRequests).be.empty();
 
     stats.completedRequest(request);
+    should(stats.currentStats.completedRequests).be.empty();
+  });
+
+  it('should do nothing for completedRequest if module is disabled', () => {
+    stats.currentStats.ongoingRequests.set('foobar', 2);
+    request.context.protocol = 'foobar';
+    stats.enabled = false;
+
+    stats.completedRequest();
+
     should(stats.currentStats.completedRequests).be.empty();
   });
 
@@ -115,12 +134,31 @@ describe('Test: statistics core component', () => {
     should(stats.currentStats.failedRequests).be.empty();
   });
 
+  it('should do nothing for failedRequest if module is disabled', () => {
+    stats.currentStats.ongoingRequests.set('foobar', 2);
+    request.context.protocol = 'foobar';
+    stats.enabled = false;
+
+    stats.failedRequest(request);
+
+    should(stats.currentStats.failedRequests).be.empty();
+  });
+
   it('should handle new connections', () => {
     const context = new RequestContext({connection: {protocol: 'foobar'}});
     stats.newConnection(context);
     should(stats.currentStats.connections.get('foobar')).not.be.undefined().and.be.exactly(1);
     stats.newConnection(context);
     should(stats.currentStats.connections.get('foobar')).not.be.undefined().and.be.exactly(2);
+  });
+
+  it('should not handle new connections if module is disabled', () => {
+    const context = new RequestContext({connection: {protocol: 'foobar'}});
+    stats.enabled = false;
+
+    stats.newConnection(context);
+
+    should(stats.currentStats.connections.get('foobar')).be.undefined();
   });
 
   it('should be able to unregister a connection', () => {
@@ -131,6 +169,16 @@ describe('Test: statistics core component', () => {
     should(stats.currentStats.connections.get('foobar')).be.exactly(1);
     stats.dropConnection(context);
     should(stats.currentStats.connections.get('foobar')).be.undefined();
+  });
+
+  it('should not handle unregister a connection if module is disabled', () => {
+    const context = new RequestContext({connection: {protocol: 'foobar'}});
+    stats.currentStats.connections.set('foobar', 2);
+    stats.enabled = false;
+
+    stats.dropConnection(context);
+
+    should(stats.currentStats.connections.get('foobar')).be.exactly(2);
   });
 
   it('should return the current frame when there is still no statistics in cache', () => {
@@ -327,6 +375,15 @@ describe('Test: statistics core component', () => {
       '{stats/}' + stats.lastFrame,
       JSON.stringify(fakeStats),
       { ttl: stats.ttl });
+  });
+
+  it('should not write statistics frames in cache if module is disabled', async () => {
+    stats.currentStats = Object.assign({}, fakeStats);
+    stats.enabled = false;
+
+    await stats.writeStats();
+
+    should(kuzzle.ask).not.be.called()
   });
 
   it('should reject the promise if the cache returns an error', () => {


### PR DESCRIPTION
## What does this PR do ?

Kuzzle statistics module collect information about requests and connections handled by a node and store them into Redis with a limited TTL.

This PR allows to completely deactivate this module/
