### PR TITLE
Fix error when using access log with non clonable objects

### DIFF
--- a/lib/core/network/accessLogger.js
+++ b/lib/core/network/accessLogger.js
@@ -96,12 +96,17 @@ class AccessLogger {
       ? Buffer.byteLength(JSON.stringify(request.response)).toString()
       : '-';
 
-    this.worker.postMessage({
-      connection,
-      extra,
-      request: serialized,
-      size,
-    });
+    try {
+      this.worker.postMessage({
+        connection,
+        extra,
+        request: serialized,
+        size,
+      });
+    }
+    catch (error) {
+      global.kuzzle.log.error(`Failed to write access log for request "${request.id}": ${error.message}`);
+    }
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle",
-  "version": "2.17.6",
+  "version": "2.17.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.17.6",
+  "version": "2.17.7",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "bin": {
     "kuzzle": "bin/start-kuzzle-server"


### PR DESCRIPTION
## What does this PR do ?

Access logs are written by an external process to avoid blocking main Node.js process.

The Worker Thread module from Node.js need to serialize messages with the structured clone algorithm, so if the object contain a function it will raise an error.

Now the error is properly catched

Example code causing the error:

```js
app.controller.register('tests', {
  actions: {
    customError: {
      handler: async (req) => {
        req.input.args.bad = function () {}
      }
    },
```