### PR TITLE
Upgrade node-segfault-handler to v1.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5074,9 +5074,9 @@
       "dev": true
     },
     "node-segfault-handler": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/node-segfault-handler/-/node-segfault-handler-1.0.3.tgz",
-      "integrity": "sha512-bUuedMv9cnXAwc62DZs41f1s6R1j1Gs0ALohyVzl4SeSf5wchEyFPexlhKSxI1OnYFpSvwMCczgYGB7joaCoCA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/node-segfault-handler/-/node-segfault-handler-1.0.4.tgz",
+      "integrity": "sha512-fjZrmhfE+Mv98ijg/Z5HBCOBsy2nzFze3PJ91QCoRJc4CW23RwomEiGOQVb+PZxYgwmd6oRBeDlMokFHk1veAw==",
       "requires": {
         "bindings": "^1.5.0",
         "nan": "^2.15.0"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "ms": "^2.1.3",
     "murmurhash-native": "^3.5.0",
     "nanoid": "^3.1.30",
-    "node-segfault-handler": "^1.0.3",
+    "node-segfault-handler": "^1.0.4",
     "openapi-enforcer": "^1.15.5",
     "passport": "^0.5.0",
     "protobufjs": "~6.11.2",


### PR DESCRIPTION
## What does this PR do ?

Upgrade the version of the `node-segfault-handler` dependency to 1.0.4

## Why ?
Prior to version 1.0.4 `node-segfault-handler` was using python to find if `libunwind` was installed on the system, but they where some issue where sometimes the `libunwind` was partially installed causing the python script to find the library even though the linker could not find it, causing some compilation errors.

Some people were also struggling with having the good version of python installed with the exact binary name.

Now the library uses a much better way of detecting if the library is installed on the system using the `pkg-config` command, getting rid of python.
Using the `pkg-config` provide a consistent way of detecting the libraries and helps avoiding false positives when libraries are partially installed.

If the command `pkg-config` is not installed on the system, the compiler will avoid compiling with the `libunwind` since it has no way of knowing if the library is installed  and related sections of code will then be disabled by the preprocessor.