### PR TITLE
Allows to match KuzzleRequest with Koncorde

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -80,3 +80,5 @@ lib/core/storage/indexCache.js
 lib/api/openApiGenerator.js
 lib/api/openapi/document/index.js
 lib/api/openapi/tools.js
+lib/api/openapi/index.js
+lib/util/readYamlFile.js

--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,5 @@ lib/core/storage/indexCache.js
 lib/api/openApiGenerator.js
 lib/api/openapi/document/index.js
 lib/api/openapi/tools.js
+lib/api/openapi/index.js
+lib/util/readYamlFile.js

--- a/lib/api/request/kuzzleRequest.ts
+++ b/lib/api/request/kuzzleRequest.ts
@@ -317,6 +317,41 @@ export class KuzzleRequest {
   }
 
   /**
+   * Return a POJO representing the request.
+   *
+   * This can be used to match Koncorde filter rather than the Request object
+   * because it has properties defined with invisible unicode characters.
+   */
+  pojo () {
+    return {
+      internalId: this.internalId,
+      id: this.id,
+      timestamp: this.timestamp,
+      status: this.status,
+      input: {
+        jwt: this.input.jwt,
+        volatile: this.input.volatile,
+        body: this.input.body,
+        controller: this.input.controller,
+        action: this.input.action,
+        args: this.input.args,
+      },
+      context: {
+        token: this.context.token,
+        user: this.context.user,
+        connection: this.context.connection,
+      },
+      error: this.error,
+      result: this.result,
+      response: {
+        raw: this.response.raw,
+        headers: this.response.headers
+      },
+      deprecations: this.deprecations,
+    };
+  }
+
+  /**
    * Returns the `lang` param of the request.
    *
    * It can only be 'elasticsearch' or 'koncorde'

--- a/lib/api/request/kuzzleRequest.ts
+++ b/lib/api/request/kuzzleRequest.ts
@@ -324,30 +324,30 @@ export class KuzzleRequest {
    */
   pojo () {
     return {
-      internalId: this.internalId,
-      id: this.id,
-      timestamp: this.timestamp,
-      status: this.status,
-      input: {
-        jwt: this.input.jwt,
-        volatile: this.input.volatile,
-        body: this.input.body,
-        controller: this.input.controller,
-        action: this.input.action,
-        args: this.input.args,
-      },
       context: {
+        connection: this.context.connection,
         token: this.context.token,
         user: this.context.user,
-        connection: this.context.connection,
-      },
-      error: this.error,
-      result: this.result,
-      response: {
-        raw: this.response.raw,
-        headers: this.response.headers
       },
       deprecations: this.deprecations,
+      error: this.error,
+      id: this.id,
+      input: {
+        action: this.input.action,
+        args: this.input.args,
+        body: this.input.body,
+        controller: this.input.controller,
+        jwt: this.input.jwt,
+        volatile: this.input.volatile,
+      },
+      internalId: this.internalId,
+      response: {
+        headers: this.response.headers,
+        raw: this.response.raw,
+      },
+      result: this.result,
+      status: this.status,
+      timestamp: this.timestamp,
     };
   }
 

--- a/lib/api/request/requestContext.ts
+++ b/lib/api/request/requestContext.ts
@@ -21,7 +21,19 @@
 
 import { JSONObject } from 'kuzzle-sdk';
 
+import * as assert from '../../util/assertType';
 import { User, Token } from '../../types';
