### PR TITLE
Anonymous token if we have no token

### DIFF
--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -430,11 +430,11 @@ class AuthController extends NativeController {
       token = request.input.jwt;
     }
     else {
-      token = request.getBodyString('token');
+      token = request.getBodyString('token', '') || null;
     }
 
     try {
-      const { expiresAt, userId } = await this.ask('core:security:token:verify', token);
+      const { expiresAt = -1, userId } = await this.ask('core:security:token:verify', token);
 
       return { expiresAt, kuid: userId, valid: true };
     }


### PR DESCRIPTION
<!--- This template is optional. -->

## What does this PR do ?

no longer throw an error when a browser connects to Kuzzle for the first time during the request ```auth:checkToken```

### How should this be manually tested?

```
npm run test:unit
```

### Other changes

Update unit tests
