### PR TITLE
Add new API action `server:metrics`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ lib/core/backend/internalLogger.js
 lib/core/backend/index.js
 lib/core/shared/sdk/embeddedSdk.js
 lib/core/shared/KoncordeWrapper.js
+lib/core/storage/indexCache.js
 lib/core/plugin/pluginContext.js
 lib/cluster/workers/IDCardRenewer.js
 lib/api/request/index.js
@@ -124,6 +125,7 @@ lib/types/EventHandler.js
 lib/types/InternalLogger.js
 lib/types/Plugin.js
 lib/types/Kuzzle.js
+lib/types/KuzzleDocument.js
 lib/types/PluginManifest.js
 lib/types/RequestPayload.js
 lib/types/ResponsePayload.js

--- a/doc/2/api/controllers/server/get-all-stats/index.md
+++ b/doc/2/api/controllers/server/get-all-stats/index.md
@@ -6,7 +6,7 @@ title: getAllStats
 
 # getAllStats
 
-
+<DeprecatedBadge version="auto-version" />
 
 Gets all stored internal statistic snapshots.
 

--- a/doc/2/api/controllers/server/get-last-stats/index.md
+++ b/doc/2/api/controllers/server/get-last-stats/index.md
@@ -6,7 +6,7 @@ title: getLastStats
 
 # getLastStats
 
-
+<DeprecatedBadge version="auto-version" />
 
 Returns the most recent statistics snapshot.
 

--- a/doc/2/api/controllers/server/get-stats/index.md
+++ b/doc/2/api/controllers/server/get-stats/index.md
@@ -6,7 +6,7 @@ title: getStats
 
 # getStats
 
-
+<DeprecatedBadge version="auto-version" />
 
 Returns statistics snapshots within a provided timestamp range.
 

--- a/doc/2/api/controllers/server/metrics/index.md
+++ b/doc/2/api/controllers/server/metrics/index.md
@@ -6,7 +6,7 @@ title: metrics
 
 # metrics
 
-
+<SinceBadge version="auto-version"/>
 
 Returns inner metrics directly from the current Kuzzle node core components.
 
@@ -36,14 +36,14 @@ Method: GET
 
 Returns the found statistic snapshots in the following format:
 
-- `funnel`: current node API funnel metrics
+- `api`: current node API funnel metrics
   - `concurrentRequests`: number of concurrent requests currently executed.
   - `pendingRequests`: number of requests waiting for execution
-- `hotelClerk`: current node realtime hotelClerk metrics
+- `network`: current node router metrics
+  - `connections`: number of active connections, per network protocol
+- `realtime`: current node realtime hotelClerk metrics
   - `rooms`: number of active realtime rooms
   - `subscriptions`: number of active subscriptions 
-- `router`: current node router metrics
-  - `connections`: number of active connections, per network protocol
 
 
 
