### PR TITLE
Support Elasticsearch 7.14+

### DIFF
--- a/.ci/test-cluster.yml
+++ b/.ci/test-cluster.yml
@@ -78,7 +78,11 @@ services:
     container_name: kuzzle_redis
 
   elasticsearch:
-    image: kuzzleio/elasticsearch:7
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.16.2
     container_name: kuzzle_elasticsearch
+    environment:
+      - cluster.name=kuzzle
+      - node.name=alyx
+      - discovery.type=single-node
     ulimits:
       nofile: 65536

--- a/.ci/test-cluster.yml
+++ b/.ci/test-cluster.yml
@@ -78,11 +78,7 @@ services:
     container_name: kuzzle_redis
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.16.2
+    image: kuzzleio/elasticsearch:7.16.2
     container_name: kuzzle_elasticsearch
-    environment:
-      - cluster.name=kuzzle
-      - node.name=alyx
-      - discovery.type=single-node
     ulimits:
       nofile: 65536

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -2779,8 +2779,6 @@ class ElasticSearch extends Service {
    */
   async _getAliasFromIndice (indice) {
     const { body } = await this._client.indices.getAlias({ index: indice});
-    console.log(`Index: ${indice} ====`);
-    console.log(body);
     const aliases = Object.keys(body[indice].aliases);
 
     if (aliases.length < 1) {

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -128,11 +128,6 @@ class ElasticSearch extends Service {
       '_source_includes'
     ];
 
-    // Elasticsearch system indices that must be ignored
-    this.ignoredIndices = [
-      '.geoip_databases'
-    ];
-
     /**
      * Only allow stored-scripts in queries
      */
@@ -238,11 +233,16 @@ class ElasticSearch extends Service {
     };
 
     const { body } = await this._client.indices.stats(esRequest);
-    const filteredIndices = Object.keys(body).filter(index => !this.ignoredIndices.includes(index));
     const indexes = {};
     let size = 0;
 
-    for (const [indice, indiceInfo] of filteredIndices) {
+    for (const [indice, indiceInfo] of Object.entries(body.indices)) {
+      // Ignore non-Kuzzle indices
+      if ( indice[INDEX_PREFIX_POSITION_IN_INDICE] !== PRIVATE_PREFIX
+        && indice[INDEX_PREFIX_POSITION_IN_INDICE] !== PUBLIC_PREFIX ) {
+        continue;
+      }
+
       const alias = await this._getAliasFromIndice(indice);
       const indexName = this._extractIndex(alias);
       const collectionName = this._extractCollection(alias);

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -128,6 +128,11 @@ class ElasticSearch extends Service {
       '_source_includes'
     ];
 
+    // Elasticsearch system indices that must be ignored
+    this.ignoredIndices = [
+      '.geoip_databases'
+    ];
+
     /**
      * Only allow stored-scripts in queries
      */
@@ -233,10 +238,11 @@ class ElasticSearch extends Service {
     };
 
     const { body } = await this._client.indices.stats(esRequest);
+    const filteredIndices = Object.keys(body).filter(index => !this.ignoredIndices.includes(index));
     const indexes = {};
     let size = 0;
 
-    for (const [indice, indiceInfo] of Object.entries(body.indices)) {
+    for (const [indice, indiceInfo] of filteredIndices) {
       const alias = await this._getAliasFromIndice(indice);
       const indexName = this._extractIndex(alias);
       const collectionName = this._extractCollection(alias);
@@ -2773,6 +2779,8 @@ class ElasticSearch extends Service {
    */
   async _getAliasFromIndice (indice) {
     const { body } = await this._client.indices.getAlias({ index: indice});
+    console.log(`Index: ${indice} ====`);
+    console.log(body);
     const aliases = Object.keys(body[indice].aliases);
 
     if (aliases.length < 1) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "2.16.5",
+  "version": "2.16.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.16.5",
+  "version": "2.16.6",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "bin": {
     "kuzzle": "bin/start-kuzzle-server"

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -111,7 +111,11 @@ describe('Test: ElasticSearch service', () => {
             },
             '&test-index.test-collection': {
               total: { docs: { count: 2 }, store: { size_in_bytes: 20 } }
-            }
+            },
+            '.kibana': {
+              total: { docs: { count: 2 }, store: { size_in_bytes: 42 } }
+            },
+            '.geoip_databases': { /* This index nativement do not return anything on index:stats call */ }
           }
         }
       });


### PR DESCRIPTION
# Why this need some changes by our side?

There is a new feature introduced in 7.14 version of Elasticsearch and enabled by default. This one create an index called `.geoip_databases` incompatible with the custom Kuzzle data model.
It can be disabled in the `elasticsearch.yml`:
```yaml
ingest:
  geoip:
    downloader:
      enabled: false
```
But since this is enable by default, we need to ignore the automatically created index to avoid issues when using the native index:stats Elasticsearch API action

