### PR TITLE
Upgrade uWs from v19.3.0 to v20.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7633,8 +7633,8 @@
       "dev": true
     },
     "uWebSockets.js": {
-      "version": "https://github.com/uNetworking/uWebSockets.js/archive/refs/tags/v20.4.0.tar.gz",
-      "integrity": "sha512-pVhNHMMjMILRK942aVfRcv3rtfZ1bvMChcJWJVkpV5LudYIiknWUvUv28NzioCyowbnHJqQmCEFAXBsjqrCP4Q=="
+      "version": "https://github.com/uNetworking/uWebSockets.js/archive/refs/tags/v20.0.0.tar.gz",
+      "integrity": "sha512-dubJxOLu45q6HWYu1/jVoeE51TgKE17X0K21iTX6jxc+KUcip8CQuO7xIfE5TjOPGfnrHDRLIizq3LKgPXMgaw=="
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7633,8 +7633,8 @@
       "dev": true
     },
     "uWebSockets.js": {
-      "version": "https://github.com/uNetworking/uWebSockets.js/archive/refs/tags/v19.3.0.tar.gz",
-      "integrity": "sha512-8bv3Jwumx3FL6gkZT9K9eFjO04VfMEXaIlubqpaSu7sCfj0PLIwhsslM1LNJFKmTlR+0bu2U8t92zbHck714MQ=="
+      "version": "https://github.com/uNetworking/uWebSockets.js/archive/refs/tags/v20.4.0.tar.gz",
+      "integrity": "sha512-pVhNHMMjMILRK942aVfRcv3rtfZ1bvMChcJWJVkpV5LudYIiknWUvUv28NzioCyowbnHJqQmCEFAXBsjqrCP4Q=="
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "segfault-handler": "^1.3.0",
     "semver": "^7.3.5",
     "sorted-array": "^2.0.4",
-    "uWebSockets.js": "https://github.com/uNetworking/uWebSockets.js/archive/refs/tags/v19.3.0.tar.gz",
+    "uWebSockets.js": "https://github.com/uNetworking/uWebSockets.js/archive/refs/tags/v20.4.0.tar.gz",
     "uuid": "^8.3.2",
     "validator": "^13.6.0",
     "winston": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "segfault-handler": "^1.3.0",
     "semver": "^7.3.5",
     "sorted-array": "^2.0.4",
-    "uWebSockets.js": "https://github.com/uNetworking/uWebSockets.js/archive/refs/tags/v20.4.0.tar.gz",
+    "uWebSockets.js": "https://github.com/uNetworking/uWebSockets.js/archive/refs/tags/v20.0.0.tar.gz",
     "uuid": "^8.3.2",
     "validator": "^13.6.0",
     "winston": "^3.3.3",


### PR DESCRIPTION
## What does this PR do ?

Upgrade uWebSocket to the v20.0.0 version. This library is responsible of the HTTP and WebSocket network layers in Kuzzle.

We **can't** update to further version because this library just dropped the Node.js 12 support after the v20.1.0 (See https://github.com/uNetworking/uWebSockets.js/discussions/632)

The v20.x should be backward compatible with the v19.x since we don't use MQTT like wildcards in WebSocket subscriptions (See https://github.com/uNetworking/uWebSockets/releases/tag/v20.0.0 for more info)