+
+// private properties
+// \u200b is a zero width space, used to masquerade console.log output
+const _token = 'token\u200b';
+const _user = 'user\u200b';
+const _connection = 'connection\u200b';
+// Connection class properties
+const _c_id = 'id\u200b';
+const _c_protocol = 'protocol\u200b';
+const _c_ips = 'ips\u200b';
+const _c_misc = 'misc\u200b';
 
 export type ContextMisc = {
   /**
@@ -29,17 +41,14 @@ export type ContextMisc = {
    * @deprecated use "path" instead
    */
   url?: string;
-
   /**
    * HTTP path
    */
   path?: string;
-
   /**
    * HTTP headers
    */
   verb?: string;
-
   /**
    * HTTP headers
    */
@@ -52,27 +61,14 @@ export type ContextMisc = {
  * Information about the connection at the origin of the request.
  */
 export class Connection {
-  /**
-   * Unique identifier of the user connection
-   */
-  public id: string = null;
-
-  /**
-   * Network protocol name
-   */
-  public protocol: string = null;
-
-  /**
-   * Chain of IP addresses, starting from the client
-   */
-  public ips: string[] = [];
-
-  /**
-   * Additional informations about the connection
-   */
-  public misc: ContextMisc = {};
-
   constructor (connection: any) {
+    this[_c_id] = null;
+    this[_c_protocol] = null;
+    this[_c_ips] = [];
+    this[_c_misc] = {};
+
+    Object.seal(this);
+
     if (typeof connection !== 'object' || connection === null) {
       return;
     }
@@ -88,14 +84,54 @@ export class Connection {
   }
 
   /**
+   * Unique identifier of the user connection
+   */
+  set id (str: string) {
+    this[_c_id] = assert.assertString('connection.id', str);
+  }
+
+  get id (): string | null {
+    return this[_c_id];
+  }
+
+  /**
+   * Network protocol name
+   */
+  set protocol (str: string) {
+    this[_c_protocol] = assert.assertString('connection.protocol', str);
+  }
+
+  get protocol (): string | null {
+    return this[_c_protocol];
+  }
+
+  /**
+   * Chain of IP addresses, starting from the client
+   */
+  set ips (arr: string[]) {
+    this[_c_ips] = assert.assertArray('connection.ips', arr, 'string');
+  }
+
+  get ips(): string[] {
+    return this[_c_ips];
+  }
+
+  /**
+   * Additional informations about the connection
+   */
+  get misc (): ContextMisc {
+    return this[_c_misc];
+  }
+
+  /**
    * Serializes the Connection object
    */
   toJSON (): JSONObject {
     return {
-      id: this.id,
-      ips: this.ips,
-      protocol: this.protocol,
-      ...this.misc
+      id: this[_c_id],
+      ips: this[_c_ips],
+      protocol: this[_c_protocol],
+      ...this[_c_misc]
     };
   }
 }
@@ -107,32 +143,16 @@ export class Connection {
  * and origin (connection, protocol).
  */
 export class RequestContext {
-  /**
-   * Connection that initiated the request
-   */
-  public connection: Connection;
-
-  /**
-   * Authentication token
-   */
-  public token: Token | null = null;
-
-  /**
-   * Associated user
-   */
-  public user: User | null = null;
-
   constructor(options: any = {}) {
-    this.token = null;
-    this.user = null;
-    this.connection = new Connection(options.connection);
 
-    if (options.token) {
-      this.token = options.token;
-    }
-    if (options.user) {
-      this.user = options.user;
-    }
+    this[_token] = null;
+    this[_user] = null;
+    this[_connection] = new Connection(options.connection);
+
+    Object.seal(this);
+
+    this.token = options.token;
+    this.user = options.user;
 
     // @deprecated - backward compatibility only
     if (options.connectionId) {
@@ -149,9 +169,9 @@ export class RequestContext {
    */
   toJSON (): JSONObject {
     return {
-      connection: this.connection.toJSON(),
-      token: this.token,
-      user: this.user,
+      connection: this[_connection].toJSON(),
+      token: this[_token],
+      user: this[_user],
     };
   }
 
@@ -160,21 +180,50 @@ export class RequestContext {
    * Internal connection ID
    */
   get connectionId (): string | null {
-    return this.connection.id;
+    return this[_connection].id;
   }
 
   set connectionId (str: string) {
-    this.connection.id = str;
+    this[_connection].id = assert.assertString('connectionId', str);
   }
 
   /**
    * @deprecated use connection.protocol instead
    */
   get protocol (): string | null {
-    return this.connection.protocol;
+    return this[_connection].protocol;
   }
 
   set protocol (str: string) {
-    this.connection.protocol = str;
+    this[_connection].protocol = assert.assertString('protocol', str);
+  }
+
+  /**
+   * Connection that initiated the request
+   */
+  get connection (): Connection {
+    return this[_connection];
+  }
+
+  /**
+   * Authentication token
+   */
+  get token (): Token | null {
+    return this[_token];
+  }
+
+  set token (obj: Token | null) {
+    this[_token] = assert.assertObject('token', obj);
+  }
+
+  /**
+   * Associated user
+   */
+  get user (): User | null {
+    return this[_user];
+  }
+
+  set user (obj: User | null) {
+    this[_user] = assert.assertObject('user', obj);
   }
 }

--- a/lib/api/request/requestInput.ts
+++ b/lib/api/request/requestInput.ts
@@ -292,6 +292,8 @@ export class RequestInput {
 
   /**
    * Request headers (Http only).
+   *
+   * @deprecated Use RequestContext.connection.misc.headers instead
    */
   get headers (): JSONObject | null {
     return this[_headers];

--- a/lib/core/plugin/pluginsManager.js
+++ b/lib/core/plugin/pluginsManager.js
@@ -265,9 +265,7 @@ class PluginsManager {
 
           debug('[%s] plugin started', plugin.name);
 
-          if (! plugin.application) {
-            this.loadedPlugins.push(plugin.name);
-          }
+          this.loadedPlugins.push(plugin.name);
 
           return null;
         });

--- a/lib/kuzzle/kuzzle.ts
+++ b/lib/kuzzle/kuzzle.ts
@@ -56,31 +56,26 @@ import { version } from '../../package.json';
 
 const BACKEND_IMPORT_KEY = 'backend:init:import';
 
-Reflect.defineProperty(global, '_kuzzle', {
-  value: null,
-  writable: true,
-});
+let _kuzzle = null;
 
-/* eslint-disable dot-notation */
 Reflect.defineProperty(global, 'kuzzle', {
   configurable: true,
   enumerable: false,
   get () {
-    if (global['_kuzzle'] === null) {
+    if (_kuzzle === null) {
       throw new Error('Kuzzle instance not found. Did you try to use a live-only feature before starting your application?');
     }
 
-    return global['_kuzzle'];
+    return _kuzzle;
   },
   set (value) {
-    if (global['_kuzzle'] !== null) {
+    if (_kuzzle !== null) {
       throw new Error('Cannot build a Kuzzle instance: another one already exists');
     }
 
-    global['_kuzzle'] = value;
+    _kuzzle = value;
   },
 });
-/* eslint-enable dot-notation */
 
 /**
  * @class Kuzzle

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "2.16.2",
+  "version": "2.16.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.16.2",
+  "version": "2.16.3",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "bin": {
     "kuzzle": "bin/start-kuzzle-server"

--- a/test/api/controllers/documentController.test.js
+++ b/test/api/controllers/documentController.test.js
@@ -638,7 +638,7 @@ describe('DocumentController', () => {
       await documentController._mChanges(request, 'mUpsert', actionEnum.UPSERT);
 
       const updatedItems = [
-        {
+        { 
           _id: '_id1',
           _source: { field: '_source' },
           _version: '_version',
@@ -646,14 +646,14 @@ describe('DocumentController', () => {
           created: false,
           result: 'created'
         },
-        {
+        { 
           _id: '_id2',
           _source: { field: '_source' },
           _version: '_version',
           _updatedFields: ['field'],
           created: false,
           result: 'created' },
-        {
+        { 
           _id: '_id3',
           _source: { field: '_source' },
           _version: '_version',

--- a/test/api/request/request.test.js
+++ b/test/api/request/request.test.js
@@ -1054,7 +1054,7 @@ describe('#Request', () => {
   });
 
   describe('#pojo', () => {
-    it.only('returns a POJO usable to match with Koncorde', () => {
+    it('returns a POJO usable to match with Koncorde', () => {
       const koncorde = new Koncorde();
       const request = new KuzzleRequest({
         controller: 'document',

--- a/test/api/request/request.test.js
+++ b/test/api/request/request.test.js
@@ -1052,39 +1052,4 @@ describe('#Request', () => {
       });
     });
   });
-
-  describe.only('Usage with Koncorde', () => {
-    let koncorde;
-    let requestArgs;
-
-    beforeEach(() => {
-      koncorde = new Koncorde();
-
-      requestArgs = {
-        controller: 'document',
-        action: 'create',
-        index: 'montenegro',
-        collection: 'budva',
-        _id: 'dana',
-        body: {
-          age: 30
-        }
-      };
-    });
-
-    it('should be able to match request inputs', () => {
-      const request = new KuzzleRequest(requestArgs);
-      const id1 = koncorde.register({
-        equals: { 'input.args.collection': 'budva' }
-      });
-      const id2 = koncorde.register({
-        equals: { 'input.resource.collection': 'budva' }
-      });
-
-      const ids = koncorde.test(request);
-
-      should(ids.includes(id1)).be.true();
-      should(ids.includes(id2)).be.true();
-    })
-  });
 });

--- a/test/api/request/request.test.js
+++ b/test/api/request/request.test.js
@@ -11,6 +11,7 @@ const { Request, KuzzleRequest } = require('../../../lib/api/request');
 const { RequestContext } = require('../../../lib/api/request');
 const { RequestInput } = require('../../../lib/api/request');
 const KuzzleMock = require('../../mocks/kuzzle.mock');
+const { Koncorde } = require('koncorde');
 
 describe('#Request', () => {
   let rq;
@@ -1050,5 +1051,40 @@ describe('#Request', () => {
         should(request.getBody()).exactly(body);
       });
     });
+  });
+
+  describe.only('Usage with Koncorde', () => {
+    let koncorde;
+    let requestArgs;
+
+    beforeEach(() => {
+      koncorde = new Koncorde();
+
+      requestArgs = {
+        controller: 'document',
+        action: 'create',
+        index: 'montenegro',
+        collection: 'budva',
+        _id: 'dana',
+        body: {
+          age: 30
+        }
+      };
+    });
+
+    it('should be able to match request inputs', () => {
+      const request = new KuzzleRequest(requestArgs);
+      const id1 = koncorde.register({
+        equals: { 'input.args.collection': 'budva' }
+      });
+      const id2 = koncorde.register({
+        equals: { 'input.resource.collection': 'budva' }
+      });
+
+      const ids = koncorde.test(request);
+
+      should(ids.includes(id1)).be.true();
+      should(ids.includes(id2)).be.true();
+    })
   });
 });

--- a/test/api/request/request.test.js
+++ b/test/api/request/request.test.js
@@ -1052,4 +1052,27 @@ describe('#Request', () => {
       });
     });
   });
+
+  describe('#pojo', () => {
+    it.only('returns a POJO usable to match with Koncorde', () => {
+      const koncorde = new Koncorde();
+      const request = new KuzzleRequest({
+        controller: 'document',
+        action: 'create',
+        index: 'montenegro',
+        collection: 'budva',
+        _id: 'dana',
+        body: {
+          age: 30
+        }
+      });
+      const id1 = koncorde.register({
+        equals: { 'input.args.collection': 'budva' }
+      });
+
+      const ids = koncorde.test(request.pojo());
+
+      should(ids).be.eql([id1]);
+    });
+  });
 });

--- a/test/api/request/request.test.js
+++ b/test/api/request/request.test.js
@@ -97,6 +97,13 @@ describe('#Request', () => {
     should(function () { new Request({}, 123.45); }).throw('Request options must be an object');
   });
 
+  it('should throw if an invalid optional status is provided', () => {
+    should(function () { new Request({}, { status: [] }); }).throw('Attribute status must be an integer');
+    should(function () { new Request({}, { status: {} }); }).throw('Attribute status must be an integer');
+    should(function () { new Request({}, { status: 'foobar' }); }).throw('Attribute status must be an integer');
+    should(function () { new Request({}, { status: 123.45 }); }).throw('Attribute status must be an integer');
+  });
+
   it('should set an error properly', () => {
     let foo = new KuzzleError('bar', 666);
 
@@ -142,6 +149,13 @@ describe('#Request', () => {
 
   it('should throw if trying to set an error object as a result', () => {
     should(function () { rq.setResult(new Error('foobar')); }).throw(/cannot set an error/);
+  });
+
+  it('should throw if trying to set a non-integer status', () => {
+    should(function () { rq.setResult('foobar', { status: {} }); }).throw('Attribute status must be an integer');
+    should(function () { rq.setResult('foobar', { status: [] }); }).throw('Attribute status must be an integer');
+    should(function () { rq.setResult('foobar', { status: true }); }).throw('Attribute status must be an integer');
+    should(function () { rq.setResult('foobar', { status: 123.45 }); }).throw('Attribute status must be an integer');
   });
 
   it('should throw if trying to set some non-object headers', () => {

--- a/test/api/request/requestContext.test.js
+++ b/test/api/request/requestContext.test.js
@@ -35,6 +35,35 @@ describe('#RequestContext', () => {
     should(context.protocol).eql('protocol');
   });
 
+  it('should throw if an invalid argument type is provided', () => {
+    // string arguments
+    ['connectionId', 'protocol'].forEach(k => {
+      should(function () { new RequestContext({[k]: {}}); }).throw(`Attribute ${k} must be of type "string"`);
+      should(function () { new RequestContext({[k]: []}); }).throw(`Attribute ${k} must be of type "string"`);
+      should(function () { new RequestContext({[k]: 132}); }).throw(`Attribute ${k} must be of type "string"`);
+      should(function () { new RequestContext({[k]: true}); }).throw(`Attribute ${k} must be of type "string"`);
+    });
+
+    // object arguments
+    ['token', 'user'].forEach(k => {
+      should(function () { new RequestContext({[k]: 'foobar'}); }).throw(`Attribute ${k} must be of type "object"`);
+      should(function () { new RequestContext({[k]: []}); }).throw(`Attribute ${k} must be of type "object"`);
+      should(function () { new RequestContext({[k]: 132}); }).throw(`Attribute ${k} must be of type "object"`);
+      should(function () { new RequestContext({[k]: true}); }).throw(`Attribute ${k} must be of type "object"`);
+    });
+
+    // string arguments for the connection sub-object
+    for (const key of ['id', 'protocol']) {
+      for (const val of [{}, [], 123, true, false]) {
+        should(() => new RequestContext({connection: {[key]: val}})).throw(`Attribute connection.${key} must be of type "string"`);
+      }
+    }
+
+    // invalid IPs arrays
+    should(() => new RequestContext({connection: {ips: 'foobar'}})).throw('Attribute connection.ips must be of type "array"');
+    should(() => new RequestContext({connection: {ips: ['foo', 123, {}]}})).throw('Attribute connection.ips must contain only values of type "string"');
+  });
+
   it('should serialize properly', () => {
     should(context.toJSON())
       .match(args);

--- a/test/api/request/requestInput.test.js
+++ b/test/api/request/requestInput.test.js
@@ -64,4 +64,46 @@ describe('#RequestInput', () => {
     should(function () { new RequestInput(123); }).throw('Input request data must be a non-null object');
     should(function () { new RequestInput(true); }).throw('Input request data must be a non-null object');
   });
+
+  it('should throw if an invalid data parameter is provided', () => {
+    // testing object-only parameters
+    ['volatile', 'body'].forEach(k => {
+      should(function () { new RequestInput({[k]: []}); }).throw(`Attribute ${k} must be of type "object"`);
+      should(function () { new RequestInput({[k]: 123}); }).throw(`Attribute ${k} must be of type "object"`);
+      should(function () { new RequestInput({[k]: false}); }).throw(`Attribute ${k} must be of type "object"`);
+      should(function () { new RequestInput({[k]: 'foobar'}); }).throw(`Attribute ${k} must be of type "object"`);
+    });
+
+    // testing string-only parameters
+    ['controller', 'action', 'jwt'].forEach(k => {
+      should(function () { new RequestInput({[k]: []}); }).throw(`Attribute ${k} must be of type "string"`);
+      should(function () { new RequestInput({[k]: 123}); }).throw(`Attribute ${k} must be of type "string"`);
+      should(function () { new RequestInput({[k]: false}); }).throw(`Attribute ${k} must be of type "string"`);
+      should(function () { new RequestInput({[k]: {}}); }).throw(`Attribute ${k} must be of type "string"`);
+    });
+  });
+
+  it('should not overwrite the controller value if it has already been set', () => {
+    let input = new RequestInput({});
+
+    input.controller = 'foo';
+
+    should(input.controller).eql('foo');
+
+    input.controller = 'bar';
+
+    should(input.controller).eql('foo');
+  });
+
+  it('should not overwrite the action value if it has already been set', () => {
+    let input = new RequestInput({});
+
+    input.action = 'foo';
+
+    should(input.action).eql('foo');
+
+    input.action = 'bar';
+
+    should(input.action).eql('foo');
+  });
 });

--- a/test/api/request/requestResponse.test.js
+++ b/test/api/request/requestResponse.test.js
@@ -42,6 +42,12 @@ describe('#RequestResponse', () => {
       should(response.node).be.eql(kuzzle.id);
       should(response.deprecations).be.undefined();
     });
+
+    it('should throw if we try to extend the response', () => {
+      let response = new RequestResponse(req);
+
+      should(() => { response.foo = 'bar'; }).throw(TypeError);
+    });
   });
 
   describe('#properties', () => {

--- a/test/core/realtime/hotelClerk/subscribe.test.js
+++ b/test/core/realtime/hotelClerk/subscribe.test.js
@@ -68,7 +68,7 @@ describe('Test: hotelClerk.subscribe', () => {
   });
 
   it('should register a new room and customer', async () => {
-    request.context.user = { _id: 'Umraniye' };
+    request['context\u200b'].user = { _id: 'Umraniye' };
     request.input.args.propagate = false;
     kuzzle.koncorde.normalize
       .onFirstCall().returns({id: 'foobar', index: 'foo/bar', filter: []})

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -17,11 +17,6 @@ class KuzzleMock extends KuzzleEventEmitter {
       config.plugins.common.maxConcurrentPipes,
       config.plugins.common.pipesBufferSize);
 
-    Reflect.defineProperty(global, '_kuzzle', {
-      value: this,
-      writable: true,
-    });
-
     Reflect.defineProperty(global, 'kuzzle', {
       value: this,
       writable: true,


### PR DESCRIPTION
## What does this PR do ?

Revert https://github.com/kuzzleio/kuzzle/pull/2216

Having getter setter + invisible unicode properties allows to have a safe Kuzzle object. Despite the fact that the developers are responsible for not messing with the `KuzzleRequest` object, the fact that it was not editable allowed more stability in Kuzzle applications.

The whole point is was to be able to match KuzzleRequest object in Koncorde filters. There is only 2 solutions:
 - rename unicode properties so we can match them (e.g. `{ equals:  { "input.args.collection": "devices" } }`)
 - modify Koncorde to handle getters

The first solution leads to stability issues for Kuzzle.
The second solution results in a massive performance drop for Koncorde.

This PR adds a `request.pojo()` method that returns a POJO that can be matched with Koncorde, without unicode properties