### PR TITLE
Add header to force close connection after HTTP Requests

### DIFF
--- a/lib/core/network/protocols/httpwsProtocol.js
+++ b/lib/core/network/protocols/httpwsProtocol.js
@@ -76,11 +76,13 @@ const HTTP_ALLOWED_CONTENT_TYPES = [
   'application/x-www-form-urlencoded',
   'multipart/form-data',
 ];
+const HTTP_HEADER_CONNECTION = Buffer.from('Connection');
 const HTTP_HEADER_CONTENT_LENGTH = Buffer.from('Content-Length');
 const HTTP_HEADER_ACCESS_CONTROL_ALLOW_ORIGIN = Buffer.from('Access-Control-Allow-Origin');
 const HTTP_HEADER_VARY = Buffer.from('Vary');
 const WILDCARD = Buffer.from('*');
 const ORIGIN = Buffer.from('Origin');
+const CLOSE = Buffer.from('close');
 const CHARSET_REGEX = /charset=([\w-]+)/i;
 
 /**
@@ -593,6 +595,8 @@ class HttpWsProtocol extends Protocol {
 
         response.cork(() => {
           response.writeStatus(Buffer.from(request.response.status.toString()));
+
+          response.writeHeader(HTTP_HEADER_CONNECTION, CLOSE);
 
           for (const header of this.httpConfig.headers) {
             // If header is missing, add the default one


### PR DESCRIPTION
## What does this PR do ?

Kuzzle does not support pipelining, so connection should be closed after each HTTP Requests
Adding the header `Connection: close` should tell the client to close the connection on their side, leading to Kuzzle closing its connection.

🤞 
