### PR TITLE
Add optional history of cluster state sync messages

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -74,3 +74,4 @@ lib/core/realtime/connectionRooms.js
 lib/core/realtime/room.js
 lib/core/realtime/subscription.js
 lib/types/realtime/RoomList.js
+lib/types/KuzzleDocument.js

--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,4 @@ lib/core/realtime/connectionRooms.js
 lib/core/realtime/room.js
 lib/core/realtime/subscription.js
 lib/types/realtime/RoomList.js
+lib/types/KuzzleDocument.js

--- a/lib/cluster/node.js
+++ b/lib/cluster/node.js
@@ -1135,7 +1135,6 @@ class ClusterNode {
   }
 
   shutdownNode () {
-    global.kuzzle.log.error(JSON.stringify(this.fullState.serialize()));
     global.kuzzle.shutdown();
   }
 }

--- a/lib/cluster/stateSyncHistory.ts
+++ b/lib/cluster/stateSyncHistory.ts
@@ -1,0 +1,185 @@
+/*
+ * Kuzzle, a backend software, self-hostable and ready to use
+ * to power modern apps
+ *
+ * Copyright 2015-2020 Kuzzle
+ * mailto: support AT kuzzle.io
+ * website: http://kuzzle.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { JSONObject } from 'kuzzle-sdk';
+
+import { BadRequestError } from '../kerror/errors';
+import { SerializedState } from './state';
+
+const REDIS_PREFIX = '{cluster/node}/';
+
+type StateSyncEntry = {
+  topic: string;
+
+  message: string;
+
+  state: string;
+};
+
+function parseInteger (integerString: string): number {
+  const integer = parseInt(integerString, 10);
+
+  if (isNaN(integer)) {
+    throw new BadRequestError(`Cannot parse "${integerString}" into an integer.`);
+  }
+
+  return integer;
+}
+
+export class StateSyncHistory {
+  /**
+   * List of topics that modify the full state
+   */
+  static SYNC_TOPICS = [
+    // Realtime sync messages
+    'NewRealtimeRoom', 'RemoveRealtimeRoom', 'Subscription', 'Unsubscription',
+
+    // Auth strategy sync messages
+    'NewAuthStrategy', 'RemoveAuthStrategy',
+  ];
+
+  /**
+   * If this key is set with, each node will keep state sync messages
+   * and the full state into a fixed length array.
+   *
+   * This history will be saved into Redis when a desync error occur.
+   *
+   * This key value is the TTL of the sync history in ms.
+   *
+   * @example
+   *
+   * 7 days: 604800000 ms
+   * 1 day:   86400000 ms
+   */
+  static REDIS_KEY_SYNC_HISTORY_TTL = REDIS_PREFIX + 'sync-history-ttl';
+
+  /**
+   * Max entries for the state sync history.
+   *
+   * Each entry is composed of:
+   *  - topic (e.g. NewRealtimeRoom)
+   *  - message
+   *  - current fullstate before the message processing
+   */
+  static REDIS_KEY_SYNC_HISTORY_MAX_ENTRIES = REDIS_PREFIX + 'sync-history-max-entries';
+
+  private enabledTimer: any;
+  private historyTTL: number = null;
+  private redisKeySyncHistory: string;
+  private entries: StateSyncEntry[];
+  private maxEntries = 200;
+
+  constructor (nodeId: string) {
+    this.redisKeySyncHistory = REDIS_PREFIX + `${nodeId}/sync-history`;
+
+    /**
+     * Instead of making a request to Redis for every sync message, we are checking
+     * every 5 seconds if this config is still the same.
+     *
+     * This should be replaced with the cluster common synchronization mechanism
+     * once is ready.
+     */
+    this.enabledTimer = setInterval(async () => {
+      try {
+        const [ historyTTL, maxEntries ] = await Promise.all([
+          global.kuzzle.ask(
+            'core:cache:internal:get',
+            StateSyncHistory.REDIS_KEY_SYNC_HISTORY_TTL),
+          global.kuzzle.ask(
+            'core:cache:internal:get',
+            StateSyncHistory.REDIS_KEY_SYNC_HISTORY_MAX_ENTRIES)
+        ]);
+
+        if (historyTTL) {
+          this.historyTTL = parseInteger(historyTTL);
+          this.maxEntries = parseInteger(maxEntries);
+
+          return;
+        }
+      }
+      catch (error) {
+        global.kuzzle.log.error(`[CLUSTER] Cannot get the state sync history TTL or max entries: ${error}`);
+      }
+
+      this.historyTTL = null;
+      this.maxEntries = 200;
+    }, 5 * 1000);
+  }
+
+  /**
+   * Returns true if an historyTTL has been set in Redis and if the current
+   * topic should be historized.
+   */
+  enabled (topic: string): boolean {
+    if (this.historyTTL === null) {
+      return false;
+    }
+
+    return StateSyncHistory.SYNC_TOPICS.includes(topic);
+  }
+
+  /**
+   * Clear the timer
+   */
+  dispose () {
+    if (this.enabledTimer) {
+      clearInterval(this.enabledTimer);
+    }
+
+    this.enabledTimer = null;
+  }
+
+  /**
+   * Push a new state sync history entry.
+   *
+   * If the size exceed to maximum size, the first item will be removed.
+   */
+  push (topic: string, message: JSONObject, state: SerializedState) {
+    if (this.entries.length + 1 > this.maxEntries) {
+      this.entries.shift();
+    }
+
+    this.entries.push({
+      topic,
+      message: JSON.stringify(message),
+      state: JSON.stringify(state)
+    });
+  }
+
+  /**
+   * Save the state sync history into Redis
+   */
+  async save (): Promise<void> {
+    const serialized = JSON.stringify(this.entries);
+
+    try {
+      await global.kuzzle.ask(
+        'core:cache:internal:store',
+        this.redisKeySyncHistory,
+        serialized,
+        { ttl: this.historyTTL });
+    }
+    catch (error) {
+      global.kuzzle.log.error(`[CLUSTER] Cannot save the state sync history: ${error}`);
+      global.kuzzle.log.info(serialized);
+    }
+  }
+}

