### PR TITLE
Better notification dispatch pipe

### DIFF
--- a/doc/2/framework/events/realtime/index.md
+++ b/doc/2/framework/events/realtime/index.md
@@ -21,7 +21,7 @@ Use `core:realtime:user:subscribe:after` instead.
 <DeprecatedBadge version="2.5.0">
 
 | Arguments      | Type              | Description                                       |
-|----------------|-------------------|---------------------------------------------------|
+| -------------- | ----------------- | ------------------------------------------------- |
 | `subscription` | <pre>object</pre> | Contains information about the added subscription |
 
 Triggered whenever a [subscription](/core/2/api/controllers/realtime/subscribe) is added.
@@ -30,12 +30,12 @@ Triggered whenever a [subscription](/core/2/api/controllers/realtime/subscribe) 
 
 The provided `subscription` object has the following properties:
 
-| Properties     | Type               | Description                                                                                                |
-|----------------|--------------------|------------------------------------------------------------------------------------------------------------|
-| `roomId`       | <pre>string</pre>  | Room unique identifier                                                                                     |
-| `connectionId` | <pre>integer</pre> | [ClientConnection](/core/2/guides/write-protocols/context/clientconnection) unique identifier              |
-| `index`        | <pre>string</pre>  | Index                                                                                                      |
-| `collection`   | <pre>string</pre>  | Collection                                                                                                 |
+| Properties     | Type               | Description                                                                                                    |
+| -------------- | ------------------ | -------------------------------------------------------------------------------------------------------------- |
+| `roomId`       | <pre>string</pre>  | Room unique identifier                                                                                         |
+| `connectionId` | <pre>integer</pre> | [ClientConnection](/core/2/guides/write-protocols/context/clientconnection) unique identifier                  |
+| `index`        | <pre>string</pre>  | Index                                                                                                          |
+| `collection`   | <pre>string</pre>  | Collection                                                                                                     |
 | `filters`      | <pre>object</pre>  | Filters in [Koncorde's normalized format](https://github.com/kuzzleio/koncorde/wiki/Filter-Unique-Identifiers) |
 
 </DeprecatedBadge>
@@ -51,7 +51,7 @@ Use `core:realtime:user:unsubscribe:after` instead.
 <DeprecatedBadge version="2.5.0">
 
 | Arguments        | Type              | Description                                                                     |
-|------------------|-------------------|---------------------------------------------------------------------------------|
+| ---------------- | ----------------- | ------------------------------------------------------------------------------- |
 | `RequestContest` | <pre>object</pre> | [requestContext](/core/2/guides/write-protocols/context/requestcontext/) object |
 | `room`           | <pre>object</pre> | Joined room information in Koncorde format                                      |
 
@@ -62,7 +62,7 @@ Triggered whenever a user is removed from a room.
 The provided `room` object has the following properties:
 
 | Properties   | Type              | Description            |
-|--------------|-------------------|------------------------|
+| ------------ | ----------------- | ---------------------- |
 | `id`         | <pre>string</pre> | Room unique identifier |
 | `index`      | <pre>string</pre> | Index                  |
 | `collection` | <pre>string</pre> | Collection             |
@@ -82,7 +82,7 @@ Pipes cannot listen to this event, only hooks can.
 :::
 
 | Arguments | Type              | Description             |
-|-----------|-------------------|-------------------------|
+| --------- | ----------------- | ----------------------- |
 | `room`    | <pre>object</pre> | Joined room information |
 
 ### room
@@ -90,7 +90,7 @@ Pipes cannot listen to this event, only hooks can.
 The provided `room` object has the following properties:
 
 | Properties   | Type              | Description                    |
-|--------------|-------------------|--------------------------------|
+| ------------ | ----------------- | ------------------------------ |
 | `index`      | <pre>string</pre> | Index name                     |
 | `collection` | <pre>string</pre> | Collection name                |
 | `roomId`     | <pre>string</pre> | The new room unique identifier |
@@ -108,7 +108,7 @@ Pipes cannot listen to this event, only hooks can.
 :::
 
 | Arguments | Type              | Description            |
-|-----------|-------------------|------------------------|
+| --------- | ----------------- | ---------------------- |
 | `roomId`  | <pre>string</pre> | Room unique identifier |
 
 
@@ -125,7 +125,7 @@ Pipes cannot listen to this event, only hooks can.
 <SinceBadge version="2.5.0"/>
 
 | Arguments      | Type              | Description                                       |
-|----------------|-------------------|---------------------------------------------------|
+| -------------- | ----------------- | ------------------------------------------------- |
 | `subscription` | <pre>object</pre> | Contains information about the added subscription |
 
 
@@ -134,7 +134,7 @@ Pipes cannot listen to this event, only hooks can.
 The provided `subscription` object has the following properties:
 
 | Properties     | Type               | Description                                                                                                |
-|----------------|--------------------|------------------------------------------------------------------------------------------------------------|
+| -------------- | ------------------ | ---------------------------------------------------------------------------------------------------------- |
 | `roomId`       | <pre>string</pre>  | Room unique identifier                                                                                     |
 | `connectionId` | <pre>integer</pre> | [ClientConnection](/core/2/guides/write-protocols/context/clientconnection) unique identifier              |
 | `index`        | <pre>string</pre>  | Index                                                                                                      |
@@ -154,8 +154,8 @@ Pipes cannot listen to this event, only hooks can.
 
 <SinceBadge version="2.5.0"/>
 
-| Arguments        | Type              | Description                                                                                                                |
-|------------------|-------------------|----------------------------------------------------------------------------------------------------------------------------|
+| Arguments        | Type              | Description                                                                                                          |
+| ---------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------- |
 | `RequestContest` | <pre>object</pre> | [RequestContext](/core/2/guides/write-protocols/context/requestcontext/) object <DeprecatedBadge version="2.14.1" /> |
 | `room`           | <pre>object</pre> | Joined room information in Koncorde format <DeprecatedBadge version="2.14.1" />                                      |
 | `subscription`   | <pre>object</pre> | Contains information about the removed subscription <SinceBadge version="2.14.1" />                                  |
@@ -165,7 +165,7 @@ Pipes cannot listen to this event, only hooks can.
 The provided `room` object has the following properties:
 
 | Properties   | Type              | Description            |
-|--------------|-------------------|------------------------|
+| ------------ | ----------------- | ---------------------- |
 | `id`         | <pre>string</pre> | Room unique identifier |
 | `index`      | <pre>string</pre> | Index                  |
 | `collection` | <pre>string</pre> | Collection             |
@@ -175,7 +175,7 @@ The provided `room` object has the following properties:
 The provided `subscription` object has the following properties:
 
 | Properties     | Type               | Description                                                                                   |
-|----------------|--------------------|-----------------------------------------------------------------------------------------------|
+| -------------- | ------------------ | --------------------------------------------------------------------------------------------- |
 | `roomId`       | <pre>string</pre>  | Room unique identifier                                                                        |
 | `connectionId` | <pre>integer</pre> | [ClientConnection](/core/2/guides/write-protocols/context/clientconnection) unique identifier |
 | `index`        | <pre>string</pre>  | Index                                                                                         |
@@ -184,20 +184,46 @@ The provided `subscription` object has the following properties:
 
 ---
 
+## core:realtime:notification:dispatch:before
+
+<SinceBadge version="auto-version"/>
+
+| Arguments             | Type              | Description                                 |
+| --------------------- | ----------------- | ------------------------------------------- |
+| `notificationContext` | <pre>object</pre> | Contains information about the notification |
+
+### notificationContext
+
+| Arguments      | Type                                                                    | Description                                                                                   |
+| -------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `notification` | <pre><a href=/core/2/api/payloads/notifications>Notifications</a></pre> | The normalized real-time notification                                                         |
+| `channels`     | <pre>string[]</pre>                                                     | List of Subscribers channels to notify                                                        |
+| `connectionId` | <pre>integer</pre>                                                      | [ClientConnection](/core/2/guides/write-protocols/context/clientconnection) unique identifier |
+
+---
+
 ## notify:dispatch
 
+<DeprecatedBadge version="auto-version">
+
+This event is deprecated and will be removed in the next major version of Kuzzle.
+
+Use `core:realtime:notification:dispatch:before` instead.
+
 | Arguments | Type                                                                    | Description                           |
-|-----------|-------------------------------------------------------------------------|---------------------------------------|
+| --------- | ----------------------------------------------------------------------- | ------------------------------------- |
 | `message` | <pre><a href=/core/2/api/payloads/notifications>Notifications</a></pre> | The normalized real-time notification |
 
 Triggered whenever a real-time notification is about to be sent.
+
+</DeprecatedBadge>
 
 ---
 
 ## notify:document
 
 | Arguments | Type                                                                    | Description                           |
-|-----------|-------------------------------------------------------------------------|---------------------------------------|
+| --------- | ----------------------------------------------------------------------- | ------------------------------------- |
 | `message` | <pre><a href=/core/2/api/payloads/notifications>Notifications</a></pre> | The normalized real-time notification |
 
 Triggered whenever a real-time document notification is about to be sent.
@@ -207,7 +233,7 @@ Triggered whenever a real-time document notification is about to be sent.
 ## notify:server
 
 | Arguments | Type                                                                    | Description                           |
-|-----------|-------------------------------------------------------------------------|---------------------------------------|
+| --------- | ----------------------------------------------------------------------- | ------------------------------------- |
 | `message` | <pre><a href=/core/2/api/payloads/notifications>Notifications</a></pre> | The normalized real-time notification |
 
 Triggered whenever a real-time server notification is about to be sent.
@@ -217,7 +243,7 @@ Triggered whenever a real-time server notification is about to be sent.
 ## notify:user
 
 | Arguments | Type                                                                    | Description                           |
-|-----------|-------------------------------------------------------------------------|---------------------------------------|
+| --------- | ----------------------------------------------------------------------- | ------------------------------------- |
 | `message` | <pre><a href=/core/2/api/payloads/notifications>Notifications</a></pre> | The normalized real-time notification |
 
 Triggered whenever a real-time user notification is about to be sent.
@@ -234,7 +260,7 @@ Use `core:realtime:room:create:after` instead.
 
 
 | Arguments | Type              | Description             |
-|-----------|-------------------|-------------------------|
+| --------- | ----------------- | ----------------------- |
 | `room`    | <pre>object</pre> | Joined room information |
 
 Triggered whenever a new [subscription](/core/2/api/controllers/realtime/subscribe) is created.
@@ -248,7 +274,7 @@ Pipes cannot listen to this event, only hooks can.
 The provided `room` object has the following properties:
 
 | Properties   | Type              | Description                    |
-|--------------|-------------------|--------------------------------|
+| ------------ | ----------------- | ------------------------------ |
 | `index`      | <pre>string</pre> | Index name                     |
 | `collection` | <pre>string</pre> | Collection name                |
 | `roomId`     | <pre>string</pre> | The new room unique identifier |
@@ -266,7 +292,7 @@ Use `core:realtime:room:remove:before` instead.
 <DeprecatedBadge version="2.5.0">
 
 | Arguments | Type              | Description            |
-|-----------|-------------------|------------------------|
+| --------- | ----------------- | ---------------------- |
 | `roomId`  | <pre>string</pre> | Room unique identifier |
 
 Triggered whenever a real-time subscription is cancelled.

--- a/lib/core/realtime/notifier.js
+++ b/lib/core/realtime/notifier.js
@@ -382,14 +382,23 @@ class NotifierController {
   async _dispatch (event, channels, notification, connectionId) {
     try {
       let updated = await global.kuzzle.pipe(event, notification);
+      /**
+       * @deprecated  Should be replaced by `core:realtime:notification:dispatch`
+       */
       updated = await global.kuzzle.pipe('notify:dispatch', updated);
 
-      const action = connectionId ? 'notify' : 'broadcast';
+      const updatedInfo = await global.kuzzle.pipe('core:realtime:notification:dispatch:before', {
+        channels: channels,
+        connectionId: connectionId,
+        notification: updated,
+      });
+
+      const action = updatedInfo.connectionId ? 'notify' : 'broadcast';
 
       global.kuzzle.entryPoint.dispatch(action, {
-        channels,
-        connectionId,
-        payload: updated
+        channels: updatedInfo.channels,
+        connectionId: updatedInfo.connectionId,
+        payload: updatedInfo.notification
       });
     }
     catch (error) {

--- a/test/core/realtime/notifier/notifyMethods.test.js
+++ b/test/core/realtime/notifier/notifyMethods.test.js
@@ -192,13 +192,22 @@ describe('notify methods', () => {
           result: content,
         });
 
-        should(kuzzle.pipe.callCount).be.eql(2);
+        should(kuzzle.pipe.callCount).be.eql(3);
 
         should(kuzzle.pipe.getCall(0).args).match(
           ['notify:document', notification]);
 
         should(kuzzle.pipe.getCall(1).args).match(
           ['notify:dispatch', notification]);
+
+        should(kuzzle.pipe.getCall(2).args).match(
+          [
+            'core:realtime:notification:dispatch:before',
+            {
+              channels: ['matching_all', 'matching_out', 'always', 'clusterOn', 'clusterOff'],
+              notification,
+            }
+          ]);
       });
 
       it('should not notify if no channel match the provided scope argument', async () => {
@@ -294,13 +303,22 @@ describe('notify methods', () => {
           room: 'matchingSome',
         }
       ]);
-      should(kuzzle.pipe.callCount).be.eql(2);
+      should(kuzzle.pipe.callCount).be.eql(3);
 
       should(kuzzle.pipe.getCall(0).args).match(
         ['notify:user', notification]);
 
       should(kuzzle.pipe.getCall(1).args).match(
         ['notify:dispatch', notification]);
+      
+      should(kuzzle.pipe.getCall(2).args).match(
+        [
+          'core:realtime:notification:dispatch:before',
+          {
+            channels: ['matching_all', 'matching_userOut'],
+            notification,
+          }
+        ]);
     });
   });
 
