### PR TITLE
Store ID Card's keys in a Redis set to speed up handshake

### DIFF
--- a/docker/docker-compose-swarm.yml
+++ b/docker/docker-compose-swarm.yml
@@ -1,0 +1,100 @@
+version: '3.4'
+
+services:
+  traefik:
+    image: traefik
+    container_name: traefik
+    ports:
+      - "7512:7512"
+      - "1883:1883"
+    command:
+      - --log.level=WARN
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --providers.docker.endpoint=unix:///var/run/docker.sock
+      - --entrypoints.kuzzle_http.address=:7512
+      - --entrypoints.kuzzle_mqtt.address=:1883
+    depends_on:
+      kuzzle:
+        condition: service_healthy
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+
+  kuzzle:
+    image: kuzzleio/core-dev:2
+    command: node app.js
+    volumes:
+      - "..:/var/app"
+      - "./scripts/run-dev.sh:/run-dev.sh"
+      - "./fixtures:/fixtures"
+    cap_add:
+      - SYS_PTRACE
+    ulimits:
+      nofile: 65536
+    sysctls:
+      - net.core.somaxconn=8192
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7512/_healthCheck"]
+      timeout: 1s
+      interval: 2s
+      retries: 30
+    depends_on:
+      redis:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
+    labels:
+      - "traefik.enable=true"
+      # Kuzzle HTTP/WS
+      - "traefik.http.services.kuzzle_http.loadbalancer.server.port=7512"
+      - "traefik.http.services.kuzzle_http.loadbalancer.healthCheck.path=/_healthCheck"
+      - "traefik.http.services.kuzzle_http.loadbalancer.healthCheck.interval=5s"
+      - "traefik.http.routers.kuzzle.entrypoints=kuzzle_http"
+      - "traefik.http.routers.kuzzle.rule=Host(`localhost`)"
+      - "traefik.http.routers.kuzzle.service=kuzzle_http"
+      # Kuzzle MQTT
+      - "traefik.tcp.services.kuzzle_mqtt.loadbalancer.server.port=1883"
+      - "traefik.tcp.routers.kuzzle.entrypoints=kuzzle_mqtt"
+      - "traefik.tcp.routers.kuzzle.rule=HostSNI(`*`)"
+      - "traefik.tcp.routers.kuzzle.service=kuzzle_mqtt"
+    environment:
+      - kuzzle_services__storageEngine__client__node=http://elasticsearch:9200
+      - kuzzle_services__storageEngine__commonMapping__dynamic=true
+      - kuzzle_services__internalCache__node__host=redis
+      - kuzzle_services__memoryStorage__node__host=redis
+      - kuzzle_server__protocols__mqtt__enabled=true
+      - kuzzle_server__protocols__mqtt__developmentMode=false
+      - kuzzle_limits__loginsPerSecond=50
+      # - NODE_ENV=${NODE_ENV:-development}
+      - NODE_ENV=production
+      # - DEBUG=${DEBUG:-kuzzle:*,-kuzzle:network:protocols:websocket,-kuzzle:events}
+      - DEBUG=${DEBUG:-kuzzle:cluster:sync}
+      - DEBUG_DEPTH=${DEBUG_DEPTH:-0}
+      - DEBUG_MAX_ARRAY_LENGTH=${DEBUG_MAX_ARRAY:-100}
+      - DEBUG_EXPAND=${DEBUG_EXPAND:-off}
+      - DEBUG_SHOW_HIDDEN={$DEBUG_SHOW_HIDDEN:-on}
+      - DEBUG_COLORS=${DEBUG_COLORS:-on}
+
+  redis:
+    image: redis:6.2.4
+    container_name: kuzzle_redis
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 1s
+      timeout: 3s
+      retries: 30
+    ports:
+      - "6379:6379"
+
+  elasticsearch:
+    image: kuzzleio/elasticsearch:7
+    container_name: kuzzle_elasticsearch
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+      interval: 2s
+      timeout: 2s
+      retries: 10
+    ports:
+      - "9200:9200"
+    ulimits:
+      nofile: 65536

