### PR TITLE
Remove unicode property names from KuzzleRequest

### DIFF
--- a/lib/api/request/kuzzleRequest.ts
+++ b/lib/api/request/kuzzleRequest.ts
@@ -151,8 +151,6 @@ export class KuzzleRequest {
         this.status = options.status;
       }
     }
-
-    Object.seal(this);
   }
 
   /**

--- a/lib/api/request/kuzzleRequest.ts
+++ b/lib/api/request/kuzzleRequest.ts
@@ -34,18 +34,6 @@ import { get, isPlainObject } from '../../util/safeObject';
 
 const assertionError = kerror.wrap('api', 'assert');
 
-// private properties
-// \u200b is a zero width space, used to masquerade console.log output
-const _internalId = 'internalId\u200b';
-const _status = 'status\u200b';
-const _input = 'input\u200b';
-const _error = 'error\u200b';
-const _result = 'result\u200b';
-const _context = 'context\u200b';
-const _timestamp = 'timestamp\u200b';
-const _response = 'response\u200b';
-const _deprecations = 'deprecations\u200b';
-
 /**
  * The `KuzzleRequest` class represents a request being processed by Kuzzle.
  *

--- a/lib/api/request/requestContext.ts
+++ b/lib/api/request/requestContext.ts
@@ -73,8 +73,6 @@ export class Connection {
   public misc: ContextMisc = {};
 
   constructor (connection: any) {
-    Object.seal(this);
-
     if (typeof connection !== 'object' || connection === null) {
       return;
     }
@@ -128,8 +126,6 @@ export class RequestContext {
     this.token = null;
     this.user = null;
     this.connection = new Connection(options.connection);
-
-    Object.seal(this);
 
     if (options.token) {
       this.token = options.token;

--- a/lib/api/request/requestContext.ts
+++ b/lib/api/request/requestContext.ts
@@ -21,19 +21,7 @@
 
 import { JSONObject } from 'kuzzle-sdk';
 
-import * as assert from '../../util/assertType';
 import { User, Token } from '../../types';
-
-// private properties
-// \u200b is a zero width space, used to masquerade console.log output
-const _token = 'token\u200b';
-const _user = 'user\u200b';
-const _connection = 'connection\u200b';
-// Connection class properties
-const _c_id = 'id\u200b';
-const _c_protocol = 'protocol\u200b';
-const _c_ips = 'ips\u200b';
-const _c_misc = 'misc\u200b';
 
 export type ContextMisc = {
   /**
@@ -41,14 +29,17 @@ export type ContextMisc = {
    * @deprecated use "path" instead
    */
   url?: string;
+
   /**
    * HTTP path
    */
   path?: string;
+
   /**
    * HTTP headers
    */
   verb?: string;
+
   /**
    * HTTP headers
    */
