### PR TITLE
Support lodash syntax in request argument extractors

### DIFF
--- a/doc/2/framework/classes/kuzzle-request/get-body-array/index.md
+++ b/doc/2/framework/classes/kuzzle-request/get-body-array/index.md
@@ -10,6 +10,7 @@ description: KuzzleRequest class getBodyArray() method
 <SinceBadge version="2.11.0" />
 
 Gets a parameter from the request body and checks that it is an array.
+We also support lodash syntax. [(```relations.lebron[0]```)](https://lodash.com/docs/4.17.15#get)
 
 ### Arguments
 

--- a/doc/2/framework/classes/kuzzle-request/get-body-boolean/index.md
+++ b/doc/2/framework/classes/kuzzle-request/get-body-boolean/index.md
@@ -10,6 +10,7 @@ description: KuzzleRequest class getBodyBoolean() method
 <SinceBadge version="2.11.0" />
 
 Gets a parameter from the request body and checks that it is a boolean.
+We also support lodash syntax. [(```relations.lebron[0]```)](https://lodash.com/docs/4.17.15#get)
 
 Contrary to other parameter types, an unset boolean does not trigger an
 error, instead it's considered as `false`

--- a/doc/2/framework/classes/kuzzle-request/get-body-integer/index.md
+++ b/doc/2/framework/classes/kuzzle-request/get-body-integer/index.md
@@ -10,6 +10,7 @@ description: KuzzleRequest class getBodyInteger() method
 <SinceBadge version="2.11.0" />
 
 Gets a parameter from the request body and checks that it is an integer.
+We also support lodash syntax. [(```relations.lebron[0]```)](https://lodash.com/docs/4.17.15#get)
 
 ### Arguments
 

--- a/doc/2/framework/classes/kuzzle-request/get-body-number/index.md
+++ b/doc/2/framework/classes/kuzzle-request/get-body-number/index.md
@@ -10,6 +10,7 @@ description: KuzzleRequest class getBodyNumber() method
 <SinceBadge version="2.11.0" />
 
 Gets a parameter from the request body and checks that it is a number.
+We also support lodash syntax. [(```relations.lebron[0]```)](https://lodash.com/docs/4.17.15#get)
 
 ### Arguments
 

--- a/doc/2/framework/classes/kuzzle-request/get-body-object/index.md
+++ b/doc/2/framework/classes/kuzzle-request/get-body-object/index.md
@@ -10,6 +10,7 @@ description: KuzzleRequest class getBodyObject() method
 <SinceBadge version="2.11.0" />
 
 Gets a parameter from the request body and checks that it is an object.
+We also support lodash syntax. [(```relations.lebron[0]```)](https://lodash.com/docs/4.17.15#get)
 
 ### Arguments
 

--- a/doc/2/framework/classes/kuzzle-request/get-body-string/index.md
+++ b/doc/2/framework/classes/kuzzle-request/get-body-string/index.md
@@ -10,6 +10,7 @@ description: KuzzleRequest class getBodyString() method
 <SinceBadge version="2.11.0" />
 
 Gets a parameter from the request body and checks that it is a string.
+We also support lodash syntax. [(```relations.lebron[0]```)](https://lodash.com/docs/4.17.15#get)
 
 ### Arguments
 

--- a/doc/2/framework/classes/kuzzle-request/get-boolean/index.md
+++ b/doc/2/framework/classes/kuzzle-request/get-boolean/index.md
@@ -10,6 +10,7 @@ description: KuzzleRequest class getBoolean() method
 <SinceBadge version="2.11.0" />
 
 Gets a parameter from the request arguments and checks that it is a boolean.
+We also support lodash syntax. [(```relations.lebron[0]```)](https://lodash.com/docs/4.17.15#get)
 
 Contrary to other parameter types, an unset boolean does not trigger an
 error, instead it's considered as `false`

--- a/doc/2/framework/classes/kuzzle-request/get-integer/index.md
+++ b/doc/2/framework/classes/kuzzle-request/get-integer/index.md
@@ -10,6 +10,7 @@ description: KuzzleRequest class getInteger() method
 <SinceBadge version="2.11.0" />
 
 Gets a parameter from a request arguments and checks that it is an integer.
+We also support lodash syntax. [(```relations.lebron[0]```)](https://lodash.com/docs/4.17.15#get)
 
 ### Arguments
 

--- a/doc/2/framework/classes/kuzzle-request/get-number/index.md
+++ b/doc/2/framework/classes/kuzzle-request/get-number/index.md
@@ -10,6 +10,7 @@ description: KuzzleRequest class getNumber() method
 <SinceBadge version="2.11.0" />
 
 Gets a parameter from the request arguments and checks that it is a number.
+We also support lodash syntax. [(```relations.lebron[0]```)](https://lodash.com/docs/4.17.15#get)
 
 ### Arguments
 

--- a/doc/2/framework/classes/kuzzle-request/get-object/index.md
+++ b/doc/2/framework/classes/kuzzle-request/get-object/index.md
@@ -10,6 +10,7 @@ description: KuzzleRequest class getObject() method
 <SinceBadge version="2.11.0" />
 
 Gets a parameter from the request arguments and checks that it is an object.
+We also support lodash syntax. [(```relations.lebron[0]```)](https://lodash.com/docs/4.17.15#get)
 
 ### Arguments
 

--- a/doc/2/framework/classes/kuzzle-request/get-string/index.md
+++ b/doc/2/framework/classes/kuzzle-request/get-string/index.md
@@ -10,6 +10,7 @@ description: KuzzleRequest class getString() method
 <SinceBadge version="2.11.0" />
 
 Gets a parameter from the request arguments and checks that it is a string.
+We also support lodash syntax. [(```relations.lebron[0]```)](https://lodash.com/docs/4.17.15#get)
 
 ### Arguments
 

--- a/lib/api/request/kuzzleRequest.ts
+++ b/lib/api/request/kuzzleRequest.ts
@@ -30,7 +30,8 @@ import { KuzzleError, InternalError } from '../../kerror/errors';
 import kerror from '../../kerror';
 import { Deprecation, User } from '../../types';
 import * as assert from '../../util/assertType';
-import { get, isPlainObject } from '../../util/safeObject';
+import { isPlainObject } from '../../util/safeObject';
+import { get } from 'lodash';
 
 const assertionError = kerror.wrap('api', 'assert');
 

--- a/test/api/request/request.test.js
+++ b/test/api/request/request.test.js
@@ -421,11 +421,27 @@ describe('#Request', () => {
             Valentine: 'sister'
           },
           year: '5270',
-          defeatedBugsAt: 11
+          defeatedBugsAt: 11,
+          relations: {
+            'lebron': ['james', 'curry', 'harden'],
+            'kobe': ['bryant', 'jordan', 'love']
+          },
+          powers: {
+            fire: {
+              level: 'high',
+              mana: 10,
+              damage: 10.8,
+            }
+          }
         };
       });
 
       describe('#getBodyArray', () => {
+        it('should return the array of the body (lodash parameter)', () => {
+          should(request.getBodyArray('relations.lebron'))
+            .exactly(request.input.body.relations.lebron);
+        });
+
         it('extracts the required parameter', () => {
           should(request.getBodyArray('names'))
             .exactly(request.input.body.names);
@@ -466,6 +482,21 @@ describe('#Request', () => {
       });
 
       describe('#getBodyString', () => {
+        it('should return the string of the body (lodash parameter)', () => {
+          should(request.getBodyString('relatives.Peter'))
+            .exactly(request.input.body.relatives.Peter);
+        });
+
+        it('should return the string of an array (lodash parameter)', () => {
+          should(request.getBodyString('names.0'))
+            .exactly(request.input.body.names[0]);
+        });
+
+        it('should return the string of an array (lodash parameter)', () => {
+          should(request.getBodyString('relations.lebron[0]'))
+            .exactly(request.input.body.relations.lebron[0]);
+        });
+ 
         it('extracts the required parameter', () => {
           should(request.getBodyString('fullname'))
             .exactly(request.input.body.fullname);
@@ -506,6 +537,11 @@ describe('#Request', () => {
       });
 
       describe('#getBodyObject', () => {
+        it('should return the object of the body (lodash parameter)', () => {
+          should(request.getBodyObject('powers.fire'))
+            .exactly(request.input.body.powers.fire);
+        });
+  
         it('extracts the required parameter', () => {
           should(request.getBodyObject('relatives'))
             .exactly(request.input.body.relatives);
@@ -546,6 +582,10 @@ describe('#Request', () => {
       });
 
       describe('#getBodyNumber', () => {
+        it('should return the number of the body (lodash parameter)', () => {
+          should(request.getBodyNumber('powers.fire.damage'))
+            .exactly(request.input.body.powers.fire.damage);
+        });
         it('extracts the required parameter and convert it', () => {
           should(request.getBodyNumber('age'))
             .exactly(3011.5);
@@ -589,6 +629,11 @@ describe('#Request', () => {
       });
 
       describe('#getBodyInteger', () => {
+        it('should return the integer of the body (lodash parameter)', () => {
+          should(request.getBodyInteger('powers.fire.mana'))
+            .exactly(request.input.body.powers.fire.mana);
+        });
+
         it('extracts the required parameter and convert it', () => {
           should(request.getBodyInteger('year'))
             .exactly(5270);


### PR DESCRIPTION
<!--- This template is optional. -->

## What does this PR do ?

We should support lodash syntax in body argument extractors

Example:

```ts
const name = request.getBodyString('person.name');
```

### How should this be manually tested?

```
npm run test
```
