### PR TITLE
Fix missing origin header after ws upgrade

### DIFF
--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -896,6 +896,10 @@ class Funnel {
   _isOriginAuthorized (origin) {
     const httpConfig = global.kuzzle.config.http;
 
+    if (! origin) {
+      return true;
+    }
+
     if (global.kuzzle.config.internal.allowAllOrigins) {
       return true;
     }

--- a/lib/core/network/protocols/httpwsProtocol.js
+++ b/lib/core/network/protocols/httpwsProtocol.js
@@ -258,6 +258,7 @@ class HttpWsProtocol extends Protocol {
     res.upgrade(
       {
         cookie: req.getHeader('cookie'),
+        origin: req.getHeader('origin'),
       },
       req.getHeader('sec-websocket-key'),
       req.getHeader('sec-websocket-protocol'),
@@ -268,7 +269,14 @@ class HttpWsProtocol extends Protocol {
 
   wsOnOpenHandler (socket) {
     const ip = Buffer.from(socket.getRemoteAddressAsText()).toString();
-    const connection = new ClientConnection(this.name, [ip], { cookie: socket.cookie });
+    const connection = new ClientConnection(
+      this.name,
+      [ip],
+      {
+        cookie: socket.cookie,
+        origin: socket.origin
+      }
+    );
 
     this.entryPoint.newConnection(connection);
     this.connectionBySocket.set(socket, connection);

--- a/test/core/network/protocols/websocket.test.js
+++ b/test/core/network/protocols/websocket.test.js
@@ -163,6 +163,33 @@ describe('core/network/protocols/websocket', () => {
         context
       );
     });
+
+    it('should upgrade the connection and store the origin in the UserData if present', () => {
+      const response = new MockHttpResponse();
+      const request = new MockHttpRequest(
+        '',
+        '',
+        '',
+        {
+          origin: 'my-website.com',
+          'sec-websocket-key': 'websocket-key',
+          'sec-websocket-protocol': 'websocket-protocol',
+          'sec-websocket-extensions': 'websocket-extension',
+        }
+      );
+      const context = {}; // context object
+      httpWs.server._wsOnUpgrade(response, request, context);
+
+      should(response.upgrade).be.calledWithMatch(
+        {
+          origin: 'my-website.com',
+        },
+        'websocket-key',
+        'websocket-protocol',
+        'websocket-extension',
+        context
+      );
+    });
   });
 
   describe('new connection', () => {


### PR DESCRIPTION
## What does this PR do ?

Forward `origin` after Websocket upgrade  so Kuzzle can refuse ws connection based on CORS

### How should this be manually tested?

`npm run test`