### PR TITLE
Add a Debug Controller

### DIFF
--- a/lib/api/controllers/debugController.ts
+++ b/lib/api/controllers/debugController.ts
@@ -1,0 +1,108 @@
+/*
+ * Kuzzle, a backend software, self-hostable and ready to use
+ * to power modern apps
+ *
+ * Copyright 2015-2022 Kuzzle
+ * mailto: support AT kuzzle.io
+ * website: http://kuzzle.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+import { Request } from '../request';
+import { NativeController } from './baseController';
+import v8 from 'v8';
+import { HttpStream } from '../../types';
+
+/**
+ * @class DebugController
+ */
+export class DebugController extends NativeController {
+  constructor () {
+    super([
+      'heapSnapshot',
+      'getHeapStatistics',
+      'getHeapSpaceStatistics',
+      'getHeapCodeStatistics',
+      'setFlags',
+    ]);
+  }
+
+  /**
+   * Take a heap snapshot and returns the filename of the snapshot.
+   * If the download parameter is set to true, the snapshot will be downloaded using an HTTP Stream instead of saved on the disk.
+   * 
+   * @param {Request} request
+   */
+  async heapSnapshot (request) {
+    if (request.getBoolean('download')) {
+      if (request.context.connection.protocol !== 'http') {
+        throw new Error('Downloading heap snapshots is only supported over HTTP');
+      }
+
+      const stream = v8.getHeapSnapshot();
+
+      const date = new Date();
+      const filename = `heap-${date.getFullYear()}-${date.getMonth()}-${date.getDate()}-${date.getHours()}-${date.getMinutes()}.heapsnapshot`;
+      request.response.configure({
+        headers: {
+          'Content-Disposition': `attachment; filename="${filename}"`,
+          'Content-Type': 'application/json',
+        }
+      });
+
+      return new HttpStream(stream);
+    }
+
+    return v8.writeHeapSnapshot();
+  }
+
+  /**
+   * See https://nodejs.org/dist/latest-v16.x/docs/api/v8.html#v8getheapstatistics
+   * 
+   * @returns {Promise}
+   */
+  async getHeapStatistics () {
+    return v8.getHeapStatistics();
+  }
+
+  /**
+   * Returns statistics about the V8 heap spaces, i.e. the segments which make up the V8 heap.
+   * See https://nodejs.org/dist/latest-v16.x/docs/api/v8.html#v8getheapspacestatistics
+   * 
+   * @returns {Promise}
+   */
+   async getHeapSpaceStatistics () {
+    return v8.getHeapSpaceStatistics();
+  }
+
+
+  /**
+   * The v8.setFlagsFromString() method can be used to programmatically set V8 command-line flags. This method should be used with care. Changing settings after the VM has started may result in unpredictable behavior, including crashes and data loss; or it may simply do nothing.
+   * See https://nodejs.org/dist/latest-v16.x/docs/api/v8.html#v8getheapcodestatistics
+   */
+  async getHeapCodeStatistics () {
+    return v8.getHeapCodeStatistics();
+  }
+
+  /**
+   * See https://nodejs.org/dist/latest-v16.x/docs/api/v8.html#v8setflagsfromstringflags
+   */
+  async setFlags (request: Request) {
+    const flags = request.getString('flags');
+
+    return v8.setFlagsFromString(flags);
+  }
+}

--- a/lib/api/controllers/index.js
+++ b/lib/api/controllers/index.js
@@ -28,6 +28,7 @@ module.exports = {
   ClusterController: require('./clusterController'),
   CollectionController: require('./collectionController'),
   DocumentController: require('./documentController'),
+  DebugController: require('./debugController').DebugController,
   IndexController: require('./indexController'),
   MemoryStorageController: require('./memoryStorageController'),
   RealtimeController: require('./realtimeController'),

--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -33,6 +33,7 @@ const {
   BulkController,
   ClusterController,
   CollectionController,
+  DebugController,
   DocumentController,
   IndexController,
   MemoryStorageController,
@@ -115,6 +116,7 @@ class Funnel {
     this.controllers.set('bulk', new BulkController());
     this.controllers.set('cluster', new ClusterController());
     this.controllers.set('collection', new CollectionController());
+    this.controllers.set('debug', new DebugController());
     this.controllers.set('document', new DocumentController());
     this.controllers.set('index', new IndexController());
     this.controllers.set('realtime', new RealtimeController());

--- a/lib/api/httpRoutes.js
+++ b/lib/api/httpRoutes.js
@@ -52,6 +52,12 @@ const routes = [
   { verb: 'get', path: '/credentials/:strategy/_me', controller: 'auth', action: 'getMyCredentials', deprecated: { since: '2.4.0', message: 'Use this route instead: http://kuzzle:7512/_me/credentials/:strategy' } }, // @deprecated
   { verb: 'get', path: '/credentials/:strategy/_me/_exists', controller: 'auth', action: 'credentialsExist', deprecated: { since: '2.4.0', message: 'Use this route instead: http://kuzzle:7512/_me/credentials/:strategy/_exists' } }, // @deprecated
 
+  { verb: 'get', path: '/debug/_heapSnapshot', controller: 'debug', action: 'heapSnapshot' },
+  { verb: 'get', path: '/debug/_getHeapStatistics', controller: 'debug', action: 'getHeapStatistics' },
+  { verb: 'get', path: '/debug/_getHeapSpaceStatistics', controller: 'debug', action: 'getHeapSpaceStatistics' },
+  { verb: 'get', path: '/debug/_getHeapCodeStatistics', controller: 'debug', action: 'getHeapCodeStatistics' },
+  { verb: 'get', path: '/debug/_setFlags', controller: 'debug', action: 'setFlags' },
+
   // We need to expose a GET method for "login" action in order to make authentication protocol like Oauth2 or CAS work:
   { verb: 'get', path: '/_login/:strategy', controller: 'auth', action: 'login' },
 


### PR DESCRIPTION
## What does this PR do ?

This PR adds a new controller that should help debugging instances remotely
The main features for now are:

**Gathering informations on the Heap:**
- getHeapStatistics
- getHeapSpaceStatistics
- getHeapCodeStatistics
**Dumping the heap:**
- heapSnapshot: Allow to dump the heap in a file or directly downloading it via HTTP Connection
**Modify VM/JIT behaviour at runtime:**
- setFlags: Allows to manipulate VM/JIT flags at runtime, can be used to further debug by showing gc_traces and many other things

**To discuss / To implement:**
- Allow to run the CPU Profiler
- Allow to run the Heap Profiler and monitor dynamic allocations
- Allow to access the debugger of the current Kuzzle node directly without opening the debug port to the public (safer since connection limited by funnel authorization mechanism) 
