### PR TITLE
Check Redis service before usage in IdCardRenewer

### DIFF
--- a/lib/cluster/workers/IDCardRenewer.js
+++ b/lib/cluster/workers/IDCardRenewer.js
@@ -8,7 +8,6 @@ class IDCardRenewer {
   constructor () {
     this.parentPort = parentPort;
     this.redis = null;
-    this.redisReady = false;
     this.refreshTimer = null;
     this.nodeIdKey = null;
     this.refreshDelay = 2000;
@@ -32,7 +31,6 @@ class IDCardRenewer {
     try {
       const redisConf = config.redis || {};
       await this.initRedis(redisConf.config, redisConf.name);
-      this.redisReady = true;
     }
     catch (error) {
       this.parentPort.postMessage({
@@ -57,8 +55,9 @@ class IDCardRenewer {
   }
 
   async initRedis (config, name) {
-    this.redis = new Redis(config, name);
-    await this.redis.init();
+    const redis = new Redis(config, name);
+    await redis.init();
+    this.redis = redis;
   }
 
   async renewIDCard () {
@@ -97,9 +96,10 @@ class IDCardRenewer {
 
     // If the worker is disposed before it had time to starts, redis service
     // may not have been initialized
-    if (! this.redisReady) {
+    if (! this.redis) {
       return;
     }
+
     try {
       await this.redis.commands.del(this.nodeIdKey);
     }

--- a/lib/cluster/workers/IDCardRenewer.js
+++ b/lib/cluster/workers/IDCardRenewer.js
@@ -8,6 +8,7 @@ class IDCardRenewer {
   constructor () {
     this.parentPort = parentPort;
     this.redis = null;
+    this.redisReady = false;
     this.refreshTimer = null;
     this.nodeIdKey = null;
     this.refreshDelay = 2000;
@@ -31,6 +32,7 @@ class IDCardRenewer {
     try {
       const redisConf = config.redis || {};
       await this.initRedis(redisConf.config, redisConf.name);
+      this.redisReady = true;
     }
     catch (error) {
       this.parentPort.postMessage({
@@ -89,8 +91,15 @@ class IDCardRenewer {
     }
 
     this.disposed = true;
+
     clearInterval(this.refreshTimer);
     this.refreshTimer = null;
+
+    // If the worker is disposed before it had time to starts, redis service
+    // may not have been initialized
+    if (! this.redisReady) {
+      return;
+    }
     try {
       await this.redis.commands.del(this.nodeIdKey);
     }

--- a/test/cluster/workers/IDCardRenewer.test.js
+++ b/test/cluster/workers/IDCardRenewer.test.js
@@ -37,7 +37,6 @@ describe('ClusterIDCardRenewer', () => {
             initTimeout: 42
           },
           'foo');
-      should(idCardRenewer.redisReady).be.true()
     });
 
     it('should init variable based on the given config', async () => {
@@ -199,6 +198,15 @@ describe('ClusterIDCardRenewer', () => {
       should(idCardRenewer.redis.commands.del).be.calledWith('foo');
       should(idCardRenewer.disposed).be.true();
       should(idCardRenewer.refreshTimer).be.null();
+    });
+
+    it('should not delete redis key if redis is not init', async () => {
+      const redis = idCardRenewer.redis;
+      idCardRenewer.redis = null;
+
+      await idCardRenewer.dispose();
+
+      should(redis.commands.del).not.be.called();
     });
 
     it('should do nothing when already disposed', async () => {

--- a/test/cluster/workers/IDCardRenewer.test.js
+++ b/test/cluster/workers/IDCardRenewer.test.js
@@ -37,6 +37,7 @@ describe('ClusterIDCardRenewer', () => {
             initTimeout: 42
           },
           'foo');
+      should(idCardRenewer.redisReady).be.true()
     });
 
     it('should init variable based on the given config', async () => {


### PR DESCRIPTION
## What does this PR do ?

If the node has to shut down before the `IdCardRenewer` worker is fully initialized then the worker redis service will be called to remove the ID Card but since it's not initialized it will result in an error
