### PR TITLE
Allows stored-scripts in queries

### DIFF
--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -128,12 +128,11 @@ class ElasticSearch extends Service {
       '_source_includes'
     ];
 
-    // Forbidden keys in a query
-    this.scriptKeys = [
-      'script',
-      '_script'
-    ];
-
+    /**
+     * Only allow stored-scripts in queries
+     */
+    this.scriptKeys = ['script', '_script'];
+    this.scriptAllowedArgs = ['id', 'params'];
 
     this.maxScrollDuration = this._loadMsConfig('maxScrollDuration');
 
@@ -2979,14 +2978,20 @@ class ElasticSearch extends Service {
   }
 
   /**
-   * Throw if any script keyword is contained in the object
+   * Throw if a script is used in the query.
+   *
+   * Only Stored Scripts are accepted
    *
    * @param {Object} object
    */
-  _scriptCheck(object) {
+  _scriptCheck (object) {
     for (const [key, value] of Object.entries(object)) {
       if (this.scriptKeys.includes(key)) {
-        throw kerror.get('invalid_query_keyword', key);
+        for (const scriptArg of Object.keys(value)) {
+          if (! this.scriptAllowedArgs.includes(scriptArg)) {
+            throw kerror.get('invalid_query_keyword', `${key}.${scriptArg}`);
+          }
+        }
       }
       // Every object must be checked here, even the ones nested into an array
       else if (typeof value === 'object' && value !== null) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2459,12 +2459,12 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.1.0.tgz",
-      "integrity": "sha512-JZvNneArGSUsluHWJ8g8MMs3CfIEzwaLx9KyH4tZ2i+R2/rPWzL8c0zg3rHdwYVpN/1sB9gqnjHwz9HoeJpGHw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.3.0.tgz",
+      "integrity": "sha512-aIay56Ph6RxOTC7xyr59Kt3ewX185SaGnAr8eWukoPLeriCrvGjvAubxuvaXOfsxhtwV5g0uBOsyhAom4qJdww==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.0.3",
+        "@eslint/eslintrc": "^1.0.4",
         "@humanwhocodes/config-array": "^0.6.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -2473,10 +2473,10 @@
         "doctrine": "^3.0.0",
         "enquirer": "^2.3.5",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^6.0.0",
+        "eslint-scope": "^7.1.0",
         "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.0.0",
-        "espree": "^9.0.0",
+        "eslint-visitor-keys": "^3.1.0",
+        "espree": "^9.1.0",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -2498,16 +2498,16 @@
         "progress": "^2.0.0",
         "regexpp": "^3.2.0",
         "semver": "^7.2.1",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
         "@eslint/eslintrc": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.3.tgz",
-          "integrity": "sha512-DHI1wDPoKCBPoLZA3qDR91+3te/wDSc1YhKg3jR8NxKKRJq2hwHwcWv31cSwSYvIBrmbENoYMWcenW8uproQqg==",
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.4.tgz",
+          "integrity": "sha512-h8Vx6MdxwWI2WM8/zREHMoqdgLNXEL4QX3MWSVMdyNJGvXVOs+6lp+m2hc3FnuMHDc4poxFNI20vCk0OmI4G0Q==",
           "dev": true,
           "requires": {
             "ajv": "^6.12.4",
@@ -2516,21 +2516,9 @@
             "globals": "^13.9.0",
             "ignore": "^4.0.6",
             "import-fresh": "^3.2.1",
-            "js-yaml": "^3.13.1",
+            "js-yaml": "^4.1.0",
             "minimatch": "^3.0.4",
             "strip-json-comments": "^3.1.1"
-          },
-          "dependencies": {
-            "js-yaml": {
-              "version": "3.14.1",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-              "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-              "dev": true,
-              "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-              }
-            }
           }
         },
         "@humanwhocodes/config-array": {
@@ -2545,19 +2533,16 @@
           }
         },
         "acorn": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-          "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+          "version": "8.6.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
+          "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
           "dev": true
         },
-        "argparse": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "dev": true,
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "4.0.0",
@@ -2566,24 +2551,30 @@
           "dev": true
         },
         "eslint-scope": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-6.0.0.tgz",
-          "integrity": "sha512-uRDL9MWmQCkaFus8RF5K9/L/2fn+80yoW3jkD53l4shjCh26fCtvJGasxjUqP5OT87SYTxCVA3BwTUzuELx9kA==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.0.tgz",
+          "integrity": "sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==",
           "dev": true,
           "requires": {
             "esrecurse": "^4.3.0",
             "estraverse": "^5.2.0"
           }
         },
