### PR TITLE
Fix index:mDelete usage with EmbeddedSDK

### DIFF
--- a/lib/api/controllers/indexController.js
+++ b/lib/api/controllers/indexController.js
@@ -21,8 +21,6 @@
 
 'use strict';
 
-const Bluebird = require('bluebird');
-
 const { Request } = require('../request');
 const { NativeController } = require('./baseController');
 
@@ -119,7 +117,7 @@ class IndexController extends NativeController {
         );
       }
 
-      await Bluebird.all(promises);
+      await Promise.all(promises);
     }
 
     return response;
@@ -148,12 +146,18 @@ class IndexController extends NativeController {
   }
 
   /**
-   * Returns a list of indexes allowed to be deleted by the user
+   * Returns a list of indexes allowed to be deleted by the user.
+   *
+   * Returns entire list of public indexes when called from EmbeddedSDK
    *
    * @param {Request} request
-   * @param {String[]} publicIndexes - Complete indexes list
+   * @param {String[]} publicIndexes - Public indexes list
    */
   _allowedIndexes (request, publicIndexes) {
+    if (request.getUser() === null) {
+      return publicIndexes;
+    }
+
     const allowedIndexes = [];
 
     const promises = publicIndexes
@@ -171,7 +175,7 @@ class IndexController extends NativeController {
           });
       });
 
-    return Bluebird.all(promises)
+    return Promise.all(promises)
       .then(() => allowedIndexes);
   }
 }

--- a/test/api/controllers/indexController.test.js
+++ b/test/api/controllers/indexController.test.js
@@ -70,6 +70,19 @@ describe('IndexController', () => {
 
       should(response).match({ deleted: ['a', 'e', 'i'] });
     });
+
+    it('should returns all indexes when used with embedded SDK', async () => {
+      request.input.body = {
+        indexes: ['a', 'c', 'e', 'g', 'i']
+      };
+      request.context.token = null;
+      request.context.user = null;
+
+      await indexController.mDelete(request);
+
+      should(kuzzle.ask)
+        .be.calledWith('core:storage:public:index:mDelete', ['a', 'c', 'e', 'g', 'i']);
+    });
   });
 
   describe('#create', () => {


### PR DESCRIPTION
## What does this PR do ?

The `index:mDelete` action was filtering the list of indexes according to the user rights.  
When used with the EmbeddedSDK, there is no user so we can returns the entire list of indexes.


### Boyscout

- Replace `Bluebird.all` usage
