### PR TITLE
Mappings update trigger a reindex

### DIFF
--- a/features/CollectionController.feature
+++ b/features/CollectionController.feature
@@ -38,6 +38,29 @@ Feature: Collection Controller
     Then I should receive a "hits" array of objects matching:
       | _id          | _source      |
       | "document-1" | { "age": 2 } |
+  
+  Scenario: Update a collection and search document (dyanmic false)
+    Given an index "nyc-open-data"
+    And I "create" the collection "nyc-open-data":"green-taxi" with:
+      | mappings | { "dynamic": "false", "properties": { "name": { "type": "keyword" }, "metadata": {"properties": {}, "dynamic": "false"} } } |
+    And I "create" the following documents:
+      | _id          | body        |
+      | "document-1" | {"age": 2} |
+    And I refresh the collection
+    When I "update" the collection "nyc-open-data":"green-taxi" with:
+      | mappings | { "properties": { "age": { "type": "long" } } } |
+    When I search documents with the following query:
+      """
+      {
+        "match": {
+          "age": 2
+        }
+      }
+      """
+    And I execute the search query
+    Then I should receive a "hits" array of objects matching:
+      | _id          | _source      |
+      | "document-1" | { "age": 2 } |
 
   # collection:truncate ========================================================
 

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -1397,8 +1397,7 @@ class ElasticSearch extends Service {
             });
           }
           catch (err) {
-            debug('Error while updating documents with new mappings: %o', err);
-            throw err;
+            throw this._esWrapper.formatESError(err);
           }
         }
 

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -1386,48 +1386,16 @@ class ElasticSearch extends Service {
         const previousMappings = await this.getMapping(index, collection);
 
         
-        // reindex documents in collection
-        if (previousMappings.dynamic === 'false') {
+        await this.updateMapping(index, collection, mappings);
+
+        if (previousMappings.dynamic === 'false' && (await this._client.search(esRequest)).body.hits.hits.length > 0) {
           console.log('------------> previousMappings:', JSON.stringify(previousMappings));
           console.log('------------> typeof:', typeof previousMappings.dynamic);
-  
-          // get lists of all documents in index
-          const
-            esRequest = {
-              index: await this._getIndice(index, collection)
-            },
-            { body } = await this._client.search(esRequest);
-          
-          console.log('------------> body:', JSON.stringify(body, null, 2));
-          const res = await this._client.reindex({
-            body: {
-              source: {
-                index: esRequest.index
-              },
-              dest: {
-                index: await this._getAvailableIndice(index, collection)
-              }
-            }
-          });
-          console.log('------------> reindex result:', res)
-          // for (const document of body.hits.hits) {
-            // this._client.reindex({
-            //   body: {
-            //     conflicts: 'proceed',
-            //     source: {
-            //       index: esRequest.index,
-            //       type: document._type
-            //     },
-            //     dest: {
-            //       index: await this._getAvailableIndice(index, collection),
-            //       type: document._type
-            //     }
-            //   }
-            // })
-          // }
-        }
+          // upate documents with new mappings
+          const res = await this.updateByQuery(index, collection, {}, {});
 
-        await this.updateMapping(index, collection, mappings);
+          console.log('------------> res:', JSON.stringify(res));
+        }
 
         if (this._dynamicChanges(previousMappings, mappings)) {
           await this.updateSearchIndex(index, collection);

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -1385,13 +1385,16 @@ class ElasticSearch extends Service {
       if (! _.isEmpty(mappings)) {
         const previousMappings = await this.getMapping(index, collection);
 
-        
         await this.updateMapping(index, collection, mappings);
 
-        // upate documents with new mappings
+        // update documents with new mappings
         if (previousMappings.dynamic === 'false' && (await this._client.search(esRequest)).body.hits.hits.length > 0) {
           try {
-            await this.updateByQuery(index, collection, {}, {});
+            await this._client.updateByQuery({
+              conflicts: 'proceed',
+              index: esRequest.index,
+              refresh: true,
+            });
           }
           catch (err) {
             debug('Error while updating documents with new mappings: %o', err);

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -1385,6 +1385,48 @@ class ElasticSearch extends Service {
       if (! _.isEmpty(mappings)) {
         const previousMappings = await this.getMapping(index, collection);
 
+        
+        // reindex documents in collection
+        if (previousMappings.dynamic === 'false') {
+          console.log('------------> previousMappings:', JSON.stringify(previousMappings));
+          console.log('------------> typeof:', typeof previousMappings.dynamic);
+  
+          // get lists of all documents in index
+          const
+            esRequest = {
+              index: await this._getIndice(index, collection)
+            },
+            { body } = await this._client.search(esRequest);
+          
+          console.log('------------> body:', JSON.stringify(body, null, 2));
+          const res = await this._client.reindex({
+            body: {
+              source: {
+                index: esRequest.index
+              },
+              dest: {
+                index: await this._getAvailableIndice(index, collection)
+              }
+            }
+          });
+          console.log('------------> reindex result:', res)
+          // for (const document of body.hits.hits) {
+            // this._client.reindex({
+            //   body: {
+            //     conflicts: 'proceed',
+            //     source: {
+            //       index: esRequest.index,
+            //       type: document._type
+            //     },
+            //     dest: {
+            //       index: await this._getAvailableIndice(index, collection),
+            //       type: document._type
+            //     }
+            //   }
+            // })
+          // }
+        }
+
         await this.updateMapping(index, collection, mappings);
 
         if (this._dynamicChanges(previousMappings, mappings)) {

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -1388,13 +1388,15 @@ class ElasticSearch extends Service {
         
         await this.updateMapping(index, collection, mappings);
 
+        // upate documents with new mappings
         if (previousMappings.dynamic === 'false' && (await this._client.search(esRequest)).body.hits.hits.length > 0) {
-          console.log('------------> previousMappings:', JSON.stringify(previousMappings));
-          console.log('------------> typeof:', typeof previousMappings.dynamic);
-          // upate documents with new mappings
-          const res = await this.updateByQuery(index, collection, {}, {});
-
-          console.log('------------> res:', JSON.stringify(res));
+          try {
+            await this.updateByQuery(index, collection, {}, {});
+          }
+          catch (err) {
+            debug('Error while updating documents with new mappings: %o', err);
+            throw err;
+          }
         }
 
         if (this._dynamicChanges(previousMappings, mappings)) {

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -2451,6 +2451,14 @@ describe('Test: ElasticSearch service', () => {
       elasticsearch.updateMapping = sinon.stub().resolves();
       elasticsearch.updateSettings = sinon.stub().resolves();
       elasticsearch.updateSearchIndex = sinon.stub().resolves();
+      elasticsearch._client.search = sinon.stub().resolves({
+        body: {
+          hits: {
+            total: 0,
+            hits: [],
+          },
+        }
+      });
       sinon.stub(elasticsearch, '_getIndice').resolves(indice);
     });
 

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -2466,6 +2466,33 @@ describe('Test: ElasticSearch service', () => {
       elasticsearch._getIndice.restore();
     });
 
+    it('should call updateSettings, updateMapping, updateByQuery', async () => {
+      elasticsearch.getMapping = sinon.stub().resolves({ dynamic: 'false', properties: { city: { type: 'keyword' } } });
+      elasticsearch.updateByQuery = sinon.stub().resolves({});
+      elasticsearch._client.search = sinon.stub().resolves({
+        body: {
+          hits: {
+            total: 1,
+            hits: [
+              {
+                _id: 'id',
+                _score: 1,
+                _source: {
+                  content: 'content',
+                }
+              }
+            ],
+          },
+        }
+      });
+
+      await elasticsearch.updateCollection(index, collection, { mappings, settings });
+
+      should(elasticsearch.updateSettings).be.calledWith(index, collection, settings);
+      should(elasticsearch.updateMapping).be.calledWith(index, collection, mappings);
+      should(elasticsearch.updateByQuery).be.calledWith(index, collection, {}, {});
+    });
+
     it('should call updateSettings, updateMapping', async () => {
       elasticsearch.getMapping = sinon.stub().resolves({ dynamic: 'true', properties: { city: { type: 'keyword' }, dynamic: 'false' } });
       await elasticsearch.updateCollection(index, collection, { mappings, settings });

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -2468,7 +2468,7 @@ describe('Test: ElasticSearch service', () => {
 
     it('should call updateSettings, updateMapping, updateByQuery', async () => {
       elasticsearch.getMapping = sinon.stub().resolves({ dynamic: 'false', properties: { city: { type: 'keyword' } } });
-      elasticsearch.updateByQuery = sinon.stub().resolves({});
+      elasticsearch._client.updateByQuery = sinon.stub().resolves({});
       elasticsearch._client.search = sinon.stub().resolves({
         body: {
           hits: {
@@ -2490,7 +2490,11 @@ describe('Test: ElasticSearch service', () => {
 
       should(elasticsearch.updateSettings).be.calledWith(index, collection, settings);
       should(elasticsearch.updateMapping).be.calledWith(index, collection, mappings);
-      should(elasticsearch.updateByQuery).be.calledWith(index, collection, {}, {});
+      should(elasticsearch._client.updateByQuery).be.calledWith({
+        conflicts: 'proceed',
+        index: `&${index}.${collection}`,
+        refresh: true
+      });
     });
 
     it('should call updateSettings, updateMapping', async () => {


### PR DESCRIPTION
## What does this PR do ?

reindex documents with the new mappings (`collection:update`)

### How should this be manually tested?

Add a few documents in it.
Then add mappings to describe the fields in the added documents.

Expected: running a document:search in the collection should return the searched documents.

or run the functional tests