### PR TITLE
Add kuzzle config settings for internal index's number of shards and replicas

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -774,54 +774,90 @@
       "internalIndex": {
         "name": "kuzzle",
         "collections": {
-          "dynamic": "false",
           "users": {
-            "properties": {
-              "profileIds": { "type": "keyword" }
+            "settings": {
+              "number_of_shards": 1,
+              "number_of_replicas": 1
+            },
+            "mappings": {
+              "dynamic": "false",
+              "properties": {
+                "profileIds": { "type": "keyword" }
+              }
             }
           },
           "profiles": {
-            "dynamic": "false",
-            "properties": {
-              "policies": {
-                "properties":  {
-                  "roleId": { "type": "keyword" }
+            "settings": {
+              "number_of_shards": 1,
+              "number_of_replicas": 1
+            },
+            "mappings": {
+              "dynamic": "false",
+              "properties": {
+                "policies": {
+                  "properties":  {
+                    "roleId": { "type": "keyword" }
+                  }
                 }
               }
             }
           },
           "roles": {
-            "dynamic": "false",
-            "properties": {
-              "controllers": {
-                "dynamic": "false",
-                "properties": {}
+            "settings": {
+              "number_of_shards": 1,
+              "number_of_replicas": 1
+            },
+            "mappings": {
+              "dynamic": "false",
+              "properties": {
+                "controllers": {
+                  "dynamic": "false",
+                  "properties": {}
+                }
               }
             }
           },
           "validations": {
-            "properties": {
-              "index": { "type": "keyword" },
-              "collection": { "type": "keyword" },
-              "validations": {
-                "dynamic": "false",
-                "properties": {}
+            "settings": {
+              "number_of_shards": 1,
+              "number_of_replicas": 1
+            },
+            "mappings": {
+              "properties": {
+                "index": { "type": "keyword" },
+                "collection": { "type": "keyword" },
+                "validations": {
+                  "dynamic": "false",
+                  "properties": {}
+                }
               }
             }
           },
           "config": {
-            "dynamic": "false",
-            "properties": {}
+            "settings": {
+              "number_of_shards": 1,
+              "number_of_replicas": 1
+            },
+            "mappings": {
+              "dynamic": "false",
+              "properties": {}
+            }
           },
           "api-keys": {
-            "dynamic": "false",
-            "properties": {
-              "userId": { "type": "keyword" },
-              "hash": { "type": "keyword" },
-              "expiresAt": { "type": "long" },
-              "ttl": { "type": "keyword" },
-              "description": { "type": "text" },
-              "token": { "type": "keyword" }
+            "settings": {
+              "number_of_shards": 1,
+              "number_of_replicas": 1
+            },
+            "mappings": {
+              "dynamic": "false",
+              "properties": {
+                "userId": { "type": "keyword" },
+                "hash": { "type": "keyword" },
+                "expiresAt": { "type": "long" },
+                "ttl": { "type": "keyword" },
+                "description": { "type": "text" },
+                "token": { "type": "keyword" }
+              }
             }
           }
         }

--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -771,6 +771,11 @@
         }
       },
       // Internal index default name and collections
+      // When starting, at initialisation, kuzzle will attempt
+      // to update all ES dynamic settings of existing internal
+      // index's collections. Static settings are setted only at
+      // creation.
+      // See https://www.elastic.co/guide/en/elasticsearch/reference/7.5/index-modules.html#index-modules-settings
       "internalIndex": {
         "name": "kuzzle",
         "collections": {

--- a/lib/config/default.config.ts
+++ b/lib/config/default.config.ts
@@ -308,23 +308,35 @@ const defaultConfig: KuzzleConfiguration = {
         name: 'kuzzle',
         collections: {
           users: {
-            dynamic: 'false',
-            properties: {
-              profileIds: { type: 'keyword' }
+            settings: {
+              number_of_shards: 1,
+              number_of_replicas: 1,
+            },
+            mappings: {
+              dynamic: 'false',
+              properties: {
+                profileIds: { type: 'keyword' }
+              }
             }
           },
           profiles: {
-            dynamic: 'false',
-            properties: {
-              tags: { type: 'keyword' },
-              policies: {
-                properties: {
-                  roleId: { type: 'keyword' },
-                  restrictedTo: {
-                    type: 'nested',
-                    properties: {
-                      index: { type: 'keyword' },
-                      collections: { type: 'keyword' }
+            settings: {
+              number_of_shards: 1,
+              number_of_replicas: 1,
+            },
+            mappings: {
+              dynamic: 'false',
+              properties: {
+                tags: { type: 'keyword' },
+                policies: {
+                  properties: {
+                    roleId: { type: 'keyword' },
+                    restrictedTo: {
+                      type: 'nested',
+                      properties: {
+                        index: { type: 'keyword' },
+                        collections: { type: 'keyword' }
+                      }
                     }
                   }
                 }
@@ -332,47 +344,77 @@ const defaultConfig: KuzzleConfiguration = {
             }
           },
           roles: {
-            dynamic: 'false',
-            properties: {
-              tags: { type: 'keyword' },
-              controllers: {
-                dynamic: 'false',
-                properties: {}
+            settings: {
+              number_of_shards: 1,
+              number_of_replicas: 1,
+            },
+            mappings: {
+              dynamic: 'false',
+              properties: {
+                tags: { type: 'keyword' },
+                controllers: {
+                  dynamic: 'false',
+                  properties: {}
+                }
               }
             }
           },
           validations: {
-            properties: {
-              index: { type: 'keyword' },
-              collection: { type: 'keyword' },
-              validations: {
-                dynamic: 'false',
-                properties: {}
+            settings: {
+              number_of_shards: 1,
+              number_of_replicas: 1,
+            },
+            mappings: {
+              properties: {
+                index: { type: 'keyword' },
+                collection: { type: 'keyword' },
+                validations: {
+                  dynamic: 'false',
+                  properties: {}
+                }
               }
             }
           },
           config: {
-            dynamic: 'false',
-            properties: {}
+            settings: {
+              number_of_shards: 1,
+              number_of_replicas: 1,
+            },
+            mappings: {
+              dynamic: 'false',
+              properties: {}
+            }
           },
           'api-keys': {
-            dynamic: 'false',
-            properties: {
-              userId: { type: 'keyword' },
-              hash: { type: 'keyword' },
-              description: { type: 'text' },
-              expiresAt: { type: 'long' },
-              ttl: { type: 'keyword' },
-              token: { type: 'keyword' }
+            settings: {
+              number_of_shards: 1,
+              number_of_replicas: 1,
+            },
+            mappings: {
+              dynamic: 'false',
+              properties: {
+                userId: { type: 'keyword' },
+                hash: { type: 'keyword' },
+                description: { type: 'text' },
+                expiresAt: { type: 'long' },
+                ttl: { type: 'keyword' },
+                token: { type: 'keyword' }
+              }
             }
           },
           installations: {
-            dynamic: 'strict',
-            properties: {
-              description: { type: 'text' },
-              handler: { type: 'text' },
-              installedAt: { type: 'date' }
+            settings: {
+              number_of_shards: 1,
+              number_of_replicas: 1,
             },
+            mappings: {
+              dynamic: 'strict',
+              properties: {
+                description: { type: 'text' },
+                handler: { type: 'text' },
+                installedAt: { type: 'date' }
+              },
+            }
           }
         }
       },

--- a/lib/config/default.config.ts
+++ b/lib/config/default.config.ts
@@ -308,10 +308,11 @@ const defaultConfig: KuzzleConfiguration = {
         name: 'kuzzle',
         collections: {
           users: {
-            settings: {
-              number_of_shards: 1,
-              number_of_replicas: 1,
-            },
+            // @deprecated : Uncomment (made to not change existing config)
+            // settings: {
+            // number_of_shards: 1,
+            // number_of_replicas: 1,
+            // },
             mappings: {
               dynamic: 'false',
               properties: {
@@ -320,10 +321,11 @@ const defaultConfig: KuzzleConfiguration = {
             }
           },
           profiles: {
-            settings: {
-              number_of_shards: 1,
-              number_of_replicas: 1,
-            },
+            // @deprecated : Uncomment (made to not change existing config)
+            // settings: {
+            // number_of_shards: 1,
+            // number_of_replicas: 1,
+            // },
             mappings: {
               dynamic: 'false',
               properties: {
@@ -344,10 +346,11 @@ const defaultConfig: KuzzleConfiguration = {
             }
           },
           roles: {
-            settings: {
-              number_of_shards: 1,
-              number_of_replicas: 1,
-            },
+            // @deprecated : Uncomment (made to not change existing config)
+            // settings: {
+            // number_of_shards: 1,
+            // number_of_replicas: 1,
+            // },
             mappings: {
               dynamic: 'false',
               properties: {
@@ -360,10 +363,11 @@ const defaultConfig: KuzzleConfiguration = {
             }
           },
           validations: {
-            settings: {
-              number_of_shards: 1,
-              number_of_replicas: 1,
-            },
+            // @deprecated : Uncomment (made to not change existing config)
+            // settings: {
+            // number_of_shards: 1,
+            // number_of_replicas: 1,
+            // },
             mappings: {
               properties: {
                 index: { type: 'keyword' },
@@ -376,20 +380,22 @@ const defaultConfig: KuzzleConfiguration = {
             }
           },
           config: {
-            settings: {
-              number_of_shards: 1,
-              number_of_replicas: 1,
-            },
+            // @deprecated : Uncomment (made to not change existing config)
+            // settings: {
+            // number_of_shards: 1,
+            // number_of_replicas: 1,
+            // },
             mappings: {
               dynamic: 'false',
               properties: {}
             }
           },
           'api-keys': {
-            settings: {
-              number_of_shards: 1,
-              number_of_replicas: 1,
-            },
+            // @deprecated : Uncomment (made to not change existing config)
+            // settings: {
+            // number_of_shards: 1,
+            // number_of_replicas: 1,
+            // },
             mappings: {
               dynamic: 'false',
               properties: {
@@ -403,10 +409,11 @@ const defaultConfig: KuzzleConfiguration = {
             }
           },
           installations: {
-            settings: {
-              number_of_shards: 1,
-              number_of_replicas: 1,
-            },
+            // @deprecated : Uncomment (made to not change existing config)
+            // settings: {
+            // number_of_shards: 1,
+            // number_of_replicas: 1,
+            // },
             mappings: {
               dynamic: 'strict',
               properties: {

--- a/lib/core/shared/store.js
+++ b/lib/core/shared/store.js
@@ -129,8 +129,11 @@ class Store {
       async ([collection, config]) => {
 
         // @deprecated
-        // config should have fields mappings and settings
-        if (config.mappings !== undefined) {
+        if (config.mappings !== undefined &&
+          config.settings !== undefined &&
+          config.settings.number_of_shards !== undefined &&
+          config.settings.number_of_replicas !== undefined
+        ) {
 
           if (indexCacheOnly) {
             return global.kuzzle.ask(
@@ -204,21 +207,20 @@ class Store {
             { indexCacheOnly }
           );
         }
-      }
 
-
-      return global.kuzzle.ask(
-        `core:storage:${this.scope}:collection:create`,
-        this.index,
-        collection,
-        {
-          mappings: config
-        },
-        { indexCacheOnly }
-      );
-  },
-    { concurrency: 10 });
-}
+        // @deprecated
+        return global.kuzzle.ask(
+          `core:storage:${this.scope}:collection:create`,
+          this.index,
+          collection,
+          {
+            mappings: config
+          },
+          { indexCacheOnly }
+        );
+      },
+      { concurrency: 10 });
+  }
 }
 
 module.exports = Store;

--- a/lib/core/shared/store.js
+++ b/lib/core/shared/store.js
@@ -24,6 +24,8 @@
 const Bluebird = require('bluebird');
 
 const { Mutex } = require('../../util/mutex');
+const kerror = require('../../kerror');
+const { getESIndexDynamicSettings } = require('../../util/store');
 
 /**
  * Wrapper around the document store.
@@ -93,17 +95,21 @@ class Store {
    */
   async init (collections = {}) {
     const mutex = new Mutex(`Store.init(${this.index})`, {
-      timeout: -1,
+      timeout: 0,
       ttl: 30000,
     });
 
-    await mutex.lock();
+    const locked = await mutex.lock();
 
     try {
-      await this.createCollections(collections);
+      await this.createCollections(collections, {
+        indexCacheOnly: !locked
+      });
     }
     finally {
-      await mutex.unlock();
+      if (locked) {
+        await mutex.unlock();
+      }
     }
   }
 
@@ -114,15 +120,89 @@ class Store {
    *
    * @returns {Promise}
    */
-  createCollections (collections) {
+  createCollections (
+    collections,
+    { indexCacheOnly = false, propagate = true } = {}
+  ) {
     return Bluebird.map(
       Object.entries(collections),
-      ([collection, mappings]) => {
+      async ([collection, config]) => {
+
+        // @deprecated
+        // config should have fields mappings and settings
+        if (config.mappings !== undefined) {
+
+          const exist = await global.kuzzle.ask(
+            `core:storage:${this.scope}:collection:exist`,
+            this.index,
+            collection,
+            { indexCacheOnly, propagate }
+          );
+
+          if (exist) {
+
+            const dynamicSettings = getESIndexDynamicSettings(config.settings);
+
+            const existingSettings = await global.kuzzle.ask(
+              `core:storage:${this.scope}:collection:settings:get`,
+              this.index,
+              collection
+            );
+
+            if (parseInt(existingSettings.number_of_shards) !== config.settings.number_of_shards) {
+              if (global.NODE_ENV === 'development') {
+                throw kerror.get(
+                  'storage',
+                  'wrong_collection_number_of_shards',
+                  collection,
+                  this.index,
+                  this.scope,
+                  'number_of_shards',
+                  config.settings.number_of_shards,
+                  existingSettings.number_of_shards
+                );
+              }
+              else {
+                global.kuzzle.log.warn([
+
+                `Attempt to recreate`,
+                  `an existing collection ${collection}`,
+                  `of index ${this.index} of scope ${this.scope}`,
+                  `with non matching`,
+                  `static setting : number_of_shards`,
+                  `at ${config.settings.number_of_shards} while existing one`,
+                  `is at ${existingSettings.number_of_shards}`,
+                ].join('\n'));
+              }
+            }
+
+            return global.kuzzle.ask(
+              `core:storage:${this.scope}:collection:update`,
+              this.index,
+              collection,
+              {
+                mappings: config.mappings,
+                settings: dynamicSettings
+              },
+            );
+          }
+
+          return global.kuzzle.ask(
+            `core:storage:${this.scope}:collection:create`,
+            this.index,
+            collection,
+            config
+          );
+        }
+
         return global.kuzzle.ask(
           `core:storage:${this.scope}:collection:create`,
           this.index,
           collection,
-          { mappings });
+          {
+            mappings: config
+          }
+        );
       },
       { concurrency: 10 });
   }

--- a/lib/core/shared/store.js
+++ b/lib/core/shared/store.js
@@ -103,7 +103,7 @@ class Store {
 
     try {
       await this.createCollections(collections, {
-        indexCacheOnly: !locked
+        indexCacheOnly: ! locked
       });
     }
     finally {
@@ -164,12 +164,11 @@ class Store {
               }
               else {
                 global.kuzzle.log.warn([
-
-                `Attempt to recreate`,
+                  'Attempt to recreate',
                   `an existing collection ${collection}`,
                   `of index ${this.index} of scope ${this.scope}`,
-                  `with non matching`,
-                  `static setting : number_of_shards`,
+                  'with non matching',
+                  'static setting : number_of_shards',
                   `at ${config.settings.number_of_shards} while existing one`,
                   `is at ${existingSettings.number_of_shards}`,
                 ].join('\n'));

--- a/lib/core/shared/store.js
+++ b/lib/core/shared/store.js
@@ -122,7 +122,7 @@ class Store {
    */
   createCollections (
     collections,
-    { indexCacheOnly = false, propagate = true } = {}
+    { indexCacheOnly = false } = {}
   ) {
     return Bluebird.map(
       Object.entries(collections),
@@ -132,11 +132,20 @@ class Store {
         // config should have fields mappings and settings
         if (config.mappings !== undefined) {
 
+          if (indexCacheOnly) {
+            return global.kuzzle.ask(
+              `core:storage:${this.scope}:collection:create`,
+              this.index,
+              collection,
+              config,
+              { indexCacheOnly }
+            );
+          }
+
           const exist = await global.kuzzle.ask(
             `core:storage:${this.scope}:collection:exist`,
             this.index,
-            collection,
-            { indexCacheOnly, propagate }
+            collection
           );
 
           if (exist) {
@@ -175,14 +184,15 @@ class Store {
               }
             }
 
+            // Update and add to cache
             return global.kuzzle.ask(
-              `core:storage:${this.scope}:collection:update`,
+              `core:storage:${this.scope}:collection:create`,
               this.index,
               collection,
               {
                 mappings: config.mappings,
                 settings: dynamicSettings
-              },
+              }
             );
           }
 
@@ -190,21 +200,25 @@ class Store {
             `core:storage:${this.scope}:collection:create`,
             this.index,
             collection,
-            config
+            config,
+            { indexCacheOnly }
           );
         }
+      }
 
-        return global.kuzzle.ask(
-          `core:storage:${this.scope}:collection:create`,
-          this.index,
-          collection,
-          {
-            mappings: config
-          }
-        );
-      },
-      { concurrency: 10 });
-  }
+
+      return global.kuzzle.ask(
+        `core:storage:${this.scope}:collection:create`,
+        this.index,
+        collection,
+        {
+          mappings: config
+        },
+        { indexCacheOnly }
+      );
+  },
+    { concurrency: 10 });
+}
 }
 
 module.exports = Store;

--- a/lib/core/storage/clientAdapter.js
+++ b/lib/core/storage/clientAdapter.js
@@ -216,6 +216,18 @@ class ClientAdapter {
       (index, collection) => this.deleteCollection(index, collection));
 
     /**
+     * Get settings of a collection
+     * @param {string} index
+     * @param {string} collection
+     */
+    global.kuzzle.onAsk(
+      `core:storage:${this.scope}:collection:settings:get`,
+      (index, collection) => {
+        this.cache.assertCollectionExists(index, collection);
+        return this.client.getSettings(index, collection);
+      });
+
+    /**
      * Check a collection existence
      * @param {string} index
      * @param {string} collection

--- a/lib/kerror/codes/1-services.json
+++ b/lib/kerror/codes/1-services.json
@@ -287,6 +287,12 @@
           "message": "The %s (\"%s\") contains invalid characters \",+*\" or is equal to \"_all\" which is forbidden",
           "code": 50,
           "class": "BadRequestError"
+        },
+        "wrong_es_static_settings_for_collection_recreation": {
+          "description": "The ES static settings specified at the creation of an existing collection does not match existing settings",
+          "message": "Attempt to recreate an existing collection %s of index %s of scope %s with non matching static setting : %s at %s while existing one is at %s",
+          "code": 51,
+          "class": "BadRequestError"
         }
       }
     },

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -1315,6 +1315,34 @@ class ElasticSearch extends Service {
   }
 
   /**
+   * Retrieves settings definition for index/type
+   *
+   * @param {String} index - Index name
+   * @param {String} collection - Collection name
+   * @param {Object} options - includeKuzzleMeta (false)
+   *
+   * @returns {Promise.<{ settings }>}
+   */
+  async getSettings (index, collection) {
+    const
+      indice = await this._getIndice(index, collection),
+      esRequest = {
+        index: indice
+      };
+
+    debug('Get settings: %o', esRequest);
+
+    try {
+      const { body } = await this._client.indices.getSettings(esRequest);
+
+      return body[indice].settings.index;
+    }
+    catch (error) {
+      throw this._esWrapper.formatESError(error);
+    }
+  }
+
+  /**
    * Retrieves mapping definition for index/type
    *
    * @param {String} index - Index name

--- a/lib/types/config/storageEngine/StorageEngineElasticsearchConfiguration.ts
+++ b/lib/types/config/storageEngine/StorageEngineElasticsearchConfiguration.ts
@@ -3,12 +3,12 @@ import { ClientOptions } from '@elastic/elasticsearch';
 export type StorageEngineElasticsearch = {
   /**
    * @default ['storageEngine']
-  */
+   */
   aliases: string[];
 
   /**
    * @default "elasticsearch"
-  */
+   */
   backend: 'elasticsearch';
 
   /**
@@ -24,7 +24,7 @@ export type StorageEngineElasticsearch = {
    *    node: 'http://localhost:9200'
    * }
    *
-  */
+   */
   client: ClientOptions;
 
   /**
@@ -42,7 +42,7 @@ export type StorageEngineElasticsearch = {
   commonMapping: {
     /**
      * @default "false"
-    */
+     */
     dynamic: 'true' | 'false' | 'strict';
 
     properties: {
@@ -70,11 +70,11 @@ export type StorageEngineElasticsearch = {
            *   }
            * ]
            */
-            createdAt: {
-              type: string;
-            };
+          createdAt: {
+            type: string;
+          };
 
-            /**
+          /**
            * @default
            *
            * [
@@ -83,11 +83,11 @@ export type StorageEngineElasticsearch = {
            *   }
            * ]
            */
-            updater: {
-              type: string;
-            };
+          updater: {
+            type: string;
+          };
 
-            /**
+          /**
            * @default
            *
            * [
@@ -96,43 +96,71 @@ export type StorageEngineElasticsearch = {
            *   }
            * ]
            */
-            updatedAt: {
-              type: string;
-            };
+          updatedAt: {
+            type: string;
+          };
         };
       };
-      };
     };
+  };
 
-    internalIndex: {
-      /**
-      * @default "kuzzle"
-      */
-      name: string;
+  internalIndex: {
+    /**
+     * @default "kuzzle"
+     */
+    name: string;
 
-      collections: {
-        users: {
+    collections: {
+      users: {
+        settings: {
           /**
-          * @default 'false'
-          */
+           * @default 1
+           */
+          number_of_shards: number;
+
+          /**
+           * @default 1
+           */
+          number_of_replicas: number;
+        };
+
+        mappings: {
+          /**
+           * @default 'false'
+           */
           dynamic: 'true' | 'false' | 'strict';
 
           properties: {
             /**
-              * @default
-              *
-              * [
-              *   {
-              *     type: 'keyword',
-              *   }
-              * ]
-              */
+             * @default
+             *
+             * [
+             *   {
+             *     type: 'keyword',
+             *   }
+             * ]
+             */
             profileIds: {
               type: string;
             };
           };
         };
-        profiles: {
+      };
+
+      profiles: {
+        settings: {
+          /**
+           * @default 1
+           */
+          number_of_shards: number;
+
+          /**
+           * @default 1
+           */
+          number_of_replicas: number;
+        };
+
+        mappings: {
           dynamic: 'false';
           properties: {
             tags: { type: 'keyword' };
@@ -150,7 +178,22 @@ export type StorageEngineElasticsearch = {
             };
           };
         };
-        roles: {
+      };
+
+      roles: {
+        settings: {
+          /**
+           * @default 1
+           */
+          number_of_shards: number;
+
+          /**
+           * @default 1
+           */
+          number_of_replicas: number;
+        };
+
+        mappings: {
           dynamic: 'false';
           properties: {
             tags: { type: 'keyword' };
@@ -160,7 +203,22 @@ export type StorageEngineElasticsearch = {
             };
           };
         };
-        validations: {
+      };
+
+      validations: {
+        settings: {
+          /**
+           * @default 1
+           */
+          number_of_shards: number;
+
+          /**
+           * @default 1
+           */
+          number_of_replicas: number;
+        };
+
+        mappings: {
           properties: {
             index: { type: 'keyword' };
             collection: { type: 'keyword' };
@@ -170,11 +228,41 @@ export type StorageEngineElasticsearch = {
             };
           };
         };
-        config: {
+      };
+
+      config: {
+        settings: {
+          /**
+           * @default 1
+           */
+          number_of_shards: number;
+
+          /**
+           * @default 1
+           */
+          number_of_replicas: number;
+        };
+
+        mappings: {
           dynamic: 'false';
           properties: Record<string, unknown>;
         };
-        'api-keys': {
+      };
+
+      'api-keys': {
+        settings: {
+          /**
+           * @default 1
+           */
+          number_of_shards: number;
+
+          /**
+           * @default 1
+           */
+          number_of_replicas: number;
+        };
+
+        mappings: {
           dynamic: 'false';
           properties: {
             userId: { type: 'keyword' };
@@ -185,7 +273,22 @@ export type StorageEngineElasticsearch = {
             token: { type: 'keyword' };
           };
         };
-        installations: {
+      };
+
+      installations: {
+        settings: {
+          /**
+           * @default 1
+           */
+          number_of_shards: number;
+
+          /**
+           * @default 1
+           */
+          number_of_replicas: number;
+        };
+
+        mappings: {
           dynamic: 'strict';
           properties: {
             description: { type: 'text' };
@@ -195,9 +298,10 @@ export type StorageEngineElasticsearch = {
         };
       };
     };
-    maxScrollDuration: '1m';
-    defaults: {
-      onUpdateConflictRetries: 0;
-      scrollTTL: '15s';
-    };
+  };
+  maxScrollDuration: '1m';
+  defaults: {
+    onUpdateConflictRetries: 0;
+    scrollTTL: '15s';
+  };
 }

--- a/lib/util/store.ts
+++ b/lib/util/store.ts
@@ -1,0 +1,64 @@
+/*
+ * Kuzzle, a backend software, self-hostable and ready to use
+ * to power modern apps
+ *
+ * Copyright 2015-2020 Kuzzle
+ * mailto: support AT kuzzle.io
+ * website: http://kuzzle.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Dynamic index settings specified in the elasticsearch documentation :
+// https://www.elastic.co/guide/en/elasticsearch/reference/7.5/index-modules.html#index-modules-settings
+const dynamicESSettings = new Set<string> ([
+  'number_of_replicas',
+  'search',
+  'search.idle.after',
+  'refresh_interval',
+  'max_result_window',
+  'max_inner_result_window',
+  'max_rescore_window',
+  'max_docvalue_fields_search',
+  'max_script_fields',
+  'max_ngram_diff',
+  'max_shingle_diff',
+  'blocks',
+  'blocks.read_only',
+  'blocks.read_only_allow_delete',
+  'blocks.read',
+  'blocks.write',
+  'blocks.write',
+  'blocks.metadata',
+  'max_refresh_listeners',
+  'highlight.max_analyzed_offset',
+  'max_terms_count',
+  'max_regex_length',
+  'routing.allocation.enable',
+  'routing.rebalance.enable',
+  'gc_deletes',
+  'default_pipeline',
+  'final_pipeline'
+]);
+
+export function getESIndexDynamicSettings (settings: object): object {
+  const dynamicSettings: object = {};
+
+  Object.keys(settings).forEach(key => {
+    if (dynamicESSettings.has(key)) {
+      dynamicSettings[key] = settings[key];
+    }
+  });
+
+  return dynamicSettings;
+}


### PR DESCRIPTION
#2208 #2275

## What does this PR do ?

Add the possibility to give ES index settings for internal index's collection in kuzzle configuration. Also update dynamic ES settings of internal index's collection when restarting kuzzle.

The changes also affect plugins as there ES indexes are treated by kuzzle as internal index's collection.

### How should this be manually tested?

  For creation :

- Step 1 : Set your number of replicas and shards for internal collection
- Step 2 : Make your elasticsearch service port 9200 accessible
- Step 3 : Start kuzzle
- Step 4 : `curl -X GET "127.0.0.1:9200/_cat/shards/%25kuzzle*"`

Update number of replicas :

- Step 1 : Set a different number of replicas
- Step 2 : Make your elasticsearch service port 9200 accessible
- Step 3 : Restart kuzzle
- Step 4 : `curl -X GET "127.0.0.1:9200/_cat/shards/%25kuzzle*"`