### PR TITLE
Fixed getArray function not working with only one element

### DIFF
--- a/lib/api/controllers/serverController.js
+++ b/lib/api/controllers/serverController.js
@@ -298,7 +298,7 @@ class ServerController extends NativeController {
 
   async openapi (request) {
     const format = request.getString('format', 'json');
-    const scope = request.getString('scope', 'kuzzle');
+    const scope = request.getString('scope', 'all');
 
     let definition;
 
@@ -308,8 +308,11 @@ class ServerController extends NativeController {
     else if (scope === 'app') {
       definition = await global.kuzzle.ask('core:api:openapi:app');
     }
+    else if (scope === 'all') {
+      definition = await global.kuzzle.ask('core:api:openapi:all');
+    }
     else {
-      throw kerror.get('api', 'assert', 'unexpected_argument', scope, ['kuzzle', 'app']);
+      throw kerror.get('api', 'assert', 'unexpected_argument', scope, ['kuzzle', 'app', 'all']);
     }
 
     request.response.configure({

--- a/lib/api/openapi/OpenApiManager.ts
+++ b/lib/api/openapi/OpenApiManager.ts
@@ -119,5 +119,13 @@ export class OpenApiManager {
     global.kuzzle.onAsk('core:api:openapi:kuzzle', () => this.kuzzleDefinition);
 
     global.kuzzle.onAsk('core:api:openapi:app', () => this.applicationDefinition);
+
+    global.kuzzle.onAsk('core:api:openapi:all', () => {
+      let mergedDefinition = ({...this.kuzzleDefinition});
+
+      mergedDefinition.tags = [...mergedDefinition.tags, ...this.applicationDefinition.tags]
+      mergedDefinition.paths = {...mergedDefinition.paths, ...this.applicationDefinition.paths}
+      return mergedDefinition;
+    });
   }
 }

--- a/lib/api/request/kuzzleRequest.ts
+++ b/lib/api/request/kuzzleRequest.ts
@@ -1063,7 +1063,8 @@ export class KuzzleRequest {
           }
         }
         catch (e) {
-          // Do nothing, let the error be thrown below
+          // Handle when only one parameter is provided
+          return [value];
         }
       }
       throw assertionError.get('invalid_type', errorName, 'array');


### PR DESCRIPTION
## What does this PR do ?

Fixes an error that is thrown when a single parameter is input and an array is requested.
This will allow to avoid having to fill at least 2 elements.

### How should this be manually tested?

  - Step 1 : Start Kuzzle instance
  - Step 2 : Send a request with one array parameter. 
 
Example: 

    https://{baseUrl}:{port}/_openapi?{arrayparameter}=one //NOT WORKING
    https://{baseUrl}:{port}/_openapi?{arrayparameter}=one&{arrayparameter}=two //WORKING
    
