### PR TITLE
HOTFIX: Deprecate EventHandler

### DIFF
--- a/lib/types/EventHandler.ts
+++ b/lib/types/EventHandler.ts
@@ -59,3 +59,8 @@ export type PipeEventHandler<
 export type ClusterEventHandler<
   TEventDefinition extends EventDefinition = EventDefinition
 > = (...args: TEventDefinition["args"]) => any;
+
+/**
+ * @deprecated Use HookEventHandler, PipeEventHandler or ClusterEventHandler
+ */
+export type EventHandler = (...payload: any) => any;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kuzzle",
-  "version": "2.19.4",
+  "version": "2.19.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kuzzle",
-      "version": "2.19.4",
+      "version": "2.19.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/elasticsearch": "https://github.com/elastic/elasticsearch-js/archive/refs/tags/v7.13.0.tar.gz",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.19.4",
+  "version": "2.19.5",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "bin": "bin/start-kuzzle-server",
   "scripts": {


### PR DESCRIPTION
## What does this PR do ?

Expose the deprecated `EventHandler` type to avoid breaking due to missing type