### PR TITLE
Allows to specify custom error domain

### DIFF
--- a/doc/2/framework/classes/backend-errors/get-from/index.md
+++ b/doc/2/framework/classes/backend-errors/get-from/index.md
@@ -14,13 +14,14 @@ Get a standardized KuzzleError from an existing error to keep the stacktrace
 ## Arguments
 
 ```js
-getFrom (source: Error, subDomain: string, name: string, placeholders: any[]): KuzzleError
+getFrom (source: Error, domain: string, subDomain: string, name: string, placeholders: any[]): KuzzleError
 ```
 
-| Argument | Type | Description |
-|----------|------|-------------|
-| `source` | <pre>Error</pre> | Original error |
-| `subDomain` | <pre>string</pre> | Subdomain name |
-| `name` | <pre>string</pre> | Standard error name |
-| `placeholders` | <pre>any[]</pre> | Other placeholder arguments |
+| Argument       | Type              | Description                 |
+| -------------- | ----------------- | --------------------------- |
+| `source`       | <pre>Error</pre>  | Original error              |
+| `domain`       | <pre>string</pre> | Domain name                 |
+| `subDomain`    | <pre>string</pre> | Subdomain name              |
+| `name`         | <pre>string</pre> | Standard error name         |
+| `placeholders` | <pre>any[]</pre>  | Other placeholder arguments |
 

--- a/doc/2/framework/classes/backend-errors/get/index.md
+++ b/doc/2/framework/classes/backend-errors/get/index.md
@@ -14,12 +14,13 @@ Get a standardized KuzzleError
 ## Arguments
 
 ```js
-get (subDomain: string, name: string, placeholders: any[]): KuzzleError
+get (domain: string, subDomain: string, name: string, placeholders: any[]): KuzzleError
 ```
 
-| Argument | Type | Description |
-|----------|------|-------------|
-| `subDomain` | <pre>string</pre> | Subdomain name |
-| `name` | <pre>string</pre> | Standard error name |
-| `placeholders` | <pre>any[]</pre> | Other placeholder arguments |
+| Argument       | Type              | Description                 |
+| -------------- | ----------------- | --------------------------- |
+| `domain`       | <pre>string</pre> | Domain name                 |
+| `subDomain`    | <pre>string</pre> | Subdomain name              |
+| `name`         | <pre>string</pre> | Standard error name         |
+| `placeholders` | <pre>any[]</pre>  | Other placeholder arguments |
 

--- a/doc/2/framework/classes/backend-errors/register/index.md
+++ b/doc/2/framework/classes/backend-errors/register/index.md
@@ -14,20 +14,21 @@ Register a new standard KuzzleError
 ## Arguments
 
 ```js
-register (subDomain: string, name: string, definition: CustomErrorDefinition): void
+register (domain: string, subDomain: string, name: string, definition: CustomErrorDefinition): void
 ```
 
-| Argument | Type | Description |
-|----------|------|-------------|
-| `subDomain` | <pre>string</pre> | Subdomain name |
-| `name` | <pre>string</pre> | Standard error name |
+| Argument     | Type                             | Description               |
+| ------------ | -------------------------------- | ------------------------- |
+| `domain`     | <pre>string</pre>                | Domain name               |
+| `subDomain`  | <pre>string</pre>                | Subdomain name            |
+| `name`       | <pre>string</pre>                | Standard error name       |
 | `definition` | <pre>CustomErrorDefinition</pre> | Standard error definition |
 
 
 ### Example
 
 ```js
-app.errors.register('api', 'custom', {
+app.errors.register('app', 'api', 'custom', {
   class: 'BadRequestError',
   description: 'This is a custom error from API subdomain',
   message: 'Custom %s error',

--- a/doc/2/guides/develop-on-kuzzle/customize-api-errors/index.md
+++ b/doc/2/guides/develop-on-kuzzle/customize-api-errors/index.md
@@ -61,7 +61,7 @@ Each standard error also have a standard [Error Code](/core/2/api/errors/error-c
 You can register custom standard errors:
 
 ```js