@@ -341,10 +359,87 @@ describe('notify methods', () => {
         info: 'This is an automated server notification',
       });
 
-      should(kuzzle.pipe.callCount).be.eql(2);
+      should(kuzzle.pipe.callCount).be.eql(3);
       should(kuzzle.pipe)
         .be.calledWith('notify:server', notification)
-        .be.calledWith('notify:dispatch', notification);
+        .be.calledWith('notify:dispatch', notification)
+        .be.calledWith('core:realtime:notification:dispatch:before', {
+          channels: ['kuzzle:notification:server'],
+          connectionId: 'foobar',
+          notification,
+        });
+    });
+  });
+
+  describe('dispatch', () => {
+    it('should call entrypoint.dispatch  with notify action when there is a connectionId',  async () => {
+      await notifier._dispatch('my-event', ['channel-foo'], { foo: 'bar' }, 'connectionId');
+
+      should(kuzzle.entryPoint.dispatch)
+        .calledOnce()
+        .and.be.calledWith('notify', {
+          channels: [ 'channel-foo' ],
+          connectionId: 'connectionId',
+          payload: { foo: 'bar' },
+        });
+    });
+
+    it('should call entrypoint.dispatch  with broadcast action when there is no connectionId',  async () => {
+      await notifier._dispatch('my-event', ['channel-foo'], { foo: 'bar' });
+
+      should(kuzzle.entryPoint.dispatch)
+        .calledOnce()
+        .and.be.calledWith('broadcast', {
+          channels: [ 'channel-foo' ],
+          connectionId: undefined,
+          payload: { foo: 'bar' },
+        });
+    });
+
+    it('should trigger the pipes', async () => {
+      kuzzle.registerPluginPipe('my-event', async (payload) => {
+        return {
+          ...payload,
+          bar: 'baz'
+        };
+      });
+
+      kuzzle.registerPluginPipe('notify:dispatch', async (payload) => {
+        return {
+          ...payload,
+          baz: 'alpha'
+        };
+      });
+
+      kuzzle.registerPluginPipe('core:realtime:notification:dispatch:before', async (notificationContext) => {
+        return {
+          channels: [ 'channel-bar' ],
+          connectionId: undefined,
+          notification: {
+            ...notificationContext.notification,
+            alpha: 'beta'
+          },
+        };
+      });
+
+      await notifier._dispatch('my-event', ['channel-foo'], { foo: 'bar' }, 'foobar');
+
+      await should(kuzzle.pipe)
+        .be.calledWith('my-event', { foo: 'bar' })
+        .be.calledWith('notify:dispatch', { foo: 'bar', bar: 'baz' })
+        .be.calledWith('core:realtime:notification:dispatch:before', {
+          channels: [ 'channel-foo' ],
+          connectionId: 'foobar',
+          notification: { foo: 'bar', bar: 'baz', baz: 'alpha' },
+        });
+
+      await should(kuzzle.entryPoint.dispatch)
+        .calledOnce()
+        .and.be.calledWith('broadcast', {
+          channels: [ 'channel-bar' ],
+          connectionId: undefined,
+          payload: { foo: 'bar', bar: 'baz', baz: 'alpha', alpha: 'beta' },
+        });
     });
   });
 });

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -31,7 +31,20 @@ class KuzzleMock extends KuzzleEventEmitter {
     // ========== EVENTS ==========
 
     // emit + pipe mocks
-    sinon.stub(this, 'pipe').callsFake((...args) => {
+    sinon.stub(this, 'pipe').callsFake(async (...args) => {
+      if (typeof args[0] === 'string' && this.pluginPipes.get(args[0])) {
+        let pipeArgs = [...args.slice(1)];
+
+        try {
+          for (const handler of this.pluginPipes.get(args[0])) {
+            pipeArgs = [await handler(...pipeArgs)].slice(0, 1);
+          }
+          return pipeArgs[0];
+        } catch (e) {
+          return args[1]
+        }
+      }
+
       if (typeof args[args.length - 1] !== 'function') {
         return Bluebird.resolve(...args.slice(1));
       }


### PR DESCRIPTION
## What does this PR do ?

Deprecate the pipe  `notify:dispatch` and add a new pipe `core:realtime:notification:dispatch:before` that allows to change the `channels`, `connectionId` and `notification`.