### PR TITLE
Add type for BackendPlugin.get

### DIFF
--- a/doc/2/framework/classes/backend-plugin/get/index.md
+++ b/doc/2/framework/classes/backend-plugin/get/index.md
@@ -12,7 +12,7 @@ description: BackendPlugin.get method
 Gets the instance of an already loaded plugin.
 
 ```ts
-get (name: string): Plugin
+get<TPlugin extends Plugin> (name: string): TPlugin
 ```
 
 <br/>
@@ -24,5 +24,5 @@ get (name: string): Plugin
 ## Usage
 
 ```js
-const mailerPlugin = app.plugin.get('mailer');
+const mailerPlugin = app.plugin.get<MailerPlugin>('mailer');
 ```

--- a/lib/core/backend/backendPlugin.ts
+++ b/lib/core/backend/backendPlugin.ts
@@ -81,7 +81,7 @@ export class BackendPlugin extends ApplicationManager {
    *
    * @param name Plugin name
    */
-  get (name: string): Plugin {
+  get<TPlugin extends Plugin> (name: string): TPlugin {
     if (! this._application._plugins[name]) {
       throw assertionError.get('plugin_not_found', name, didYouMean(name, this.list()));
     }


### PR DESCRIPTION
## What does this PR do ?

Allows to specify the type when retrieving an already loaded plugin

```
const mailerPlugin = app.plugin.get<MailerPlugin>('mailer');
```