### PR TITLE
Revert `collection:truncate` behavior

### DIFF
--- a/doc/2/api/controllers/collection/truncate/index.md
+++ b/doc/2/api/controllers/collection/truncate/index.md
@@ -8,6 +8,11 @@ title: truncate
 
 Empties a collection by removing all its documents, while keeping any associated mapping.
 
+::: info
+This action delete then recreate the related Elasticsearch index.
+Please note that deleting/creating an index cannot be done concurrently within an Elasticsearch cluster
+:::
+
 ::: warning
 Documents removed that way do not trigger real-time notifications.
 :::

--- a/doc/2/api/controllers/collection/truncate/index.md
+++ b/doc/2/api/controllers/collection/truncate/index.md
@@ -10,7 +10,7 @@ Empties a collection by removing all its documents, while keeping any associated
 
 ::: info
 This action delete then recreate the related Elasticsearch index.
-Please note that deleting/creating an index cannot be done concurrently within an Elasticsearch cluster
+Please note that deleting/creating an index cannot be done concurrently within an Elasticsearch cluster, if you need to truncate a lot of collections (for your functional tests for example), then you should use `collection:refresh` and `document:deleteByQuery`
 :::
 
 ::: warning

--- a/lib/api/controllers/collectionController.js
+++ b/lib/api/controllers/collectionController.js
@@ -269,7 +269,7 @@ class CollectionController extends NativeController {
   }
 
   /**
-   * Reset a collection by removing all documents
+   * Reset a collection by removing all documents while keeping the existing mapping
    *
    * @param {KuzzleRequest} request
    * @returns {Promise.<Object>}
@@ -277,13 +277,7 @@ class CollectionController extends NativeController {
   async truncate (request) {
     const { index, collection } = request.getIndexAndCollection();
 
-    await this.ask('core:storage:public:collection:refresh', index, collection);
-    await this.ask(
-      'core:storage:public:document:deleteByQuery',
-      index,
-      collection,
-      {},
-      { fetch: false, refresh: 'wait_for' });
+    await this.ask('core:storage:public:collection:truncate', index, collection);
 
     return {
       acknowledged: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "2.16.6",
+  "version": "2.16.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.16.6",
+  "version": "2.16.7",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "bin": {
     "kuzzle": "bin/start-kuzzle-server"

--- a/test/api/controllers/collectionController.test.js
+++ b/test/api/controllers/collectionController.test.js
@@ -119,15 +119,10 @@ describe('Test: collection controller', () => {
       const response = await collectionController.truncate(request);
 
       should(kuzzle.ask).be.calledWith(
-        'core:storage:public:collection:refresh',
+        'core:storage:public:collection:truncate',
         index,
         collection);
-      should(kuzzle.ask).be.calledWith(
-        'core:storage:public:document:deleteByQuery',
-        index,
-        collection,
-        {},
-        { refresh: 'wait_for', fetch: false });
+        
 
       should(response).match({
         acknowledged: true


### PR DESCRIPTION
# Why?

The new `collection:truncate` internal behavior using Elasticsearch `deleteByQuery` API action should be revert since this ES API action can only delete 1000 documents by default and is limited by Kuzzle limits configuration.