### PR TITLE
Fix multi-search

### DIFF
--- a/doc/2/api/controllers/document/search/index.md
+++ b/doc/2/api/controllers/document/search/index.md
@@ -33,12 +33,17 @@ Koncorde filters will be translated into an Elasticsearch query.
 Koncorde `bool` operator and `regexp` clause are not supported for search queries.
 :::
 
-## Multi Search
-<SinceBadge version="2.17.0">
+### Multi Search
+
+<SinceBadge version="2.17.0"/>
 
 This method also support searching accross multiple indexes and collections
 using the `targets` parameter instead of `index`, `collection` parameters.
 See [Target Format](#target-format).
+
+::: warning
+Multi Search is only supported in WebSocket and MQTT protocols.
+:::
 
 ---
 

--- a/lib/model/security/user.ts
+++ b/lib/model/security/user.ts
@@ -19,9 +19,9 @@
  * limitations under the License.
  */
 
-import Rights from './rights';
-import Bluebird from 'bluebird';
 import _ from 'lodash';
+
+import Rights from './rights';
 import * as kerror from '../../kerror';
 import { Profile } from './profile';
 import { KuzzleRequest } from '../../../index';
@@ -55,7 +55,7 @@ export class User {
    */
   async getRights () {
     const profiles = await this.getProfiles();
-    const results = await Bluebird.map(profiles, p => p.getRights());
+    const results = await Promise.all(profiles.map(p => p.getRights()));
 
     const rights = {};
 
@@ -87,7 +87,7 @@ export class User {
     }
 
     // Every target must be allowed by at least one profile
-    return this.areTargetsAllowed(profiles, targets);
+    return this.areTargetsAllowed(request, profiles, targets);
   }
 
   /**
@@ -95,8 +95,12 @@ export class User {
    * while skipping the ones that includes a wildcard since they will be expanded
    * later on, based on index and collections authorized for the given user.
    */
-  private async areTargetsAllowed (profiles: Profile[], targets: Target[]) {
-    const profilesPolicies = await Bluebird.map(profiles, profile => profile.getAllowedPolicies());
+  private async areTargetsAllowed (
+    request: KuzzleRequest,
+    profiles: Profile[],
+    targets: Target[],
+  ): Promise<boolean> {
+    const profilesPolicies = await Promise.all(profiles.map(profile => profile.getAllowedPolicies(request)));
 
     // Every target must be allowed by at least one profile
     for (const target of targets) {
@@ -135,5 +139,4 @@ export class User {
 
     return true;
   }
-
 }

--- a/test/model/security/user.test.js
+++ b/test/model/security/user.test.js
@@ -146,4 +146,25 @@ describe('Test: model/security/user', () => {
       { id: 'security.user.uninitialized' });
   });
 
+  describe('#areTargetsAllowed', () => {
+    it('should not support index wildcard', () => {
+
+    });
+
+    it('should not support collection wildcard', () => {
+
+    });
+
+    it('should allows when target is in authorized index and collection', () => {
+
+    });
+
+    it('should forbid when target contains unauthorized index', () => {
+
+    });
+
+    it('should forbid when target contains unauthorized collection', () => {
+
+    });
+  });
 });


### PR DESCRIPTION
## What does this PR do ?

Fix a bug in multi-search where `request` object was not passed as argument

### How should this be manually tested?

```
import { Kuzzle, WebSocket } from 'kuzzle-sdk';

const kuzzle = new Kuzzle(new WebSocket('localhost'));

async function run () {
  await kuzzle.connect();

  const res = await kuzzle.query({
    controller: 'document',
    action: 'search',
    targets: [
      {
        index: 'index1',
        collections: ['collection1']
      },
      {
        index: 'index2',
        collections: ['collection1']
      },
    ],
    body: {
     query: {
      term: { name: 'Adrien' }
     }
    },
    from: 2,
    size: 2
  })

  console.log(res.result.hits)
}

run();
```

