### PR TITLE
Add X-Kuzzle-Request-Id

### DIFF
--- a/doc/2/api/protocols/http/index.md
+++ b/doc/2/api/protocols/http/index.md
@@ -2,25 +2,25 @@
 code: false
 type: page
 title: HTTP
-description: HTTP protocol usage and configuration  
+description: HTTP protocol usage and configuration
 order: 100
 ---
 
 # HTTP
 
-The HTTP protocol is widely used to build APIs.  
+The HTTP protocol is widely used to build APIs.
 
-This protocol consumes **less energy** and easily allows **compression** or **caching** of requests.  
+This protocol consumes **less energy** and easily allows **compression** or **caching** of requests.
 
 ::: info
 The use of the HTTP protocol is recommended when the client is in an environment requiring energy saving. (e.g. IoT device, smartphone)
 :::
 
-However it can be **quite slow** because each request usually requires to establish a new connection to the server. Some clients, such as browsers, keep connections open to speed things up, but you shouldn't count on that.  
+However it can be **quite slow** because each request usually requires to establish a new connection to the server. Some clients, such as browsers, keep connections open to speed things up, but you shouldn't count on that.
 
 ::: warning
-The HTTP protocol is not meant to maintain persistent connections. It is therefore not possible to use Kuzzle's [Realtime Engine](/core/2/guides/main-concepts/realtime-engine) 
-::: 
+The HTTP protocol is not meant to maintain persistent connections. It is therefore not possible to use Kuzzle's [Realtime Engine](/core/2/guides/main-concepts/realtime-engine)
+:::
 
 ### Configuration
 
