### PR TITLE
Preserve settings when truncate collection

### DIFF
--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -183,7 +183,7 @@ class ElasticSearch extends Service {
   /**
    * Translate Koncorde filters to Elasticsearch query
    *
-   * @param {Object} koncordeFilters - Set of valid Koncorde filters
+   * @param {Object} filters - Set of valid Koncorde filters
    * @returns {Object} Equivalent Elasticsearch query
    */
   translateKoncordeFilters (filters) {
@@ -1350,8 +1350,7 @@ class ElasticSearch extends Service {
     // if putMappings fail.
     let indiceSettings;
     try {
-      const response = await this._client.indices.getSettings(esRequest);
-      indiceSettings = response.body[esRequest.index].settings;
+      indiceSettings = await this._getSettings(esRequest);
     }
     catch (error) {
       throw this._esWrapper.formatESError(error);
@@ -1496,7 +1495,7 @@ class ElasticSearch extends Service {
   }
 
   /**
-   * Empties the content of a collection. Keep the existing mapping.
+   * Empties the content of a collection. Keep the existing mapping and settings.
    *
    * @param {String} index - Index name
    * @param {String} collection - Collection name
@@ -1505,6 +1504,7 @@ class ElasticSearch extends Service {
    */
   async truncateCollection (index, collection) {
     let mappings;
+    let settings;
 
     const esRequest = {
       index: await this._getIndice(index, collection)
@@ -1512,6 +1512,7 @@ class ElasticSearch extends Service {
 
     try {
       mappings = await this.getMapping(index, collection, { includeKuzzleMeta: true });
+      settings = await this._getSettings(esRequest);
 
       await this._client.indices.delete(esRequest);
 
@@ -1521,7 +1522,8 @@ class ElasticSearch extends Service {
           aliases: {
             [this._getAlias(index, collection)]: {}
           },
-          mappings
+          mappings,
+          settings
         }
       });
 
@@ -2407,7 +2409,7 @@ class ElasticSearch extends Service {
    *
    * @param {String} index - Index name
    * @param {String} collection - Collection name
-   * @param {Array.<String>} documents - Documents IDs
+   * @param {Array.<String>} ids - Documents IDs
    * @param {Object} options - timeout (undefined), refresh (undefined)
    *
    * @returns {Promise.<{ documents, errors }>
@@ -2728,6 +2730,18 @@ class ElasticSearch extends Service {
     }
 
     return body[0].index;
+  }
+
+  /**
+   * Given an ES Request returns the settings of the corresponding indice.
+   *
+   * @param esRequest the ES Request with wanted settings.
+   * @return {Promise<*>} the settings of the indice.
+   * @private
+   */
+  async _getSettings(esRequest) {
+    const response = await this._client.indices.getSettings(esRequest);
+    return response.body[esRequest.index].settings;
   }
 
   /**

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -2739,7 +2739,7 @@ class ElasticSearch extends Service {
    * @return {Promise<*>} the settings of the indice.
    * @private
    */
-  async _getSettings(esRequest) {
+  async _getSettings (esRequest) {
     const response = await this._client.indices.getSettings(esRequest);
     return response.body[esRequest.index].settings;
   }

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -2616,20 +2616,21 @@ describe('Test: ElasticSearch service', () => {
 
       elasticsearch.getMapping = sinon.stub().resolves(existingMapping);
 
-      elasticsearch._client.indices.getSettings.resolves( {
+      elasticsearch._client.indices.getSettings.resolves({
         body: {
-          '&nyc-open-data.yellow-taxi' : {
+          '&nyc-open-data.yellow-taxi': {
             settings: {
               analysis: {
-                analyzers : {
+                analyzers: {
                   custom_analyzer: {
-                    type : 'simple'
+                    type: 'simple'
                   }
                 }
               }
             }
           }
-        }});
+        }
+      });
       sinon.stub(elasticsearch, '_getIndice').resolves(indice);
     });
 
@@ -2656,9 +2657,9 @@ describe('Test: ElasticSearch service', () => {
           },
           settings: {
             analysis: {
-              analyzers : {
+              analyzers: {
                 custom_analyzer: {
-                  type : 'simple'
+                  type: 'simple'
                 }
               }
             }

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -2615,6 +2615,21 @@ describe('Test: ElasticSearch service', () => {
       };
 
       elasticsearch.getMapping = sinon.stub().resolves(existingMapping);
+
+      elasticsearch._client.indices.getSettings.resolves( {
+        body: {
+          '&nyc-open-data.yellow-taxi' : {
+            settings: {
+              analysis: {
+                analyzers : {
+                  custom_analyzer: {
+                    type : 'simple'
+                  }
+                }
+              }
+            }
+          }
+        }});
       sinon.stub(elasticsearch, '_getIndice').resolves(indice);
     });
 
@@ -2622,30 +2637,38 @@ describe('Test: ElasticSearch service', () => {
       elasticsearch._getIndice.restore();
     });
 
-    it('should delete and then create the collection with the same mapping', () => {
-      const promise = elasticsearch.truncateCollection(index, collection);
+    it('should delete and then create the collection with the same mapping', async () => {
+      const result = await elasticsearch.truncateCollection(index, collection);
 
-      return promise
-        .then(result => {
-          should(elasticsearch.getMapping).be.calledWith(index, collection);
-          should(elasticsearch._client.indices.delete).be.calledWithMatch({
-            index: indice
-          });
-          should(elasticsearch._client.indices.create).be.calledWithMatch({
-            index: indice,
-            body: {
-              aliases: { [alias]: {} },
-              mappings: {
-                dynamic: 'false',
-                properties: {
-                  name: { type: 'keyword' }
+      should(elasticsearch.getMapping).be.calledWith(index, collection);
+      should(elasticsearch._client.indices.delete).be.calledWithMatch({
+        index: indice
+      });
+      should(elasticsearch._client.indices.create).be.calledWithMatch({
+        index: indice,
+        body: {
+          aliases: { [alias]: {} },
+          mappings: {
+            dynamic: 'false',
+            properties: {
+              name: { type: 'keyword' }
+            }
+          },
+          settings: {
+            analysis: {
+              analyzers : {
+                custom_analyzer: {
+                  type : 'simple'
                 }
               }
             }
-          });
-
-          should(result).be.null();
-        });
+          }
+        }
+      });
+      should(elasticsearch._client.indices.getSettings).be.calledWithMatch({
+        index: indice
+      });
+      should(result).be.null();
     });
 
     it('should return a rejected promise if client fails', () => {


### PR DESCRIPTION
## What does this PR do ?

Truncate collection delete indice and keep mappings but
not settings. We store settings before deleting indice
and put them in the next created indice.

### How should this be manually tested?

- specify settings in index like analyzers : https://www.elastic.co/guide/en/elasticsearch/reference/current/specify-analyzer.html#specify-index-time-default-analyzer
- truncate the collection
- check if the settings are preserved in the index of the truncated collection.

### Other changes

fix some docs

Closes #2272