### PR TITLE
Change default value for `loginPerSecond` config

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -87,7 +87,7 @@
     "concurrentRequests": 50,
     "documentsFetchCount": 10000,
     "documentsWriteCount": 200,
-    "loginsPerSecond": 1,
+    "loginsPerSecond": 2,
     "requestsBufferSize": 50000,
     "requestsBufferWarningThreshold": 5000,
     "subscriptionConditionsCount": 100,

--- a/lib/config/default.config.ts
+++ b/lib/config/default.config.ts
@@ -61,7 +61,7 @@ const defaultConfig: KuzzleConfiguration = {
     concurrentRequests: 100,
     documentsFetchCount: 10000,
     documentsWriteCount: 200,
-    loginsPerSecond: 1,
+    loginsPerSecond: 2,
     requestsBufferSize: 50000,
     requestsBufferWarningThreshold: 5000,
     subscriptionConditionsCount: 100,


### PR DESCRIPTION
## What does this PR do ?

If the limit is 1 then it's not possible to use Kourou to retrieve a token with `kourou auth:login`