@@ -61,7 +61,7 @@ The listening port can be modified under the `server.port` section of the [confi
   }
 ```
 ::: warning
-HTTP and WebSocket protocols share the same underlying server instance.  
+HTTP and WebSocket protocols share the same underlying server instance.
 Modifying the listening port will impact these two protocols.
 :::
 
@@ -69,6 +69,12 @@ Modifying the listening port will impact these two protocols.
 
 Only the HTTP protocol does support the following options in a [KuzzleRequest](/core/2/api/payloads/request)
 
-| Property     | Type               | Description                                                                           |
-| ------------ | ------------------ | ------------------------------------------------------------------------------------- |
-| `pretty`     | <pre>boolean</pre> | Prettify the JSON response, making it more readable for humans                        |
+| Property | Type               | Description                                                    |
+| -------- | ------------------ | -------------------------------------------------------------- |
+| `pretty` | <pre>boolean</pre> | Prettify the JSON response, making it more readable for humans |
+
+### HTTP headers
+
+| Property              | Type              | Description                                          |
+| --------------------- | ----------------- | ---------------------------------------------------- |
+| `X-Kuzzle-Request-Id` | <pre>string</pre> | Custom request ID. Will be returned in the response. |

--- a/lib/core/network/protocols/httpMessage.js
+++ b/lib/core/network/protocols/httpMessage.js
@@ -33,7 +33,6 @@ class HttpMessage {
     this.connection = connection;
     this._content = null;
     this.ips = connection.ips;
-    this.requestId = connection.id;
     this.query = request.getQuery();
     this.path = request.getUrl();
 
@@ -51,6 +50,8 @@ class HttpMessage {
     this.headers = {};
 
     request.forEach((name, value) => (this.headers[name] = value));
+
+    this.requestId = this.headers['x-kuzzle-request-id'] || connection.id;
   }
 
   set content (value) {

--- a/lib/core/network/protocols/httpwsProtocol.js
+++ b/lib/core/network/protocols/httpwsProtocol.js
@@ -88,6 +88,7 @@ const HTTP_HEADER_TRANSFER_ENCODING = Buffer.from('Transfer-Encoding');
 const CHUNKED = Buffer.from('chunked');
 const WILDCARD = Buffer.from('*');
 const ORIGIN = Buffer.from('Origin');
+const X_REQUEST_ID = Buffer.from('X-Kuzzle-Request-Id');
 const CLOSE = Buffer.from('close');
 const CHARSET_REGEX = /charset=([\w-]+)/i;
 
@@ -634,15 +635,16 @@ class HttpWsProtocol extends Protocol {
   }
 
   /**
-   * 
-   * @param {uWS.HttpRequest} request 
-   * @param {uWS.HttpResponse} response 
-   * @param {HttpMessage} message 
+   *
+   * @param {uWS.HttpRequest} request
+   * @param {uWS.HttpResponse} response
+   * @param {HttpMessage} message
    */
   httpWriteRequestHeaders (request, response, message) {
     response.writeStatus(Buffer.from(request.response.status.toString()));
-    
+
     response.writeHeader(HTTP_HEADER_CONNECTION, CLOSE);
+    response.writeHeader(X_REQUEST_ID, message.requestId);
 
     for (const header of this.httpConfig.headers) {
       // If header is missing, add the default one

--- a/test/core/network/protocols/http.test.js
+++ b/test/core/network/protocols/http.test.js
@@ -192,7 +192,7 @@ describe('core/network/protocols/http', () => {
     it('should set the headers', () => {
       const response = new uWSMock.MockHttpResponse();
       const stream = new PassThrough();
-      
+
       const stub = sinon.stub(httpWs, 'httpWriteRequestHeaders');
       httpWs.httpSendStream(request, response, new HttpStream(stream), message);
 
@@ -203,7 +203,7 @@ describe('core/network/protocols/http', () => {
     it('should end the connection if the stream is closed or errored', () => {
       const response = new uWSMock.MockHttpResponse();
       const stream = new PassThrough();
-      
+
       stream.destroy();
       sinon.stub(httpWs, 'httpSendError');
       httpWs.httpSendStream(request, response, new HttpStream(stream), message);
@@ -219,7 +219,7 @@ describe('core/network/protocols/http', () => {
     it('should add the content-length header if the stream has a fixed size', () => {
       const response = new uWSMock.MockHttpResponse();
       const stream = new PassThrough();
-      
+
       sinon.stub(httpWs, 'httpWriteRequestHeaders');
       httpWs.httpSendStream(request, response, new HttpStream(stream, { totalBytes: 1 }), message);
 
@@ -229,7 +229,7 @@ describe('core/network/protocols/http', () => {
     it('should add the transfer-encoding header if the stream has a dynamic size', () => {
       const response = new uWSMock.MockHttpResponse();
       const stream = new PassThrough();
-      
+
       sinon.stub(httpWs, 'httpWriteRequestHeaders');
       httpWs.httpSendStream(request, response, new HttpStream(stream), message);
 
@@ -239,7 +239,7 @@ describe('core/network/protocols/http', () => {
     it('should write chunk using tryEnd when the stream size is fixed', () => {
       const response = new uWSMock.MockHttpResponse();
       const stream = new PassThrough();
-      
+
       sinon.stub(httpWs, 'httpWriteRequestHeaders');
       httpWs.httpSendStream(request, response, new HttpStream(stream, { totalBytes: 5 }), message);
 
@@ -252,7 +252,7 @@ describe('core/network/protocols/http', () => {
     it('should write chunk using write when the stream size is dynamic', () => {
       const response = new uWSMock.MockHttpResponse();
       const stream = new PassThrough();
-      
+
       sinon.stub(httpWs, 'httpWriteRequestHeaders');
       httpWs.httpSendStream(request, response, new HttpStream(stream), message);
 
@@ -268,13 +268,13 @@ describe('core/network/protocols/http', () => {
 
       response.tryEnd.returns([false, false]);
       sinon.stub(stream, 'pause');
-      
+
       sinon.stub(httpWs, 'httpWriteRequestHeaders');
       httpWs.httpSendStream(request, response, new HttpStream(stream, { totalBytes: 5 }), message);
 
       stream.write('Hello');
       stream.end();
-      
+
       should(stream.pause).be.calledOnce();
     });
 
@@ -284,13 +284,13 @@ describe('core/network/protocols/http', () => {
 
       response.write.returns(false);
       sinon.stub(stream, 'pause');
-      
+
       sinon.stub(httpWs, 'httpWriteRequestHeaders');
       httpWs.httpSendStream(request, response, new HttpStream(stream), message);
 
       stream.write('Hello');
       stream.end();
-      
+
       should(stream.pause).be.calledOnce();
     });
   });
@@ -689,6 +689,35 @@ describe('core/network/protocols/http', () => {
       });
 
       should(entryPoint.removeConnection).calledOnce();
+    });
+
+    it.only('should allow custom X-Kuzzle-Request-Id header', () => {
+      const result = new KuzzleRequest({});
+      result.setResult(
+        'yo',
+        {
+          headers: {
+            'X-Kuzzle-Request-Id': 'my-custom-id-42',
+          }
+        }
+      );
+      kuzzle.router.http.route.yields(result);
+
+      httpWs.server._httpOnMessage('get', '/', '', { origin: 'foobar' });
+      httpWs.server._httpResponse._onData(Buffer.from('{"controller":"foo","action":"bar"}'), true);
+
+      const response = httpWs.server._httpResponse;
+
+      should(response.cork).calledOnce();
+      should(response.cork.calledBefore(response.writeStatus)).be.true();
+
+      should(response.writeStatus).calledOnce().calledWithMatch(Buffer.from('200'));
+
+      should(response.writeHeader)
+        .be.calledWithMatch(
+          Buffer.from('X-Kuzzle-Request-Id'),
+          Buffer.from('my-custom-id-42')
+        );
     });
 
     it('should compress the response with gzip if asked to', async () => {


### PR DESCRIPTION
## What does this PR do ?

Add the `X-Kuzzle-Request-Id` in HTTP response headers.

This header can also be set in the request.

### How should this be manually tested?

```bash
curl -v -H "X-Kuzzle-Request-Id: foobarFOO" "localhost:7512/_n"
```