### PR TITLE
Ensure ID Card is refreshed while worker thread starts

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -74,3 +74,4 @@ lib/core/realtime/connectionRooms.js
 lib/core/realtime/room.js
 lib/core/realtime/subscription.js
 lib/types/realtime/RoomList.js
+lib/cluster/idCardHandler.js

--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,4 @@ lib/core/realtime/connectionRooms.js
 lib/core/realtime/room.js
 lib/core/realtime/subscription.js
 lib/types/realtime/RoomList.js
+lib/cluster/idCardHandler.js

--- a/lib/cluster/idCardHandler.ts
+++ b/lib/cluster/idCardHandler.ts
@@ -218,7 +218,7 @@ export class ClusterIdCardHandler {
         await this.save();
       }
       catch (error) {
-        global.kuzzle.log.error(`Cannot refresh the ID Card before the worker starts: ${error}`);
+        global.kuzzle.log.error(`An error occurred while refreshing the ID card during WorkerThread startup: ${error}`);
       }
     }, this.refreshDelay * this.refreshMultiplier);
 

--- a/lib/cluster/idCardHandler.ts
+++ b/lib/cluster/idCardHandler.ts
@@ -334,8 +334,12 @@ export class ClusterIdCardHandler {
    *
    * @returns True if the key was set
    */
-  private save ({ creation } = { creation: false }): Promise<boolean> {
-    return global.kuzzle.ask(
+  private async save ({ creation } = { creation: false }): Promise<boolean> {
+    if (! this.idCard) {
+      return false;
+    }
+
+    return await global.kuzzle.ask(
       'core:cache:internal:store',
       this.nodeIdKey,
       JSON.stringify(this.idCard.serialize()),

--- a/lib/cluster/idCardHandler.ts
+++ b/lib/cluster/idCardHandler.ts
@@ -19,8 +19,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import { generateRandomName } from '../util/name-generator';
 import { Worker as WorkerThread } from 'worker_threads';
 import Bluebird from 'bluebird';

--- a/lib/cluster/idCardHandler.ts
+++ b/lib/cluster/idCardHandler.ts
@@ -21,50 +21,125 @@
 
 'use strict';
 
-const { generateRandomName } = require('../util/name-generator');
-const { Worker } = require('worker_threads');
-const Bluebird = require('bluebird');
+import { generateRandomName } from '../util/name-generator';
+import { Worker as WorkerThread } from 'worker_threads';
+import Bluebird from 'bluebird';
+
+import '../types';
 
 const REDIS_PREFIX = '{cluster/node}/';
 const REDIS_ID_CARDS_INDEX = REDIS_PREFIX + 'id-cards-index';
 
-/**
- * @typedef {IdCard}
- */
-class IdCard {
+export type SerializedIdCard = {
+  id: string;
+  ip: string;
+  birthdate: number;
+  topology: string[];
+}
+
+export class IdCard {
   /**
-   * @param {Object} obj - contains the ID card description
-   * @param {string} obj.id - node identifier
-   * @param {string} obj.ip - node IP address
-   * @param {Number} obj.birthdate - node creation timestamp
-   * @param {Array.<string>} obj.topology - node's known topology
+   * Node unique identifier
+   *
+   * @example
+   *
+   * knode-pensive-einstein-844221
    */
-  constructor (obj) {
-    this.id = obj.id;
-    this.ip = obj.ip;
-    this.birthdate = obj.birthdate;
-    this.topology = new Set(obj.topology);
+  private id: string;
+
+  /**
+   * Node IP address
+   */
+  private ip: string;
+
+  /**
+   * Node creation timestamp
+   */
+  private birthdate: number;
+
+  /**
+   * Node known topology composed of node IDs
+   *
+   * Set<node-id>
+   */
+  public topology: Set<string>;
+
+  constructor ({ id, ip, birthdate, topology }: SerializedIdCard) {
+    this.id = id;
+    this.ip = ip;
+    this.birthdate = birthdate;
+    this.topology = new Set(topology);
   }
 
-  serialize () {
-    return JSON.stringify({
+  serialize (): SerializedIdCard {
+    return {
       birthdate: this.birthdate,
       id: this.id,
       ip: this.ip,
       topology: Array.from(this.topology),
-    });
+    };
   }
 
-  static unserialize (value) {
-    return new IdCard(JSON.parse(value));
+  static unserialize (serialized: SerializedIdCard): IdCard {
+    return new IdCard(serialized);
   }
 }
 
 /**
  * Handles the ID Key stored in Redis, holding node information
  */
-class ClusterIdCardHandler {
-  constructor (node) {
+export class ClusterIdCardHandler {
+  /**
+   * Node instance. Represents the local node.
+   */
+  private node: any;
+
+  /**
+   * Local node ID Card
+   */
+  private idCard: IdCard;
+
+  /**
+   * Local node IP address
+   */
+  private ip: string;
+
+  /**
+   * Delay for refreshing the ID Card. The heartbeat timer is run on this delay
+   * and the node ID Card should be available on Redis otherwise it will be evicted.
+   */
+  private refreshDelay: number;
+
+  /**
+   * Multiplier used to ensure the node has enough time to refresh it's ID Card
+   * before the ID Card refresh delay
+   */
+  private refreshMultiplier: number;
+
+  /**
+   * Worker thread in charge of refreshing the ID Card once the node has started
+   */
+  private refreshWorker: WorkerThread;
+
+  /**
+   * Local node ID
+   */
+  private nodeId: string;
+
+  /**
+   * Local node Redis key
+   */
+  private nodeIdKey: string;
+
+  /**
+   * Flag to prevent updating the id card if it has been disposed.
+   * Prevents race condition if a topology update occurs at the same time as
+   * the id card is been disposed because the node is evicting itself from the
+   * cluster
+   */
+  private disposed: boolean;
+
+  constructor (node: any) {
     this.node = node;
     this.idCard = null;
     this.ip = node.ip;
@@ -73,25 +148,17 @@ class ClusterIdCardHandler {
     this.nodeId = null;
     this.nodeIdKey = null;
 
-    // Flag to prevent updating the id card if it has been disposed.
-    // Prevents race condition if a topology update occurs at the same time as
-    // the id card is been disposed because the node is evicting itself from the
-    // cluster
     this.disposed = false;
 
-    // Add a delay for key expiration to make sure the node have the time to
-    // refresh it
     this.refreshMultiplier = 4;
   }
 
   /**
    * Generates and reserves a unique ID for this node instance.
    * Makes sure that the ID is not already taken by another node instance.
-   *
-   * @return {void}
    */
-  async createIdCard () {
-    let reserved;
+  async createIdCard (): Promise<void> {
+    let reserved = false;
 
     do {
       this.nodeId = generateRandomName('knode');
@@ -103,8 +170,8 @@ class ClusterIdCardHandler {
         topology: [],
       });
 
-      reserved = await this._save({ creation: true });
-    } while (!reserved);
+      reserved = await this.save({ creation: true });
+    } while (! reserved);
 
     await this.addIdCardToIndex();
 
@@ -137,14 +204,19 @@ class ClusterIdCardHandler {
 
   // Used to Mock the creation of a worker for the tests
   _constructWorker (path) {
-    return new Worker(path);
+    return new WorkerThread(path);
   }
 
-  async dispose () {
+  async dispose (): Promise<void> {
     this.disposed = true;
+
     if (this.refreshWorker) {
       this.refreshWorker.postMessage({action: 'dispose'});
     }
+  }
+
+  private async refreshIdCard () {
+
   }
 
   /**
@@ -164,10 +236,10 @@ class ClusterIdCardHandler {
    *
    * @return {Array.<IdCard>}
    */
-  async getRemoteIdCards () {
-    const idCards = [];
+  async getRemoteIdCards (): Promise<IdCard[]> {
+    const idCards: IdCard[] = [];
 
-    let keys = await global.kuzzle.ask(
+    let keys: string[] = await global.kuzzle.ask(
       'core:cache:internal:execute',
       'smembers',
       REDIS_ID_CARDS_INDEX);
@@ -178,14 +250,14 @@ class ClusterIdCardHandler {
       return idCards;
     }
 
-    const values = await global.kuzzle.ask('core:cache:internal:mget', keys);
-    const expiredIdCards = [];
+    const rawIdCards: string[] = await global.kuzzle.ask('core:cache:internal:mget', keys);
+    const expiredIdCards: string[] = [];
 
     for (let i = 0; i < keys.length; i++) {
       // filter keys that might have expired between the key search and their
       // values retrieval
-      if (values[i] !== null) {
-        idCards.push(IdCard.unserialize(values[i]));
+      if (rawIdCards[i] !== null) {
+        idCards.push(IdCard.unserialize(JSON.parse(rawIdCards[i])));
       }
       else {
         expiredIdCards.push(keys[i]);
@@ -207,22 +279,22 @@ class ClusterIdCardHandler {
   /**
    * Adds a remote node IdCard to the node known topology
    */
-  async addNode (id) {
+  async addNode (id: string): Promise<void> {
     if (this.disposed || this.idCard.topology.has(id)) {
       return;
     }
 
     this.idCard.topology.add(id);
 
-    await this._save();
+    await this.save();
   }
 
   /**
    * Removes a remote node IdCard from the node known topology
    */
-  async removeNode (id) {
-    if (!this.disposed && this.idCard.topology.delete(id)) {
-      await this._save();
+  async removeNode (id: string): Promise<void> {
+    if (! this.disposed && this.idCard.topology.delete(id)) {
+      await this.save();
     }
   }
 
@@ -231,7 +303,7 @@ class ClusterIdCardHandler {
    *
    * This set is an index to retrieve ID Cards faster.
    */
-  async addIdCardToIndex () {
+  async addIdCardToIndex (): Promise<void> {
     await global.kuzzle.ask(
       'core:cache:internal:execute',
       'sadd',
@@ -240,14 +312,14 @@ class ClusterIdCardHandler {
 
   /**
    * Saves the local node IdCard into Redis
+   *
+   * @returns True if the key was set
    */
-  _save ({ creation } = { creation: false }) {
+  private save ({ creation } = { creation: false }): Promise<boolean> {
     return global.kuzzle.ask(
       'core:cache:internal:store',
       this.nodeIdKey,
-      this.idCard.serialize(),
+      JSON.stringify(this.idCard.serialize()),
       { onlyIfNew: creation, ttl: this.refreshDelay * this.refreshMultiplier });
   }
 }
-
-module.exports = { ClusterIdCardHandler, IdCard };

--- a/lib/cluster/workers/IDCardRenewer.js
+++ b/lib/cluster/workers/IDCardRenewer.js
@@ -15,8 +15,8 @@ class IDCardRenewer {
   }
 
   async init (config) {
-    if (!this.disposed) {
-      return; // Already intialized
+    if (! this.disposed) {
+      return; // Already initialized
     }
 
     this.disposed = false;
@@ -50,9 +50,8 @@ class IDCardRenewer {
         this.refreshDelay);
     }
 
-    this.parentPort.postMessage({
-      message: 'initialized',
-    });
+    // Notify that the worker is running and updating the ID Card
+    this.parentPort.postMessage({ initialized: true });
   }
 
   async initRedis (config, name) {

--- a/lib/cluster/workers/IDCardRenewer.js
+++ b/lib/cluster/workers/IDCardRenewer.js
@@ -49,6 +49,10 @@ class IDCardRenewer {
         this.renewIDCard.bind(this),
         this.refreshDelay);
     }
+
+    this.parentPort.postMessage({
+      message: 'initialized',
+    });
   }
 
   async initRedis (config, name) {

--- a/test/cluster/idCardHandler.test.js
+++ b/test/cluster/idCardHandler.test.js
@@ -59,7 +59,7 @@ describe('ClusterIdCardHandler', () => {
       should(kuzzle.ask).be.calledWith(
         'core:cache:internal:store',
         `{cluster/node}/${idCardHandler.nodeId}`,
-        idCardHandler.idCard.serialize(),
+        JSON.stringify(idCardHandler.idCard.serialize()),
         {
           onlyIfNew: true,
           ttl: refreshDelay * 4
@@ -128,7 +128,7 @@ describe('ClusterIdCardHandler', () => {
         .resolves(['redis/id1', 'redis/id2', 'redis/id3', 'redis/id4']);
       kuzzle.ask
         .withArgs('core:cache:internal:mget')
-        .resolves([idCard2.serialize(), idCard3.serialize(), null]);
+        .resolves([JSON.stringify(idCard2.serialize()), JSON.stringify(idCard3.serialize()), null]);
 
       const remoteCards = await idCardHandler.getRemoteIdCards();
 
@@ -150,63 +150,63 @@ describe('ClusterIdCardHandler', () => {
 
   describe('#addNode', () => {
     it('should add the remote node to known topology and save the IdCard', async () => {
-      idCardHandler._save = sinon.stub().resolves();
+      sinon.stub(idCardHandler, 'save').resolves();
       idCardHandler.idCard = new IdCard({ id: 'id1', ip: 'ip1', birthdate: 1001 });
 
       await idCardHandler.addNode('remoteNodeId');
 
       should(idCardHandler.idCard.topology.has('remoteNodeId')).be.true();
-      should(idCardHandler._save).be.called();
+      should(idCardHandler.save).be.called();
     });
 
     it('should not add the remote node if it is already known', async () => {
-      idCardHandler._save = sinon.stub().resolves();
+      sinon.stub(idCardHandler, 'save').resolves();
       idCardHandler.idCard = new IdCard({ id: 'id1', ip: 'ip1', birthdate: 1001 });
       idCardHandler.idCard.topology.add('remoteNodeId');
 
       await idCardHandler.addNode('remoteNodeId');
 
-      should(idCardHandler._save).not.be.called();
+      should(idCardHandler.save).not.be.called();
     });
 
     it('should not add the remote node if the IdCard is disposed', async () => {
-      idCardHandler._save = sinon.stub().resolves();
+      sinon.stub(idCardHandler, 'save').resolves();
       idCardHandler.disposed = true;
 
       await idCardHandler.addNode('remoteNodeId');
 
-      should(idCardHandler._save).not.be.called();
+      should(idCardHandler.save).not.be.called();
     });
   });
 
   describe('#removeNode', () => {
     it('should remove the remote node to known topology and save the IdCard', async () => {
-      idCardHandler._save = sinon.stub().resolves();
+      sinon.stub(idCardHandler, 'save').resolves();
       idCardHandler.idCard = new IdCard({ id: 'id1', ip: 'ip1', birthdate: 1001 });
       idCardHandler.idCard.topology.add('remoteNodeId');
 
       await idCardHandler.removeNode('remoteNodeId');
 
       should(idCardHandler.idCard.topology.has('remoteNodeId')).be.false();
-      should(idCardHandler._save).be.called();
+      should(idCardHandler.save).be.called();
     });
 
     it('should not remove the remote node if it is not present', async () => {
-      idCardHandler._save = sinon.stub().resolves();
+      sinon.stub(idCardHandler, 'save').resolves();
       idCardHandler.idCard = new IdCard({ id: 'id1', ip: 'ip1', birthdate: 1001 });
 
       await idCardHandler.removeNode('remoteNodeId');
 
-      should(idCardHandler._save).not.be.called();
+      should(idCardHandler.save).not.be.called();
     });
 
     it('should not remove the remote node if the IdCard is disposed', async () => {
-      idCardHandler._save = sinon.stub().resolves();
+      sinon.stub(idCardHandler, 'save').resolves();
       idCardHandler.disposed = true;
 
       await idCardHandler.removeNode('remoteNodeId');
 
-      should(idCardHandler._save).not.be.called();
+      should(idCardHandler.save).not.be.called();
     });
   });
 });


### PR DESCRIPTION
## What does this PR do ?

The node ID Card is refreshed by a [Worker Thread](https://nodejs.org/docs/latest-v12.x/api/worker_threads.html) in a different process (and a different event loop) to ensure that the Node is always able to make the necessary request to Redis.

Worker Thread can take a long time to start, so a timer is started from the main process to refresh the ID Card until the Worker Thread starts. 

This allows to reduce the ID Card expiration time and thus fix the error users can get when a node is restarting to fast (see #2194)

### Boyscout

 - convert IdCardHandler to Typescript