### PR TITLE
Adding parameters to OpenAPI requests

### DIFF
--- a/lib/api/controllers/serverController.js
+++ b/lib/api/controllers/serverController.js
@@ -299,8 +299,11 @@ class ServerController extends NativeController {
   async openapi (request) {
     const format = request.getString('format', 'json');
     const scope = request.getString('scope', 'all');
+    const exclude = request.getString('exclude', '').split(',').map(e => e.trim()).filter(e => e);
+    const only = request.getString('only', '').split(',').map(e => e.trim()).filter(e => e);
 
     let definition;
+
 
     if (scope === 'kuzzle') {
       definition = await global.kuzzle.ask('core:api:openapi:kuzzle');
@@ -313,6 +316,34 @@ class ServerController extends NativeController {
     }
     else {
       throw kerror.get('api', 'assert', 'unexpected_argument', scope, ['kuzzle', 'app', 'all']);
+    }
+
+    if (exclude.length) {
+      definition.tags = definition.tags.filter(tag => ! exclude.includes(tag.name));
+      Object.entries(definition.paths).forEach(([path, pathDefinition]) => {
+        Object.entries(pathDefinition).forEach(([method, methodDefinition]) => {
+          if (methodDefinition.tags.some(tag => exclude.includes(tag))) {
+            delete pathDefinition[method];
+          }
+        });
+        if (Object.keys(pathDefinition).length === 0) {
+          delete definition.paths[path];
+        }
+      });
+    }
+
+    if (only.length) {
+      definition.tags = definition.tags.filter(tag => only.includes(tag.name));
+      Object.entries(definition.paths).forEach(([path, pathDefinition]) => {
+        Object.entries(pathDefinition).forEach(([method, methodDefinition]) => {
+          if (! methodDefinition.tags.some(tag => only.includes(tag))) {
+            delete pathDefinition[method];
+          }
+        });
+        if (Object.keys(pathDefinition).length === 0) {
+          delete definition.paths[path];
+        }
+      });
     }
 
     request.response.configure({

--- a/lib/api/controllers/serverController.js
+++ b/lib/api/controllers/serverController.js
@@ -299,8 +299,8 @@ class ServerController extends NativeController {
   async openapi (request) {
     const format = request.getString('format', 'json');
     const scope = request.getString('scope', 'all');
-    const exclude = request.getString('exclude', '').split(',').map(e => e.trim()).filter(e => e);
-    const only = request.getString('only', '').split(',').map(e => e.trim()).filter(e => e);
+    const exclude = request.getArray('exclude', []);
+    const only = request.getArray('only', []);
 
     let definition;
 
@@ -320,30 +320,24 @@ class ServerController extends NativeController {
 
     if (exclude.length) {
       definition.tags = definition.tags.filter(tag => ! exclude.includes(tag.name));
-      Object.entries(definition.paths).forEach(([path, pathDefinition]) => {
-        Object.entries(pathDefinition).forEach(([method, methodDefinition]) => {
+      for (const pathDefinition of Object.values(definition.paths)) {
+        for (const [method, methodDefinition] of Object.entries(pathDefinition)) {
           if (methodDefinition.tags.some(tag => exclude.includes(tag))) {
-            delete pathDefinition[method];
+            pathDefinition[method] = null;
           }
-        });
-        if (Object.keys(pathDefinition).length === 0) {
-          delete definition.paths[path];
         }
-      });
+      }
     }
 
     if (only.length) {
       definition.tags = definition.tags.filter(tag => only.includes(tag.name));
-      Object.entries(definition.paths).forEach(([path, pathDefinition]) => {
-        Object.entries(pathDefinition).forEach(([method, methodDefinition]) => {
-          if (! methodDefinition.tags.some(tag => only.includes(tag))) {
-            delete pathDefinition[method];
+      for (const pathDefinition of Object.values(definition.paths)) {
+        for (const [method, methodDefinition] of Object.entries(pathDefinition)) {
+          if (! methodDefinition || ! methodDefinition.tags.some(tag => only.includes(tag))) {
+            pathDefinition[method] = null;
           }
-        });
-        if (Object.keys(pathDefinition).length === 0) {
-          delete definition.paths[path];
         }
-      });
+      }
     }
 
     request.response.configure({

--- a/lib/api/controllers/serverController.js
+++ b/lib/api/controllers/serverController.js
@@ -298,7 +298,7 @@ class ServerController extends NativeController {
 
   async openapi (request) {
     const format = request.getString('format', 'json');
-    const scope = request.getString('scope', 'kuzzle');
+    const scope = request.getString('scope', 'all');
 
     let definition;
 
@@ -308,8 +308,11 @@ class ServerController extends NativeController {
     else if (scope === 'app') {
       definition = await global.kuzzle.ask('core:api:openapi:app');
     }
+    else if (scope === 'all') {
+      definition = await global.kuzzle.ask('core:api:openapi:all');
+    }
     else {
-      throw kerror.get('api', 'assert', 'unexpected_argument', scope, ['kuzzle', 'app']);
+      throw kerror.get('api', 'assert', 'unexpected_argument', scope, ['kuzzle', 'app', 'all']);
     }
 
     request.response.configure({

--- a/lib/api/openapi/OpenApiManager.ts
+++ b/lib/api/openapi/OpenApiManager.ts
@@ -119,5 +119,13 @@ export class OpenApiManager {
     global.kuzzle.onAsk('core:api:openapi:kuzzle', () => this.kuzzleDefinition);
 
     global.kuzzle.onAsk('core:api:openapi:app', () => this.applicationDefinition);
+
+    global.kuzzle.onAsk('core:api:openapi:all', () => {
+      let mergedDefinition = ({...this.kuzzleDefinition});
+
+      mergedDefinition.tags = [...mergedDefinition.tags, ...this.applicationDefinition.tags]
+      mergedDefinition.paths = {...mergedDefinition.paths, ...this.applicationDefinition.paths}
+      return mergedDefinition;
+    });
   }
 }

--- a/lib/api/openapi/OpenApiManager.ts
+++ b/lib/api/openapi/OpenApiManager.ts
@@ -121,10 +121,10 @@ export class OpenApiManager {
     global.kuzzle.onAsk('core:api:openapi:app', () => this.applicationDefinition);
 
     global.kuzzle.onAsk('core:api:openapi:all', () => {
-      let mergedDefinition = ({...this.kuzzleDefinition});
+      const mergedDefinition = ({ ...this.kuzzleDefinition });
 
-      mergedDefinition.tags = [...mergedDefinition.tags, ...this.applicationDefinition.tags]
-      mergedDefinition.paths = {...mergedDefinition.paths, ...this.applicationDefinition.paths}
+      mergedDefinition.tags = [ ...mergedDefinition.tags, ...this.applicationDefinition.tags ];
+      mergedDefinition.paths = { ...mergedDefinition.paths, ...this.applicationDefinition.paths };
       return mergedDefinition;
     });
   }

--- a/test/api/controllers/serverController.test.js
+++ b/test/api/controllers/serverController.test.js
@@ -358,9 +358,15 @@ describe('ServerController', () => {
       kuzzle.ask.withArgs('core:api:openapi:app').resolves({
         swagger: '2.0',
       });
+
+      kuzzle.ask.withArgs('core:api:openapi:all').resolves({
+        swagger: '2.0',
+      });
     });
 
-    it('should return JSON Kuzzle OpenAPI definition by default', async () => {
+    it('should return JSON Kuzzle OpenApi definition', async () => {
+      request.input.args.scope = 'kuzzle';
+
       const definition = await serverController.openapi(request);
 
       should(definition).be.an.Object();
@@ -374,6 +380,13 @@ describe('ServerController', () => {
 
       should(definition).be.an.Object();
       should(kuzzle.ask).be.calledWith('core:api:openapi:app');
+    });
+
+    it('should return JSON All OpenAPI definition by default', async () => {
+      const definition = await serverController.openapi(request);
+
+      should(definition).be.an.Object();
+      should(kuzzle.ask).be.calledWith('core:api:openapi:all');
     });
 
     it('should return YAML formated OpenAPI specifications if specified', async () => {


### PR DESCRIPTION
## What does this PR do ?

Add "All" scope for OpenApi requests
Add unit tests for this scope

### How should this be manually tested?

  - Step 1 : Start Kuzzle instance
  - Step 2 : Send a GET request on https://{baseUrl}:{port}/_openapi?scope=all

### Other changes

See Commit: [#8a7f0c6](https://github.com/kuzzleio/kuzzle/commit/8a7f0c691e48719c17cecd53b594782bb402090d)

### TODO

@MaximCosta is working on "exclude" parameter to exclude tags