### PR TITLE
Allows refresh param to admin:loadFixtures

### DIFF
--- a/lib/api/controllers/adminController.js
+++ b/lib/api/controllers/adminController.js
@@ -154,10 +154,11 @@ class AdminController extends NativeController {
 
   loadFixtures (request) {
     const fixtures = request.getBody();
+    const refresh = request.getRefresh('wait_for');
 
     return this._waitForAction(
-      request.getRefresh('wait_for'),
-      global.kuzzle.ask('core:storage:public:document:import', fixtures));
+      refresh,
+      global.kuzzle.ask('core:storage:public:document:import', fixtures, { refresh }));
   }
 
   loadMappings (request) {

--- a/lib/core/storage/clientAdapter.js
+++ b/lib/core/storage/clientAdapter.js
@@ -499,7 +499,7 @@ class ClientAdapter {
      */
     global.kuzzle.onAsk(
       `core:storage:${this.scope}:document:import`,
-      fixtures => this.loadFixtures(fixtures));
+      (fixtures, options) => this.loadFixtures(fixtures, options));
 
     /**
      * Create multiple documents
@@ -690,7 +690,7 @@ class ClientAdapter {
             this.cache.assertCollectionExists(target.index, collection);
           }
         }
-        
+
         return this.client.search({ searchBody, targets }, opts);
       });
 
@@ -861,7 +861,7 @@ class ClientAdapter {
    * @param {String} fixturesId
    * @returns {Promise}
    */
-  async loadFixtures (fixtures = {}) {
+  async loadFixtures (fixtures = {}, { refresh = 'wait_for' } = { }) {
     if (! isPlainObject(fixtures)) {
       throw kerror.get('api', 'assert', 'invalid_argument', fixtures, 'object');
     }
@@ -878,7 +878,7 @@ class ClientAdapter {
           index,
           collection,
           payload,
-          { refresh: 'wait_for' });
+          { refresh });
 
         if (errors.length > 0) {
           throw servicesError.get('import_failed', errors);

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -361,7 +361,7 @@ class ElasticSearch extends Service {
       for (const target of targets) {
         for (const targetCollection of target.collections) {
           const alias = this._getAlias(target.index, targetCollection);
-          
+
           indexes.add(alias);
         }
       }
@@ -415,10 +415,10 @@ class ElasticSearch extends Service {
   }
 
   async _formatSearchResult (body) {
-    
+
     const formatHit = async (hit) => {
       let alias = null;
-      
+
       if (hit._index) {
         alias = await this._getAliasFromIndice(hit._index);
       }
@@ -1566,7 +1566,8 @@ class ElasticSearch extends Service {
     index,
     collection,
     documents,
-    { refresh, timeout, userId = null } = {}) {
+    { refresh, timeout, userId = null } = {},
+  ) {
     const alias = this._getAlias(index, collection);
     const actionNames = ['index', 'create', 'update', 'delete'];
     const dateNow = Date.now();

--- a/test/api/controllers/adminController.test.js
+++ b/test/api/controllers/adminController.test.js
@@ -248,6 +248,7 @@ describe('AdminController', () => {
     beforeEach(() => {
       request.input.action = 'loadFixtures';
       request.input.body = { city: { seventeen: [] } };
+      request.input.args.refresh = 'false';
     });
 
     it('should call loadFixtures from the public storage engine', async () => {
@@ -255,7 +256,7 @@ describe('AdminController', () => {
 
       should(kuzzle.ask).be.calledWith(
         'core:storage:public:document:import',
-        request.input.body);
+        request.input.body, { refresh: 'false' });
     });
 
     it('should handle promise rejections when not waiting for a refresh', async () => {


### PR DESCRIPTION
## What does this PR do ?

Support the `refresh` param when loading fixtures through the admin controller.

This is useful when loading fixtures between each test because we don't want to wait up to 1 sec for the next indexation by Lucène and slowing down all the test suite.