+        "eslint-visitor-keys": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
+          "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
+          "dev": true
+        },
         "espree": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-9.0.0.tgz",
-          "integrity": "sha512-r5EQJcYZ2oaGbeR0jR0fFVijGOcwai07/690YRXLINuhmVeRY4UKSAsQPe/0BNuDgwP7Ophoc1PRsr2E3tkbdQ==",
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-9.1.0.tgz",
+          "integrity": "sha512-ZgYLvCS1wxOczBYGcQT9DDWgicXwJ4dbocr9uYN+/eresBAUuBu+O4WzB21ufQ/JqQT8gyp7hJ3z8SHii32mTQ==",
           "dev": true,
           "requires": {
-            "acorn": "^8.5.0",
+            "acorn": "^8.6.0",
             "acorn-jsx": "^5.3.1",
-            "eslint-visitor-keys": "^3.0.0"
+            "eslint-visitor-keys": "^3.1.0"
           }
         },
         "estraverse": {
@@ -2610,6 +2601,15 @@
                 "is-extglob": "^2.1.1"
               }
             }
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "codecov": "^3.8.3",
     "cucumber": "^6.0.5",
     "ergol": "^1.0.1",
-    "eslint": "^8.1.0",
+    "eslint": "^8.3.0",
     "mocha": "^9.1.3",
     "mock-require": "^3.0.3",
     "mqtt": "^4.2.8",

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -5033,7 +5033,7 @@ describe('Test: ElasticSearch service', () => {
 
         should(() => publicES._sanitizeSearchBody(searchParams))
           .throw(BadRequestError, { id: 'services.storage.invalid_query_keyword'});
-        });
+      });
 
       it('should throw if any deeply nested script keyword is found in the query', () => {
         const searchParams = {

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -4978,16 +4978,31 @@ describe('Test: ElasticSearch service', () => {
     });
 
     describe('#_scriptCheck', () => {
-      let object;
+      it('should allows stored-scripts', () => {
+        const searchParams = {
+          query: {
+            match: {
+              script: {
+                id: 'count-documents',
+                params: {
+                  length: 25
+                }
+              }
+            }
+          }
+        };
 
-      it('should not throw when there is not a single script', () => {
-        object = { foo: 'bar' };
-
-        should(() => publicES._scriptCheck(object)).not.throw();
+        should(() => publicES._scriptCheck(searchParams)).not.throw();
       });
 
-      it('should throw if any script keyword is found in the query', () => {
-        object = {
+      it('should not throw when there is not a single script', () => {
+        const searchParams = { foo: 'bar' };
+
+        should(() => publicES._scriptCheck(searchParams)).not.throw();
+      });
+
+      it('should throw if any script is found in the query', () => {
+        let searchParams = {
           query: {
             match: {
               script: {
@@ -5000,12 +5015,28 @@ describe('Test: ElasticSearch service', () => {
           }
         };
 
-        should(() => publicES._sanitizeSearchBody(object))
+        should(() => publicES._sanitizeSearchBody(searchParams))
           .throw(BadRequestError, { id: 'services.storage.invalid_query_keyword'});
-      });
+
+        searchParams = {
+          query: {
+            match: {
+              script: {
+                source: 'doc[message.keyword].value.length() > params.length',
+                params: {
+                  length: 25
+                }
+              }
+            }
+          }
+        };
+
+        should(() => publicES._sanitizeSearchBody(searchParams))
+          .throw(BadRequestError, { id: 'services.storage.invalid_query_keyword'});
+        });
 
       it('should throw if any deeply nested script keyword is found in the query', () => {
-        object = {
+        const searchParams = {
           query: {
             bool: {
               filter: [
@@ -5024,7 +5055,7 @@ describe('Test: ElasticSearch service', () => {
           }
         };
 
-        should(() => publicES._sanitizeSearchBody(object))
+        should(() => publicES._sanitizeSearchBody(searchParams))
           .throw(BadRequestError, { id: 'services.storage.invalid_query_keyword'});
       });
     });


### PR DESCRIPTION
## What does this PR do ?

Allows to use [Elasticsearch Stored Scripts](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting-stored-scripts.html) in search queries.

Now Kuzzle allows the usage of the `script` keyword in queries, only when the subsequent object contains the `id` or `params` properties.

This query is now valid for example:
```js
{
  script: {                                        
    id: "calculate-score",                                 
    params: {                             
      value: 3                                           
    }                                                  
  }                                                                              
}
```

Inline scripts are still forbidden.