### PR TITLE
Fix API Key id not generated when missing

### DIFF
--- a/features/AuthController.feature
+++ b/features/AuthController.feature
@@ -85,6 +85,34 @@ Feature: Auth Controller
       | _id        | _source.userId | _source.ttl | _source.expiresAt | _source.description | _source.fingerprint |
       | "_STRING_" | "test-admin"   | -1          | -1                | "Sigfox API key"    | "_STRING_"          |
 
+  @security @login
+  Scenario: Create two API key consecutively
+    When I successfully execute the action "auth":"createApiKey" with args:
+      | expiresIn | -1                                  |
+      | refresh   | "wait_for"                          |
+      | body      | { "description": "Sigfox API key" } |
+    Then The property "_source" of the result should match:
+      | expiresAt   | -1               |
+      | ttl         | -1               |
+      | description | "Sigfox API key" |
+      | token       | "_STRING_"       |
+    And The result should contain a property "_id" of type "string"
+    When I successfully execute the action "auth":"createApiKey" with args:
+      | expiresIn | -1                                  |
+      | refresh   | "wait_for"                          |
+      | body      | { "description": "LoRa API key" }   |
+    Then The property "_source" of the result should match:
+      | expiresAt   | -1               |
+      | ttl         | -1               |
+      | description | "LoRa API key"   |
+      | token       | "_STRING_"       |
+    And The result should contain a property "_id" of type "string"
+    And I successfully execute the action "auth":"searchApiKeys"
+    Then I should receive a "hits" array of objects matching:
+      | _id        | _source.userId | _source.ttl | _source.expiresAt | _source.description | _source.fingerprint |
+      | "_STRING_" | "test-admin"   | -1          | -1                | "Sigfox API key"    | "_STRING_"          |
+      | "_STRING_" | "test-admin"   | -1          | -1                | "LoRa API key"      | "_STRING_"          |
+
   # auth:login =================================================================
 
   @security @http

--- a/features/SecurityController.feature
+++ b/features/SecurityController.feature
@@ -113,6 +113,41 @@ Feature: Security Controller
       | _id        | _source.userId | _source.ttl | _source.expiresAt | _source.description | _source.fingerprint |
       | "_STRING_" | "My"           | -1          | -1                | "Le Huong"          | "_STRING_"          |
 
+
+  @security @login
+  Scenario: Create two API key for a user consecutively
+    Given I create a user "My" with content:
+      | profileIds | ["default"] |
+    When I successfully execute the action "security":"createApiKey" with args:
+      | userId    | "My"                          |
+      | expiresIn | -1                            |
+      | refresh   | "wait_for"                    |
+      | body      | { "description": "Le Huong" } |
+    Then The property "_source" of the result should match:
+      | expiresAt   | -1         |
+      | ttl         | -1         |
+      | description | "Le Huong" |
+      | token       | "_STRING_" |
+    And The result should contain a property "_id" of type "string"
+    When I successfully execute the action "security":"createApiKey" with args:
+      | userId    | "My"                          |
+      | expiresIn | -1                            |
+      | refresh   | "wait_for"                    |
+      | body      | { "description": "Foobar" } |
+    Then The property "_source" of the result should match:
+      | expiresAt   | -1         |
+      | ttl         | -1         |
+      | description | "Foobar" |
+      | token       | "_STRING_" |
+    And The result should contain a property "_id" of type "string"
+    And I successfully execute the action "security":"searchApiKeys" with args:
+      | userId | "My" |
+    Then I should receive a "hits" array of objects matching:
+      | _id        | _source.userId | _source.ttl | _source.expiresAt | _source.description | _source.fingerprint |
+      | "_STRING_" | "My"           | -1          | -1                | "Le Huong"          | "_STRING_"          |
+      | "_STRING_" | "My"           | -1          | -1                | "Foobar"            | "_STRING_"          |
+
+
   # security:searchApiKeys =====================================================
 
   @security

