### PR TITLE
Allow to use vault key from env

### DIFF
--- a/lib/kuzzle/vault.js
+++ b/lib/kuzzle/vault.js
@@ -27,6 +27,10 @@ const path = require('path');
 const _ = require('lodash');
 const { Vault } = require('kuzzle-vault');
 
+// The Vault package remove the variable from env after reading it and we have
+// to instantiate the Vault two times with Kaaf (one before init and one after)
+let ENV_VAULT_KEY;
+
 function load (vaultKey, secretsFile) {
   // Using KaaF kuzzle is an npm package and is located under node_modules folder
   // We need to get back to root folder of the project to get the secret file
@@ -38,8 +42,9 @@ function load (vaultKey, secretsFile) {
     secretsFile || process.env.KUZZLE_SECRETS_FILE || defaultEncryptedSecretsFile;
 
   let key = vaultKey;
-  if (_.isEmpty(vaultKey) && ! _.isEmpty(process.env.KUZZLE_VAULT_KEY)) {
-    key = process.env.KUZZLE_VAULT_KEY;
+  if (_.isEmpty(vaultKey) && (! _.isEmpty(process.env.KUZZLE_VAULT_KEY) || ! _.isEmpty(ENV_VAULT_KEY))) {
+    // Keep the vault key value when reading it from the env
+    key = ENV_VAULT_KEY = process.env.KUZZLE_VAULT_KEY || ENV_VAULT_KEY;
   }
 
   const fileExists = fs.existsSync(encryptedSecretsFile);


### PR DESCRIPTION
## What does this PR do ?

The Vault package remove the key from the env after reading it but we are instantiating it two time because of Kaaf.

This PR save the vault key after reading it from the env

