### PR TITLE
Strong typing for pipe and hooks

### DIFF
--- a/doc/2/framework/abstract-classes/plugin/properties/index.md
+++ b/doc/2/framework/abstract-classes/plugin/properties/index.md
@@ -7,11 +7,11 @@ description: Plugin abstract class properties
 
 # Plugin
 
-Base class for [External Plugins](/core/2/guides/write-plugins).  
+Base class for [External Plugins](/core/2/guides/write-plugins).
 
 Plugins registered with the [BackendPlugin.use](/core/2/framework/classes/backend-plugin/use) method must extends this abstract class.
 
-Some properties of the `Plugin` class allows to define a set of features that will be integrated to the plugin. 
+Some properties of the `Plugin` class allows to define a set of features that will be integrated to the plugin.
 
 ## `api`
 
@@ -57,14 +57,14 @@ This property allows to define plugin features.
 |------------------------------------------------------------------------|-------------------------|
 | <pre>`PluginHookDefinition`</pre> | Allows to define hooks on events |
 
-The `PluginHookDefinition` type is an object with each key as an event name and the value is a valid [EventHandler](/core/2/framework/types/event-handler).
+The `PluginHookDefinition` type is an object with each key as an event name and the value is a valid [HookEventHandler](/core/2/framework/types/event-handler).
 
 ```js
 export type PluginHookDefinition = {
   /**
    * Event name or wildcard event.
    */
-  [event: string]: EventHandler | EventHandler[]
+  [event: string]: HookEventHandler | HookEventHandler[]
 }
 ```
 
@@ -78,14 +78,14 @@ This property allows to define plugin features.
 |------------------------------------------------------------------------|-------------------------|
 | <pre>`PluginPipeDefinition`</pre> | Allows to define pipess on events |
 
-The `PluginPipeDefinition` type is an object with each key as an event name and the value is a valid [EventHandler](/core/2/framework/types/event-handler).
+The `PluginPipeDefinition` type is an object with each key as an event name and the value is a valid [PipeEventHandler](/core/2/framework/types/event-handler).
 
 ```js
 export type PluginPipeDefinition = {
   /**
    * Event name or wildcard event.
    */
-  [event: string]: EventHandler | EventHandler[]
+  [event: string]: PipeEventHandler | PipeEventHandler[]
 }
 ```
 

--- a/doc/2/framework/classes/backend-cluster/off/index.md
+++ b/doc/2/framework/classes/backend-cluster/off/index.md
@@ -14,7 +14,7 @@ Unregisters a listener.
 If multiple instances of the same listener are registered, only the first one is removed.
 
 ```ts
-off (event: string, listener: EventHandler): Promise<void>
+off (event: string, listener: ClusterEventHandler): Promise<void>
 ```
 
 <br/>
@@ -22,7 +22,7 @@ off (event: string, listener: EventHandler): Promise<void>
 | Argument | Type                  | Description                   |
 |----------|-----------------------|-------------------------------|
 | `event` | <pre>string</pre> | Event name |
-| `listener` | <pre>[EventHandler](/core/2/framework/types/event-handler)</pre> | Listener function to remove. |
+| `listener` | <pre>[ClusterEventHandler](/core/2/framework/types/event-handler)</pre> | Listener function to remove. |
 
 ## Usage
 

--- a/doc/2/framework/classes/backend-cluster/on/index.md
+++ b/doc/2/framework/classes/backend-cluster/on/index.md
@@ -12,7 +12,7 @@ description: BackendCluster.on method
 Listens to event emitted with [BackendCluster.broadcast](/core/2/framework/classes/backend-cluster/broadcast).
 
 ```ts
-on (event: string, listener: EventHandler): Promise<void>
+on (event: string, listener: ClusterEventHandler): Promise<void>
 ```
 
 <br/>
@@ -20,7 +20,7 @@ on (event: string, listener: EventHandler): Promise<void>
 | Argument | Type                  | Description                   |
 |----------|-----------------------|-------------------------------|
 | `event` | <pre>string</pre> | Event name |
