### PR TITLE
Expose errors placeholders 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 <p align="center">
   <img src="https://user-images.githubusercontent.com/7868838/103797784-32337580-5049-11eb-8917-3fcf4487644c.png"/>
-
 </p>
 <p align="center">
   <img alt="GitHub branch checks state" src="https://img.shields.io/github/checks-status/kuzzleio/kuzzle/master">

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <p align="center">
   <img src="https://user-images.githubusercontent.com/7868838/103797784-32337580-5049-11eb-8917-3fcf4487644c.png"/>
+
 </p>
 <p align="center">
   <img alt="GitHub branch checks state" src="https://img.shields.io/github/checks-status/kuzzleio/kuzzle/master">

--- a/doc/2/api/payloads/error/index.md
+++ b/doc/2/api/payloads/error/index.md
@@ -2,7 +2,7 @@
 code: false
 type: page
 title: Error
-description: Error payload reference  
+description: Error payload reference
 order: 400
 ---
 
@@ -10,13 +10,14 @@ order: 400
 
 Errors returned by the Kuzzle API in the `error` part of a response are objects with the following properties:
 
-| Property  | Type              | Description                                            |
-|-----------|-------------------|--------------------------------------------------------|
-| `status`  | <pre>number</pre> | HTTP status code                                       |
-| `message` | <pre>string</pre> | Short description of the error                         |
-| `stack`   | <pre>string</pre> | Error stack trace (Available in development mode only) |
-| `id`      | <pre>string</pre> | Error unique identifier                                |
-| `code`    | <pre>number</pre> | Error unique code                                      |
+| Property  | Type                | Description                                                                                    |
+| --------- | ------------------- | ---------------------------------------------------------------------------------------------- |
+| `status`  | <pre>number</pre>   | HTTP status code                                                                               |
+| `message` | <pre>string</pre>   | Short description of the error                                                                 |
+| `stack`   | <pre>string</pre>   | Error stack trace (Available in development mode only)                                         |
+| `id`      | <pre>string</pre>   | Error unique identifier                                                                        |
+| `code`    | <pre>number</pre>   | Error unique code                                                                              |
+| `props`   | <pre>string[]</pre> | Array of placeholders used to construct the error message. Can be used to construct new errors. |
 
 
 ### id

--- a/lib/kerror/errors/kuzzleError.ts
+++ b/lib/kerror/errors/kuzzleError.ts
@@ -44,14 +44,21 @@ export class KuzzleError extends Error {
    */
   public id: string;
 
+  /**
+   * Placeholders used to construct the error message.
+   */
+  public props: string[];
+
   constructor (message: string, status: number, id?: string, code?: number) {
     super(message);
 
     this.status = status;
     this.code = code;
     this.id = id;
+    this.props = undefined;
+    this.stack = undefined;
 
-    if (util.isError(message)) {
+    if (util.types.isNativeError(message)) {
       this.message = message.message;
       this.stack = message.stack;
     }
@@ -73,6 +80,7 @@ export class KuzzleError extends Error {
       code: this.code,
       id: this.id,
       message: this.message,
+      props: this.props,
       stack: this.stack,
       status: this.status,
     };

--- a/lib/kerror/index.ts
+++ b/lib/kerror/index.ts
@@ -93,6 +93,8 @@ export function rawGet (domains: ErrorDomains, domain: string, subdomain: string
     kerror = new errors[kuzzleError.class](message, id as any, code as any);
   }
 
+  kerror.props = placeholders;
+
   if (kuzzleError.class !== 'InternalError') {
     cleanStackTrace(kerror);
   }

--- a/test/kerror/kerror.test.js
+++ b/test/kerror/kerror.test.js
@@ -38,6 +38,7 @@ describe('#kerror', () => {
 
     should(err).be.instanceOf(KuzzleError);
     should(err.status).be.eql(409);
+    should(err.props).be.eql(['conflict']);
   });
 
   it('should return an ExternalServiceError with right name, msg and code', () => {

--- a/test/kerror/kerror.test.js
+++ b/test/kerror/kerror.test.js
@@ -24,7 +24,7 @@ describe('#kerror', () => {
             errors: {
               conflict: {
                 status: 409,
-                message: '9 more for the teapot',
+                message: 'add 9 for the teapot %s',
                 code: 1,
                 class: 'KuzzleError',
               }
@@ -34,11 +34,11 @@ describe('#kerror', () => {
       }
     };
 
-    const err = kerror.rawGet(domains, 'custom', 'httpStatus', 'conflict');
+    const err = kerror.rawGet(domains, 'custom', 'httpStatus', 'conflict', 'placeHolder-1');
 
     should(err).be.instanceOf(KuzzleError);
     should(err.status).be.eql(409);
-    should(err.props).be.eql(['conflict']);
+    should(err.props).be.eql(['placeHolder-1']);
   });
 
   it('should return an ExternalServiceError with right name, msg and code', () => {


### PR DESCRIPTION
## What does this PR do ?

When developing with Kuzzle, the application layer using the framework may want to expose it's own errors rather than generic Kuzzle errors.

We can identify uniquely every error with the `id` property but to create a meaningful application error we may need additional information to generate a new meaningful error message.

For example, the `strict_mappings_rejection` error indicate which property is not included in a collection mappings. 

```js
app.errors.register('app', 'resources', 'unknown_property', {
  class: 'BadRequestError',
  description: 'Error description',
  message: 'Unknown property "%s"',
})

if (error.id === 'services.storage.strict_mappings_rejection') {
  throw app.errors.get('app', 'resources', 'unknown_property', /* here we need the incorrect property name */);
}
```

This PR exposes placeholders used by Kuzzle Error Manager to create error messages inside the error payload returned by the API in the `props` property:

```js
app.errors.register('app', 'resources', 'unknown_property', {
  class: 'BadRequestError',
  description: 'Error description',
  message: 'Unknown property "%s"',
})

if (error.id === 'services.storage.strict_mappings_rejection') {
  throw app.errors.get('app', 'resources', 'unknown_property', error.props[0);
}

```
