### PR TITLE
Add retry function and cluster steps for cucumber framework

### DIFF
--- a/doc/2/api/payloads/response/index.md
+++ b/doc/2/api/payloads/response/index.md
@@ -2,7 +2,7 @@
 code: false
 type: page
 title: Response
-description: Response payload reference  
+description: Response payload reference
 order: 200
 ---
 
@@ -18,7 +18,6 @@ The Response Payload is a standardized response sent by Kuzzle in JSON format.
 | `collection` | string       | Collection name                                                           |
 | `_id`        | string       | Document unique identifier                                                |
 | `error`      | [ErrorPayload](/core/2/api/payloads/error) | API error                                   |
-| `jwt`        | string       | Authentication token                                                      |
 | `node`       | string       | Unique identifier of the node who processed the request                   |
 | `result`     | any          | API action result                                                         |
 | `status`     | number       | HTTP status code                                                          |

--- a/features/step_definitions/cluster-steps.js
+++ b/features/step_definitions/cluster-steps.js
@@ -1,0 +1,8 @@
+const should = require('should');
+const { Then } = require('cucumber');
+
+Then('I target {string}', async function (node) {
+  should(this).have.property(node);
+
+  this.sdk = this[node];
+});

--- a/features/step_definitions/cluster-steps.js
+++ b/features/step_definitions/cluster-steps.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const should = require('should');
 const { Then } = require('cucumber');
 

--- a/features/step_definitions/realtime-steps.js
+++ b/features/step_definitions/realtime-steps.js
@@ -38,17 +38,14 @@ Then('I unsubscribe from the current room via the plugin', async function () {
   this.props.result = response.result;
 });
 
