### PR TITLE
Send document body in notification when exiting the scope

### DIFF
--- a/doc/2/api/payloads/notifications/index.md
+++ b/doc/2/api/payloads/notifications/index.md
@@ -2,7 +2,7 @@
 code: false
 type: page
 title: Notifications
-description: Notifications payloads reference  
+description: Notifications payloads reference
 order: 300
 ---
 
@@ -43,11 +43,11 @@ A document notification contains the following fields:
 
 The `result` object is the notification content, and it has the following structure:
 
-| Property         | Type     | Description                                                                                 |
-|------------------|----------|---------------------------------------------------------------------------------------------|
-| `_id`            | string   | Document unique ID<br/>`null` if the notification is from a real-time message               |
-| `_source`        | object   | The message or full document content. Not present if the event is about a document deletion |
-| `_updatedFields` | string[] | List of fields that have been updated (only available on document partial updates)          |
+| Property         | Type     | Description                                                                        |
+|------------------|----------|------------------------------------------------------------------------------------|
+| `_id`            | string   | Document unique ID<br/>`null` if the notification is from a real-time message      |
+| `_source`        | object   | The message or full document content.                                              |
+| `_updatedFields` | string[] | List of fields that have been updated (only available on document partial updates) |
 
 ### Example
 

--- a/doc/2/guides/main-concepts/api/index.md
+++ b/doc/2/guides/main-concepts/api/index.md
@@ -2,13 +2,13 @@
 code: false
 type: page
 title: API
-description: Discover Kuzzle API usage and formats  
+description: Discover Kuzzle API usage and formats
 order: 100
 ---
 
 # API
 
-Kuzzle exposes most of its features through a **multi-protocol API**.  
+Kuzzle exposes most of its features through a **multi-protocol API**.
 
 This API uses the **JSON format** to communicate with a **standardized request and response format**.
 
@@ -22,8 +22,8 @@ The Kuzzle API is accessible by default through 3 protocols:
 Each protocol has advantages and disadvantages. The choice of a protocol must therefore be adapted to a situation and a use.
 
 ::: info