-app.errors.register('api', 'custom', {
+app.errors.register('app', 'api', 'custom', {
   class: 'BadRequestError',
   description: 'This is a custom error from API subdomain',
   message: 'Custom %s error',
@@ -71,5 +71,5 @@ app.errors.register('api', 'custom', {
 And then retrieve them to throw standard errors:
 
 ```js
-throw app.errors.get('api', 'custom', 'Something bad happen');
+throw app.errors.get('app', 'api', 'custom', 'Something bad happen');
 ```

--- a/docker/scripts/start-kuzzle-dev.ts
+++ b/docker/scripts/start-kuzzle-dev.ts
@@ -157,7 +157,7 @@ app.controller.register('openapi-test', {
   }
 });
 
-app.errors.register('api', 'custom', {
+app.errors.register('app', 'api', 'custom', {
   class: 'BadRequestError',
   description: 'This is a custom error from API subdomain',
   message: 'Custom %s error',
@@ -167,7 +167,7 @@ app.controller.register('tests', {
   actions: {
     customError: {
       handler: async () => {
-        throw app.errors.get('api', 'custom', 'Tbilisi');
+        throw app.errors.get('app', 'api', 'custom', 'Tbilisi');
       }
     },
 

--- a/lib/core/backend/backendErrors.ts
+++ b/lib/core/backend/backendErrors.ts
@@ -25,14 +25,7 @@ import { ApplicationManager, Backend } from './index';
 import { CustomErrorDefinition, ErrorDomains } from '../../types';
 
 export class BackendErrors extends ApplicationManager {
-  private domains: ErrorDomains = {
-    app: {
-      code: 9,
-      subDomains: {},
-    }
-  };
-
-  private subDomains = 0;
+  private domains: ErrorDomains = {};
 
   constructor (application: Backend) {
     super(application);
@@ -41,29 +34,37 @@ export class BackendErrors extends ApplicationManager {
   /**
    * Register a new standard KuzzleError
    *
+   * @param domain Domain name
    * @param subDomain Subdomain name
    * @param name Standard error name
    * @param definition Standard error definition
    *
    * @example
    * ```
-   * app.errors.register('api', 'custom', {
+   * app.errors.register('app', 'api', 'custom', {
    *   class: 'BadRequestError',
    *   description: 'This is a custom error from API subdomain',
    *   message: 'Custom API error: %s',
    * });
    * ```
    */
-  register (subDomain: string, name: string, definition: CustomErrorDefinition) {
-    if (! this.domains.app.subDomains[subDomain]) {
-      this.domains.app.subDomains[subDomain] = {
-        code: this.subDomains++,
+  register (domain: string, subDomain: string, name: string, definition: CustomErrorDefinition) {
+    if (! this.domains[domain]) {
+      this.domains[domain] = {
+        code: Object.keys(this.domains).length - 1,
+        subDomains: {},
+      };
+    }
+
+    if (! this.domains[domain].subDomains[subDomain]) {
+      this.domains[domain].subDomains[subDomain] = {
+        code: Object.keys(this.domains[domain].subDomains).length - 1,
         errors: {},
       };
     }
 
-    this.domains.app.subDomains[subDomain].errors[name] = {
-      code: Object.keys(this.domains.app.subDomains[subDomain].errors).length,
+    this.domains[domain].subDomains[subDomain].errors[name] = {
+      code: Object.keys(this.domains[domain].subDomains[subDomain].errors).length,
       ...definition,
     };
   }
@@ -71,38 +72,41 @@ export class BackendErrors extends ApplicationManager {
   /**
    * Get a standardized KuzzleError
    *
+   * @param domain Domain name
    * @param subDomain Subdomain name
    * @param name Standard error name
    * @param placeholders Other placeholder arguments
    *
-   * @example throw app.errors.get('api', 'custom', 'Tbilisi');
+   * @example throw app.errors.get('app', 'api', 'custom', 'Tbilisi');
    *
    * @returns Standardized KuzzleError
    */
-  get (subDomain: string, name: string, ...placeholders): KuzzleError {
-    return kerror.rawGet(this.domains, 'app', subDomain, name, ...placeholders);
+  get (domain: string, subDomain: string, name: string, ...placeholders): KuzzleError {
+    return kerror.rawGet(this.domains, domain, subDomain, name, ...placeholders);
   }
 
   /**
    * Get a standardized KuzzleError from an existing error to keep the stacktrace
    *
    * @param source Original error
+   * @param domain Domain name
    * @param subDomain Subdomain name
    * @param name Standard error name
    * @param placeholders Other placeholder arguments
    *
    * @returns Standardized KuzzleError
    */
-  getFrom (source: Error, subDomain: string, name: string, ...placeholders): KuzzleError {
-    return kerror.rawGetFrom(this.domains, source, 'app', subDomain, name, ...placeholders);
+  getFrom (source: Error, domain: string, subDomain: string, name: string, ...placeholders): KuzzleError {
+    return kerror.rawGetFrom(this.domains, source, domain, subDomain, name, ...placeholders);
   }
 
   /**
-   * Wrap an error manager on the subDomain
+   * Wrap an error manager on the domain and subDomain
    *
+   * @param domain Domain name
    * @param subDomain Subdomain to wrap to
    */
-  wrap (subDomain: string) {
-    return kerror.rawWrap(this.domains, 'app', subDomain);
+  wrap (domain: string, subDomain: string) {
+    return kerror.rawWrap(this.domains, domain, subDomain);
   }
 }

--- a/lib/core/backend/backendErrors.ts
+++ b/lib/core/backend/backendErrors.ts
@@ -51,14 +51,14 @@ export class BackendErrors extends ApplicationManager {
   register (domain: string, subDomain: string, name: string, definition: CustomErrorDefinition) {
     if (! this.domains[domain]) {
       this.domains[domain] = {
-        code: Object.keys(this.domains).length - 1,
+        code: Object.keys(this.domains).length,
         subDomains: {},
       };
     }
 
     if (! this.domains[domain].subDomains[subDomain]) {
       this.domains[domain].subDomains[subDomain] = {
-        code: Object.keys(this.domains[domain].subDomains).length - 1,
+        code: Object.keys(this.domains[domain].subDomains).length,
         errors: {},
       };
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "bin": {
     "kuzzle": "bin/start-kuzzle-server"

--- a/test/core/backend/BackendErrors.test.js
+++ b/test/core/backend/BackendErrors.test.js
@@ -24,17 +24,18 @@ describe('BackendErrors', () => {
 
   describe('BackendErrors#register', () => {
     it('should allows to register a standard error', () => {
-      app.errors.register('api', 'wtf', {
+      app.errors.register('app', 'api', 'wtf', {
         description: 'WTF',
         message: 'WTF bruh',
         class: 'BadRequestError',
       });
-      app.errors.register('api', 'stfu', {
+      app.errors.register('app', 'api', 'stfu', {
         description: 'STFU',
         message: 'STFU bro',
         class: 'BadRequestError',
       });
 
+      should(app.errors.domains.app.code).be.eql(0);
       const apiSubDomain = app.errors.domains.app.subDomains.api;
       should(apiSubDomain.code).be.eql(0);
       should(apiSubDomain.errors.wtf).match({
@@ -49,17 +50,17 @@ describe('BackendErrors', () => {
 
   describe('BackendErrors#get', () => {
     it('should get a standard error', () => {
-      app.errors.register('api', 'wtf', {
+      app.errors.register('iot', 'api', 'wtf', {
         description: 'WTF',
         message: 'WTF bruh %s',
         class: 'BadRequestError',
       });
 
-      const error = app.errors.get('api', 'wtf', 'custom');
+      const error = app.errors.get('iot', 'api', 'wtf', 'custom');
 
       should(error).match({
         message: 'WTF bruh custom',
-        id: 'app.api.wtf'
+        id: 'iot.api.wtf'
       });
       should(error).be.instanceOf(BadRequestError);
     });


### PR DESCRIPTION
## What does this PR do ?

Allows to specify custom error domains instead of using a single `app` domain.

This will allows plugins to register errors on their own domain for example.

:warning: This is a breaking change but since the feature was released last week I doubt people are already using it besides us.

```js
app.errors.register('app', 'api', 'custom', {
  class: 'BadRequestError',
  description: 'This is a custom error from API subdomain',
  message: 'Custom %s error',
});

app.errors.register('iot', 'api', 'custom', {
  class: 'BadRequestError',
  description: 'This is a custom error from API subdomain',
  message: 'Custom %s error',
});

app.errors.register('plugin-auth', 'api', 'custom', {
  class: 'BadRequestError',
  description: 'This is a custom error from API subdomain',
  message: 'Custom %s error',
});

```