### PR TITLE
Allows custom KuzzleError with custom HTTP status

### DIFF
--- a/doc/build-error-codes.js
+++ b/doc/build-error-codes.js
@@ -115,7 +115,7 @@ function buildErrorCodes (name) {
 
   let doc = getHeader(`0x${buffer.toString('hex', 3)}: ${name}`);
 
-  for (const [subname, subdomain] of Object.entries(domain.subdomains)) {
+  for (const [subname, subdomain] of Object.entries(domain.subDomains)) {
 
     buffer.writeUInt16BE(domain.code << 8 | subdomain.code, 2);
 

--- a/lib/core/backend/backendErrors.ts
+++ b/lib/core/backend/backendErrors.ts
@@ -28,7 +28,7 @@ export class BackendErrors extends ApplicationManager {
   private domains: ErrorDomains = {
     app: {
       code: 9,
-      subdomains: {},
+      subDomains: {},
     }
   };
 
@@ -55,15 +55,15 @@ export class BackendErrors extends ApplicationManager {
    * ```
    */
   register (subDomain: string, name: string, definition: CustomErrorDefinition) {
-    if (! this.domains.app.subdomains[subDomain]) {
-      this.domains.app.subdomains[subDomain] = {
+    if (! this.domains.app.subDomains[subDomain]) {
+      this.domains.app.subDomains[subDomain] = {
         code: this.subDomains++,
         errors: {},
       };
     }
 
-    this.domains.app.subdomains[subDomain].errors[name] = {
-      code: Object.keys(this.domains.app.subdomains[subDomain].errors).length,
+    this.domains.app.subDomains[subDomain].errors[name] = {
+      code: Object.keys(this.domains.app.subDomains[subDomain].errors).length,
       ...definition,
     };
   }

--- a/lib/kerror/codes/0-core.json
+++ b/lib/kerror/codes/0-core.json
@@ -1,6 +1,6 @@
 {
   "code": 0,
-  "subdomains": {
+  "subDomains": {
     "fatal": {
       "code": 0,
       "errors": {

--- a/lib/kerror/codes/1-services.json
+++ b/lib/kerror/codes/1-services.json
@@ -1,6 +1,6 @@
 {
   "code": 1,
-  "subdomains": {
+  "subDomains": {
     "storage": {
       "code": 1,
       "errors": {

--- a/lib/kerror/codes/2-api.json
+++ b/lib/kerror/codes/2-api.json
@@ -1,6 +1,6 @@
 {
   "code": 2,
-  "subdomains": {
+  "subDomains": {
     "assert": {
       "code": 1,
       "errors": {

--- a/lib/kerror/codes/3-network.json
+++ b/lib/kerror/codes/3-network.json
@@ -1,6 +1,6 @@
 {
   "code": 3,
-  "subdomains": {
+  "subDomains": {
     "http": {
       "code": 1,
       "errors": {

--- a/lib/kerror/codes/4-plugin.json
+++ b/lib/kerror/codes/4-plugin.json
@@ -1,6 +1,6 @@
 {
   "code": 4,
-  "subdomains": {
+  "subDomains": {
     "assert": {
       "code": 1,
       "errors" : {

--- a/lib/kerror/codes/5-validation.json
+++ b/lib/kerror/codes/5-validation.json
@@ -1,6 +1,6 @@
 {
   "code": 5,
-  "subdomains": {
+  "subDomains": {
     "assert": {
       "code": 1,
       "errors": {

--- a/lib/kerror/codes/6-protocol.json
+++ b/lib/kerror/codes/6-protocol.json
@@ -1,6 +1,6 @@
 {
   "code": 6,
-  "subdomains": {
+  "subDomains": {
     "runtime": {
       "code": 1,
       "errors": {

--- a/lib/kerror/codes/7-security.json
+++ b/lib/kerror/codes/7-security.json
@@ -1,6 +1,6 @@
 {
   "code": 7,
-  "subdomains": {
+  "subDomains": {
     "token": {
       "code": 1,
       "errors": {

--- a/lib/kerror/codes/8-cluster.json
+++ b/lib/kerror/codes/8-cluster.json
@@ -1,6 +1,6 @@
 {
   "code": 8,
-  "subdomains": {
+  "subDomains": {
     "fatal": {
       "code": 0,
       "errors": {

--- a/lib/kerror/codes/index.js
+++ b/lib/kerror/codes/index.js
@@ -97,8 +97,8 @@ function checkErrors (subdomain, domain, options) {
 function checkSubdomains (domain, options) {
   const subdomainCodes = new Set();
 
-  for (const subdomainName of Object.keys(domain.subdomains)) {
-    const subdomain = domain.subdomains[subdomainName];
+  for (const subdomainName of Object.keys(domain.subDomains)) {
+    const subdomain = domain.subDomains[subdomainName];
 
     // Subdomain code for plugins is not required and is automatically set to 0
     if (! options.plugin) {
@@ -158,11 +158,11 @@ function checkDomains (errorCodesFiles, options = { plugin: false }) {
     domainCodes.add(domain.code);
 
     assert(
-      has(domain, 'subdomains'),
-      `Error configuration file : Missing required 'subdomains' field. (domain: '${domainName}').`);
+      has(domain, 'subDomains'),
+      `Error configuration file : Missing required 'subDomains' field. (domain: '${domainName}').`);
     assert(
-      isPlainObject(domain.subdomains),
-      `Error configuration file : Field 'subdomains' must be an object. (domain: '${domainName}').`);
+      isPlainObject(domain.subDomains),
+      `Error configuration file : Field 'subDomains' must be an object. (domain: '${domainName}').`);
 
     checkSubdomains(domain, options);
   }
@@ -170,7 +170,7 @@ function checkDomains (errorCodesFiles, options = { plugin: false }) {
 
 function loadPluginsErrors (pluginManifest, pluginCode) {
   // @todo this should be in its own, independant domain
-  domains.plugin.subdomains[pluginManifest.name] = {
+  domains.plugin.subDomains[pluginManifest.name] = {
     code: pluginCode,
     errors: pluginManifest.errors
   };

--- a/lib/kerror/index.ts
+++ b/lib/kerror/index.ts
@@ -48,7 +48,7 @@ function _getCurrentFileName () {
 /**
  * Construct and return the corresponding error
  *
- * @param  domains - Domains object with subdomains and error names
+ * @param  domains - Domains object with subDomains and error names
  * @param  domain - Domain (eg: 'external')
  * @param  subdomain - Subdomain (eg: 'elasticsearch')
  * @param  error - Error name: (eg: 'index_not_found')
@@ -63,7 +63,7 @@ export function rawGet (domains: ErrorDomains, domain: string, subdomain: string
     options = placeholders.pop();
   }
 
-  const kuzzleError = _.get(domains, `${domain}.subdomains.${subdomain}.errors.${error}`) as any as ErrorDefinition;
+  const kuzzleError = _.get(domains, `${domain}.subDomains.${subdomain}.errors.${error}`) as any as ErrorDefinition;
 
   if (! kuzzleError) {
     return get('core', 'fatal', 'unexpected_error', `${domain}.${subdomain}.${error}`);
@@ -78,12 +78,18 @@ export function rawGet (domains: ErrorDomains, domain: string, subdomain: string
   const message = options.message || format(kuzzleError.message, ...placeholders);
   const id = `${domain}.${subdomain}.${error}`;
   const code = domains[domain].code << 24
-    | domains[domain].subdomains[subdomain].code << 16
-    | domains[domain].subdomains[subdomain].errors[error].code;
+    | domains[domain].subDomains[subdomain].code << 16
+    | domains[domain].subDomains[subdomain].errors[error].code;
 
   let kerror;
+  console.log({kuzzleError})
   if (kuzzleError.class === 'PartialError' || kuzzleError.class === 'MultipleErrorsError') {
     kerror = new errors[kuzzleError.class](message, body, id, code);
+  }
+  else if (kuzzleError.class === 'KuzzleError') {
+    console.log(kuzzleError)
+    const status = kuzzleError.status || 500;
+    kerror = new errors.KuzzleError(message, status, id, code);
   }
   else {
     kerror = new errors[kuzzleError.class](message, id as any, code as any);
@@ -136,7 +142,7 @@ function cleanStackTrace (error: KuzzleError): void {
 /**
  * Returns a promise rejected with the corresponding error
  *
- * @param  domains - Domains object with subdomains and error names
+ * @param  domains - Domains object with subDomains and error names
  * @param  domain - Domain (eg: 'external')
  * @param  subdomain - Subdomain (eg: 'elasticsearch')
  * @param  error - Error name: (eg: 'index_not_found')
@@ -150,7 +156,7 @@ export function rawReject (domains: ErrorDomains, domain: string, subdomain: str
  * Construct and return the corresponding error, with its stack
  * trace derivated from a provided source error
  *
- * @param  domains - Domains object with subdomains and error names
+ * @param  domains - Domains object with subDomains and error names
  * @param  source - Original error
  * @param  domain - Domain (eg: 'external')
  * @param  subdomain - Subdomain (eg: 'elasticsearch')

--- a/lib/types/errors/ErrorDefinition.ts
+++ b/lib/types/errors/ErrorDefinition.ts
@@ -27,5 +27,12 @@ export type CustomErrorDefinition = {
   /**
    * Error class
    */
-  class: ErrorClassNames
+  class: ErrorClassNames;
+
+  /**
+   * Custom HTTP status.
+   *
+   * Only available for generic KuzzleError.
+   */
+  status?: number;
 };

--- a/lib/types/errors/ErrorDomains.ts
+++ b/lib/types/errors/ErrorDomains.ts
@@ -1,12 +1,12 @@
 import { ErrorDefinition } from './ErrorDefinition';
 
 /**
- * Represents the domains, subdomains and error names with associated definitions
+ * Represents the domains, subDomains and error names with associated definitions
  */
 export type ErrorDomains = {
   [domain: string]: {
     code: number;
-    subdomains?: {
+    subDomains?: {
       [subDomain: string]: {
         code: number;
         errors: {

--- a/test/core/backend/BackendErrors.test.js
+++ b/test/core/backend/BackendErrors.test.js
@@ -35,7 +35,7 @@ describe('BackendErrors', () => {
         class: 'BadRequestError',
       });
 
-      const apiSubDomain = app.errors.domains.app.subdomains.api;
+      const apiSubDomain = app.errors.domains.app.subDomains.api;
       should(apiSubDomain.code).be.eql(0);
       should(apiSubDomain.errors.wtf).match({
         description: 'WTF',

--- a/test/core/plugin/plugin.test.js
+++ b/test/core/plugin/plugin.test.js
@@ -199,7 +199,7 @@ describe('Plugin', () => {
         .calledOnce()
         .calledWith('[lambda-core] Custom errors successfully loaded.');
 
-      const pluginErrors = errors.domains.plugin.subdomains;
+      const pluginErrors = errors.domains.plugin.subDomains;
 
       should(pluginErrors).have.ownProperty(plugin.manifest.name);
       should(pluginErrors[plugin.manifest.name]).have.ownProperty('errors');

--- a/test/kerror/codes.test.js
+++ b/test/kerror/codes.test.js
@@ -45,7 +45,7 @@ describe('kerror: error codes loader', () => {
     domains = {
       foo: {
         code: 111,
-        subdomains: {
+        subDomains: {
           sub1: {
             code: 234,
             errors: {
@@ -78,7 +78,7 @@ describe('kerror: error codes loader', () => {
       },
       bar: {
         code: 222,
-        subdomains: {
+        subDomains: {
           sub1: {
             code: 234,
             errors: {
@@ -133,34 +133,34 @@ describe('kerror: error codes loader', () => {
       }
     });
 
-    it('should throw if no subdomains are defined', () => {
-      delete domains.foo.subdomains;
-      should(() => checkDomains(domains)).throw(/missing required 'subdomains' field/i);
+    it('should throw if no subDomains are defined', () => {
+      delete domains.foo.subDomains;
+      should(() => checkDomains(domains)).throw(/missing required 'subDomains' field/i);
     });
 
-    it('should throw if the subdomains property is not an object', () => {
-      for (const subdomains of [null, undefined, [], 3.14, 'foo', false, true]) {
-        domains.foo.subdomains = subdomains;
+    it('should throw if the subDomains property is not an object', () => {
+      for (const subDomains of [null, undefined, [], 3.14, 'foo', false, true]) {
+        domains.foo.subDomains = subDomains;
 
         /* eslint-disable-next-line no-loop-func -- false positive */
-        should(() => checkDomains(domains)).throw(/field 'subdomains' must be an object/i);
+        should(() => checkDomains(domains)).throw(/field 'subDomains' must be an object/i);
       }
     });
 
     it('should throw if a non-plugin subdomain is missing a code', () => {
-      delete domains.bar.subdomains.sub1.code;
+      delete domains.bar.subDomains.sub1.code;
       should(() => checkDomains(domains)).throw(/missing required 'code' field/i);
     });
 
-    it('should default plugin subdomains code to 0 if not set', () => {
-      delete domains.bar.subdomains.sub1.code;
+    it('should default plugin subDomains code to 0 if not set', () => {
+      delete domains.bar.subDomains.sub1.code;
       should(() => checkDomains(domains, { plugin: true })).not.throw();
-      should(domains.bar.subdomains.sub1.code).eql(0);
+      should(domains.bar.subDomains.sub1.code).eql(0);
     });
 
     it('should throw if a subdomain code is not an integer', () => {
       for (const code of [null, undefined, [], {}, 3.14, 'foo', false, true]) {
-        domains.foo.subdomains.sub2.code = code;
+        domains.foo.subDomains.sub2.code = code;
 
         /* eslint-disable-next-line no-loop-func -- false positive */
         should(() => checkDomains(domains)).throw(/field 'code' must be an integer/i);
@@ -168,35 +168,35 @@ describe('kerror: error codes loader', () => {
     });
 
     it('should throw if a subdomain code is already used', () => {
-      domains.foo.subdomains.sub1.code = 0;
-      domains.foo.subdomains.sub2.code = 0;
+      domains.foo.subDomains.sub1.code = 0;
+      domains.foo.subDomains.sub2.code = 0;
       should(() => checkDomains(domains)).throw(/code .* is not unique/i);
     });
 
     it('should not throw if a plugin subdomain contains multiple defaulted codes', () => {
-      delete domains.foo.subdomains.sub1;
-      delete domains.foo.subdomains.sub2;
+      delete domains.foo.subDomains.sub1;
+      delete domains.foo.subDomains.sub2;
       should(() => checkDomains(domains, { plugin: true })).not.throw();
     });
 
     it('should throw if a plugin subdomain contain duplicates, non-default, codes', () => {
-      domains.foo.subdomains.sub1.code = 42;
-      domains.foo.subdomains.sub2.code = 42;
+      domains.foo.subDomains.sub1.code = 42;
+      domains.foo.subDomains.sub2.code = 42;
       should(() => checkDomains(domains, { plugin: true })).throw(/code .* is not unique/i);
     });
 
     it('should throw if a subdomain code exceeds the allowed range', () => {
       for (const code of [-1, 256]) {
-        domains.foo.subdomains.sub2.code = code;
+        domains.foo.subDomains.sub2.code = code;
         /* eslint-disable-next-line no-loop-func -- false positive */
         should(() => checkDomains(domains)).throw(/field 'code' must be between 0 and 255/i);
       }
 
       // prevent subdomain code conflict
-      delete domains.foo.subdomains.sub2;
+      delete domains.foo.subDomains.sub2;
 
       for (let code = 0; code <= 0xff; code++) {
-        domains.foo.subdomains.sub1.code = code;
+        domains.foo.subDomains.sub1.code = code;
 
         /* eslint-disable-next-line no-loop-func -- false positive */
         should(() => checkDomains(domains)).not.throw();
@@ -204,13 +204,13 @@ describe('kerror: error codes loader', () => {
     });
 
     it('should throw if a subdomain is missing an errors object', () => {
-      delete domains.foo.subdomains.sub2.errors;
+      delete domains.foo.subDomains.sub2.errors;
       should(() => checkDomains(domains)).throw(/missing required 'errors' field/i);
     });
 
     it('should throw if a subdomain has a non-object errors property', () => {
       for (const errors of [null, undefined, [], 3.14, 'foo', false, true]) {
-        domains.foo.subdomains.sub2.errors = errors;
+        domains.foo.subDomains.sub2.errors = errors;
 
         /* eslint-disable-next-line no-loop-func -- false positive */
         should(() => checkDomains(domains)).throw(/field 'errors' must be an object/i);
@@ -218,13 +218,13 @@ describe('kerror: error codes loader', () => {
     });
 
     it('should throw if an error is missing a code', () => {
-      delete domains.foo.subdomains.sub1.errors.err1.code;
+      delete domains.foo.subDomains.sub1.errors.err1.code;
       should(() => checkDomains(domains)).throw(/missing required 'code' field/i);
     });
 
     it('should throw if an error code is not an integer', () => {
       for (const code of [null, undefined, [], {}, 3.14, 'foo', false, true]) {
-        domains.foo.subdomains.sub2.errors.err1.code = code;
+        domains.foo.subDomains.sub2.errors.err1.code = code;
 
         /* eslint-disable-next-line no-loop-func -- false positive */
         should(() => checkDomains(domains)).throw(/field 'code' must be an integer/i);
@@ -233,14 +233,14 @@ describe('kerror: error codes loader', () => {
 
     it('should throw if an error code is outside its allowing range', () => {
       for (const code of [-1, 0, 65536]) {
-        domains.foo.subdomains.sub2.errors.err1.code = code;
+        domains.foo.subDomains.sub2.errors.err1.code = code;
 
         /* eslint-disable-next-line no-loop-func -- false positive */
         should(() => checkDomains(domains)).throw(/field 'code' must be between 1 and 65535/i);
       }
 
       for (let code = 1; code <= 0xffff; code++) {
-        domains.foo.subdomains.sub2.errors.err1.code = code;
+        domains.foo.subDomains.sub2.errors.err1.code = code;
 
         /* eslint-disable-next-line no-loop-func -- false positive */
         should(() => checkDomains(domains)).not.throw();
@@ -248,14 +248,14 @@ describe('kerror: error codes loader', () => {
     });
 
     it('should throw if an error is missing a message', () => {
-      delete domains.foo.subdomains.sub1.errors.err1.message;
+      delete domains.foo.subDomains.sub1.errors.err1.message;
 
       should(() => checkDomains(domains)).throw(/missing required 'message' field/i);
     });
 
     it('should throw if an error message is not a non-empty string', () => {
       for (const message of [null, undefined, [], {}, 3.14, false, true, '']) {
-        domains.foo.subdomains.sub2.errors.err1.message = message;
+        domains.foo.subDomains.sub2.errors.err1.message = message;
 
         /* eslint-disable-next-line no-loop-func -- false positive */
         should(() => checkDomains(domains)).throw(/field 'message' must be a non-empty string/i);
@@ -263,14 +263,14 @@ describe('kerror: error codes loader', () => {
     });
 
     it('should throw if an error is missing an error class', () => {
-      delete domains.foo.subdomains.sub1.errors.err1.class;
+      delete domains.foo.subDomains.sub1.errors.err1.class;
 
       should(() => checkDomains(domains)).throw(/missing required 'class' field/i);
     });
 
     it('should throw if an error class is not a string', () => {
       for (const className of [null, undefined, [], {}, 3.14, false, true]) {
-        domains.foo.subdomains.sub2.errors.err1.class = className;
+        domains.foo.subDomains.sub2.errors.err1.class = className;
 
         /* eslint-disable-next-line no-loop-func -- false positive */
         should(() => checkDomains(domains)).throw(/field 'class' must be a string/i);
@@ -278,12 +278,12 @@ describe('kerror: error codes loader', () => {
     });
 
     it('should throw if an error class name does not match a known KuzzleError class', () => {
-      domains.foo.subdomains.sub2.errors.err1.class = 'foo';
+      domains.foo.subDomains.sub2.errors.err1.class = 'foo';
 
       should(() => checkDomains(domains)).throw(/field 'class' must target a known KuzzleError object/i);
 
       for (const name of Object.keys(kuzzleObjectErrors)) {
-        domains.foo.subdomains.sub2.errors.err1.class = name;
+        domains.foo.subDomains.sub2.errors.err1.class = name;
 
         /* eslint-disable-next-line no-loop-func -- false positive */
         should(() => checkDomains(domains)).not.throw();
@@ -291,12 +291,12 @@ describe('kerror: error codes loader', () => {
     });
 
     it('should throw if a native error does not contain a description', () => {
-      delete domains.foo.subdomains.sub2.errors.err1.description;
+      delete domains.foo.subDomains.sub2.errors.err1.description;
 
       should(() => checkDomains(domains)).throw(/field 'description' must be a non-empty string/i);
 
       for (const description of [null, undefined, [], {}, 3.14, false, true, '']) {
-        domains.foo.subdomains.sub2.errors.err1.description = description;
+        domains.foo.subDomains.sub2.errors.err1.description = description;
 
         /* eslint-disable-next-line no-loop-func -- false positive */
         should(() => checkDomains(domains)).throw(/field 'description' must be a non-empty string/i);
@@ -304,14 +304,14 @@ describe('kerror: error codes loader', () => {
     });
 
     it('should not throw if a plugin error does not contain a description', () => {
-      delete domains.foo.subdomains.sub2.errors.err1.description;
+      delete domains.foo.subDomains.sub2.errors.err1.description;
 
       should(() => checkDomains(domains, { plugin: true })).not.throw();
     });
 
     it('should throw if a deprecated field is present and not a non-empty string', () => {
       for (const deprecated of [[], {}, 3.14, false, true, '']) {
-        domains.foo.subdomains.sub2.errors.err1.deprecated = deprecated;
+        domains.foo.subDomains.sub2.errors.err1.deprecated = deprecated;
 
         /* eslint-disable-next-line no-loop-func -- false positive */
         should(() => checkDomains(domains)).throw(/field 'deprecated' must be a non-empty string/i);

--- a/test/kerror/kerror.test.js
+++ b/test/kerror/kerror.test.js
@@ -9,10 +9,37 @@ const {
   NotFoundError,
   PreconditionError,
   PartialError,
-  UnauthorizedError
+  UnauthorizedError,
+  KuzzleError,
 } = require('../../index');
 
 describe('#kerror', () => {
+  it('should allows custom KuzzleError', () => {
+    const domains = {
+      custom: {
+        code: 1,
+        subDomains: {
+          httpStatus: {
+            code: 1,
+            errors: {
+              conflict: {
+                status: 409,
+                message: '9 more for the teapot',
+                code: 1,
+                class: 'KuzzleError',
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const err = kerror.rawGet(domains, 'custom', 'httpStatus', 'conflict');
+
+    should(err).be.instanceOf(KuzzleError);
+    should(err.status).be.eql(409);
+  });
+
   it('should return an ExternalServiceError with right name, msg and code', () => {
     const err = kerror.get('core', 'fatal', 'service_unavailable', '{"status":"red"}');
     should(err).be.instanceOf(ExternalServiceError);


### PR DESCRIPTION
## What does this PR do ?

Allows custom KuzzleError with custom HTTP status

```js
app.errors.register('api', 'custom', {
  class: 'KuzzleError',
  description: 'This is a custom error from API subdomain',
  message: 'Custom %s error',
  status: 409
});
```
