### PR TITLE
Increase ID card expiration delay

### DIFF
--- a/lib/cluster/idCardHandler.js
+++ b/lib/cluster/idCardHandler.js
@@ -76,6 +76,10 @@ class ClusterIdCardHandler {
     // the id card is been disposed because the node is evicting itself from the
     // cluster
     this.disposed = false;
+
+    // Add a delay for key expiration to make sure the node have the time to
+    // refresh it
+    this.refreshMultiplier = 4;
   }
 
   /**
@@ -123,11 +127,12 @@ class ClusterIdCardHandler {
         name: 'internal_adapter',
       },
       refreshDelay: this.refreshDelay,
+      refreshMultiplier: this.refreshMultiplier,
     });
   }
 
   // Used to Mock the creation of a worker for the tests
-  _constructWorker(path) {
+  _constructWorker (path) {
     return new Worker(path);
   }
 
@@ -198,7 +203,7 @@ class ClusterIdCardHandler {
       'core:cache:internal:store',
       this.nodeIdKey,
       this.idCard.serialize(),
-      { onlyIfNew: creation, ttl: this.refreshDelay * 3 });
+      { onlyIfNew: creation, ttl: this.refreshDelay * this.refreshMultiplier });
   }
 }
 

--- a/lib/cluster/workers/IDCardRenewer.js
+++ b/lib/cluster/workers/IDCardRenewer.js
@@ -22,7 +22,8 @@ class IDCardRenewer {
     this.disposed = false;
     this.nodeIdKey = config.nodeIdKey;
     this.refreshDelay = config.refreshDelay || 2000;
-    
+    this.refreshMultiplier = config.refreshMultiplier;
+
     /**
     * Since we do not have access to the Kuzzle Context we can't use kuzzle.ask('core:cache:internal:*',...),
     * so we need to have an instance of Redis similar to the one used in the Cache Engine
@@ -63,7 +64,7 @@ class IDCardRenewer {
     try {
       const refreshed = await this.redis.commands.pexpire(
         this.nodeIdKey,
-        this.refreshDelay * 3);
+        this.refreshDelay * this.refreshMultiplier);
       // Unable to refresh the key in time before it expires
       // => this node is too slow, we need to remove it from the cluster
       if (refreshed === 0) {
@@ -99,7 +100,8 @@ class IDCardRenewer {
 
 if (!isMainThread) {
   const idCardRenewer = new IDCardRenewer();
-  parentPort.on('message', async (message) => {
+
+  parentPort.on('message', async message => {
     if (message.action === 'start') {
       // Simulate basic global Kuzzle Context
       global.kuzzle = { ...message.kuzzle };
@@ -111,11 +113,12 @@ if (!isMainThread) {
       };
       // Should never throw
       await idCardRenewer.init(message);
-    } else if (message.action === 'dispose') {
+    }
+    else if (message.action === 'dispose') {
       // Should never throw
       await idCardRenewer.dispose();
     }
-  });  
+  });
 }
 
 module.exports = { IDCardRenewer };

--- a/test/cluster/idCardHandler.test.js
+++ b/test/cluster/idCardHandler.test.js
@@ -62,7 +62,7 @@ describe('ClusterIdCardHandler', () => {
         idCardHandler.idCard.serialize(),
         {
           onlyIfNew: true,
-          ttl: refreshDelay * 3
+          ttl: refreshDelay * 4
         });
     });
 

--- a/test/cluster/workers/IDCardRenewer.test.js
+++ b/test/cluster/workers/IDCardRenewer.test.js
@@ -102,19 +102,18 @@ describe('ClusterIDCardRenewer', () => {
         nodeIdKey: 'foo',
         redis: {},
         refreshDelay: 100,
+        refreshMultiplier: 4
       });
     });
 
     it('should call pexpire to refresh the key expiration time', async () => {
       idCardRenewer.redis.commands.pexpire.resetHistory();
+
       await idCardRenewer.renewIDCard();
 
       should(idCardRenewer.redis.commands.pexpire)
         .be.calledOnce()
-        .and.be.calledWith(
-          'foo',
-          300
-        );
+        .and.be.calledWith('foo', 400);
 
       should(idCardRenewer.dispose).not.be.called();
       should(idCardRenewer.parentPort.postMessage).not.be.called();
@@ -123,7 +122,7 @@ describe('ClusterIDCardRenewer', () => {
     it('should call the dispose method and notify the main thread that the node was too slow to refresh the ID Card', async () => {
       idCardRenewer.redis.commands.pexpire.resolves(0); // Failed to renew the ID Card before the key expired
       await idCardRenewer.renewIDCard();
-      
+
       should(idCardRenewer.redis.commands.pexpire).be.called();
 
       should(idCardRenewer.dispose).be.called();


### PR DESCRIPTION
## What does this PR do ?

Increase the ID Card expiration delay. Now the refresh delay is multiplied by 4 so by default it's 8 seconds TTL.

I noticed that Node.js takes a lot of time to start the worker and because of that sometime when the worker start and try to refresh the ID card it's already expired.