-| `listener` | <pre>[EventHandler](/core/2/framework/types/event-handler)</pre> | Listener function. Called as many times as the listened event is received. |
+| `listener` | <pre>[ClusterEventHandler](/core/2/framework/types/event-handler)</pre> | Listener function. Called as many times as the listened event is received. |
 
 ## Usage
 

--- a/doc/2/framework/classes/backend-cluster/once/index.md
+++ b/doc/2/framework/classes/backend-cluster/once/index.md
@@ -14,7 +14,7 @@ Listens to an event emitted with [BackendCluster.broadcast](/core/2/framework/cl
 The registered listener will be called exactly once, after which it will be removed from the listeners list.
 
 ```ts
-once (event: string, listener: EventHandler): Promise<void>
+once (event: string, listener: ClusterEventHandler): Promise<void>
 ```
 
 <br/>
@@ -22,7 +22,7 @@ once (event: string, listener: EventHandler): Promise<void>
 | Argument | Type                  | Description                   |
 |----------|-----------------------|-------------------------------|
 | `event` | <pre>string</pre> | Event name |
-| `listener` | <pre>[EventHandler](/core/2/framework/types/event-handler)</pre> | Listener function. Called exactly once. |
+| `listener` | <pre>[ClusterEventHandler](/core/2/framework/types/event-handler)</pre> | Listener function. Called exactly once. |
 
 ## Usage
 

--- a/doc/2/framework/classes/backend-hook/register/index.md
+++ b/doc/2/framework/classes/backend-hook/register/index.md
@@ -16,7 +16,7 @@ This method can only be used before the application is started.
 :::
 
 ```ts
-register(event: string, handler: EventHandler): void
+register(event: string, handler: ClusterEventHandler): void
 ```
 
 <br/>
@@ -24,12 +24,12 @@ register(event: string, handler: EventHandler): void
 | Argument | Type                  | Description                   |
 |----------|-----------------------|-------------------------------|
 | `event` | <pre>string</pre> | Event name |
-| `handler` | <pre>[EventHandler](/core/2/framework/types/event-handler)</pre> | Function to execute when the event is triggered |
+| `handler` | <pre>[ClusterEventHandler](/core/2/framework/types/event-handler)</pre> | Function to execute when the event is triggered |
 
 ## Usage
 
 ```js
-app.hook.register('request:onError', async (request: KuzzleRequest) => {
+app.hook.register('request:onError', (request: KuzzleRequest) => {
   app.log.error(error)
 });
 ```
@@ -39,9 +39,15 @@ app.hook.register('request:onError', async (request: KuzzleRequest) => {
 It's possible to specify the arguments with whom the handler will be called.
 
 ```js
-app.hook.register<[Document[], KuzzleRequest]>(
+type EventGenericDocumentAfterWrite = {
+  name: 'generic:document:afterWrite';
+
+  args: [Document[], KuzzleRequest];
+}
+
+app.hook.register<EventGenericDocumentAfterWrite>(
   'generic:document:afterWrite',
   async (documents: Document[], request: KuzzleRequest) => {
-    app.log.error(documents)
-  }),
+    app.log.error(documents);
+  });
 ```

--- a/doc/2/framework/classes/backend-hook/register/index.md
+++ b/doc/2/framework/classes/backend-hook/register/index.md
@@ -29,7 +29,19 @@ register(event: string, handler: EventHandler): void
 ## Usage
 
 ```js
-app.pipe.register('request:onError', async (request: KuzzleRequest) => {
+app.hook.register('request:onError', async (request: KuzzleRequest) => {
   app.log.error(error)
-})
+});
+```
+
+## Strong typing
+
+It's possible to specify the arguments with whom the handler will be called.
+
+```js
+app.hook.register<[Document[], KuzzleRequest]>(
+  'generic:document:afterWrite',
+  async (documents: Document[], request: KuzzleRequest) => {
+    app.log.error(documents)
+  }),
 ```

--- a/doc/2/framework/classes/backend-pipe/register/index.md
+++ b/doc/2/framework/classes/backend-pipe/register/index.md
@@ -16,7 +16,7 @@ This method can only be used before the application is started.
 :::
 
 ```ts
-register(event: string, handler: EventHandler): void
+register(event: string, handler: PipeEventHandler): void
 ```
 
 <br/>
@@ -24,7 +24,7 @@ register(event: string, handler: EventHandler): void
 | Argument | Type                  | Description                   |
 |----------|-----------------------|-------------------------------|
 | `event` | <pre>string</pre> | Event name |
-| `handler` | <pre>[EventHandler](/core/2/framework/types/event-handler)</pre> | Function to execute when the event is triggered |
+| `handler` | <pre>[PipeEventHandler](/core/2/framework/types/event-handler)</pre> | Function to execute when the event is triggered |
 
 ## Usage
 
@@ -43,11 +43,17 @@ It's possible to specify the arguments with whom the handler will be called.
 This will also ensure that the first argument is returned at the end of the pipe handler.
 
 ```js
-app.pipe.register<[Document[], KuzzleRequest]>(
+type EventGenericDocumentAfterWrite = {
+  name: 'generic:document:afterWrite';
+
+  args: [Document[], KuzzleRequest];
+}
+
+app.pipe.register<EventGenericDocumentAfterWrite>(
   'generic:document:afterWrite',
   async (documents: Document[], request: KuzzleRequest) => {
-    app.log.error(documents)
+    app.log.error(documents);
 
     return documents;
-  })
+  });
 ```

--- a/doc/2/framework/classes/backend-pipe/register/index.md
+++ b/doc/2/framework/classes/backend-pipe/register/index.md
@@ -30,8 +30,24 @@ register(event: string, handler: EventHandler): void
 
 ```js
 app.pipe.register('server:afterNow', async (request: KuzzleRequest) => {
-  request.result.now = (new Date()).toUTCString()
+  request.result.now = (new Date()).toUTCString();
 
-  return request
-})
+  return request;
+});
+```
+
+## Strong typing
+
+It's possible to specify the arguments with whom the handler will be called.
+
+This will also ensure that the first argument is returned at the end of the pipe handler.
+
+```js
+app.pipe.register<[Document[], KuzzleRequest]>(
+  'generic:document:afterWrite',
+  async (documents: Document[], request: KuzzleRequest) => {
+    app.log.error(documents)
+
+    return documents;
+  })
 ```

--- a/doc/2/framework/types/event-handler/index.md
+++ b/doc/2/framework/types/event-handler/index.md
@@ -7,7 +7,7 @@ description: EventHandler type definition
 
 # EventHandler
 
-The `EventHandler` type represents a handler function used with a pipe or a hook to listen to events.
+The `XXXEventHandler` typse represents a handler function used with a pipe or a hook to listen to events.
 
 See [Event System](/core/2/guides/develop-on-kuzzle/event-system)
 
@@ -16,7 +16,7 @@ See [Event System](/core/2/guides/develop-on-kuzzle/event-system)
 **Example:**
 
 ```js
-import { EventHandler, KuzzleRequest } from 'kuzzle';
+import { PipeEventHandler, KuzzleRequest } from 'kuzzle';
 
-const pipeHandler: EventHandler = async (request: KuzzleRequest) => request
+const pipeHandler: PipeEventHandler = async (request: KuzzleRequest) => request
 ```

--- a/docker/scripts/start-kuzzle-dev.ts
+++ b/docker/scripts/start-kuzzle-dev.ts
@@ -6,7 +6,7 @@
 import should from 'should/as-function';
 import { omit } from 'lodash';
 
-import { Backend, KuzzleRequest, Mutex } from '../../index';
+import { Backend, EventDefinition, KuzzleRequest, Mutex } from '../../index';
 import { FunctionalTestsController } from './functional-tests-controller';
 import functionalFixtures from '../../features/fixtures/imports.json';
 
@@ -85,6 +85,16 @@ app.controller.register('pipes', {
 });
 
 /* Actual code for tests start here */
+
+type EventToto = {
+  name: 'event:lol';
+
+  args: [number, string];
+}
+
+app.pipe.register<EventToto>('event:lol', async (age, name) => {
+  return age;
+})
 
 // Pipe registration
 app.pipe.register('server:afterNow', async (request) => {

--- a/docker/scripts/start-kuzzle-dev.ts
+++ b/docker/scripts/start-kuzzle-dev.ts
@@ -6,7 +6,7 @@
 import should from 'should/as-function';
 import { omit } from 'lodash';
 
-import { Backend, EventDefinition, KuzzleRequest, Mutex } from '../../index';
+import { Backend, KDocument, KDocumentContent, EventGenericDocumentBeforeUpdate, KuzzleRequest, Mutex } from '../../index';
 import { FunctionalTestsController } from './functional-tests-controller';
 import functionalFixtures from '../../features/fixtures/imports.json';
 
@@ -86,15 +86,40 @@ app.controller.register('pipes', {
 
 /* Actual code for tests start here */
 
-type EventToto = {
-  name: 'event:lol';
+/**
+ * This function is never call bu simply ensure the correctness of types definition
+ */
+function ensureEventDefinitionTypes () {
+  type EventFoobar = {
+    name: 'event:foobar';
 
-  args: [number, string];
+    args: [number, string];
+  }
+
+  app.pipe.register<EventFoobar>('event:foobar', async (age: number, name: string) => {
+    return age;
+  });
+
+  app.hook.register<EventFoobar>('event:foobar', (age: number, name: string) => {
+  });
+
+  app.cluster.on<EventFoobar>('event:foobar', async (age: number, name: string) => {
+  });
+
+  app.cluster.broadcast<EventFoobar>('event:foobar', 30);
+
+  const promise: Promise<number> = app.trigger<EventFoobar>('event:foobar', 30, 'Tuan');
+
+  interface PersonContent extends KDocumentContent {
+    name: string;
+  }
+
+  app.pipe.register<EventGenericDocumentBeforeUpdate<PersonContent>>(
+    'generic:document:beforeUpdate',
+    async (documents: KDocument<PersonContent>[], request: KuzzleRequest) => {
+      return documents
+    });
 }
-
-app.pipe.register<EventToto>('event:lol', async (age, name) => {
-  return age;
-})
 
 // Pipe registration
 app.pipe.register('server:afterNow', async (request) => {

--- a/lib/core/backend/backend.ts
+++ b/lib/core/backend/backend.ts
@@ -24,7 +24,7 @@ import fs from "fs";
 import Kuzzle from "../../kuzzle";
 import { EmbeddedSDK } from "../shared/sdk/embeddedSdk";
 import * as kerror from "../../kerror";
-import { JSONObject } from "../../../index";
+import { EventDefinition, JSONObject } from "../../../index";
 import {
   BackendCluster,
   BackendConfig,
@@ -338,7 +338,10 @@ export class Backend {
    *
    * @returns {Promise<any>}
    */
-  trigger(event: string, ...payload): Promise<any> {
+  trigger<TEventDefinition extends EventDefinition = EventDefinition>(
+    event: TEventDefinition["name"],
+    ...payload: TEventDefinition["args"]
+  ): Promise<TEventDefinition["args"][0]> {
     if (!this.started) {
       throw runtimeError.get("unavailable_before_start", "trigger");
     }

--- a/lib/core/backend/backendCluster.ts
+++ b/lib/core/backend/backendCluster.ts
@@ -19,10 +19,7 @@
  * limitations under the License.
  */
 
-import {
-  EventDefinition,
-  ClusterEventHandler,
-} from "../../../index";
+import { EventDefinition, ClusterEventHandler } from "../../../index";
 
 export class BackendCluster {
   /**

--- a/lib/core/backend/backendCluster.ts
+++ b/lib/core/backend/backendCluster.ts
@@ -21,7 +21,6 @@
 
 import {
   EventDefinition,
-  JSONObject,
   ClusterEventHandler,
 } from "../../../index";
 

--- a/lib/core/backend/backendCluster.ts
+++ b/lib/core/backend/backendCluster.ts
@@ -19,8 +19,11 @@
  * limitations under the License.
  */
 
-import { JSONObject } from "../../../index";
-import { EventHandler } from "../../types";
+import {
+  EventDefinition,
+  JSONObject,
+  ClusterEventHandler,
+} from "../../../index";
 
 export class BackendCluster {
   /**
@@ -30,7 +33,10 @@ export class BackendCluster {
    * @param  {JSONObject}    payload
    * @return {Promise<void>}
    */
-  async broadcast(event: string, payload: JSONObject): Promise<void> {
+  async broadcast<TEventDefinition extends EventDefinition = EventDefinition>(
+    event: TEventDefinition["name"],
+    payload: TEventDefinition["args"][0]
+  ): Promise<void> {
     await global.kuzzle.ask("cluster:event:broadcast", event, payload);
   }
 
@@ -38,10 +44,13 @@ export class BackendCluster {
    * Registers a listener to the provided event name.
    *
    * @param  {string}        event
-   * @param  {EventHandler}      listener
+   * @param  {ClusterEventHandler}      listener
    * @return {Promise<void>}       [description]
    */
-  async on(event: string, listener: EventHandler): Promise<void> {
+  async on<TEventDefinition extends EventDefinition = EventDefinition>(
+    event: TEventDefinition["name"],
+    listener: ClusterEventHandler<TEventDefinition>
+  ): Promise<void> {
     await global.kuzzle.ask("cluster:event:on", event, listener);
   }
 
@@ -50,10 +59,13 @@ export class BackendCluster {
    * invoked only once, after which it will be removed from the listeners list.
    *
    * @param  {string}        event
-   * @param  {EventHandler}      listener
+   * @param  {ClusterEventHandler}      listener
    * @return {Promise<void>}
    */
-  async once(event: string, listener: EventHandler): Promise<void> {
+  async once<TEventDefinition extends EventDefinition = EventDefinition>(
+    event: TEventDefinition["name"],
+    listener: ClusterEventHandler<TEventDefinition>
+  ): Promise<void> {
     await global.kuzzle.ask("cluster:event:once", event, listener);
   }
 
@@ -63,10 +75,13 @@ export class BackendCluster {
    * one is removed.
    *
    * @param  {string}        event
-   * @param  {EventHandler}      listener
+   * @param  {ClusterEventHandler}      listener
    * @return {Promise<void>}
    */
-  async off(event: string, listener: EventHandler): Promise<void> {
+  async off<TEventDefinition extends EventDefinition = EventDefinition>(
+    event: TEventDefinition["name"],
+    listener: ClusterEventHandler<TEventDefinition>
+  ): Promise<void> {
     await global.kuzzle.ask("cluster:event:off", event, listener);
   }
 

--- a/lib/core/backend/backendHook.ts
+++ b/lib/core/backend/backendHook.ts
@@ -20,7 +20,7 @@
  */
 
 import * as kerror from "../../kerror";
-import { EventHandler } from "../../types";
+import { HookEventHandler, EventDefinition } from "../../types";
 import { ApplicationManager } from "./index";
 
 const assertionError = kerror.wrap("plugin", "assert");
@@ -34,9 +34,9 @@ export class BackendHook extends ApplicationManager {
    * @param handler - Function to execute when the event is triggered
    *
    */
-  register<TPayload extends [any, any?, any?, any?, any?]>(
+  register<TEventDefinition extends EventDefinition = EventDefinition>(
     event: string,
-    handler: EventHandler<TPayload>
+    handler: HookEventHandler<TEventDefinition>,
   ): void {
     if (this._application.started) {
       throw runtimeError.get("already_started", "hook");

--- a/lib/core/backend/backendHook.ts
+++ b/lib/core/backend/backendHook.ts
@@ -34,7 +34,10 @@ export class BackendHook extends ApplicationManager {
    * @param handler - Function to execute when the event is triggered
    *
    */
-  register(event: string, handler: EventHandler): void {
+   register <TPayload extends [any, any?, any?, any?, any?]> (
+    event: string,
+    handler: EventHandler<TPayload>,
+  ): void {
     if (this._application.started) {
       throw runtimeError.get("already_started", "hook");
     }

--- a/lib/core/backend/backendHook.ts
+++ b/lib/core/backend/backendHook.ts
@@ -35,8 +35,8 @@ export class BackendHook extends ApplicationManager {
    *
    */
   register<TEventDefinition extends EventDefinition = EventDefinition>(
-    event: string,
-    handler: HookEventHandler<TEventDefinition>,
+    event: TEventDefinition["name"],
+    handler: HookEventHandler<TEventDefinition>
   ): void {
     if (this._application.started) {
       throw runtimeError.get("already_started", "hook");

--- a/lib/core/backend/backendHook.ts
+++ b/lib/core/backend/backendHook.ts
@@ -34,9 +34,9 @@ export class BackendHook extends ApplicationManager {
    * @param handler - Function to execute when the event is triggered
    *
    */
-   register <TPayload extends [any, any?, any?, any?, any?]> (
+  register<TPayload extends [any, any?, any?, any?, any?]>(
     event: string,
-    handler: EventHandler<TPayload>,
+    handler: EventHandler<TPayload>
   ): void {
     if (this._application.started) {
       throw runtimeError.get("already_started", "hook");

--- a/lib/core/backend/backendPipe.ts
+++ b/lib/core/backend/backendPipe.ts
@@ -20,7 +20,7 @@
  */
 
 import * as kerror from "../../kerror";
-import { EventHandler } from "../../types";
+import { PipeEventHandler } from "../../types";
 import { ApplicationManager } from "./index";
 
 const assertionError = kerror.wrap("plugin", "assert");
@@ -33,9 +33,9 @@ export class BackendPipe extends ApplicationManager {
    * @param event - Event name
    * @param handler - Function to execute when the event is triggered
    */
-  register(
+  register <TPayload extends [any, any?, any?, any?, any?]> (
     event: string,
-    handler: EventHandler,
+    handler: PipeEventHandler<TPayload>,
     options: any = {}
   ): string | void {
     if (this._application.started && options.dynamic !== true) {

--- a/lib/core/backend/backendPipe.ts
+++ b/lib/core/backend/backendPipe.ts
@@ -33,7 +33,7 @@ export class BackendPipe extends ApplicationManager {
    * @param event - Event name
    * @param handler - Function to execute when the event is triggered
    */
-  register <TPayload extends [any, any?, any?, any?, any?]> (
+  register<TPayload extends [any, any?, any?, any?, any?]>(
     event: string,
     handler: PipeEventHandler<TPayload>,
     options: any = {}

--- a/lib/core/backend/backendPipe.ts
+++ b/lib/core/backend/backendPipe.ts
@@ -20,7 +20,7 @@
  */
 
 import * as kerror from "../../kerror";
-import { PipeEventHandler } from "../../types";
+import { EventDefinition, PipeEventHandler } from "../../types";
 import { ApplicationManager } from "./index";
 
 const assertionError = kerror.wrap("plugin", "assert");
@@ -33,9 +33,9 @@ export class BackendPipe extends ApplicationManager {
    * @param event - Event name
    * @param handler - Function to execute when the event is triggered
    */
-  register<TPayload extends [any, any?, any?, any?, any?]>(
+  register<TEventDefinition extends EventDefinition = EventDefinition>(
     event: string,
-    handler: PipeEventHandler<TPayload>,
+    handler: PipeEventHandler<TEventDefinition>,
     options: any = {}
   ): string | void {
     if (this._application.started && options.dynamic !== true) {

--- a/lib/core/backend/backendPipe.ts
+++ b/lib/core/backend/backendPipe.ts
@@ -34,7 +34,7 @@ export class BackendPipe extends ApplicationManager {
    * @param handler - Function to execute when the event is triggered
    */
   register<TEventDefinition extends EventDefinition = EventDefinition>(
-    event: string,
+    event: TEventDefinition["name"],
     handler: PipeEventHandler<TEventDefinition>,
     options: any = {}
   ): string | void {

--- a/lib/types/EventHandler.ts
+++ b/lib/types/EventHandler.ts
@@ -19,10 +19,12 @@
  * limitations under the License.
  */
 
-
 /**
  * Type for handler attached to Kuzzle events. Either hooks or pipes.
  */
-export type EventHandler<TPayload extends [any, any?, any?, any?, any?] = any> = (...payload: TPayload) => any;
+export type EventHandler<TPayload extends [any, any?, any?, any?, any?] = any> =
+  (...payload: TPayload) => any;
 
-export type PipeEventHandler<TPayload extends [any, any?, any?, any?, any?] = any> = (...payload: TPayload) => Promise<TPayload[0]>;
+export type PipeEventHandler<
+  TPayload extends [any, any?, any?, any?, any?] = any
+> = (...payload: TPayload) => Promise<TPayload[0]>;

--- a/lib/types/EventHandler.ts
+++ b/lib/types/EventHandler.ts
@@ -19,7 +19,10 @@
  * limitations under the License.
  */
 
+
 /**
  * Type for handler attached to Kuzzle events. Either hooks or pipes.
  */
-export type EventHandler = (...payload: any) => any;
+export type EventHandler<TPayload extends [any, any?, any?, any?, any?] = any> = (...payload: TPayload) => any;
+
+export type PipeEventHandler<TPayload extends [any, any?, any?, any?, any?] = any> = (...payload: TPayload) => Promise<TPayload[0]>;

--- a/lib/types/EventHandler.ts
+++ b/lib/types/EventHandler.ts
@@ -20,11 +20,33 @@
  */
 
 /**
+ * Describe an event with it's name and the handler function arguments
+ */
+export type EventDefinition = {
+  /**
+   * Name of the event
+   *
+   * @example
+   * "core:document:create:after"
+   */
+  name: string;
+
+  /**
+   * Arguments of the event
+   */
+  args: any[];
+}
+
+export type HookEventHandler<TEventDefinition extends EventDefinition = EventDefinition> = (...args: TEventDefinition["args"]) => void;
+
+export type PipeEventHandler<TEventDefinition extends EventDefinition = EventDefinition> = (...args: TEventDefinition["args"]) => Promise<TEventDefinition["args"][0]>;
+
+/**
  * Type for handler attached to Kuzzle events. Either hooks or pipes.
  */
-export type EventHandler<TPayload extends [any, any?, any?, any?, any?] = any> =
-  (...payload: TPayload) => any;
+// export type EventHandler<TPayload extends [any, any?, any?, any?, any?] = any> =
+//   (...payload: TPayload) => any;
 
-export type PipeEventHandler<
-  TPayload extends [any, any?, any?, any?, any?] = any
-> = (...payload: TPayload) => Promise<TPayload[0]>;
+// export type PipeEventHandler<
+//   TPayload extends [any, any?, any?, any?, any?] = any
+// > = (...payload: TPayload) => Promise<TPayload[0]>;

--- a/lib/types/EventHandler.ts
+++ b/lib/types/EventHandler.ts
@@ -35,18 +35,27 @@ export type EventDefinition = {
    * Arguments of the event
    */
   args: any[];
-}
-
-export type HookEventHandler<TEventDefinition extends EventDefinition = EventDefinition> = (...args: TEventDefinition["args"]) => void;
-
-export type PipeEventHandler<TEventDefinition extends EventDefinition = EventDefinition> = (...args: TEventDefinition["args"]) => Promise<TEventDefinition["args"][0]>;
+};
 
 /**
- * Type for handler attached to Kuzzle events. Either hooks or pipes.
+ * Handler for hook events
  */
-// export type EventHandler<TPayload extends [any, any?, any?, any?, any?] = any> =
-//   (...payload: TPayload) => any;
+export type HookEventHandler<
+  TEventDefinition extends EventDefinition = EventDefinition
+> = (...args: TEventDefinition["args"]) => void;
 
-// export type PipeEventHandler<
-//   TPayload extends [any, any?, any?, any?, any?] = any
-// > = (...payload: TPayload) => Promise<TPayload[0]>;
+/**
+ * Handler for pipe event.
+ *
+ * It should return a promise resolving the first received argument.
+ */
+export type PipeEventHandler<
+  TEventDefinition extends EventDefinition = EventDefinition
+> = (...args: TEventDefinition["args"]) => Promise<TEventDefinition["args"][0]>;
+
+/**
+ * Handler for cluster event.
+ */
+export type ClusterEventHandler<
+  TEventDefinition extends EventDefinition = EventDefinition
+> = (...args: TEventDefinition["args"]) => any;

--- a/lib/types/Plugin.ts
+++ b/lib/types/Plugin.ts
@@ -23,7 +23,7 @@ import { PluginContext } from "../core/plugin/pluginContext";
 import { ControllerDefinition } from "./ControllerDefinition";
 import { PluginManifest } from "./PluginManifest";
 import { StrategyDefinition } from "./StrategyDefinition";
-import { EventHandler } from "./EventHandler";
+import { PipeEventHandler, HookEventHandler } from "./EventHandler";
 import { JSONObject } from "../../index";
 import * as kerror from "../kerror";
 import { has } from "../util/safeObject";
@@ -45,7 +45,7 @@ export type PluginHookDefinition = {
   /**
    * Event name or wildcard event.
    */
-  [event: string]: EventHandler | EventHandler[];
+  [event: string]: HookEventHandler | HookEventHandler[];
 };
 
 /**
@@ -55,7 +55,7 @@ export type PluginPipeDefinition = {
   /**
    * Event name or wildcard event.
    */
-  [event: string]: EventHandler | EventHandler[];
+  [event: string]: PipeEventHandler | PipeEventHandler[];
 };
 
 /**

--- a/lib/types/events/EventGenericDocument.ts
+++ b/lib/types/events/EventGenericDocument.ts
@@ -1,0 +1,43 @@
+import { KuzzleRequest, KDocument, JSONObject } from "../../../";
+
+/**
+ * Events with documents having only have the `_id`
+ */
+type EventGenericDocumentPartial<name extends string> = {
+  name: `generic:document:${name}`;
+
+  args: [Array<{ _id: string }>, KuzzleRequest];
+};
+
+export type EventGenericDocumentBeforeDelete =
+  EventGenericDocumentPartial<"beforeDelete">;
+
+export type EventGenericDocumentAfterDelete =
+  EventGenericDocumentPartial<"afterDelete">;
+
+export type EventGenericDocumentBeforeGet =
+  EventGenericDocumentPartial<"beforeGet">;
+
+/**
+ * Events having entire documents
+ */
+type EventGenericDocument<name extends string, KDocumentContent> = {
+  name: `generic:document:${name}`;
+
+  args: [KDocument<KDocumentContent>[], KuzzleRequest];
+};
+
+export type EventGenericDocumentBeforeWrite<KDocumentContent = JSONObject> =
+  EventGenericDocument<"beforeWrite", KDocumentContent>;
+
+export type EventGenericDocumentAfterWrite<KDocumentContent = JSONObject> =
+  EventGenericDocument<"afterWrite", KDocumentContent>;
+
+export type EventGenericDocumentBeforeUpdate<KDocumentContent = JSONObject> =
+  EventGenericDocument<"beforeUpdate", KDocumentContent>;
+
+export type EventGenericDocumentAfterUpdate<KDocumentContent = JSONObject> =
+  EventGenericDocument<"afterUpdate", KDocumentContent>;
+
+export type EventGenericDocumentAfterGet<KDocumentContent = JSONObject> =
+  EventGenericDocument<"afterGet", KDocumentContent>;

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -57,3 +57,4 @@ export * from "./config/DumpConfiguration";
 export * from "./OpenApiDefinition";
 export * from "./errors/ErrorDefinition";
 export * from "./errors/ErrorDomains";
+export * from "./events/EventGenericDocument";


### PR DESCRIPTION
## What does this PR do ?

Implements https://github.com/kuzzleio/kuzzle/issues/2382

This PR allows to specify type when registering pipes or hooks.

This can be used to have strong interface contracts between modules emitting events and modules listening to those events.

Modules emitting events should define the type of the arguments received by a listening handler function:

```js
  type EventFoobar = {
    name: 'event:foobar';

    args: [number, string];
  }

  await app.trigger<EventFoobar>('event:foobar', 30, 'Tuan');
```

On the other hand, the listening module can use this type to ensure that the handler will have the correct arguments:
```js
app.pipe.register<EventFoobar>('event:foobar', async (age: number, name: string) => {
  return age;
});
```

### Other changes

 - The type for pipes handler function now ensure that the first argument is returned in a promise as expected
 - also did this for cluster events
 - add types for generic events
```js
app.pipe.register<EventGenericDocumentBeforeUpdate<PersonContent>>(
  'generic:document:beforeUpdate',
  async (documents: KDocument<PersonContent>[], request: KuzzleRequest) => {
    return documents
  });
```
