### PR TITLE
Fix realtime:shutdown event race condition

### DIFF
--- a/lib/core/realtime/hotelClerk.ts
+++ b/lib/core/realtime/hotelClerk.ts
@@ -175,7 +175,7 @@ export class HotelClerk {
     /**
      * Clear the hotel clerk and properly disconnect connections.
      */
-    global.kuzzle.onAsk('core:realtime:shutdown', () => this.clearConnections());
+    global.kuzzle.on('kuzzle:shutdown', () => this.clearConnections());
 
     /**
      * Clear subscriptions when a connection is dropped

--- a/lib/kuzzle/kuzzle.ts
+++ b/lib/kuzzle/kuzzle.ts
@@ -299,15 +299,14 @@ class Kuzzle extends KuzzleEventEmitter {
     this._state = kuzzleStateEnum.SHUTTING_DOWN;
 
     this.log.info('Initiating shutdown...');
-    await this.pipe('kuzzle:shutdown');
-
-    // @deprecated
-    this.emit('core:shutdown');
 
     // Ask the network layer to stop accepting new request
     this.entryPoint.dispatch('shutdown');
 
-    await this.ask('core:realtime:shutdown');
+    await this.pipe('kuzzle:shutdown');
+
+    // @deprecated
+    this.emit('core:shutdown');
 
     while (this.funnel.remainingRequests !== 0) {
       this.log.info(`[shutdown] Waiting: ${this.funnel.remainingRequests} remaining requests`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "2.14.11",
+  "version": "2.14.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.14.11",
+  "version": "2.14.12",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "bin": {
     "kuzzle": "bin/start-kuzzle-server"

--- a/test/core/realtime/hotelClerk/hotelClerk.test.js
+++ b/test/core/realtime/hotelClerk/hotelClerk.test.js
@@ -30,8 +30,8 @@ describe('HotelClerk', () => {
     it('should have been registered with the "core:realtime:shutdown" event', async () => {
       sinon.stub(hotelClerk, 'clearConnections').resolves();
 
-      kuzzle.ask.restore();
-      await kuzzle.ask('core:realtime:shutdown');
+      kuzzle.pipe.restore();
+      await kuzzle.pipe('kuzzle:shutdown');
 
       should(hotelClerk.clearConnections).be.calledOnce();
     });

--- a/test/kuzzle/kuzzle.test.js
+++ b/test/kuzzle/kuzzle.test.js
@@ -246,8 +246,6 @@ describe('/lib/kuzzle/kuzzle.js', () => {
         should(kuzzle.pipe).calledWith('kuzzle:shutdown');
         should(Bluebird.delay.callCount).approximately(5, 1);
 
-        should(kuzzle.ask).be.calledWith('core:realtime:shutdown');
-
         // @deprecated
         should(kuzzle.emit).calledWith('core:shutdown');
 


### PR DESCRIPTION
## What does this PR do ?

Fix a race condition on the `core:realtime:shutdown` event being used before module initialization and answerer registration