--- a/lib/cluster/idCardHandler.js
+++ b/lib/cluster/idCardHandler.js
@@ -23,8 +23,10 @@
 
 const { generateRandomName } = require('../util/name-generator');
 const { Worker } = require('worker_threads');
+const Bluebird = require('bluebird');
 
 const REDIS_PREFIX = '{cluster/node}/';
+const REDIS_ID_CARDS_INDEX = REDIS_PREFIX + 'id-cards-index';
 
 /**
  * @typedef {IdCard}
@@ -100,6 +102,8 @@ class ClusterIdCardHandler {
       reserved = await this._save({ creation: true });
     } while (!reserved);
 
+    await this.addIdCardToIndex();
+
     this.refreshWorker = this._constructWorker(`${__dirname}/workers/IDCardRenewer.js`);
     this.refreshWorker.unref();
 
@@ -140,32 +144,58 @@ class ClusterIdCardHandler {
 
   /**
    * Retrieves the ID cards from other nodes
+   *
+   * Each node store it's ID Card under a specific key name. When Redis database
+   * is growing, searching for those keys can be quite expensive and can slow down
+   * the handshake process.
+   *
+   * We are storing a set containing ID Card's keys under a set so when a new node
+   * is started, it can directly get the other nodes ID Cards with SMEMBERS and
+   * then MGET instead of using SEARCH.
+   *
+   * When a new node retrieve the ID Card's keys from the set, it try to get them
+   * with MGET, those who cannot be retrieved are expired ID Cards so the node update
+   * the set accordingly.
+   *
    * @return {Array.<IdCard>}
    */
   async getRemoteIdCards () {
-    const result = [];
+    const idCards = [];
 
     let keys = await global.kuzzle.ask(
-      'core:cache:internal:searchKeys',
-      `${REDIS_PREFIX}*`);
+      'core:cache:internal:execute',
+      'smembers',
+      REDIS_ID_CARDS_INDEX);
 
     keys = keys.filter(nodeIdKey => nodeIdKey !== this.nodeIdKey);
 
     if (keys.length === 0) {
-      return result;
+      return idCards;
     }
 
     const values = await global.kuzzle.ask('core:cache:internal:mget', keys);
+    const expiredIdCards = [];
 
     for (let i = 0; i < keys.length; i++) {
       // filter keys that might have expired between the key search and their
       // values retrieval
       if (values[i] !== null) {
-        result.push(IdCard.unserialize(values[i]));
+        idCards.push(IdCard.unserialize(values[i]));
+      }
+      else {
+        expiredIdCards.push(keys[i]);
       }
     }
 
