### PR TITLE
Fix race condition when creating index hidden indice

### DIFF
--- a/doc/2/guides/advanced/configuration/index.md
+++ b/doc/2/guides/advanced/configuration/index.md
@@ -112,7 +112,7 @@ See the [Configuration](/core/2/guides/advanced/configuration) guide for more in
 console.log(`Kuzzle will listen on port ${app.config.content.server.port}`);
 
 // Set log level to verbose
-app.config.content['kuzzle-plugin-logger'].services.stdout.level = 'verbose';
+app.config.content.plugins['kuzzle-plugin-logger'].services.stdout.level = 'verbose';
 
 // Listen to port 4242
 app.config.content.server.port = 4242;

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -1819,21 +1819,13 @@ class ElasticSearch extends Service {
       index: await this._getIndice(index, collection)
     };
 
-    const mutex = new Mutex(`hiddenCollection/${index}`);
     try {
-      await mutex.lock();
-
       await this._client.indices.delete(esRequest);
 
-      if (! await this._hasHiddenCollection(index)) {
-        await this._createHiddenCollection(index);
-      }
+      await this._createHiddenCollection(index);
     }
     catch (e) {
       throw this._esWrapper.formatESError(e);
-    }
-    finally {
-      await mutex.unlock();
     }
 
     return null;

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -1821,9 +1821,9 @@ class ElasticSearch extends Service {
 
     const mutex = new Mutex(`hiddenCollection/${index}`);
     try {
-      await this._client.indices.delete(esRequest);
-
       await mutex.lock();
+
+      await this._client.indices.delete(esRequest);
 
       if (! await this._hasHiddenCollection(index)) {
         await this._createHiddenCollection(index);

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -1819,7 +1819,7 @@ class ElasticSearch extends Service {
       index: await this._getIndice(index, collection)
     };
 
-    const mutex = new Mutex(`hiddenCollection/delete/${index}`);
+    const mutex = new Mutex(`hiddenCollection/${index}`);
     try {
       await this._client.indices.delete(esRequest);
 
@@ -2960,13 +2960,21 @@ class ElasticSearch extends Service {
   }
 
   /**
-   * Creates the hidden collection on the provided index.
+   * Creates the hidden collection on the provided index if it does not already
+   * exists
    *
    * @param {String} index Index name
    */
   async _createHiddenCollection (index) {
+    const mutex = new Mutex(`hiddenCollection/${index}`);
 
     try {
+      await mutex.lock();
+
+      if (await this._hasHiddenCollection(index)) {
+        return;
+      }
+
       await this._client.indices.create({
         body: {
           aliases: {
@@ -2982,6 +2990,9 @@ class ElasticSearch extends Service {
     }
     catch (e) {
       throw this._esWrapper.formatESError(e);
+    }
+    finally {
+      await mutex.unlock();
     }
   }
 

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -3168,7 +3168,6 @@ describe('Test: ElasticSearch service', () => {
 
   describe('#deleteCollection', () => {
     beforeEach(() => {
-      sinon.stub(elasticsearch, '_hasHiddenCollection').resolves(true);
       sinon.stub(elasticsearch, '_createHiddenCollection').resolves();
       sinon.stub(elasticsearch, '_getIndice').resolves(indice);
     });
@@ -3186,16 +3185,12 @@ describe('Test: ElasticSearch service', () => {
 
       should(result).be.null();
 
-      should(elasticsearch._createHiddenCollection).not.be.called();
+      should(elasticsearch._createHiddenCollection).be.called();
     });
 
     it('should create the hidden collection if the index is empty', async () => {
-      elasticsearch._hasHiddenCollection.resolves(false);
-
       await elasticsearch.deleteCollection(index, collection);
 
-      should(Mutex.prototype.lock).be.called();
-      should(Mutex.prototype.unlock).be.called();
       should(elasticsearch._createHiddenCollection).be.called();
     });
   });
@@ -4651,6 +4646,8 @@ describe('Test: ElasticSearch service', () => {
           }
         }
       });
+      should(Mutex.prototype.lock).be.called();
+      should(Mutex.prototype.unlock).be.called();
     });
 
     it('does not create the hidden collection if it already exists', async () => {

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -4625,6 +4625,10 @@ describe('Test: ElasticSearch service', () => {
     const hiddenAlias = `@${hiddenIndice}`;
 
     beforeEach(() => {
+      elasticsearch._client.cat.aliases.resolves({
+        body: []
+      });
+
       sinon.stub(elasticsearch, '_getAvailableIndice').resolves(hiddenIndice);
     });
 
@@ -4647,6 +4651,16 @@ describe('Test: ElasticSearch service', () => {
           }
         }
       });
+    });
+
+    it('does not create the hidden collection if it already exists', async () => {
+      elasticsearch._client.cat.aliases.resolves({
+        body: [{ alias: hiddenAlias }]
+      });
+
+      await elasticsearch._createHiddenCollection('nisantasi');
+
+      should(elasticsearch._client.indices.create).not.be.called();
     });
   });
 


### PR DESCRIPTION
## What does this PR do ?

When creating a new index, an special ES indice is created (`&<index>._kuzzle_keep`) to reserve the index name.

If `index:create` is called in the same time, then we have a race condition when trying to create this indice since it could have been created between the check for existence and the creation.

This PR use a mutex to prevent such race conditions