### PR TITLE
Properly disconnect connections on shutdown

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       - "9231:9229" # Debug port
 
   redis:
-    image: redis:6.2.4
+    image: redis:6
     container_name: kuzzle_redis
     ports:
       - "6379:6379"

--- a/lib/core/realtime/hotelClerk.ts
+++ b/lib/core/realtime/hotelClerk.ts
@@ -173,6 +173,11 @@ export class HotelClerk {
       });
 
     /**
+     * Clear the hotel clerk and properly disconnect connections.
+     */
+    global.kuzzle.onAsk('core:realtime:shutdown', () => this.clearConnections());
+
+    /**
      * Clear subscriptions when a connection is dropped
      */
     global.kuzzle.on('connection:remove', connection => {
@@ -357,6 +362,17 @@ export class HotelClerk {
 
     await Bluebird.map(connectionRooms.roomIds, (roomId: string) => (
       this.unsubscribe(connectionId, roomId).catch(global.kuzzle.log.error)
+    ));
+  }
+
+  /**
+   * Clear all connections made to this node:
+   *   - trigger appropriate core events
+   *   - send user exit room notifications
+   */
+  async clearConnections (): Promise<void> {
+    await Bluebird.map(this.subscriptions.keys(), (connectionId: string) => (
+      this.removeConnection(connectionId)
     ));
   }
 

--- a/lib/kuzzle/kuzzle.ts
+++ b/lib/kuzzle/kuzzle.ts
@@ -307,6 +307,8 @@ class Kuzzle extends KuzzleEventEmitter {
     // Ask the network layer to stop accepting new request
     this.entryPoint.dispatch('shutdown');
 
+    await this.ask('core:realtime:shutdown');
+
     while (this.funnel.remainingRequests !== 0) {
       this.log.info(`[shutdown] Waiting: ${this.funnel.remainingRequests} remaining requests`);
       await Bluebird.delay(1000);

--- a/test/core/realtime/hotelClerk/disconnect.test.js
+++ b/test/core/realtime/hotelClerk/disconnect.test.js
@@ -10,7 +10,7 @@ const { ConnectionRooms } = require('../../../../lib/core/realtime/connectionRoo
 const { Room } = require('../../../../lib/core/realtime/room');
 const { Channel } = require('../../../../lib/core/realtime/channel');
 
-describe('Test: hotelClerk.removeUser', () => {
+describe('Test: hotelClerk.removeConnection', () => {
   const connectionId = 'connectionid';
   const collection = 'user';
   const index = '%test';

--- a/test/core/realtime/hotelClerk/hotelClerk.test.js
+++ b/test/core/realtime/hotelClerk/hotelClerk.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const should = require('should');
+const sinon = require('sinon');
+
+const KuzzleMock = require('../../../mocks/kuzzle.mock');
+
+const { HotelClerk } = require('../../../../lib/core/realtime/hotelClerk');
+const { ConnectionRooms } = require('../../../../lib/core/realtime/connectionRooms');
+
+describe('HotelClerk', () => {
+  let kuzzle;
+  let hotelClerk;
+  let realtimeModule;
+
+  beforeEach(() => {
+    kuzzle = new KuzzleMock();
+
+    hotelClerk = new HotelClerk(realtimeModule);
+
+    realtimeModule = {};
+
+    hotelClerk.subscriptions.set('a', new ConnectionRooms(new Map([['foo', null]])));
+    hotelClerk.subscriptions.set('b', new ConnectionRooms(new Map([['foo', null]])));
+
+    return hotelClerk.init();
+  });
+
+  describe('#clearConnections', () => {
+    it('should have been registered with the "core:realtime:shutdown" event', async () => {
+      sinon.stub(hotelClerk, 'clearConnections').resolves();
+
+      kuzzle.ask.restore();
+      await kuzzle.ask('core:realtime:shutdown');
+
+      should(hotelClerk.clearConnections).be.calledOnce();
+    });
+
+    it('should properly remove each connection', async () => {
+      sinon.stub(hotelClerk, 'removeConnection').resolves();
+
+      await hotelClerk.clearConnections();
+
+      should(hotelClerk.removeConnection)
+        .be.calledTwice()
+        .be.calledWith('a')
+        .be.calledWith('b');
+    });
+  });
+});

--- a/test/kuzzle/kuzzle.test.js
+++ b/test/kuzzle/kuzzle.test.js
@@ -219,7 +219,7 @@ describe('/lib/kuzzle/kuzzle.js', () => {
     });
   });
 
-  describe('#kuzzle/shutdown', () => {
+  describe('#shutdown', () => {
     it('should exit only when there is no request left in the funnel', async () => {
       sinon.stub(process, 'exit');
 
@@ -245,6 +245,8 @@ describe('/lib/kuzzle/kuzzle.js', () => {
         should(kuzzle.entryPoint.dispatch).calledOnce().calledWith('shutdown');
         should(kuzzle.pipe).calledWith('kuzzle:shutdown');
         should(Bluebird.delay.callCount).approximately(5, 1);
+
+        should(kuzzle.ask).be.calledWith('core:realtime:shutdown');
 
         // @deprecated
         should(kuzzle.emit).calledWith('core:shutdown');


### PR DESCRIPTION
## What does this PR do ?

Properly disconnect every connection when the node is shutting down:
  - emit the `core:realtime:user:unsubscribe:after` event
  - send notification about user leaving a room 