-    return result;
+    // Clean expired ID Card's keys in the index
+    await Bluebird.map(expiredIdCards, idCardKey => {
+      return global.kuzzle.ask(
+        'core:cache:internal:execute',
+        'srem',
+        REDIS_ID_CARDS_INDEX, idCardKey)
+    });
+
+    return idCards;
   }
 
   /**
@@ -188,6 +218,18 @@ class ClusterIdCardHandler {
     if (!this.disposed && this.idCard.topology.delete(id)) {
       await this._save();
     }
+  }
+
+  /**
+   * Store the key under which this node ID Card is stored inside the set.
+   *
+   * This set is an index to retrieve ID Cards faster.
+   */
+  async addIdCardToIndex () {
+    await global.kuzzle.ask(
+      'core:cache:internal:execute',
+      'sadd',
+      REDIS_ID_CARDS_INDEX, this.nodeIdKey);
   }
 
   /**

--- a/lib/cluster/idCardHandler.js
+++ b/lib/cluster/idCardHandler.js
@@ -151,7 +151,7 @@ class ClusterIdCardHandler {
    *
    * We are storing a set containing ID Card's keys under a set so when a new node
    * is started, it can directly get the other nodes ID Cards with SMEMBERS and
-   * then MGET instead of using SEARCH.
+   * then MGET instead of using SCAN.
    *
    * When a new node retrieve the ID Card's keys from the set, it try to get them
    * with MGET, those who cannot be retrieved are expired ID Cards so the node update
@@ -192,7 +192,8 @@ class ClusterIdCardHandler {
       return global.kuzzle.ask(
         'core:cache:internal:execute',
         'srem',
-        REDIS_ID_CARDS_INDEX, idCardKey)
+        REDIS_ID_CARDS_INDEX,
+        idCardKey);
     });
 
     return idCards;

--- a/lib/cluster/node.js
+++ b/lib/cluster/node.js
@@ -474,21 +474,21 @@ class ClusterNode {
       // to prevent race conditions (other nodes attempting to connect to this
       // node while it's still initializing)
       await this.idCardHandler.createIdCard();
-      global.kuzzle.log.debug('[CLUSTER] ID Card created');
+      debug('[CLUSTER] ID Card created');
 
       this.nodeId = this.idCardHandler.nodeId;
 
       await this.startHeartbeat();
-      global.kuzzle.log.debug('[CLUSTER] Start heartbeat');
+      debug('[CLUSTER] Start heartbeat');
 
       let retried = false;
       let fullState = null;
       let nodes;
 
-      global.kuzzle.log.debug('[CLUSTER] Start retrieving full state..');
+      debug('[CLUSTER] Start retrieving full state..');
       do {
         nodes = await this.idCardHandler.getRemoteIdCards();
-        global.kuzzle.log.debug(`[CLUSTER] ${nodes.length} remote nodes discovered`);
+        debug('[CLUSTER] %s remote nodes discovered', nodes.length);
 
         // No other nodes detected = no handshake required
         if (nodes.length === 0) {
@@ -511,7 +511,7 @@ class ClusterNode {
           this.remoteNodes.set(id, subscriber);
           return subscriber.init();
         });
-        global.kuzzle.log.debug('[CLUSTER] Successfully subscribed to nodes');
+        debug('[CLUSTER] Successfully subscribed to nodes');
 
         fullState = await this.command.getFullState(nodes);
 
@@ -541,18 +541,18 @@ class ClusterNode {
         }
       }
       while (fullState === null);
-      global.kuzzle.log.debug('[CLUSTER] Fullstate retrieved, loading into node..');
+      debug('[CLUSTER] Fullstate retrieved, loading into node..');
 
       await this.fullState.loadFullState(fullState);
       this.activity = fullState.activity
         ? fullState.activity
         : this.activity;
 
-      global.kuzzle.log.debug('[CLUSTER] Fullstate loaded.');
+      debug('[CLUSTER] Fullstate loaded.');
 
       const handshakeResponses = await this.command.broadcastHandshake(nodes);
 
-      global.kuzzle.log.debug('[CLUSTER] Successful handshakes with other nodes.');
+      debug('[CLUSTER] Successful handshakes with other nodes.');
 
       // Update subscribers: start synchronizing, or unsubscribes from nodes who
       // didn't respond

--- a/lib/cluster/subscriber.js
+++ b/lib/cluster/subscriber.js
@@ -213,7 +213,7 @@ class ClusterSubscriber {
 
     const message = decoder.toObject(decoder.decode(data));
 
-    if (!await this.validateMessage(message)) {
+    if (! await this.validateMessage(message)) {
       return;
     }
 

--- a/lib/core/cache/cacheEngine.js
+++ b/lib/core/cache/cacheEngine.js
@@ -180,6 +180,15 @@ class CacheEngine {
     global.kuzzle.onAsk(
       'core:cache:internal:store',
       (key, value, opts) => this.internal.store(key, value, opts));
+
+    /**
+     * Executes an arbitrary NATIVE cache command directly
+     * @param {string} command
+     * @param {Array} args -- command arguments
+     */
+    global.kuzzle.onAsk(
+      'core:cache:internal:execute',
+      (command, ...args) => this.internal.exec(command, ...args));
   }
 
   registerPublicEvents () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "2.14.15",
+  "version": "2.14.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.14.15",
+  "version": "2.14.16",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "bin": {
     "kuzzle": "bin/start-kuzzle-server"

--- a/test/cluster/idCardHandler.test.js
+++ b/test/cluster/idCardHandler.test.js
@@ -48,7 +48,7 @@ describe('ClusterIdCardHandler', () => {
       }
     });
 