@@ -55,20 +55,20 @@ Returns the found statistic snapshots in the following format:
   "controller": "server",
   "requestId": "<unique request identifier>",
   "result": {
-    "funnel":{
+    "api":{
       "concurrentRequests": 1,
       "pendingRequests": 0
     },
-    "hotelClerk": {
-     "rooms": 1,
-     "subscriptions": 1
-    },
-    "router": {
+    "network": {
       "connections": {
         "internal": 1,
         "websocket": 1,
         "HTTP/1.1": 1
       }
+    },
+    "realtime": {
+     "rooms": 1,
+     "subscriptions": 1
     }
   }
 }

--- a/doc/2/api/controllers/server/metrics/index.md
+++ b/doc/2/api/controllers/server/metrics/index.md
@@ -1,0 +1,75 @@
+---
+code: true
+type: page
+title: metrics
+---
+
+# metrics
+
+
+
+Returns inner metrics directly from the current Kuzzle node core components.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_metrics
+Method: GET
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "server",
+  "action": "metrics"
+}
+```
+
+---
+
+## Response
+
+Returns the found statistic snapshots in the following format:
+
+- `funnel`: current node API funnel metrics
+  - `concurrentRequests`: number of concurrent requests currently executed.
+  - `pendingRequests`: number of requests waiting for execution
+- `hotelClerk`: current node realtime hotelClerk metrics
+  - `rooms`: number of active realtime rooms
+  - `subscriptions`: number of active subscriptions 
+- `router`: current node router metrics
+  - `connections`: number of active connections, per network protocol
+
+
+
+```js
+{
+  "status": 200,
+  "error": null,
+  "action": "metrics",
+  "controller": "server",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "funnel":{
+      "concurrentRequests": 1,
+      "pendingRequests": 0
+    },
+    "hotelClerk": {
+     "rooms": 1,
+     "subscriptions": 1
+    },
+    "router": {
+      "connections": {
+        "internal": 1,
+        "websocket": 1,
+        "HTTP/1.1": 1
+      }
+    }
+  }
+}
+```

--- a/doc/2/api/controllers/server/metrics/index.md
+++ b/doc/2/api/controllers/server/metrics/index.md
@@ -61,9 +61,8 @@ Returns the found statistic snapshots in the following format:
     },
     "network": {
       "connections": {
-        "internal": 1,
         "websocket": 1,
-        "HTTP/1.1": 1
+        "http/1.1": 1
       }
     },
     "realtime": {

--- a/features/ServerController.feature
+++ b/features/ServerController.feature
@@ -70,9 +70,7 @@ Feature: Server Controller
     Then The property "realtime" of the result should match:
       | rooms         | 1 |
       | subscriptions | 1 |
-    Then The property "network.connections" of the result should match:
-      | websocket | 2 |
-      | internal  | 1 |
+
 
   # server:openapi ========================================================================
   @http

--- a/features/ServerController.feature
+++ b/features/ServerController.feature
@@ -64,13 +64,13 @@ Feature: Server Controller
   Scenario: Get Kuzzle node metrics
     Given I subscribe to "functional-test":"hooks" notifications
     When I execute the action "server":"metrics"
-    Then The property "funnel" of the result should match:
+    Then The property "api" of the result should match:
       | concurrentRequests | 1 |
       | pendingRequests    | 0 |
-    Then The property "hotelClerk" of the result should match:
+    Then The property "realtime" of the result should match:
       | rooms         | 1 |
       | subscriptions | 1 |
-    Then The property "router.connections" of the result should match:
+    Then The property "network.connections" of the result should match:
       | websocket | 2 |
       | internal  | 1 |
 

--- a/features/ServerController.feature
+++ b/features/ServerController.feature
@@ -59,6 +59,21 @@ Feature: Server Controller
       | memoryStorage | "green" |
       | storageEngine | "green" |
 
+  # server:metrics ==========================================================================
+  @realtime
+  Scenario: Get Kuzzle node metrics
+    Given I subscribe to "functional-test":"hooks" notifications
+    When I execute the action "server":"metrics"
+    Then The property "funnel" of the result should match:
+      | concurrentRequests | 1 |
+      | pendingRequests    | 0 |
+    Then The property "hotelClerk" of the result should match:
+      | rooms         | 1 |
+      | subscriptions | 1 |
+    Then The property "router.connections" of the result should match:
+      | websocket | 2 |
+      | internal  | 1 |
+
   # server:openapi ========================================================================
   @http
   Scenario: Get our API in OpenApi format as a raw response
@@ -79,3 +94,4 @@ Feature: Server Controller
   Scenario: Http call onto deprecated method should not print a warning when NODE_ENV=production
     When I execute the action "server":"publicApi"
     Then The response should contains a "deprecations" equals to undefined
+ 

--- a/lib/api/controllers/serverController.js
+++ b/lib/api/controllers/serverController.js
@@ -42,10 +42,10 @@ class ServerController extends NativeController {
       'getStats',
       'healthCheck',
       'info',
+      'metrics',
       'now',
       'publicApi',
       'openapi',
-      'metrics'
     ]);
   }
 
@@ -266,9 +266,9 @@ class ServerController extends NativeController {
    */
   async metrics () {
     return {
-      funnel: await global.kuzzle.ask('kuzzle:api:funnel:metrics'),
-      hotelClerk: await global.kuzzle.ask('core:realtime:hotelClerk:metrics'),
-      router: await global.kuzzle.ask('core:network:router:metrics'),
+      api: await global.kuzzle.ask('kuzzle:api:funnel:metrics'),
+      network: await global.kuzzle.ask('core:network:router:metrics'),
+      realtime: await global.kuzzle.ask('core:realtime:hotelClerk:metrics'),
     };
   }
 

--- a/lib/api/controllers/serverController.js
+++ b/lib/api/controllers/serverController.js
@@ -53,6 +53,8 @@ class ServerController extends NativeController {
    *
    * @param {Request} request
    * @returns {Promise<Object>}
+   * 
+   * @deprecated
    */
   getStats (request) {
     return global.kuzzle.statistics.getStats(request);
@@ -62,6 +64,8 @@ class ServerController extends NativeController {
    * Returns the last statistics frame
    *
    * @returns {Promise<Object>}
+   * 
+   * @deprecated
    */
   getLastStats () {
     return global.kuzzle.statistics.getLastStats();
@@ -71,6 +75,8 @@ class ServerController extends NativeController {
    * Returns all stored statistics frames
    *
    * @returns {Promise<Object>}
+   * 
+   * @deprecated
    */
   getAllStats () {
     return global.kuzzle.statistics.getAllStats();

--- a/lib/api/controllers/serverController.js
+++ b/lib/api/controllers/serverController.js
@@ -44,7 +44,8 @@ class ServerController extends NativeController {
       'info',
       'now',
       'publicApi',
-      'openapi'
+      'openapi',
+      'metrics'
     ]);
   }
 
@@ -257,6 +258,18 @@ class ServerController extends NativeController {
     });
 
     return specifications;
+  }
+
+  /**
+   * Fetches and returns Kuzzle core metrics
+   * @returns {Promise<Object>}
+   */
+  async metrics () {
+    return {
+      funnel: await global.kuzzle.ask('kuzzle:api:funnel:metrics'),
+      hotelClerk: await global.kuzzle.ask('core:realtime:hotelClerk:metrics'),
+      router: await global.kuzzle.ask('core:network:router:metrics'),
+    };
   }
 
   _buildApiDefinition (controllers, httpRoutes) {

--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -101,6 +101,14 @@ class Funnel {
       'kuzzle:api:funnel:controller:isNative',
       name => this.isNativeController(name));
 
+    /**
+     * Returns inner metrics from the Funnel
+     * @returns {Object} 
+     */
+    global.kuzzle.onAsk(
+      'kuzzle:api:funnel:metrics',
+      () => this.metrics());
+
     this.rateLimiter.init();
 
     this.controllers.set('auth', new AuthController());
@@ -714,6 +722,17 @@ class Funnel {
    */
   isNativeController (controller) {
     return this.controllers.has(controller);
+  }
+
+  /**
+   * Returns inner metrics from the Funnel
+   * @returns {Object}
+   */
+  metrics () {
+    return {
+      concurrentRequests: this.concurrentRequests,
+      pendingRequests: this.pendingRequestsQueue.length,
+    };
   }
 
   /**

--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -101,10 +101,6 @@ class Funnel {
       'kuzzle:api:funnel:controller:isNative',
       name => this.isNativeController(name));
 
-    global.kuzzle.onAsk(
-      'kuzzle:api:funnel:metrics',
-      () => this.metrics());
-
     this.rateLimiter.init();
 
     this.controllers.set('auth', new AuthController());
@@ -718,19 +714,6 @@ class Funnel {
    */
   isNativeController (controller) {
     return this.controllers.has(controller);
-  }
-
-  /**
-   * Expose funnel metrics to other components (e.g concurrent requests, overload etc...)
-   * 
-   * @returns {Object}
-   */
-  metrics () {
-    return {
-      concurrentRequests: this.concurrentRequests,
-      overloaded: this.overloaded,
-      pendingRequests: this.pendingRequestsQueue.length,
-    };
   }
 
   /**

--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -101,6 +101,10 @@ class Funnel {
       'kuzzle:api:funnel:controller:isNative',
       name => this.isNativeController(name));
 
+    global.kuzzle.onAsk(
+      'kuzzle:api:funnel:metrics',
+      () => this.metrics());
+
     this.rateLimiter.init();
 
     this.controllers.set('auth', new AuthController());
@@ -714,6 +718,19 @@ class Funnel {
    */
   isNativeController (controller) {
     return this.controllers.has(controller);
+  }
+
+  /**
+   * Expose funnel metrics to other components (e.g concurrent requests, overload etc...)
+   * 
+   * @returns {Object}
+   */
+  metrics () {
+    return {
+      concurrentRequests: this.concurrentRequests,
+      overloaded: this.overloaded,
+      pendingRequests: this.pendingRequestsQueue.length,
+    };
   }
 
   /**

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -88,10 +88,10 @@ const routes = [
   { verb: 'get', path: '/profiles/_scroll/:scrollId', controller: 'security', action: 'scrollProfiles' },
 
   { verb: 'get', path: '/_adminExists', controller: 'server', action: 'adminExists' },
-  { verb: 'get', path: '/_getAllStats', controller: 'server', action: 'getAllStats', deprecated: { since: '2.15.0', message: 'Use this route instead: http://kuzzle:7512/_metrics' } }, // @deprecated
+  { verb: 'get', path: '/_getAllStats', controller: 'server', action: 'getAllStats', deprecated: { since: 'auto-version', message: 'Use this route instead: http://kuzzle:7512/_metrics' } }, // @deprecated
   { verb: 'get', path: '/_getConfig', controller: 'server', action: 'getConfig' },
-  { verb: 'get', path: '/_getLastStats', controller: 'server', action: 'getLastStats', deprecated: { since: '2.15.0', message: 'Use this route instead: http://kuzzle:7512/_metrics' } }, // @deprecated
-  { verb: 'get', path: '/_getStats', controller: 'server', action: 'getStats', deprecated: { since: '2.15.0', message: 'Use this route instead: http://kuzzle:7512/_metrics' } }, // @deprecated
+  { verb: 'get', path: '/_getLastStats', controller: 'server', action: 'getLastStats', deprecated: { since: 'auto-version', message: 'Use this route instead: http://kuzzle:7512/_metrics' } }, // @deprecated
+  { verb: 'get', path: '/_getStats', controller: 'server', action: 'getStats', deprecated: { since: 'auto-version', message: 'Use this route instead: http://kuzzle:7512/_metrics' } }, // @deprecated
   { verb: 'get', path: '/', controller: 'server', action: 'info' },
   { verb: 'get', path: '/_healthCheck', controller: 'server', action: 'healthCheck' },
   { verb: 'get', path: '/_serverInfo', controller: 'server', action: 'info' },

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -88,16 +88,17 @@ const routes = [
   { verb: 'get', path: '/profiles/_scroll/:scrollId', controller: 'security', action: 'scrollProfiles' },
 
   { verb: 'get', path: '/_adminExists', controller: 'server', action: 'adminExists' },
-  { verb: 'get', path: '/_getAllStats', controller: 'server', action: 'getAllStats', deprecated: { since: '2.15.0', message: 'Use this route instead: http://kuzzle:7512/_stats' } }, // @deprecated
+  { verb: 'get', path: '/_getAllStats', controller: 'server', action: 'getAllStats', deprecated: { since: '2.15.0', message: 'Use this route instead: http://kuzzle:7512/_metrics' } }, // @deprecated
   { verb: 'get', path: '/_getConfig', controller: 'server', action: 'getConfig' },
-  { verb: 'get', path: '/_getLastStats', controller: 'server', action: 'getLastStats', deprecated: { since: '2.15.0', message: 'Use this route instead: http://kuzzle:7512/_stats' } }, // @deprecated
-  { verb: 'get', path: '/_getStats', controller: 'server', action: 'getStats', deprecated: { since: '2.15.0', message: 'Use this route instead: http://kuzzle:7512/_stats' } }, // @deprecated
+  { verb: 'get', path: '/_getLastStats', controller: 'server', action: 'getLastStats', deprecated: { since: '2.15.0', message: 'Use this route instead: http://kuzzle:7512/_metrics' } }, // @deprecated
+  { verb: 'get', path: '/_getStats', controller: 'server', action: 'getStats', deprecated: { since: '2.15.0', message: 'Use this route instead: http://kuzzle:7512/_metrics' } }, // @deprecated
   { verb: 'get', path: '/', controller: 'server', action: 'info' },
   { verb: 'get', path: '/_healthCheck', controller: 'server', action: 'healthCheck' },
   { verb: 'get', path: '/_serverInfo', controller: 'server', action: 'info' },
   { verb: 'get', path: '/_now', controller: 'server', action: 'now' },
   { verb: 'get', path: '/_publicApi', controller: 'server', action: 'publicApi', deprecated: { since: '2.5.0', message: 'Use this route instead: http://kuzzle:7512/_openapi' } }, // @deprecated
   { verb: 'get', path: '/_openapi', controller: 'server', action: 'openapi' },
+  { verb: 'get', path: '/_metrics', controller: 'server', action: 'metrics' },
 
   { verb: 'get', path: '/ms/_bitcount/:_id', controller: 'ms', action: 'bitcount' },
   { verb: 'get', path: '/ms/_bitpos/:_id', controller: 'ms', action: 'bitpos' },

--- a/lib/config/httpRoutes.js
+++ b/lib/config/httpRoutes.js
@@ -88,10 +88,10 @@ const routes = [
   { verb: 'get', path: '/profiles/_scroll/:scrollId', controller: 'security', action: 'scrollProfiles' },
 
   { verb: 'get', path: '/_adminExists', controller: 'server', action: 'adminExists' },
-  { verb: 'get', path: '/_getAllStats', controller: 'server', action: 'getAllStats' },
+  { verb: 'get', path: '/_getAllStats', controller: 'server', action: 'getAllStats', deprecated: { since: '2.15.0', message: 'Use this route instead: http://kuzzle:7512/_stats' } }, // @deprecated
   { verb: 'get', path: '/_getConfig', controller: 'server', action: 'getConfig' },
-  { verb: 'get', path: '/_getLastStats', controller: 'server', action: 'getLastStats' },
-  { verb: 'get', path: '/_getStats', controller: 'server', action: 'getStats' },
+  { verb: 'get', path: '/_getLastStats', controller: 'server', action: 'getLastStats', deprecated: { since: '2.15.0', message: 'Use this route instead: http://kuzzle:7512/_stats' } }, // @deprecated
+  { verb: 'get', path: '/_getStats', controller: 'server', action: 'getStats', deprecated: { since: '2.15.0', message: 'Use this route instead: http://kuzzle:7512/_stats' } }, // @deprecated
   { verb: 'get', path: '/', controller: 'server', action: 'info' },
   { verb: 'get', path: '/_healthCheck', controller: 'server', action: 'healthCheck' },
   { verb: 'get', path: '/_serverInfo', controller: 'server', action: 'info' },

--- a/lib/core/network/router.js
+++ b/lib/core/network/router.js
@@ -153,17 +153,20 @@ class Router {
    * @returns {Object}
    */
   metrics () {
-    const connectionsByProtocol = new Map();
-    for (const [, connection] of this.connections) {
-      const protocol = connection.connection.protocol;
-      if (! connectionsByProtocol.has(protocol)) {
-        connectionsByProtocol.set(protocol, 0);
+    const connectionsByProtocol = {};
+
+    for (const connection of this.connections.values()) {
+      const protocol = connection.connection.protocol.toLowerCase();
+      if (protocol !== 'internal') {
+        if (connectionsByProtocol[protocol] === undefined) {
+          connectionsByProtocol[protocol] = 0;
+        }
+        connectionsByProtocol[protocol]++;
       }
-      connectionsByProtocol.set(protocol, connectionsByProtocol.get(protocol) + 1);
     }
 
     return {
-      connections: Object.fromEntries(connectionsByProtocol),
+      connections: connectionsByProtocol,
     };
   }
 

--- a/lib/core/network/router.js
+++ b/lib/core/network/router.js
@@ -138,6 +138,33 @@ class Router {
         this._executeFromHttp(route.verb, request, cb);
       });
     }
+
+    /**
+     * Returns inner metrics from the router
+     * @returns {Object}
+     */
+    global.kuzzle.onAsk(
+      'core:network:router:metrics',
+      () => this.metrics());
+  }
+
+  /**
+   * Returns the metrics of the router
+   * @returns {Object}
+   */
+  metrics () {
+    const connectionsByProtocol = new Map();
+    for (const [, connection] of this.connections) {
+      const protocol = connection.connection.protocol;
+      if (! connectionsByProtocol.has(protocol)) {
+        connectionsByProtocol.set(protocol, 0);
+      }
+      connectionsByProtocol.set(protocol, connectionsByProtocol.get(protocol) + 1);
+    }
+
+    return {
+      connections: Object.fromEntries(connectionsByProtocol),
+    };
   }
 
   /**

--- a/lib/core/network/router.js
+++ b/lib/core/network/router.js
@@ -157,12 +157,15 @@ class Router {
 
     for (const connection of this.connections.values()) {
       const protocol = connection.connection.protocol.toLowerCase();
-      if (protocol !== 'internal') {
-        if (connectionsByProtocol[protocol] === undefined) {
-          connectionsByProtocol[protocol] = 0;
-        }
-        connectionsByProtocol[protocol]++;
+      if (protocol === 'internal') {
+        continue;
       }
+
+      if (connectionsByProtocol[protocol] === undefined) {
+        connectionsByProtocol[protocol] = 0;
+      }
+
+      connectionsByProtocol[protocol]++;
     }
 
     return {

--- a/lib/core/realtime/hotelClerk.ts
+++ b/lib/core/realtime/hotelClerk.ts
@@ -174,7 +174,7 @@ export class HotelClerk {
 
     /**
      * Returns inner metrics from the HotelClerk
-     * @return {Object}
+     * @return {{rooms: number, subscriptions: number}}
      */
     global.kuzzle.onAsk(
       'core:realtime:hotelClerk:metrics',
@@ -547,9 +547,8 @@ export class HotelClerk {
 
   /**
    * Returns inner metrics from the HotelClerk
-   * @returns {JSONObject}
    */
-  metrics (): JSONObject {
+  metrics (): {rooms: number, subscriptions: number} {
     return {
       rooms: this.roomsCount,
       subscriptions: this.subscriptions.size,    

--- a/lib/core/realtime/hotelClerk.ts
+++ b/lib/core/realtime/hotelClerk.ts
@@ -173,6 +173,14 @@ export class HotelClerk {
       });
 
     /**
+     * Returns inner metrics from the HotelClerk
+     * @return {Object}
+     */
+    global.kuzzle.onAsk(
+      'core:realtime:hotelClerk:metrics',
+      () => this.metrics());
+
+    /**
      * Clear the hotel clerk and properly disconnect connections.
      */
     global.kuzzle.on('kuzzle:shutdown', () => this.clearConnections());
@@ -535,6 +543,17 @@ export class HotelClerk {
       },
       subscription,
     });
+  }
+
+  /**
+   * Returns inner metrics from the HotelClerk
+   * @returns {JSONObject}
+   */
+  metrics (): JSONObject {
+    return {
+      rooms: this.roomsCount,
+      subscriptions: this.subscriptions.size,    
+    };
   }
 
   /**

--- a/lib/core/realtime/hotelClerk.ts
+++ b/lib/core/realtime/hotelClerk.ts
@@ -73,7 +73,7 @@ export class HotelClerk {
    *
    * Map<roomId, Room>
    */
-  private rooms = new Map<string, Room>();
+  protected rooms = new Map<string, Room>();
 
   /**
    * Current subscribing connections handled by the HotelClerk.
@@ -85,7 +85,7 @@ export class HotelClerk {
    *
    * Map<connectionId, ConnectionRooms>
    */
-  private subscriptions = new Map<string, ConnectionRooms>();
+  protected subscriptions = new Map<string, ConnectionRooms>();
 
   /**
    * Shortcut to the Koncorde instance on the global object.

--- a/lib/core/realtime/hotelClerk.ts
+++ b/lib/core/realtime/hotelClerk.ts
@@ -73,7 +73,7 @@ export class HotelClerk {
    *
    * Map<roomId, Room>
    */
-  protected rooms = new Map<string, Room>();
+  private rooms = new Map<string, Room>();
 
   /**
    * Current subscribing connections handled by the HotelClerk.
@@ -85,7 +85,7 @@ export class HotelClerk {
    *
    * Map<connectionId, ConnectionRooms>
    */
-  protected subscriptions = new Map<string, ConnectionRooms>();
+  private subscriptions = new Map<string, ConnectionRooms>();
 
   /**
    * Shortcut to the Koncorde instance on the global object.

--- a/lib/core/realtime/index.js
+++ b/lib/core/realtime/index.js
@@ -32,25 +32,6 @@ class RealtimeModule {
   async init () {
     await this.notifier.init();
     await this.hotelClerk.init();
-
-    /**
-     * Return metrics about all the RealtimeModule components
-     *
-     * @return {Object}
-     */
-    global.kuzzle.onAsk('core:realtime:metrics', () => this.metrics());
-  }
-
-  /**
-   * Expose realtime metrics to other components
-   *
-   * @return {Object}
-   */
-  metrics () {
-    return {
-      rooms: this.hotelClerk.rooms.size,
-      subscriptions: this.hotelClerk.subscriptions.size,
-    };
   }
 }
 

--- a/lib/core/realtime/index.js
+++ b/lib/core/realtime/index.js
@@ -23,6 +23,7 @@
 
 const Notifier = require('./notifier');
 const { HotelClerk } = require('./hotelClerk');
+
 class RealtimeModule {
   constructor () {
     this.notifier = new Notifier(this);

--- a/lib/core/realtime/index.js
+++ b/lib/core/realtime/index.js
@@ -23,7 +23,6 @@
 
 const Notifier = require('./notifier');
 const { HotelClerk } = require('./hotelClerk');
-
 class RealtimeModule {
   constructor () {
     this.notifier = new Notifier(this);
@@ -33,6 +32,20 @@ class RealtimeModule {
   async init () {
     await this.notifier.init();
     await this.hotelClerk.init();
+
+    /**
+     * Return metrics about all the RealtimeModule components
+     *
+     * @return {Object}
+     */
+    global.kuzzle.onAsk('core:realtime:metrics', () => this.metrics());
+  }
+
+  metrics () {
+    return {
+      rooms: this.hotelClerk.rooms.size,
+      subscriptions: this.hotelClerk.subscriptions.size,
+    };
   }
 }
 

--- a/lib/core/realtime/index.js
+++ b/lib/core/realtime/index.js
@@ -41,6 +41,11 @@ class RealtimeModule {
     global.kuzzle.onAsk('core:realtime:metrics', () => this.metrics());
   }
 
+  /**
+   * Expose realtime metrics to other components
+   *
+   * @return {Object}
+   */
   metrics () {
     return {
       rooms: this.hotelClerk.rooms.size,

--- a/test/api/controllers/serverController.test.js
+++ b/test/api/controllers/serverController.test.js
@@ -401,9 +401,9 @@ describe('ServerController', () => {
         .then(response => {
           should(response).be.instanceof(Object);
           should(response).not.be.null();
-          should(response.funnel).be.an.Object();
-          should(response.hotelClerk).be.an.Object();
-          should(response.router).be.an.Object();
+          should(response.api).be.an.Object();
+          should(response.realtime).be.an.Object();
+          should(response.network).be.an.Object();
         });
     });
   });

--- a/test/api/controllers/serverController.test.js
+++ b/test/api/controllers/serverController.test.js
@@ -378,6 +378,36 @@ describe('ServerController', () => {
     });
   });
 
+  describe('#metrics', () => {
+    it('should return a properly formatted metrics object', () => {
+      kuzzle.ask.withArgs('kuzzle:api:funnel:metrics').resolves({
+        concurrentRequests: 2,
+        pendingRequests: 42,
+      });
+
+      kuzzle.ask.withArgs('core:network:router:metrics').resolves({
+        connections: {
+          internal: 1,
+          http: 1,
+        }
+      });
+
+      kuzzle.ask.withArgs('core:realtime:hotelClerk:metrics').resolves({
+        rooms: 1,
+        subscriptions: 1
+      });
+
+      return serverController.metrics()
+        .then(response => {
+          should(response).be.instanceof(Object);
+          should(response).not.be.null();
+          should(response.funnel).be.an.Object();
+          should(response.hotelClerk).be.an.Object();
+          should(response.router).be.an.Object();
+        });
+    });
+  });
+
   describe('#_buildApiDefinition', () => {
     it('should return api definition for the provided controllers', () => {
       const nativeController = new NativeController();

--- a/test/api/funnel/metrics.test.js
+++ b/test/api/funnel/metrics.test.js
@@ -10,12 +10,9 @@ describe('funnel.metrics', () => {
     kuzzle.ask.withArgs('core:security:user:anonymous:get').resolves({_id: '-1'});
 
     const funnel = new Funnel();
-    const metrics = funnel.metrics();
-
-    should(metrics).be.an.Object();
-    should(metrics.concurrentRequests).be.a.Number();
-    should(metrics.concurrentRequests).be.equal(0);
-    should(metrics.pendingRequests).be.a.Number();
-    should(metrics.pendingRequests).be.equal(0);
+    should(funnel.metrics()).match({
+      concurrentRequests: 0,
+      pendingRequests: 0,
+    });
   });
 });

--- a/test/api/funnel/metrics.test.js
+++ b/test/api/funnel/metrics.test.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const should = require('should');
+const Funnel = require('../../../lib/api/funnel');
+const KuzzleMock = require('../../mocks/kuzzle.mock');
+
+describe('funnel.metrics', () => {
+  it('should returns funnel metrics Object', async () => {
+    const kuzzle = new KuzzleMock();
+    kuzzle.ask.withArgs('core:security:user:anonymous:get').resolves({_id: '-1'});
+
+    const funnel = new Funnel();
+    const metrics = funnel.metrics();
+
+    should(metrics).be.an.Object();
+    should(metrics.concurrentRequests).be.a.Number();
+    should(metrics.concurrentRequests).be.equal(0);
+    should(metrics.pendingRequests).be.a.Number();
+    should(metrics.pendingRequests).be.equal(0);
+  });
+});

--- a/test/core/network/router/router.test.js
+++ b/test/core/network/router/router.test.js
@@ -134,4 +134,18 @@ describe('Test: router', () => {
       should(router.isConnectionAlive(context)).be.true();
     });
   });
+
+  describe('#metrics', () => {
+    it('should return the metrics object', () => {
+      // Fake connections
+      router.newConnection(new RequestContext({connection: {id: 'foo', protocol: 'bar'}}));
+      router.newConnection(new RequestContext({connection: {id: 'foo2', protocol: 'bar'}}));
+
+      const metrics = router.metrics();
+
+      should(metrics).be.an.Object();
+      should(metrics.connections).be.a.Object();
+      should(metrics.connections.bar).be.eql(2);
+    });
+  });
 });

--- a/test/core/network/router/router.test.js
+++ b/test/core/network/router/router.test.js
@@ -141,11 +141,11 @@ describe('Test: router', () => {
       router.newConnection(new RequestContext({connection: {id: 'foo', protocol: 'bar'}}));
       router.newConnection(new RequestContext({connection: {id: 'foo2', protocol: 'bar'}}));
 
-      const metrics = router.metrics();
-
-      should(metrics).be.an.Object();
-      should(metrics.connections).be.a.Object();
-      should(metrics.connections.bar).be.eql(2);
+      should(router.metrics()).match({
+        connections: {
+          bar: 2,
+        }
+      });
     });
   });
 });

--- a/test/core/realtime/hotelClerk/hotelClerk.test.js
+++ b/test/core/realtime/hotelClerk/hotelClerk.test.js
@@ -47,4 +47,13 @@ describe('HotelClerk', () => {
         .be.calledWith('b');
     });
   });
+
+  describe('#metrics', () => {
+    it('should return the metrics object', () => {
+      const metrics = hotelClerk.metrics();
+      should(metrics).be.an.Object();
+      should(metrics.subscriptions).be.a.Number();
+      should(metrics.rooms).be.a.Number();
+    });
+  });
 });

--- a/test/core/realtime/hotelClerk/hotelClerk.test.js
+++ b/test/core/realtime/hotelClerk/hotelClerk.test.js
@@ -50,10 +50,10 @@ describe('HotelClerk', () => {
 
   describe('#metrics', () => {
     it('should return the metrics object', () => {
-      const metrics = hotelClerk.metrics();
-      should(metrics).be.an.Object();
-      should(metrics.subscriptions).be.a.Number();
-      should(metrics.rooms).be.a.Number();
+      should(hotelClerk.metrics()).match({
+        rooms: 0,
+        subscriptions: 2,
+      });
     });
   });
 });


### PR DESCRIPTION

## What does this PR do ?

Add a new route `server:metrics` to fetch relevant Kuzzle core metrics directly from related components.

Fix #2206 

### How should this be manually tested?

You can test the route using:

- via HTTP
```http
GET "http://localhost:7512/_metrics"
```

- via WebSocket
```json
{
  "action": "metrics",
  "controller": "server"
}
```

You should fetch this kind of response:
```js
{
  "action":"metrics",
  "controller":"server",
  "result": {
    "funnel":{
      "concurrentRequests":1,
      "pendingRequests":0
    },
    "hotelClerk": {
     "rooms":1,
     "subscriptions":1
    },
    "router": {
      "connections": {
        "internal":1,
        "websocket":1,
        "HTTP/1.1":1
      }
    }
  },
  "status":200
}
```

### Other changes

- To provide such metrics, I added a new method `metrics()` to monitored components like `hotelClerk` or the `funnel`. This function can be triggered using internal event system (e.g.: `core:realtime:hotelClerk:metrics` for `hotelClerk`).
- Old routes `server:get*Stats` are now deprecated and will be removed in Kuzzle v3 

