### PR TITLE
Fix double Content-Length header

### DIFF
--- a/lib/core/network/protocols/httpwsProtocol.js
+++ b/lib/core/network/protocols/httpwsProtocol.js
@@ -77,6 +77,9 @@ const HTTP_ALLOWED_CONTENT_TYPES = [
   'application/x-www-form-urlencoded',
   'multipart/form-data',
 ];
+const HTTP_SKIPPED_HEADERS = [
+  'content-length',
+];
 const HTTP_HEADER_CONNECTION = Buffer.from('Connection');
 const HTTP_HEADER_CONTENT_LENGTH = Buffer.from('Content-Length');
 const HTTP_HEADER_ACCESS_CONTROL_ALLOW_ORIGIN = Buffer.from('Access-Control-Allow-Origin');
@@ -656,6 +659,11 @@ class HttpWsProtocol extends Protocol {
     }
 
     for (const [key, value] of Object.entries(request.response.headers)) {
+      // Skip some headers that are not allowed to be sent or modified
+      if (HTTP_SKIPPED_HEADERS.includes(key.toLowerCase())) {
+        continue;
+      }
+
       response.writeHeader(Buffer.from(key), Buffer.from(value.toString()));
     }
   }

--- a/test/api/controllers/documentController.test.js
+++ b/test/api/controllers/documentController.test.js
@@ -95,7 +95,7 @@ describe('DocumentController', () => {
         { id: 'services.storage.invalid_multi_index_collection_usage' });
     });
 
-    it.only('should reject if no index and collection or targets are specified', async () => {
+    it('should reject if no index and collection or targets are specified', async () => {
       request.input.args.index = undefined;
       request.input.args.collection = undefined;
       request.input.args.targets = undefined;

--- a/test/core/network/protocols/http.test.js
+++ b/test/core/network/protocols/http.test.js
@@ -93,7 +93,8 @@ describe('core/network/protocols/http', () => {
         '',
         '',
         {
-          origin: 'foo'
+          origin: 'foo',
+          'Content-Length': 42
         });
       message = new HttpMessage(connection, req);
     });
@@ -125,6 +126,10 @@ describe('core/network/protocols/http', () => {
       should(response.writeHeader).calledWithMatch(
         Buffer.from('Content-Type'),
         Buffer.from('application/json'));
+
+      should(response.writeHeader).not.be.calledWithMatch(
+        Buffer.from('Content-Length'),
+        Buffer.from('42'));
 
       should(response.writeHeader.calledBefore(response.end));
 


### PR DESCRIPTION
## What does this PR do ?

When we are responding to an HTTP Request, uWS uses the parameters given to `tryEnd` method to send the `Content-Length` header with the appropriate value, Kuzzle should always skip writing `Content-Length` header provided in KuzzleResponse otherwise this would result in the header being duplicated and will probably override the good one, causing HTTP Parsers to fail.

### How should this be manually tested?
```
npm run test
```