### PR TITLE
Lazy load Open API definition

### DIFF
--- a/features/ServerController.feature
+++ b/features/ServerController.feature
@@ -77,7 +77,8 @@ Feature: Server Controller
   Scenario: Get our API in OpenApi format as a raw response
     When I successfully execute the action "server":"openapi"
     Then I should receive a response matching:
-      | swagger | "2.0" |
+      | swagger                                           | "2.0"                 |
+      | paths./_/functional-tests/hello-world.get.summary | "Action: helloWorld." |
 
   # server:publicApi ========================================================================
   @development @http
@@ -92,4 +93,3 @@ Feature: Server Controller
   Scenario: Http call onto deprecated method should not print a warning when NODE_ENV=production
     When I execute the action "server":"publicApi"
     Then The response should contains a "deprecations" equals to undefined
- 

--- a/lib/api/controllers/serverController.js
+++ b/lib/api/controllers/serverController.js
@@ -47,7 +47,11 @@ class ServerController extends NativeController {
       'publicApi',
       'openapi',
     ]);
-    this._docOpenapi = generateOpenApi();
+
+    this._openApiDefinition = {
+      json: null,
+      yaml: null,
+    };
   }
 
   /**
@@ -55,7 +59,7 @@ class ServerController extends NativeController {
    *
    * @param {Request} request
    * @returns {Promise<Object>}
-   * 
+   *
    * @deprecated
    */
   getStats (request) {
@@ -66,7 +70,7 @@ class ServerController extends NativeController {
    * Returns the last statistics frame
    *
    * @returns {Promise<Object>}
-   * 
+   *
    * @deprecated
    */
   getLastStats () {
@@ -77,7 +81,7 @@ class ServerController extends NativeController {
    * Returns all stored statistics frames
    *
    * @returns {Promise<Object>}
-   * 
+   *
    * @deprecated
    */
   getAllStats () {
@@ -242,23 +246,32 @@ class ServerController extends NativeController {
   }
 
   async openapi (request) {
-    const format = request.input.args.format
-      ? request.input.args.format
-      : 'json';
-    const contentType = format === 'yaml'
-      ? 'application/yaml'
-      : 'application/json';
-    const specifications = format === 'yaml'
-      ? jsonToYaml.stringify(this._docOpenapi)
-      : this._docOpenapi;
+    const format = request.getString('format', 'json');
+    const specifications = this.getOpenApiDefinition(format);
 
     request.response.configure({
       format: 'raw',
-      headers: { 'Content-Type': contentType },
+      headers: { 'Content-Type': `application/${format}` },
       status: 200,
     });
 
     return specifications;
+  }
+
+  /**
+   * Lazy loading of OpenAPI definition.
+   *
+   * Mainly because we need to wait all plugin to be loaded
+   * to generate the definition.
+   */
+  getOpenApiDefinition (format) {
+    if (! this._openApiDefinition[format]) {
+      this._openApiDefinition[format] = format === 'json'
+        ? generateOpenApi()
+        : jsonToYaml.stringify(generateOpenApi());
+    }
+
+    return this._openApiDefinition[format];
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "2.16.4",
+  "version": "2.16.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.16.4",
+  "version": "2.16.5",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "bin": {
     "kuzzle": "bin/start-kuzzle-server"


### PR DESCRIPTION
## What does this PR do ?

Open API definition was generated before the plugin were loaded so their custom Open API definitions were not in the result sent by Kuzzle.


### How should this be manually tested?

Functional test has been added