--- a/lib/cluster/stateSyncHistory.ts
+++ b/lib/cluster/stateSyncHistory.ts
@@ -101,10 +101,10 @@ export class StateSyncHistory {
       try {
         const [ historyTTL, maxEntries ] = await Promise.all([
           global.kuzzle.ask(
-            'core:cache:internal:get',
+            'core:cache:public:get',
             StateSyncHistory.REDIS_KEY_SYNC_HISTORY_TTL),
           global.kuzzle.ask(
-            'core:cache:internal:get',
+            'core:cache:public:get',
             StateSyncHistory.REDIS_KEY_SYNC_HISTORY_MAX_ENTRIES)
         ]);
 
@@ -172,7 +172,7 @@ export class StateSyncHistory {
 
     try {
       await global.kuzzle.ask(
-        'core:cache:internal:store',
+        'core:cache:public:store',
         this.redisKeySyncHistory,
         serialized,
         { ttl: this.historyTTL });

--- a/lib/cluster/subscriber.js
+++ b/lib/cluster/subscriber.js
@@ -26,11 +26,11 @@ const protobuf = require('protobufjs');
 const Long = require('long');
 
 const debug = require('../util/debug')('kuzzle:cluster:sync');
-const debugMessages = require('../util/debug')('kuzzle:cluster:messages');
 const DocumentNotification = require('../core/realtime/notification/document');
 const UserNotification = require('../core/realtime/notification/user');
 const { has } = require('../util/safeObject');
 const { fromKoncordeIndex } = require('../util/koncordeCompat');
+const { StateSyncHistory } = require('./stateSyncHistory');
 
 /* eslint-disable sort-keys */
 const stateEnum = Object.freeze({
@@ -40,8 +40,6 @@ const stateEnum = Object.freeze({
   EVICTED: 4,
 });
 /* eslint-enable sort-keys */
-
-const debugExcludedTopics = ['Heartbeat', 'UserNotification', 'DocumentNotification'];
 
 // Handles messages received from other nodes
 class ClusterSubscriber {
@@ -55,7 +53,6 @@ class ClusterSubscriber {
     // not to be confused with remote nodes
     this.localNode = localNode;
 
-    this.remoteNodeIP = remoteNodeIP;
     this.remoteNodeAddress = `tcp://${remoteNodeIP}:${this.localNode.config.ports.sync}`;
     this.remoteNodeId = remoteNodeId;
     this.socket = null;
@@ -75,6 +72,8 @@ class ClusterSubscriber {
     this.heartbeatTimer = null;
     this.lastHeartbeat = Date.now();
     this.heartbeatDelay = this.localNode.heartbeatDelay * 1.5;
+
+    this.stateSyncHistory = new StateSyncHistory(this.localNode.nodeId);
 
     // Messages handlers (quick translation between a topic name and its
     // associated handler)
@@ -218,19 +217,14 @@ class ClusterSubscriber {
     }
 
     try {
-      if (! debugExcludedTopics.includes(topic)) {
-        debugMessages('[CLUSTER] "%s": %o', topic, message);
-        debugMessages('[CLUSTER] Fullstate before: %j', this.localNode.fullState.serialize());
+      if (this.stateSyncHistory.enabled(topic)) {
+        this.stateSyncHistory.push(topic, message, this.localNode.fullState.serialize());
       }
 
       await this.handlers[topic].call(this, message);
-
-      if (! debugExcludedTopics.includes(topic)) {
-        debugMessages('[CLUSTER] Fullstate after: %j', this.localNode.fullState.serialize());
-      }
     }
     catch (e) {
-      this.localNode.evictSelf(
+      this.evictSelf(
         `Unable to process sync message (topic: ${topic}, message: ${JSON.stringify(message)}`,
         e);
     }
@@ -254,7 +248,7 @@ class ClusterSubscriber {
   async handleNodeEviction (message) {
     if (message.nodeId === this.localNode.nodeId) {
       global.kuzzle.log.error(`[CLUSTER] Node evicted by ${message.evictor}. Reason: ${message.reason}`);
-      global.kuzzle.shutdown();
+      this.localNode.shutdownNode();
       return;
     }
 
@@ -496,7 +490,7 @@ class ClusterSubscriber {
   handleShutdown () {
     debug('Cluster-wide shutdown request received from node %s', this.remoteNodeId);
     global.kuzzle.log.error(`[CLUSTER] Cluster wide shutdown from ${this.remoteNodeId}`);
-    global.kuzzle.shutdown();
+    this.localNode.shutdownNode();
   }
 
   /**
@@ -662,6 +656,7 @@ class ClusterSubscriber {
     this.socket.close();
     this.socket = null;
     clearInterval(this.heartbeatTimer);
+    this.stateSyncHistory.dispose();
   }
 
   /**
@@ -690,11 +685,15 @@ class ClusterSubscriber {
     this.lastMessageId = this.lastMessageId.add(1);
 
     if (this.lastMessageId.notEquals(message.messageId)) {
-      await this.localNode.evictSelf(`Node out-of-sync: ${message.messageId - this.lastMessageId - 1} messages lost from node ${this.remoteNodeId}`);
+      await this.evictSelf(`Node out-of-sync: ${message.messageId - this.lastMessageId - 1} messages lost from node ${this.remoteNodeId}`);
       return false;
     }
 
     return true;
+  }
+
+  async evictSelf (message) {
+    await this.localNode.evictSelf(message);
   }
 
   async evictNode ({ broadcast, reason }) {

--- a/lib/types/KuzzleDocument.ts
+++ b/lib/types/KuzzleDocument.ts
@@ -1,8 +1,6 @@
-import { JSONObject } from 'kuzzle-sdk';
-
 // Should be in the SDK instead
-export interface KuzzleDocument {
+export interface KuzzleDocument<T> {
   _id: string;
 
-  _source: JSONObject;
+  _source: T;
 }


### PR DESCRIPTION
## What does this PR do ?

This PR add an optional history mechanism intended to debug the cluster state sync messages.

The optional history can be activated with a new API action `cluster:debug`

When used with the `stateSyncHistory` argument, this action will enable an history of state sync messages on each node. Each node will keep the last X history messages and the full state before the message was processed.

If a node die because of a desync issue, this history will saved into Redis for further analysis.

### How should this be manually tested?

<!--
  Please describe your test configuration, the tests ran to verify your changes
  And give us instructions on how to reproduce them.
-->
  - Step 1 :
  - Step 2 :
  - Step 3 :

### Other changes

  - `KuzzleDocument` now use a templated type for `_source`

### Boyscout

<!--
  Finally, describe any improvements in the code base like:
  Typo fixes, improved/new comments, debug messages and so on.
-->