-    it('should create a new uniq IdCard and store it in Redis', async () => {
+    it('should create a new uniq IdCard and store it in Redis and update the index', async () => {
       await idCardHandler.createIdCard();
 
       should(idCardHandler.nodeId).be.String();
@@ -64,6 +64,11 @@ describe('ClusterIdCardHandler', () => {
           onlyIfNew: true,
           ttl: refreshDelay * 3
         });
+      should(kuzzle.ask).be.calledWith(
+        'core:cache:internal:execute',
+        'sadd',
+        '{cluster/node}/id-cards-index',
+        `{cluster/node}/${idCardHandler.nodeId}`);
     });
 
     it('should avoid collision for nodeIdKey', async () => {
@@ -74,10 +79,11 @@ describe('ClusterIdCardHandler', () => {
 
       await idCardHandler.createIdCard();
 
-      should(kuzzle.ask).be.calledTwice();
+      should(kuzzle.ask.callCount).be.eql(3);
       const args0 = kuzzle.ask.getCall(0).args;
       const args1 = kuzzle.ask.getCall(1).args;
       should(args0[1]).not.eql(args1[1]);
+      should(kuzzle.ask.getCall(2).args[0]).be.eql('core:cache:internal:execute');
     });
 
     it('should evict the node an error is received from the refresh worker', async () => {
@@ -118,20 +124,26 @@ describe('ClusterIdCardHandler', () => {
       idCardHandler.idCard = idCard1;
       idCardHandler.nodeIdKey = 'redis/id1';
       kuzzle.ask
-        .withArgs('core:cache:internal:searchKeys')
-        .resolves(['redis/id1', 'redis/id2', 'redis/id3']);
+        .withArgs('core:cache:internal:execute')
+        .resolves(['redis/id1', 'redis/id2', 'redis/id3', 'redis/id4']);
       kuzzle.ask
         .withArgs('core:cache:internal:mget')
-        .resolves([idCard2.serialize(), idCard3.serialize()]);
+        .resolves([idCard2.serialize(), idCard3.serialize(), null]);
 
       const remoteCards = await idCardHandler.getRemoteIdCards();
 
       should(kuzzle.ask).be.calledWith(
-        'core:cache:internal:searchKeys',
-        '{cluster/node}/*');
+        'core:cache:internal:execute',
+        'smembers',
+        '{cluster/node}/id-cards-index');
       should(kuzzle.ask).be.calledWith(
         'core:cache:internal:mget',
-        ['redis/id2', 'redis/id3']);
+        ['redis/id2', 'redis/id3', 'redis/id4']);
+      should(kuzzle.ask).be.calledWith(
+        'core:cache:internal:execute',
+        'srem',
+        '{cluster/node}/id-cards-index',
+        'redis/id4');
       should(remoteCards).be.eql([idCard2, idCard3]);
     });
   });

--- a/test/cluster/subscriber.test.js
+++ b/test/cluster/subscriber.test.js
@@ -220,6 +220,9 @@ describe('ClusterSubscriber', () => {
         subscriber.handlers = {
           [topic]: addIndexHandler
         };
+        subscriber.localNode.fullState = {
+          serialize: sinon.stub()
+        };
       });
 
       it('should validate the message and call the appropriate handler', async () => {


### PR DESCRIPTION
## What does this PR do ?

Each node ID Card is stored in Redis so when a new node starts, it can retrieve other nodes ID Cards to connect to them. The SCAN command was used to retrieve keys corresponding to a node ID Card. 

When Redis database is growing, the time needed is also growing so the handshake procedure can end up with a timeout and preventing new nodes to join the cluster.

The cluster now use an Redis Set to store the list of ID Card's keys, when a new node starts, it will store it's own key inside the set, then get it to retrieve the name of each ID Card's keys to finally retrieve the ID Cards themselves.  
If some ID Cards can not be retrieved, it means they expired so the new node will clean their keys from the set.