-Kuzzle is able to integrate to its API any protocol operating on [IP](https://en.wikipedia.org/wiki/Internet_Protocol).  
-More info on [Writing Protocol Plugin](/core/2/guides/write-protocols/start-writing-protocols).  
+Kuzzle is able to integrate to its API any protocol operating on [IP](https://en.wikipedia.org/wiki/Internet_Protocol).
+More info on [Writing Protocol Plugin](/core/2/guides/write-protocols/start-writing-protocols).
 :::
 
 ## Request Format
@@ -55,7 +55,7 @@ Body contents can be sent in the following formats:
 - `application/json`: raw JSON
 - `multipart/form-data`: HTML forms; both field-value pairs and field-files pairs can be sent that way
 
-If a HTML form is sent that way, the **resulting body content will be translated into a JSON object**, with as many keys as the provided form fields.  
+If a HTML form is sent that way, the **resulting body content will be translated into a JSON object**, with as many keys as the provided form fields.
 If the form field holds a file, then the corresponding JSON key will refer to an object instead of a mere value, with the following properties:
 
 - `filename`: file's name
@@ -65,7 +65,7 @@ If the form field holds a file, then the corresponding JSON key will refer to an
 
 #### JSON Query Endpoint
 
-Kuzzle also exposes an endpoint to **send requests using the standard JSON request format** used by other protocols.  
+Kuzzle also exposes an endpoint to **send requests using the standard JSON request format** used by other protocols.
 
 This makes it possible to avoid the use of the REST API and to send requests via the HTTP protocol the same way as for any other protocols.
 
@@ -73,8 +73,8 @@ This endpoint is accessible with the route `POST /_query`:
 
 ```bash
 curl -X POST -H  "Content-Type: application/json" "http://localhost:7512/_query" --data '{
-  "controller":"server", 
-  "action":"now" 
+  "controller":"server",
+  "action":"now"
 }'
 ```
 
@@ -221,11 +221,11 @@ A document notification contains the following fields:
 
 The `result` object is the notification content, and it has the following structure:
 
-| Property         | Type     | Description                                                                                 |
-|------------------|----------|---------------------------------------------------------------------------------------------|
-| `_id`            | string   | Document unique ID<br/>`null` if the notification is from a real-time message               |
-| `_source`        | object   | The message or full document content. Not present if the event is about a document deletion |
-| `_updatedFields` | string[] | List of fields that have been updated (only available on document partial updates)          |
+| Property         | Type     | Description                                                                        |
+|------------------|----------|------------------------------------------------------------------------------------|
+| `_id`            | string   | Document unique ID<br/>`null` if the notification is from a real-time message      |
+| `_source`        | object   | The message or full document content.                                              |
+| `_updatedFields` | string[] | List of fields that have been updated (only available on document partial updates) |
 
 **Example:** _Document notification_
 ```js

--- a/features-legacy/kuzzle.feature
+++ b/features-legacy/kuzzle.feature
@@ -213,7 +213,7 @@ Feature: Kuzzle functional tests
     When I write the document "documentGrace"
     Then I remove the document
     Then I should receive a document notification with field action equal to "delete"
-    And The notification should not have a "_source" member
+    And The notification should have a "_source" member
     And The notification should have volatile
 
   @realtime
@@ -232,7 +232,7 @@ Feature: Kuzzle functional tests
     When I write the document "documentGrace"
     Then I update the document with value "Foo" in field "lastName"
     Then I should receive a document notification with field action equal to "update"
-    And The notification should not have a "_source" member
+    And The notification should have a "_source" member
     And The notification should have volatile
 
   @realtime
@@ -250,7 +250,7 @@ Feature: Kuzzle functional tests
     When I write the document "documentGrace"
     Then I replace the document with "documentAda" document
     Then I should receive a document notification with field action equal to "replace"
-    And The notification should not have a "_source" member
+    And The notification should have a "_source" member
     And The notification should have volatile
 
   @realtime
@@ -269,7 +269,7 @@ Feature: Kuzzle functional tests
     And I refresh the collection
     Then I remove documents with field "info.hobby" equals to value "computer"
     Then I should receive a document notification with field action equal to "delete"
-    And The notification should not have a "_source" member
+    And The notification should have a "_source" member
     And The notification should have volatile
 
   @realtime

--- a/lib/api/controllers/documentController.js
+++ b/lib/api/controllers/documentController.js
@@ -515,11 +515,7 @@ class DocumentController extends NativeController {
         document);
     }
 
-    if (!source) {
-      return { _id: document._id };
-    }
-
-    return document;
+    return source ? document : { _id: document._id };
   }
 
   /**

--- a/lib/core/realtime/notifier.js
+++ b/lib/core/realtime/notifier.js
@@ -249,9 +249,7 @@ class NotifierController {
     if (cache !== null) {
       const stopListening = difference(JSON.parse(cache), rooms);
 
-      await this.notifyDocument(stopListening, request, 'out', 'replace', {
-        _id: document._id,
-      });
+      await this.notifyDocument(stopListening, request, 'out', 'replace', document);
     }
 
     return rooms;
@@ -281,25 +279,29 @@ class NotifierController {
       : [];
 
     const result = await Bluebird.map(documents, (doc, index) => {
-      switch(action) {
+      switch (action) {
         case actionEnum.CREATE:
           return this.notifyDocumentCreate(request, doc);
+
         case actionEnum.DELETE:
           return this.notifyDocumentDelete(request, doc);
+
         case actionEnum.REPLACE:
           return this.notifyDocumentReplace(request, doc, cache[index]);
+
         case actionEnum.UPDATE:
           return this.notifyDocumentUpdate(request, doc, cache[index]);
+
         case actionEnum.UPSERT:
-          if (doc.created) {
-            return this.notifyDocumentCreate(request, doc);
-          }
-          return this.notifyDocumentUpdate(request, doc, cache[index]);
+          return doc.created
+            ? this.notifyDocumentCreate(request, doc)
+            : this.notifyDocumentUpdate(request, doc, cache[index]);
+
         case actionEnum.WRITE:
-          if (doc.created) {
-            return this.notifyDocumentCreate(request, doc);
-          }
-          return this.notifyDocumentReplace(request, doc, cache[index]);
+          return doc.created
+            ? this.notifyDocumentCreate(request, doc)
+            : this.notifyDocumentReplace(request, doc, cache[index]);
+
         default:
           throw kerror.get('core', 'fatal', 'assertion_failed', `unknown notify action "${doc.action}"`);
       }
@@ -342,9 +344,7 @@ class NotifierController {
     if (cache !== null) {
       const stopListening = difference(JSON.parse(cache), rooms);
 
-      await this.notifyDocument(stopListening, request, 'out', 'update', {
-        _id: document._id,
-      });
+      await this.notifyDocument(stopListening, request, 'out', 'update', document);
     }
 
     return rooms;
@@ -361,9 +361,7 @@ class NotifierController {
     const rooms = this._test(request, document._source, document._id);
 
     if (rooms.length > 0) {
-      await this.notifyDocument(rooms, request, 'out', 'delete', {
-        _id: document._id,
-      });
+      await this.notifyDocument(rooms, request, 'out', 'delete', document);
     }
 
     return [];

--- a/test/core/realtime/notifier/notifyDocumentDelete.test.js
+++ b/test/core/realtime/notifier/notifyDocumentDelete.test.js
@@ -35,7 +35,7 @@ describe('Test: notifier.notifyDocumentDelete', () => {
 
     should(kuzzle.koncorde.test).calledWith({ ..._source, _id }, 'index/collection');
     should(notifier.notifyDocument)
-      .calledWithMatch(rooms, request, 'out', 'delete', { _id });
+      .calledWithMatch(rooms, request, 'out', 'delete', { _id, _source });
     should(result).be.an.Array().and.be.empty();
   });
 });

--- a/test/core/realtime/notifier/notifyDocumentReplace.test.js
+++ b/test/core/realtime/notifier/notifyDocumentReplace.test.js
@@ -56,7 +56,7 @@ describe('Test: notifier.notifyDocumentReplace', () => {
       });
 
     should(notifier.notifyDocument.getCall(1))
-      .calledWith(['bar'], request, 'out', 'replace', { _id });
+      .calledWith(['bar'], request, 'out', 'replace', { _id, _source: request.input.body });
 
     should(result).match(['foo']);
   });

--- a/test/core/realtime/notifier/notifyDocumentUpdate.test.js
+++ b/test/core/realtime/notifier/notifyDocumentUpdate.test.js
@@ -63,7 +63,11 @@ describe('Test: notifier.notifyDocumentUpdate', () => {
       });
 
     should(notifier.notifyDocument.getCall(1))
-      .calledWith(['bar'], request, 'out', 'update', { _id });
+      .calledWith(['bar'], request, 'out', 'update', {
+        _id,
+        _source: { foo: 'bar' },
+        _updatedFields: ['foo']
+      });
 
     should(rooms).match(['foo']);
   });


### PR DESCRIPTION
## What does this PR do ?

When a document exit the subscription scope (for example after being updated or deleted), Kuzzle send a notification with the `scope` property equals to `out`.

This kind of notification didn't include the body of the document triggering the notification, this PR fix that incoherent behavior.

