### PR TITLE
Add missing requestId when responding with an error in websocket message handling

### DIFF
--- a/lib/core/network/protocols/httpwsProtocol.js
+++ b/lib/core/network/protocols/httpwsProtocol.js
@@ -351,7 +351,7 @@ class HttpWsProtocol extends Protocol {
       request = new Request(parsed, { connection });
     }
     catch (e) {
-      this.wsSendError(socket, connection, e);
+      this.wsSendError(socket, connection, e, parsed.requestId);
       return;
     }
 
@@ -393,8 +393,11 @@ class HttpWsProtocol extends Protocol {
    * @param  {ClientConnection} connection
    * @param  {Error} error
    */
-  wsSendError (socket, connection, error) {
+  wsSendError (socket, connection, error, requestId) {
     const request = new Request({}, { connection, error });
+
+    request.id = requestId || request.id;
+
     const sanitized = removeErrorStack(request.response.toJSON()).content;
 
     this.wsSend(socket, Buffer.from(JSON.stringify(sanitized)));

--- a/lib/core/network/protocols/httpwsProtocol.js
+++ b/lib/core/network/protocols/httpwsProtocol.js
@@ -392,10 +392,12 @@ class HttpWsProtocol extends Protocol {
    * @param  {uWS.WebSocket} socket
    * @param  {ClientConnection} connection
    * @param  {Error} error
+   * @param  {String} requestId @optional
    */
   wsSendError (socket, connection, error, requestId) {
     const request = new Request({}, { connection, error });
 
+    // If a requestId is provided we use it instead of the generated one
     request.id = requestId || request.id;
 
     const sanitized = removeErrorStack(request.response.toJSON()).content;


### PR DESCRIPTION
## What does this PR do ?

When an error occurs inside `wsOnMessageHandler` after the message has been parsed, the response did not contain the requestId of the request even though the message has been parsed successfuly.
This is causing the SDKs to not being able to know which request has failed because the given requestId is not the one sent by the SDK.

Fix: When we are able to retrieve the requestId from the parsed message we respond by using it