### PR TITLE
HTTP POST on /_query with empty json body returns HTTP 102 code causing HTTP Parsers to fail to parse response

### DIFF
--- a/.ci/test-cluster.yml
+++ b/.ci/test-cluster.yml
@@ -78,7 +78,7 @@ services:
     container_name: kuzzle_redis
 
   elasticsearch:
-    image: kuzzleio/elasticsearch:7.16.2
+    image: kuzzleio/elasticsearch:7
     container_name: kuzzle_elasticsearch
     ulimits:
       nofile: 65536

--- a/features/Api.feature
+++ b/features/Api.feature
@@ -28,7 +28,7 @@ Feature: API
   Scenario: Send /_query Request with an empty JSON
     Given an existing collection "nyc-open-data":"yellow-taxi"
     And I'm logged in Kuzzle as user "test-admin" with password "password"
-    When I send a HTTP "post" request with:
+    When I send a bad HTTP "post" request with:
       | body | {} |
     Then I should receive an error matching:
       | id     | "api.assert.missing_argument" |

--- a/features/Api.feature
+++ b/features/Api.feature
@@ -22,3 +22,13 @@ Feature: API
     Then I should receive an error matching:
       | id      | "app.api.custom"       |
       | message | "Custom Tbilisi error" |
+  
+  @mappings
+  @http
+  Scenario: Send /_query Request with an empty JSON
+    Given an existing collection "nyc-open-data":"yellow-taxi"
+    And I'm logged in Kuzzle as user "test-admin" with password "password"
+    When I send a HTTP "post" request with:
+      | body | {} |
+    Then I should receive an error matching:
+      | id     | "api.assert.missing_argument" |

--- a/features/step_definitions/controllers-steps.js
+++ b/features/step_definitions/controllers-steps.js
@@ -197,7 +197,7 @@ Then('The raw response should match:', function (dataTable) {
   should(this.props.rawResponse).matchObject(expectedResult);
 });
 
-Then('I send a HTTP {string} request with:', async function (method, dataTable) {
+Then(/I send a (bad )?HTTP "(.*?)" request with:$/, async function (expectError, method, dataTable) {
   const body = this.parseObject(dataTable);
 
   const options = {
@@ -207,7 +207,7 @@ Then('I send a HTTP {string} request with:', async function (method, dataTable) 
     method,
     body: {
       jwt: this.sdk.jwt,
-      ...body
+      ...body,
     },
     headers: body.headers,
   };
@@ -222,7 +222,12 @@ Then('I send a HTTP {string} request with:', async function (method, dataTable) 
     this.props.rawResponse = response;
   }
   catch (err) {
-    this.props.error = err.error.error;
+    if (expectError) {
+      this.props.error = err.error.error;
+    }
+    else {
+      throw err;
+    }
   }
 });
 

--- a/features/step_definitions/controllers-steps.js
+++ b/features/step_definitions/controllers-steps.js
@@ -207,18 +207,23 @@ Then('I send a HTTP {string} request with:', async function (method, dataTable) 
     method,
     body: {
       jwt: this.sdk.jwt,
-      ...body,
+      ...body
     },
     headers: body.headers,
   };
 
-  delete body.headers;
+  body.headers = undefined;
 
-  const response = await requestPromise(options);
+  try {
+    const response = await requestPromise(options);
 
-  this.props.result = response.body.result;
-  this.props.response = response.body;
-  this.props.rawResponse = response;
+    this.props.result = response.body.result;
+    this.props.response = response.body;
+    this.props.rawResponse = response;
+  }
+  catch (err) {
+    this.props.error = err.error.error;
+  }
 });
 
 Then('I wait {int} milliseconds', async function (ms) {

--- a/lib/core/network/router.js
+++ b/lib/core/network/router.js
@@ -194,11 +194,8 @@ class Router {
           const _res = result || request;
 
           if (err && ! _res.error) {
-            console.log('[Router] ERRRO R:', err);
             _res.setError(err);
           }
-
-          console.log('[Router] I send the follwing response', _res.response.toJSON());
 
           cb(removeErrorStack(_res));
         });

--- a/lib/core/network/router.js
+++ b/lib/core/network/router.js
@@ -190,12 +190,15 @@ class Router {
         cb(request);
       }
       else {
-        global.kuzzle.funnel.execute(mutatedRequest, (error, result) => {
+        global.kuzzle.funnel.execute(mutatedRequest, (err, result) => {
           const _res = result || request;
 
-          if (error && ! _res.error) {
-            _res.setError(error);
-          } 
+          if (err && ! _res.error) {
+            console.log('[Router] ERRRO R:', err);
+            _res.setError(err);
+          }
+
+          console.log('[Router] I send the follwing response', _res.response.toJSON());
 
           cb(removeErrorStack(_res));
         });

--- a/lib/core/network/router.js
+++ b/lib/core/network/router.js
@@ -24,6 +24,7 @@
 const { Request } = require('../../api/request');
 const kerror = require('../../kerror');
 const HttpRouter = require('./httpRouter');
+const removeErrorStack = require('./removeErrorStack');
 
 /**
  * @class Router
@@ -189,7 +190,15 @@ class Router {
         cb(request);
       }
       else {
-        global.kuzzle.funnel.execute(mutatedRequest, (err, result) => cb(result));
+        global.kuzzle.funnel.execute(mutatedRequest, (error, result) => {
+          const _res = result || request;
+
+          if (error && ! _res.error) {
+            _res.setError(error);
+          } 
+
+          cb(removeErrorStack(_res));
+        });
       }
     });
   }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "test:lint:js:fix": "eslint --max-warnings=0 --fix ./lib ./test ./features-legacy ./bin ./features ./doc/build-error-codes.js",
     "doc-error-codes": "node -r ts-node/register doc/build-error-codes",
     "docker:install": "docker-compose run kuzzle_node_1 npm install",
-    "docker:test:unit": "docker-compose run kuzzle_node_1 npm run test:unit"
+    "docker:test:unit": "docker-compose run kuzzle_node_1 npm run test:unit",
+    "docker:npm": "docker-compose run kuzzle_node_1 npm run --"
   },
   "directories": {
     "lib": "lib"

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -3536,7 +3536,7 @@ describe('Test: ElasticSearch service', () => {
       elasticsearch._mExecute = sinon.stub().resolves(mExecuteResult);
     });
 
-    it('should call _mExecute with formated documents', () => {
+    it('should call _mExecute with formated documents', async () => {
       const promise = elasticsearch.mCreateOrReplace(index, collection, documents);
 
       return promise

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -3536,7 +3536,7 @@ describe('Test: ElasticSearch service', () => {
       elasticsearch._mExecute = sinon.stub().resolves(mExecuteResult);
     });
 
-    it('should call _mExecute with formated documents', async () => {
+    it('should call _mExecute with formated documents', () => {
       const promise = elasticsearch.mCreateOrReplace(index, collection, documents);
 
       return promise


### PR DESCRIPTION
#2300

## What does this PR do ?

return an error when you send an empty JSON to `/_query`

### How should this be manually tested?

HTTP request to `POST` `localhost:7512/_query`

body: `{}`