### PR TITLE
Fix doc

### DIFF
--- a/doc/2/guides/main-concepts/realtime-engine/index.md
+++ b/doc/2/guides/main-concepts/realtime-engine/index.md
@@ -39,18 +39,6 @@ These information are only used to define an **ephemeral room** between several 
 :::
 
 First, subscribe to realtime notifications:
-:::: tabs
-
-::: tab wscat
-
-:::
-
-::: tab kourou
-
-:::
-
-::::
-
 
 :::: tabs
 


### PR DESCRIPTION
I removed an unused tab in the documentation: https://docs.kuzzle.io/core/2/guides/main-concepts/realtime-engine/#pub-sub

ci-allow-merge-into: master