@@ -61,12 +52,27 @@ export type ContextMisc = {
  * Information about the connection at the origin of the request.
  */
 export class Connection {
-  constructor (connection: any) {
-    this[_c_id] = null;
-    this[_c_protocol] = null;
-    this[_c_ips] = [];
-    this[_c_misc] = {};
+  /**
+   * Unique identifier of the user connection
+   */
+  public id: string = null;
 
+  /**
+   * Network protocol name
+   */
+  public protocol: string = null;
+
+  /**
+   * Chain of IP addresses, starting from the client
+   */
+  public ips: string[] = [];
+
+  /**
+   * Additional informations about the connection
+   */
+  public misc: ContextMisc = {};
+
+  constructor (connection: any) {
     Object.seal(this);
 
     if (typeof connection !== 'object' || connection === null) {
@@ -84,54 +90,14 @@ export class Connection {
   }
 
   /**
-   * Unique identifier of the user connection
-   */
-  set id (str: string) {
-    this[_c_id] = assert.assertString('connection.id', str);
-  }
-
-  get id (): string | null {
-    return this[_c_id];
-  }
-
-  /**
-   * Network protocol name
-   */
-  set protocol (str: string) {
-    this[_c_protocol] = assert.assertString('connection.protocol', str);
-  }
-
-  get protocol (): string | null {
-    return this[_c_protocol];
-  }
-
-  /**
-   * Chain of IP addresses, starting from the client
-   */
-  set ips (arr: string[]) {
-    this[_c_ips] = assert.assertArray('connection.ips', arr, 'string');
-  }
-
-  get ips(): string[] {
-    return this[_c_ips];
-  }
-
-  /**
-   * Additional informations about the connection
-   */
-  get misc (): ContextMisc {
-    return this[_c_misc];
-  }
-
-  /**
    * Serializes the Connection object
    */
   toJSON (): JSONObject {
     return {
-      id: this[_c_id],
-      ips: this[_c_ips],
-      protocol: this[_c_protocol],
-      ...this[_c_misc]
+      id: this.id,
+      ips: this.ips,
+      protocol: this.protocol,
+      ...this.misc
     };
   }
 }
@@ -143,11 +109,25 @@ export class Connection {
  * and origin (connection, protocol).
  */
 export class RequestContext {
-  constructor(options: any = {}) {
+  /**
+   * Connection that initiated the request
+   */
+  public connection: Connection;
 
-    this[_token] = null;
-    this[_user] = null;
-    this[_connection] = new Connection(options.connection);
+  /**
+   * Authentication token
+   */
+  public token: Token | null;
+
+  /**
+   * Associated user
+   */
+  public user: User | null;
+
+  constructor(options: any = {}) {
+    this.token = null;
+    this.user = null;
+    this.connection = new Connection(options.connection);
 
     Object.seal(this);
 
@@ -169,9 +149,9 @@ export class RequestContext {
    */
   toJSON (): JSONObject {
     return {
-      connection: this[_connection].toJSON(),
-      token: this[_token],
-      user: this[_user],
+      connection: this.connection.toJSON(),
+      token: this.token,
+      user: this.user,
     };
   }
 
@@ -180,50 +160,21 @@ export class RequestContext {
    * Internal connection ID
    */
   get connectionId (): string | null {
-    return this[_connection].id;
+    return this.connection.id;
   }
 
   set connectionId (str: string) {
-    this[_connection].id = assert.assertString('connectionId', str);
+    this.connection.id = str;
   }
 
   /**
    * @deprecated use connection.protocol instead
    */
   get protocol (): string | null {
-    return this[_connection].protocol;
+    return this.connection.protocol;
   }
 
   set protocol (str: string) {
-    this[_connection].protocol = assert.assertString('protocol', str);
-  }
-
-  /**
-   * Connection that initiated the request
-   */
-  get connection (): Connection {
-    return this[_connection];
-  }
-
-  /**
-   * Authentication token
-   */
-  get token (): Token | null {
-    return this[_token];
-  }
-
-  set token (obj: Token | null) {
-    this[_token] = assert.assertObject('token', obj);
-  }
-
-  /**
-   * Associated user
-   */
-  get user (): User | null {
-    return this[_user];
-  }
-
-  set user (obj: User | null) {
-    this[_user] = assert.assertObject('user', obj);
+    this.connection.protocol = str;
   }
 }

--- a/lib/api/request/requestContext.ts
+++ b/lib/api/request/requestContext.ts
@@ -117,12 +117,12 @@ export class RequestContext {
   /**
    * Authentication token
    */
-  public token: Token | null;
+  public token: Token | null = null;
 
   /**
    * Associated user
    */
-  public user: User | null;
+  public user: User | null = null;
 
   constructor(options: any = {}) {
     this.token = null;
@@ -131,8 +131,12 @@ export class RequestContext {
 
     Object.seal(this);
 
-    this.token = options.token;
-    this.user = options.user;
+    if (options.token) {
+      this.token = options.token;
+    }
+    if (options.user) {
+      this.user = options.user;
+    }
 
     // @deprecated - backward compatibility only
     if (options.connectionId) {

--- a/lib/api/request/requestInput.ts
+++ b/lib/api/request/requestInput.ts
@@ -22,6 +22,7 @@
 import { JSONObject } from 'kuzzle-sdk';
 
 import { InternalError } from '../../kerror/errors/internalError';
+import assert from '../../util/assertType';
 
 // any property not listed here will be copied into
 // RequestInput.args
@@ -274,11 +275,7 @@ export class RequestInput {
     if (data.body) {
       this.body = data.body;
     }
-    if (data.controller) {
-      this.controller = data.controller;
-    }
-    if (data.action) {
-      this.action = data.action;
-    }
+    this.controller = assert.assertString('controller', data.controller);
+    this.action = assert.assertString('controller', data.action);
   }
 }

--- a/lib/api/request/requestInput.ts
+++ b/lib/api/request/requestInput.ts
@@ -263,9 +263,6 @@ export class RequestInput {
       }
     }
 
-    Object.seal(this);
-
-
     if (data.jwt) {
       this.jwt = data.jwt;
     }

--- a/lib/api/request/requestResponse.ts
+++ b/lib/api/request/requestResponse.ts
@@ -20,6 +20,8 @@
  */
 
 import { JSONObject } from 'kuzzle-sdk';
+
+import '../../../lib/types/Global';
 import * as assert from '../../util/assertType';
 import { Deprecation } from '../../types';
 import { KuzzleError } from '../../kerror/errors/kuzzleError';
@@ -43,7 +45,10 @@ export class Headers {
       set: (target, name, value) => this.setHeader(name as string, value),
     });
 
-    this.setHeader('X-Kuzzle-Node', (global as any).kuzzle.id);
+    // eslint-disable-next-line dot-notation
+    if (global['_kuzzle']) {
+      this.setHeader('X-Kuzzle-Node', global.kuzzle.id);
+    }
   }
 
   /**
@@ -154,7 +159,11 @@ export class RequestResponse {
 
   constructor (request) {
     this.raw = false;
-    this[_request] = request;
+
+    Reflect.defineProperty(this, _request, {
+      value: request,
+    });
+
     this[_headers] = new Headers();
 
     Object.seal(this);

--- a/lib/api/request/requestResponse.ts
+++ b/lib/api/request/requestResponse.ts
@@ -230,14 +230,14 @@ export class RequestResponse {
    * Collection name
    */
   get collection (): string | null {
-    return this.request.input.resource.collection;
+    return this.request.getCollection();
   }
 
   /**
    * Index name
    */
   get index (): string | null {
-    return this.request.input.resource.index;
+    return this.request.getIndex();
   }
 
   /**

--- a/lib/api/request/requestResponse.ts
+++ b/lib/api/request/requestResponse.ts
@@ -159,7 +159,10 @@ export class RequestResponse {
   constructor (request: KuzzleRequest) {
     this.raw = false;
 
-    this.request = request;
+    // Make a private property otherwise the tests are ending in recursive loop
+    Reflect.defineProperty(this, 'request', {
+      value: request,
+    });
 
     this._headers = new Headers();
   }

--- a/lib/api/request/requestResponse.ts
+++ b/lib/api/request/requestResponse.ts
@@ -46,7 +46,7 @@ export class Headers {
     });
 
     // eslint-disable-next-line dot-notation
-    if (global['_kuzzle']) {
+    if (global['_kuzzle'] && global.kuzzle) {
       this.setHeader('X-Kuzzle-Node', global.kuzzle.id);
     }
   }

--- a/lib/api/request/requestResponse.ts
+++ b/lib/api/request/requestResponse.ts
@@ -159,13 +159,9 @@ export class RequestResponse {
   constructor (request: KuzzleRequest) {
     this.raw = false;
 
-    Reflect.defineProperty(this, 'request', {
-      value: request,
-    });
+    this.request = request;
 
     this._headers = new Headers();
-
-    Object.seal(this);
   }
 
   /**
@@ -270,7 +266,12 @@ export class RequestResponse {
    * Node identifier
    */
   get node (): string {
-    return (global as any).kuzzle.id;
+    // eslint-disable-next-line dot-notation
+    if (global['_kuzzle'] && global.kuzzle) {
+      return (global as any).kuzzle.id;
+    }
+
+    return null;
   }
 
   /**

--- a/lib/api/request/requestResponse.ts
+++ b/lib/api/request/requestResponse.ts
@@ -25,16 +25,12 @@ import '../../../lib/types/Global';
 import * as assert from '../../util/assertType';
 import { Deprecation } from '../../types';
 import { KuzzleError } from '../../kerror/errors/kuzzleError';
-
-// private properties
-// \u200b is a zero width space, used to masquerade console.log output
-const _request = 'request\u200b';
-const _headers = 'headers\u200b';
+import { KuzzleRequest } from './kuzzleRequest';
 
 export class Headers {
   public headers: JSONObject;
   private namesMap: Map<string, string>;
-  private proxy: any;
+  public proxy: any;
 
   constructor() {
     this.namesMap = new Map();
@@ -56,7 +52,7 @@ export class Headers {
    *
    * @param name Header name. Could be a string (case-insensitive) or a symbol
    */
-  getHeader (name: any): string | void {
+  getHeader (name: any): string {
     if (typeof name === 'symbol') {
       return this.headers[name as unknown as string];
     }
@@ -152,19 +148,22 @@ export class Headers {
  * Kuzzle normalized API response
  */
 export class RequestResponse {
+  private request: KuzzleRequest;
+  private _headers: Headers;
+
   /**
    * If sets to true, "result" content will not be wrapped in a Kuzzle response
    */
   public raw: boolean;
 
-  constructor (request) {
+  constructor (request: KuzzleRequest) {
     this.raw = false;
 
-    Reflect.defineProperty(this, _request, {
+    Reflect.defineProperty(this, 'request', {
       value: request,
     });
 
-    this[_headers] = new Headers();
+    this._headers = new Headers();
 
     Object.seal(this);
   }
@@ -172,16 +171,16 @@ export class RequestResponse {
   /**
    * Get the parent request deprecations
    */
-  get deprecations (): Array<Deprecation> | void {
-    return this[_request].deprecations;
+  get deprecations (): Array<Deprecation> {
+    return this.request.deprecations;
   }
 
   /**
    * Set the parent request deprecations
    * @param {Object[]} deprecations
    */
-  set deprecations (deprecations: Array<Deprecation> | void) {
-    this[_request].deprecations = deprecations;
+  set deprecations (deprecations: Array<Deprecation>) {
+    this.request.deprecations = deprecations;
   }
 
   /**
@@ -189,82 +188,82 @@ export class RequestResponse {
    * @returns {number}
    */
   get status (): number {
-    return this[_request].status;
+    return this.request.status;
   }
 
   set status (s: number) {
-    this[_request].status = s;
+    this.request.status = s;
   }
 
   /**
    * Request error
    */
   get error (): KuzzleError | null {
-    return this[_request].error;
+    return this.request.error;
   }
 
   set error (e: KuzzleError | null) {
-    this[_request].setError(e);
+    this.request.setError(e);
   }
 
   /**
    * Request external ID
    */
   get requestId (): string | null {
-    return this[_request].id;
+    return this.request.id;
   }
 
   /**
    * API controller name
    */
   get controller (): string | null {
-    return this[_request].input.controller;
+    return this.request.input.controller;
   }
 
   /**
    * API action name
    */
   get action (): string | null {
-    return this[_request].input.action;
+    return this.request.input.action;
   }
 
   /**
    * Collection name
    */
   get collection (): string | null {
-    return this[_request].input.resource.collection;
+    return this.request.input.resource.collection;
   }
 
   /**
    * Index name
    */
   get index (): string | null {
-    return this[_request].input.resource.index;
+    return this.request.input.resource.index;
   }
 
   /**
    * Volatile object
    */
   get volatile (): JSONObject | null {
-    return this[_request].input.volatile;
+    return this.request.input.volatile;
   }
 
   /**
    * Response headers
    */
   get headers (): JSONObject {
-    return this[_headers].proxy;
+    return this._headers.proxy;
   }
 
   /**
    * Request result
    */
   get result (): any {
-    return this[_request].result;
+    return this.request.result;
   }
 
   set result (r: any) {
-    this[_request].setResult(r);
+    this.request.setResult(r);
   }
 
   /**
@@ -310,15 +309,15 @@ export class RequestResponse {
   /**
    * Gets a header value (case-insensitive)
    */
-  getHeader (name: string): string | null {
-    return this[_headers].getHeader(name);
+  getHeader (name: string): string {
+    return this._headers.getHeader(name);
   }
 
   /**
    * Deletes a header (case-insensitive)
    */
   removeHeader (name: string) {
-    return this[_headers].removeHeader(name);
+    return this._headers.removeHeader(name);
   }
 
   /**
@@ -326,7 +325,7 @@ export class RequestResponse {
    * method (@see https://nodejs.org/api/http.html#http_response_setheader_name_value)
    */
   setHeader (name: string, value: string) {
-    return this[_headers].setHeader(name, value);
+    return this._headers.setHeader(name, value);
   }
 
   /**
@@ -352,7 +351,7 @@ export class RequestResponse {
     if (this.raw === true) {
       return {
         content: this.result,
-        headers: this.headers,
+        headers: this._headers.headers,
         raw: true,
         requestId: this.requestId,
         status: this.status,
@@ -373,7 +372,7 @@ export class RequestResponse {
         status: this.status,
         volatile: this.volatile,
       },
-      headers: this.headers,
+      headers: this._headers.headers,
       raw: false,
       requestId: this.requestId,
       status: this.status,

--- a/lib/api/request/requestResponse.ts
+++ b/lib/api/request/requestResponse.ts
@@ -230,14 +230,14 @@ export class RequestResponse {
    * Collection name
    */
   get collection (): string | null {
-    return this.request.getCollection();
+    return this.request.input.resource.collection;
   }
 
   /**
    * Index name
    */
   get index (): string | null {
-    return this.request.getIndex();
+    return this.request.input.resource.index;
   }
 
   /**

--- a/lib/core/plugin/pluginsManager.js
+++ b/lib/core/plugin/pluginsManager.js
@@ -265,7 +265,9 @@ class PluginsManager {
 
           debug('[%s] plugin started', plugin.name);
 
-          this.loadedPlugins.push(plugin.name);
+          if (! plugin.application) {
+            this.loadedPlugins.push(plugin.name);
+          }
 
           return null;
         });

--- a/lib/kuzzle/kuzzle.ts
+++ b/lib/kuzzle/kuzzle.ts
@@ -56,26 +56,31 @@ import { version } from '../../package.json';
 
 const BACKEND_IMPORT_KEY = 'backend:init:import';
 
-let _kuzzle = null;
+Reflect.defineProperty(global, '_kuzzle', {
+  value: null,
+  writable: true,
+});
 
+/* eslint-disable dot-notation */
 Reflect.defineProperty(global, 'kuzzle', {
   configurable: true,
   enumerable: false,
   get () {
-    if (_kuzzle === null) {
+    if (global['_kuzzle'] === null) {
       throw new Error('Kuzzle instance not found. Did you try to use a live-only feature before starting your application?');
     }
 
-    return _kuzzle;
+    return global['_kuzzle'];
   },
   set (value) {
-    if (_kuzzle !== null) {
+    if (global['_kuzzle'] !== null) {
       throw new Error('Cannot build a Kuzzle instance: another one already exists');
     }
 
-    _kuzzle = value;
+    global['_kuzzle'] = value;
   },
 });
+/* eslint-enable dot-notation */
 
 /**
  * @class Kuzzle

--- a/test/api/controllers/documentController.test.js
+++ b/test/api/controllers/documentController.test.js
@@ -638,7 +638,7 @@ describe('DocumentController', () => {
       await documentController._mChanges(request, 'mUpsert', actionEnum.UPSERT);
 
       const updatedItems = [
-        { 
+        {
           _id: '_id1',
           _source: { field: '_source' },
           _version: '_version',
@@ -646,14 +646,14 @@ describe('DocumentController', () => {
           created: false,
           result: 'created'
         },
-        { 
+        {
           _id: '_id2',
           _source: { field: '_source' },
           _version: '_version',
           _updatedFields: ['field'],
           created: false,
           result: 'created' },
-        { 
+        {
           _id: '_id3',
           _source: { field: '_source' },
           _version: '_version',

--- a/test/api/request/request.test.js
+++ b/test/api/request/request.test.js
@@ -97,13 +97,6 @@ describe('#Request', () => {
     should(function () { new Request({}, 123.45); }).throw('Request options must be an object');
   });
 
-  it('should throw if an invalid optional status is provided', () => {
-    should(function () { new Request({}, { status: [] }); }).throw('Attribute status must be an integer');
-    should(function () { new Request({}, { status: {} }); }).throw('Attribute status must be an integer');
-    should(function () { new Request({}, { status: 'foobar' }); }).throw('Attribute status must be an integer');
-    should(function () { new Request({}, { status: 123.45 }); }).throw('Attribute status must be an integer');
-  });
-
   it('should set an error properly', () => {
     let foo = new KuzzleError('bar', 666);
 
@@ -149,13 +142,6 @@ describe('#Request', () => {
 
   it('should throw if trying to set an error object as a result', () => {
     should(function () { rq.setResult(new Error('foobar')); }).throw(/cannot set an error/);
-  });
-
-  it('should throw if trying to set a non-integer status', () => {
-    should(function () { rq.setResult('foobar', { status: {} }); }).throw('Attribute status must be an integer');
-    should(function () { rq.setResult('foobar', { status: [] }); }).throw('Attribute status must be an integer');
-    should(function () { rq.setResult('foobar', { status: true }); }).throw('Attribute status must be an integer');
-    should(function () { rq.setResult('foobar', { status: 123.45 }); }).throw('Attribute status must be an integer');
   });
 
   it('should throw if trying to set some non-object headers', () => {

--- a/test/api/request/requestContext.test.js
+++ b/test/api/request/requestContext.test.js
@@ -35,35 +35,6 @@ describe('#RequestContext', () => {
     should(context.protocol).eql('protocol');
   });
 
-  it('should throw if an invalid argument type is provided', () => {
-    // string arguments
-    ['connectionId', 'protocol'].forEach(k => {
-      should(function () { new RequestContext({[k]: {}}); }).throw(`Attribute ${k} must be of type "string"`);
-      should(function () { new RequestContext({[k]: []}); }).throw(`Attribute ${k} must be of type "string"`);
-      should(function () { new RequestContext({[k]: 132}); }).throw(`Attribute ${k} must be of type "string"`);
-      should(function () { new RequestContext({[k]: true}); }).throw(`Attribute ${k} must be of type "string"`);
-    });
-
-    // object arguments
-    ['token', 'user'].forEach(k => {
-      should(function () { new RequestContext({[k]: 'foobar'}); }).throw(`Attribute ${k} must be of type "object"`);
-      should(function () { new RequestContext({[k]: []}); }).throw(`Attribute ${k} must be of type "object"`);
-      should(function () { new RequestContext({[k]: 132}); }).throw(`Attribute ${k} must be of type "object"`);
-      should(function () { new RequestContext({[k]: true}); }).throw(`Attribute ${k} must be of type "object"`);
-    });
-
-    // string arguments for the connection sub-object
-    for (const key of ['id', 'protocol']) {
-      for (const val of [{}, [], 123, true, false]) {
-        should(() => new RequestContext({connection: {[key]: val}})).throw(`Attribute connection.${key} must be of type "string"`);
-      }
-    }
-
-    // invalid IPs arrays
-    should(() => new RequestContext({connection: {ips: 'foobar'}})).throw('Attribute connection.ips must be of type "array"');
-    should(() => new RequestContext({connection: {ips: ['foo', 123, {}]}})).throw('Attribute connection.ips must contain only values of type "string"');
-  });
-
   it('should serialize properly', () => {
     should(context.toJSON())
       .match(args);

--- a/test/api/request/requestInput.test.js
+++ b/test/api/request/requestInput.test.js
@@ -64,46 +64,4 @@ describe('#RequestInput', () => {
     should(function () { new RequestInput(123); }).throw('Input request data must be a non-null object');
     should(function () { new RequestInput(true); }).throw('Input request data must be a non-null object');
   });
-
-  it('should throw if an invalid data parameter is provided', () => {
-    // testing object-only parameters
-    ['volatile', 'body'].forEach(k => {
-      should(function () { new RequestInput({[k]: []}); }).throw(`Attribute ${k} must be of type "object"`);
-      should(function () { new RequestInput({[k]: 123}); }).throw(`Attribute ${k} must be of type "object"`);
-      should(function () { new RequestInput({[k]: false}); }).throw(`Attribute ${k} must be of type "object"`);
-      should(function () { new RequestInput({[k]: 'foobar'}); }).throw(`Attribute ${k} must be of type "object"`);
-    });
-
-    // testing string-only parameters
-    ['controller', 'action', 'jwt'].forEach(k => {
-      should(function () { new RequestInput({[k]: []}); }).throw(`Attribute ${k} must be of type "string"`);
-      should(function () { new RequestInput({[k]: 123}); }).throw(`Attribute ${k} must be of type "string"`);
-      should(function () { new RequestInput({[k]: false}); }).throw(`Attribute ${k} must be of type "string"`);
-      should(function () { new RequestInput({[k]: {}}); }).throw(`Attribute ${k} must be of type "string"`);
-    });
-  });
-
-  it('should not overwrite the controller value if it has already been set', () => {
-    let input = new RequestInput({});
-
-    input.controller = 'foo';
-
-    should(input.controller).eql('foo');
-
-    input.controller = 'bar';
-
-    should(input.controller).eql('foo');
-  });
-
-  it('should not overwrite the action value if it has already been set', () => {
-    let input = new RequestInput({});
-
-    input.action = 'foo';
-
-    should(input.action).eql('foo');
-
-    input.action = 'bar';
-
-    should(input.action).eql('foo');
-  });
 });

--- a/test/api/request/requestResponse.test.js
+++ b/test/api/request/requestResponse.test.js
@@ -42,12 +42,6 @@ describe('#RequestResponse', () => {
       should(response.node).be.eql(kuzzle.id);
       should(response.deprecations).be.undefined();
     });
-
-    it('should throw if we try to extend the response', () => {
-      let response = new RequestResponse(req);
-
-      should(() => { response.foo = 'bar'; }).throw(TypeError);
-    });
   });
 
   describe('#properties', () => {

--- a/test/core/realtime/hotelClerk/subscribe.test.js
+++ b/test/core/realtime/hotelClerk/subscribe.test.js
@@ -68,7 +68,7 @@ describe('Test: hotelClerk.subscribe', () => {
   });
 
   it('should register a new room and customer', async () => {
-    request['context\u200b'].user = { _id: 'Umraniye' };
+    request.context.user = { _id: 'Umraniye' };
     request.input.args.propagate = false;
     kuzzle.koncorde.normalize
       .onFirstCall().returns({id: 'foobar', index: 'foo/bar', filter: []})

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -17,6 +17,11 @@ class KuzzleMock extends KuzzleEventEmitter {
       config.plugins.common.maxConcurrentPipes,
       config.plugins.common.pipesBufferSize);
 
+    Reflect.defineProperty(global, '_kuzzle', {
+      value: this,
+      writable: true,
+    });
+
     Reflect.defineProperty(global, 'kuzzle', {
       value: this,
       writable: true,


### PR DESCRIPTION
## What does this PR do ?

In the `KuzzleRequest` object, most of the property were using a special Unicode character to prevents user from modifying them (private attribute emulation).

This was preventing Koncorde to match content of the `KuzzleRequest` object directly.

Those properties now have ASCII names. If an user want to edit one of them he can but Kuzzle may not works after that.