-Then('I should have receive {string} notifications for {string}:{string}', async function (rawNumber, index, collection) {
-  const expectedCount = parseInt(rawNumber, 10);
-  const notifications = this.props.subscriptions[`${index}:${collection}`].notifications;
+Then('I should have receive {string} notifications for {string}:{string}', function (rawNumber, index, collection) {
+  return this.retry(() => {
+    const expectedCount = parseInt(rawNumber, 10);
+    const notifications = this.props.subscriptions[`${index}:${collection}`].notifications;
 
-  // retry
-  for (let i = 0; notifications.length < expectedCount && i < 10; i++) {
-    await new Promise(resolve => setTimeout(resolve, 200));
-  }
-
-  should(this.props.subscriptions[`${index}:${collection}`].notifications)
-    .have.length(expectedCount);
+    should(this.props.subscriptions[`${index}:${collection}`].notifications)
+      .have.length(expectedCount);
+  });
 });
 
 Then('I should receive realtime notifications for {string}:{string} matching:', function (index, collection, datatable, done) {

--- a/features/step_definitions/realtime-steps.js
+++ b/features/step_definitions/realtime-steps.js
@@ -41,7 +41,6 @@ Then('I unsubscribe from the current room via the plugin', async function () {
 Then('I should have receive {string} notifications for {string}:{string}', function (rawNumber, index, collection) {
   return this.retry(() => {
     const expectedCount = parseInt(rawNumber, 10);
-    const notifications = this.props.subscriptions[`${index}:${collection}`].notifications;
 
     should(this.props.subscriptions[`${index}:${collection}`].notifications)
       .have.length(expectedCount);

--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -183,9 +183,9 @@ After({ tags: '@websocket' }, function () {
 Before({ tags: '@cluster' }, async function () {
   this.sdk.disconnect();
 
-  this.node1 = new Kuzzle(new WebSocket(this.host, { port: 17510 }));
-  this.node2 = new Kuzzle(new WebSocket(this.host, { port: 17511 }));
-  this.node3 = new Kuzzle(new WebSocket(this.host, { port: 17512 }));
+  this.node1 = this.getSDK({ port: 17510 });
+  this.node2 = this.getSDK({ port: 17511 });
+  this.node3 = this.getSDK({ port: 17512 });
 
   await Promise.all([
     this.node1.connect(),
@@ -197,4 +197,5 @@ Before({ tags: '@cluster' }, async function () {
 After({ tags: '@cluster' }, async function () {
   this.node1.disconnect();
   this.node2.disconnect();
+  this.node3.disconnect();
 });

--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -176,3 +176,25 @@ After({ tags: '@realtime' }, function () {
 After({ tags: '@websocket' }, function () {
   this.props.client.terminate();
 });
+
+
+// cluster hooks ===============================================================
+
+Before({ tags: '@cluster' }, async function () {
+  this.sdk.disconnect();
+
+  this.node1 = new Kuzzle(new WebSocket(this.host, { port: 17510 }));
+  this.node2 = new Kuzzle(new WebSocket(this.host, { port: 17511 }));
+  this.node3 = new Kuzzle(new WebSocket(this.host, { port: 17512 }));
+
+  await Promise.all([
+    this.node1.connect(),
+    this.node2.connect(),
+    this.node3.connect(),
+  ]);
+});
+
+After({ tags: '@cluster' }, async function () {
+  this.node1.disconnect();
+  this.node2.disconnect();
+});

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -142,7 +142,7 @@ class KuzzleWorld {
    * @param options.retries Max number of retries (`100`)
    * @param options.interval Interval between retries in ms (`50`)
    */
-   async retry (predicate, { retries=100, interval=50 } = {}) {
+  async retry (predicate, { retries = 100, interval = 50 } = {}) {
     let count = 0;
 
     while (count < retries) {

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -126,13 +126,18 @@ class KuzzleWorld {
   }
 
   /**
-   * Re-try to validate the same predicate N times
+   * Re-try to validate the same predicate N times.
+   *
+   * By default, it will wait for a maximum of 5 seconds.
+   *
+   * You may want to increase cucumber default step timeout:
+   * `Then(..., { timeout: 5000 }, async function (...) {`
    *
    * @param predicate Function throwing an exception when fail to validate
-   * @param options.retries Max number of retries (`50`)
-   * @param options.interval Interval between retries in ms (`100`)
+   * @param options.retries Max number of retries (`100`)
+   * @param options.interval Interval between retries in ms (`50`)
    */
-   async retry (predicate, { retries=50, interval=100 } = {}) {
+   async retry (predicate, { retries=100, interval=50 } = {}) {
     let count = 0;
 
     while (count < retries) {

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -144,11 +144,12 @@ class KuzzleWorld {
    */
   async retry (predicate, { retries = 100, interval = 50 } = {}) {
     let count = 0;
+    let failure = true;
 
-    while (count < retries) {
+    while (failure) {
       try {
         await predicate();
-        count = retries;
+        failure = false;
       }
       catch (error) {
         if (count === retries) {

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -124,6 +124,33 @@ class KuzzleWorld {
       throw this.props.error;
     }
   }
+
+  /**
+   * Re-try to validate the same predicate N times
+   *
+   * @param predicate Function throwing an exception when fail to validate
+   * @param options.retries Max number of retries (`50`)
+   * @param options.interval Interval between retries in ms (`100`)
+   */
+   async retry (predicate, { retries=50, interval=100 } = {}) {
+    let count = 0;
+
+    while (count < retries) {
+      try {
+        await predicate();
+        count = retries;
+      }
+      catch (error) {
+        if (count === retries) {
+          throw error;
+        }
+
+        await new Promise(resolve => setTimeout(resolve, interval));
+
+        count++;
+      }
+    }
+  }
 }
 
 setWorldConstructor(KuzzleWorld);

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -152,7 +152,7 @@ class KuzzleWorld {
         failure = false;
       }
       catch (error) {
-        if (count === retries) {
+        if (count >= retries) {
           throw error;
         }
 

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -21,7 +21,7 @@ class KuzzleWorld {
     // Intermediate steps should store values inside this object
     this.props = {};
 
-    this._sdk = this._getSdk();
+    this._sdk = this.getSDK();
   }
 
   get sdk () {
@@ -80,15 +80,20 @@ class KuzzleWorld {
     return objectArray;
   }
 
-  _getSdk () {
+  /**
+   * Intantiate a SDK
+   *
+   * @param options.port Used to connect the SDK to a specific node of the cluster
+   */
+  getSDK ({ port } = {}) {
     let protocol;
 
     switch (this.protocol) {
       case 'http':
-        protocol = new Http(this.host, { port: this.port });
+        protocol = new Http(this.host, { port: port || this.port });
         break;
       case 'websocket':
-        protocol = new WebSocket(this.host, { port: this.port });
+        protocol = new WebSocket(this.host, { port: port || this.port });
         break;
       default:
         throw new Error(`Unknown protocol "${this.protocol}".`);


### PR DESCRIPTION
## Description

Add a `retry` method in the Cucumber context. This methods allow to re-try the same predicates few times before throwing an actual error.  
This is useful to wait for notification or other kind of asynchronous resources propagation without having to wait an arbitrary number of ms.

Add cluster steps that allows to target a specific node of the cluster to ensure resources propagation across nodes