### PR TITLE
Kuzzle v1: Use latest patched elasticsearch image

### DIFF
--- a/.ci/scripts/run-test.sh
+++ b/.ci/scripts/run-test.sh
@@ -18,7 +18,7 @@ fi
 echo "Testing Kuzzle against node v$NODE_VERSION"
 n $NODE_VERSION
 
-npm i -g npm
+npm i -g npm@5
 
 npm ci --unsafe-perm
 npm install --only=dev --unsafe-perm

--- a/.ci/test-aarch64.yml
+++ b/.ci/test-aarch64.yml
@@ -45,7 +45,7 @@ services:
     image: redis:${REDIS_VERSION:-5}
 
   elasticsearch:
-    image: kuzzleio/elasticsearch:5.6.10
+    image: kuzzleio/elasticsearch:5
     ulimits:
       nofile: 65536
     environment:

--- a/.ci/test-armhf.yml
+++ b/.ci/test-armhf.yml
@@ -45,7 +45,7 @@ services:
     image: redis:${REDIS_VERSION:-5}
 
   elasticsearch:
-    image: kuzzleio/elasticsearch:5.6.10
+    image: kuzzleio/elasticsearch:5
     ulimits:
       nofile: 65536
     environment:

--- a/.ci/test.yml
+++ b/.ci/test.yml
@@ -45,7 +45,7 @@ services:
     image: redis:${REDIS_VERSION:-5}
 
   elasticsearch:
-    image: kuzzleio/elasticsearch:5.6.10
+    image: kuzzleio/elasticsearch:5
     ulimits:
       nofile: 65536
     environment:

--- a/doc/1/guides/code-examples/iot/introduction/index.md
+++ b/doc/1/guides/code-examples/iot/introduction/index.md
@@ -62,7 +62,7 @@ services:
     image: redis:5
 
   elasticsearch:
-    image: kuzzleio/elasticsearch:5.6.10
+    image: kuzzleio/elasticsearch:5
     ulimits:
       nofile: 65536
     environment:

--- a/doc/1/guides/essentials/configuration/index.md
+++ b/doc/1/guides/essentials/configuration/index.md
@@ -67,7 +67,7 @@ services:
     image: redis:5
 
   elasticsearch:
-    image: kuzzleio/elasticsearch:5.6.10
+    image: kuzzleio/elasticsearch:5
     ulimits:
       nofile: 65536
     environment:

--- a/docker-compose/dev.yml
+++ b/docker-compose/dev.yml
@@ -57,7 +57,9 @@ services:
     image: redis:${REDIS_VERSION:-5}
 
   elasticsearch:
-    image: kuzzleio/elasticsearch:5.6.10
+    image: kuzzleio/elasticsearch:5
+    ports:
+      - "9201:9200"
     ulimits:
       nofile: 65536
     environment:


### PR DESCRIPTION
## What does this PR do ?

Use latest official Kuzzle image with CVE-2021-45046 and CVE-2021-44228 mitigations.

This PR is mainly to ensure the tests are still passing. User should updates the Docker images they are using manually (`docker pull kuzzleio/elasticsearch:7`)
