### PR TITLE
Fix double content-length header when sending errors with httpSendError

### DIFF
--- a/lib/core/network/protocols/httpwsProtocol.js
+++ b/lib/core/network/protocols/httpwsProtocol.js
@@ -866,11 +866,6 @@ class HttpWsProtocol extends Protocol {
         }
       }
 
-
-      response.writeHeader(
-        HTTP_HEADER_CONTENT_LENGTH,
-        Buffer.from(content.length.toString()));
-
       response.end(content);
     });
   }

--- a/test/core/network/protocols/http.test.js
+++ b/test/core/network/protocols/http.test.js
@@ -127,9 +127,7 @@ describe('core/network/protocols/http', () => {
         Buffer.from('Content-Type'),
         Buffer.from('application/json'));
 
-      should(response.writeHeader).not.be.calledWithMatch(
-        Buffer.from('Content-Length'),
-        Buffer.from('42'));
+      should(response.writeHeader).not.be.calledWithMatch(Buffer.from('Content-Length'));
 
       should(response.writeHeader.calledBefore(response.end));
 


### PR DESCRIPTION
## What does this PR do ?

Fixes an issue where the Content-Length header was sent twice causing some HTTP Parser to fail and reject the response.
Calling `.end(content)` on `uWS.HttpResponse` do set the `Content-Length` header automatically based on the size of the content given to the method, so adding it using `writeHeader` causes the Content-Length to be present twice.

It seems that this issue was present since we did move from nodejs websockets to uWS and we forgot to remove the duplicated header.

### How should this be manually tested?

`npm run test`