--- a/lib/api/controllers/authController.js
+++ b/lib/api/controllers/authController.js
@@ -110,7 +110,7 @@ class AuthController extends NativeController {
   async createApiKey (request) {
     const expiresIn = request.input.args.expiresIn || -1;
     const refresh = request.getRefresh('wait_for');
-    const apiKeyId = request.getId({ ifMissing: 'ignore' });
+    const apiKeyId = request.getId({ ifMissing: 'generate' });
     const description = request.getBodyString('description');
 
     const user = request.context.user;

--- a/lib/api/controllers/securityController.js
+++ b/lib/api/controllers/securityController.js
@@ -136,7 +136,7 @@ class SecurityController extends NativeController {
     const expiresIn = request.input.args.expiresIn || -1;
     const refresh = request.getRefresh('wait_for');
     const userId = request.getString('userId');
-    const apiKeyId = request.getId({ ifMissing: 'ignore' });
+    const apiKeyId = request.getId({ ifMissing: 'generate' });
     const description = request.getBodyString('description');
 
     const user = await this.ask('core:security:user:get', userId);

--- a/lib/api/request/kuzzleRequest.ts
+++ b/lib/api/request/kuzzleRequest.ts
@@ -684,6 +684,8 @@ export class KuzzleRequest {
   ): string {
     const id = this.input.args._id;
 
+    options.generator = options.generator || uuid.v4; // Default to uuid v4
+
     if (! id) {
       if (options.ifMissing === 'generate') {
         return options.generator();

--- a/package-lock.json
+++ b/package-lock.json
@@ -2138,11 +2138,6 @@
         "esutils": "^2.0.2"
       }
     },
-    "drange": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
-      "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA=="
-    },
     "dumpme": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/dumpme/-/dumpme-1.0.3.tgz",
@@ -5751,15 +5746,6 @@
         "mimic-fn": "^2.1.0"
       }
     },
-    "openapi-enforcer": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/openapi-enforcer/-/openapi-enforcer-1.16.1.tgz",
-      "integrity": "sha512-MG3lwulSdL9Qo1p0r8QMLjX+jTcvEN+YgMIGDNjyOxe2sYuk4Iu1wWN/3rVtkudrU/AQXIAZZP31NcqTIWcE7Q==",
-      "requires": {
-        "js-yaml": "^4.1.0",
-        "randexp": "^0.5.3"
-      }
-    },
     "optional-js": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/optional-js/-/optional-js-2.3.0.tgz",
@@ -5910,7 +5896,7 @@
     },
     "passport-local": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
+      "resolved": "https://packages.app.kuzzle.io/passport-local/-/passport-local-1.0.0.tgz",
       "integrity": "sha1-H+YyaMkudWBmJkN+O5BmYsFbpu4=",
       "requires": {
         "passport-strategy": "1.x.x"
@@ -6189,15 +6175,6 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "optional": true
-    },
-    "randexp": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.5.3.tgz",
-      "integrity": "sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==",
-      "requires": {
-        "drange": "^1.0.2",
-        "ret": "^0.2.0"
-      }
     },
     "random-poly-fill": {
       "version": "1.0.1",
@@ -6543,11 +6520,6 @@
         "signal-exit": "^3.0.2"
       }
     },
-    "ret": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
-      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ=="
-    },
     "retimer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
@@ -6589,7 +6561,7 @@
         },
         "argparse": {
           "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "resolved": "https://packages.app.kuzzle.io/argparse/-/argparse-1.0.10.tgz",
           "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
           "dev": true,
           "requires": {
@@ -6850,7 +6822,7 @@
         },
         "js-yaml": {
           "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "resolved": "https://packages.app.kuzzle.io/js-yaml/-/js-yaml-3.14.1.tgz",
           "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
           "dev": true,
           "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2743,6 +2743,12 @@
           "requires": {
             "ansi-regex": "^5.0.1"
           }
+        },
+        "strip-json-comments": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+          "dev": true
         }
       }
     },
@@ -4282,8 +4288,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json2yaml": {
       "version": "1.1.0",
@@ -4964,6 +4969,12 @@
             "ansi-regex": "^5.0.1"
           }
         },
+        "strip-json-comments": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+          "dev": true
+        },
         "supports-color": {
           "version": "8.1.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -5123,6 +5134,18 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "ndjson": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-2.0.0.tgz",
+      "integrity": "sha512-nGl7LRGrzugTtaFcJMhLbpzJM6XdivmbkdlaGcrk/LXg2KL/YBC6z1g70xh0/al+oFuVFP8N8kiWRucmeEH/qQ==",
+      "requires": {
+        "json-stringify-safe": "^5.0.1",
+        "minimist": "^1.2.5",
+        "readable-stream": "^3.6.0",
+        "split2": "^3.0.0",
+        "through2": "^4.0.0"
+      }
     },
     "needle": {
       "version": "2.6.0",
@@ -6960,6 +6983,12 @@
             }
           }
         },
+        "strip-json-comments": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+          "dev": true
+        },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://packages.app.kuzzle.io/supports-color/-/supports-color-5.5.0.tgz",
@@ -7458,7 +7487,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
       "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-      "dev": true,
       "requires": {
         "readable-stream": "^3.0.0"
       }
@@ -7872,6 +7900,14 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "requires": {
+        "readable-stream": "3"
+      }
     },
     "timers-ext": {
       "version": "0.1.7",


### PR DESCRIPTION
## What does this PR do ?

- Change the behaviour of `auth:createApiKey` and `security:createApiKey` to make them generate an id when missing
- Added tests cases to make sure this bug does not appear in the future

### How should this be manually tested?

Creating two consecutive Api Key without providing an _id should work and not throw a `Document is already existsing` error