### PR TITLE
Early check of controller definition for better errors

### DIFF
--- a/lib/core/plugin/plugin.js
+++ b/lib/core/plugin/plugin.js
@@ -300,6 +300,13 @@ class Plugin {
         'Controller definition must be an object');
     }
 
+    if (! isPlainObject(definition.actions)) {
+      throw assertionError.get(
+        'invalid_controller_definition',
+        name,
+        'Controller definition "actions" property must be an object');
+    }
+
     for (const [action, actionDefinition] of Object.entries(definition.actions)) {
       const actionProperties = Object.keys(actionDefinition);
 

--- a/test/core/backend/BackendController.test.js
+++ b/test/core/backend/BackendController.test.js
@@ -79,6 +79,14 @@ describe('Backend', () => {
         application.controller.register('greeting', definition);
       }).throwError({ id: 'plugin.assert.invalid_controller_definition' });
     });
+
+    it('should check controller definition', () => {
+      delete definition.actions;
+
+      should(() => {
+        application.controller.register(definition);
+      }).throwError({ id: 'plugin.assert.invalid_controller_definition' });
+    });
   });
 
   describe('ControllerManager#use', () => {
@@ -131,6 +139,14 @@ describe('Backend', () => {
 
       should(() => {
         application.controller.use(controller2);
+      }).throwError({ id: 'plugin.assert.invalid_controller_definition' });
+    });
+
+    it('should check controller definition', () => {
+      delete controller.definition.actions;
+
+      should(() => {
+        application.controller.use(controller);
       }).throwError({ id: 'plugin.assert.invalid_controller_definition' });
     });
   });


### PR DESCRIPTION
## What does this PR do ?

The check of application controller definition was made in the `PluginManager` with plugins controller definition.

The check is now made when calling the `controller.use` or `controller.register` methods so we can throw an error containing the complete user stacktrace, including the line register/using the bad controller. 
