### PR TITLE
Use latest patched elasticsearch 7 image

### DIFF
--- a/.ci/services.yml
+++ b/.ci/services.yml
@@ -26,6 +26,6 @@ services:
     image: redis:6
 
   elasticsearch:
-    image: kuzzleio/elasticsearch:7
+    image: kuzzleio/elasticsearch:7.13.1-cve-2021-45046.44228
     ulimits:
       nofile: 65536

--- a/.ci/test-aarch64.yml
+++ b/.ci/test-aarch64.yml
@@ -39,6 +39,6 @@ services:
     image: redis:6
 
   elasticsearch:
-    image: kuzzleio/elasticsearch:7
+    image: kuzzleio/elasticsearch:7.13.1-cve-2021-45046.44228
     ulimits:
       nofile: 65536

--- a/.ci/test-armhf.yml
+++ b/.ci/test-armhf.yml
@@ -39,6 +39,6 @@ services:
     image: redis:6
 
   elasticsearch:
-    image: kuzzleio/elasticsearch:7
+    image: kuzzleio/elasticsearch:7.13.1-cve-2021-45046.44228
     ulimits:
       nofile: 65536

--- a/.ci/test-cluster.yml
+++ b/.ci/test-cluster.yml
@@ -78,7 +78,7 @@ services:
     container_name: kuzzle_redis
 
   elasticsearch:
-    image: kuzzleio/elasticsearch:7
+    image: kuzzleio/elasticsearch:7.13.1-cve-2021-45046.44228
     container_name: kuzzle_elasticsearch
     ulimits:
       nofile: 65536

--- a/.ci/test.yml
+++ b/.ci/test.yml
@@ -47,6 +47,6 @@ services:
     image: redis:6
 
   elasticsearch:
-    image: kuzzleio/elasticsearch:7
+    image: kuzzleio/elasticsearch:7.13.1-cve-2021-45046.44228
     ulimits:
       nofile: 65536

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       - "6379:6379"
 
   elasticsearch:
-    image: kuzzleio/elasticsearch:7
+    image: kuzzleio/elasticsearch:7.13.1-cve-2021-45046.44228
     container_name: kuzzle_elasticsearch
     ports:
       - "9200:9200"

--- a/docker/docker-compose-swarm.yml
+++ b/docker/docker-compose-swarm.yml
@@ -87,7 +87,7 @@ services:
       - "6379:6379"
 
   elasticsearch:
-    image: kuzzleio/elasticsearch:7
+    image: kuzzleio/elasticsearch:7.13.1-cve-2021-45046.44228
     container_name: kuzzle_elasticsearch
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9200"]


### PR DESCRIPTION
## What does this PR do ?

Use latest official Kuzzle image with CVE-2021-45046 and CVE-2021-44228 mitigations