### PR TITLE
Allow to force number of replicas and shards per index from Kuzzle configuration

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -127,3 +127,5 @@ lib/api/openapi/components/security/index.js
 lib/config/documentEventAliases.js
 lib/types/DebugModule.js
 lib/util/time.js
+lib/util/async.js
+lib/util/esRequest.js

--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,5 @@ lib/api/openapi/components/security/index.js
 lib/config/documentEventAliases.js
 lib/types/DebugModule.js
 lib/util/time.js
+lib/util/async.js
+lib/util/esRequest.js

--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -779,7 +779,7 @@
         }
       },
       // Global settings to apply by default (can be overriden by user requests)
-      "globalSettings": {
+      "defaultSettings": {
         "number_of_shards": 1,
         "number_of_replicas": 1
       },

--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -778,6 +778,11 @@
           }
         }
       },
+      // Global settings to apply by default (can be overriden by user requests)
+      "globalSettings": {
+        "number_of_shards": 1,
+        "number_of_replicas": 1
+      },
       // Internal index default name and collections
       // When starting, at initialisation, kuzzle will attempt
       // to update all ES dynamic settings of existing internal

--- a/lib/config/default.config.ts
+++ b/lib/config/default.config.ts
@@ -299,6 +299,10 @@ const defaultConfig: KuzzleConfiguration = {
           },
         },
       },
+      globalSettings: {
+        number_of_replicas: 1,
+        number_of_shards: 1,
+      },
       internalIndex: {
         name: "kuzzle",
         collections: {

--- a/lib/config/default.config.ts
+++ b/lib/config/default.config.ts
@@ -299,7 +299,7 @@ const defaultConfig: KuzzleConfiguration = {
           },
         },
       },
-      globalSettings: {
+      defaultSettings: {
         number_of_replicas: 1,
         number_of_shards: 1,
       },

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -1366,12 +1366,6 @@ class ElasticSearch extends Service {
       await mutex.unlock();
     }
 
-    settings.number_of_replicas =
-      settings.number_of_replicas ||
-      this.config.globalSettings.number_of_replicas;
-    settings.number_of_shards =
-      settings.number_of_shards || this.config.globalSettings.number_of_shards;
-
     const esRequest = {
       body: {
         aliases: {
@@ -1400,6 +1394,14 @@ class ElasticSearch extends Service {
         this._config.commonMapping.properties
       ),
     };
+
+    esRequest.body.settings.number_of_replicas =
+      esRequest.body.settings.number_of_replicas ||
+      this.config.globalSettings.number_of_replicas;
+
+    esRequest.body.settings.number_of_shards =
+      esRequest.body.settings.number_of_shards ||
+      this.config.globalSettings.number_of_shards;
 
     try {
       await this._client.indices.create(esRequest);

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -1397,11 +1397,11 @@ class ElasticSearch extends Service {
 
     esRequest.body.settings.number_of_replicas =
       esRequest.body.settings.number_of_replicas ||
-      this.config.globalSettings.number_of_replicas;
+      this.config.defaultSettings.number_of_replicas;
 
     esRequest.body.settings.number_of_shards =
       esRequest.body.settings.number_of_shards ||
-      this.config.globalSettings.number_of_shards;
+      this.config.defaultSettings.number_of_shards;
 
     try {
       await this._client.indices.create(esRequest);
@@ -3149,8 +3149,8 @@ class ElasticSearch extends Service {
             [this._getAlias(index, HIDDEN_COLLECTION)]: {},
           },
           settings: {
-            number_of_replicas: this.config.globalSettings.number_of_replicas,
-            number_of_shards: this.config.globalSettings.number_of_shards,
+            number_of_replicas: this.config.defaultSettings.number_of_replicas,
+            number_of_shards: this.config.defaultSettings.number_of_shards,
           },
         },
         index: await this._getAvailableIndice(index, HIDDEN_COLLECTION),

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -1366,6 +1366,12 @@ class ElasticSearch extends Service {
       await mutex.unlock();
     }
 
+    settings.number_of_replicas =
+      settings.number_of_replicas ||
+      this.config.globalSettings.number_of_replicas;
+    settings.number_of_shards =
+      settings.number_of_shards || this.config.globalSettings.number_of_shards;
+
     const esRequest = {
       body: {
         aliases: {
@@ -3141,8 +3147,8 @@ class ElasticSearch extends Service {
             [this._getAlias(index, HIDDEN_COLLECTION)]: {},
           },
           settings: {
-            number_of_replicas: 1,
-            number_of_shards: 1,
+            number_of_replicas: this.config.globalSettings.number_of_replicas,
+            number_of_shards: this.config.globalSettings.number_of_shards,
           },
         },
         index: await this._getAvailableIndice(index, HIDDEN_COLLECTION),

--- a/lib/types/config/storageEngine/StorageEngineElasticsearchConfiguration.ts
+++ b/lib/types/config/storageEngine/StorageEngineElasticsearchConfiguration.ts
@@ -104,6 +104,26 @@ export type StorageEngineElasticsearch = {
     };
   };
 
+  /**
+   * Global settings to apply by default (if not overridden by user request ones)
+   * @default
+   * {
+   *   number_of_shards: 1,
+   *   number_of_replicas: 0
+   * }
+   */
+  globalSettings: {
+    /**
+     * @default 1
+     */
+    number_of_shards: number;
+
+    /**
+     * @default 1
+     */
+    number_of_replicas: number;
+  };
+
   internalIndex: {
     /**
      * @default "kuzzle"

--- a/lib/types/config/storageEngine/StorageEngineElasticsearchConfiguration.ts
+++ b/lib/types/config/storageEngine/StorageEngineElasticsearchConfiguration.ts
@@ -109,7 +109,7 @@ export type StorageEngineElasticsearch = {
    * @default
    * {
    *   number_of_shards: 1,
-   *   number_of_replicas: 0
+   *   number_of_replicas: 1
    * }
    */
   globalSettings: {

--- a/lib/types/config/storageEngine/StorageEngineElasticsearchConfiguration.ts
+++ b/lib/types/config/storageEngine/StorageEngineElasticsearchConfiguration.ts
@@ -112,7 +112,7 @@ export type StorageEngineElasticsearch = {
    *   number_of_replicas: 1
    * }
    */
-  globalSettings: {
+  defaultSettings: {
     /**
      * @default 1
      */

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,29 +83,6 @@
         "node": ">= 12.13.0"
       }
     },
-    "../eslint-plugin-kuzzle": {
-      "version": "0.0.5",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.38.0",
-        "@typescript-eslint/parser": "^5.38.0",
-        "eslint-plugin-prettier": "^4.2.1"
-      },
-      "devDependencies": {
-        "eslint": "^8.23.1",
-        "eslint-plugin-eslint-plugin": "^5.0.6",
-        "mocha": "^10.0.0",
-        "prettier": "^2.7.1"
-      },
-      "engines": {
-        "node": "14.x || >= 16"
-      },
-      "peerDependencies": {
-        "eslint": ">=8",
-        "prettier": ">=2.7.1"
-      }
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
       "devOptional": true,
@@ -621,8 +598,7 @@
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
-      "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
+      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -975,12 +951,12 @@
     },
     "node_modules/@types/js-yaml": {
       "version": "4.0.5",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
+      "license": "MIT"
     },
     "node_modules/@types/lodash": {
       "version": "4.14.184",
@@ -998,8 +974,7 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.38.0.tgz",
-      "integrity": "sha512-GgHi/GNuUbTOeoJiEANi0oI6fF3gBQc3bGFYj40nnAPCbhrtEDf2rjBmefFadweBmO1Du1YovHeDP2h5JLhtTQ==",
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.38.0",
         "@typescript-eslint/type-utils": "5.38.0",
@@ -1029,8 +1004,7 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.38.0.tgz",
-      "integrity": "sha512-/F63giJGLDr0ms1Cr8utDAxP2SPiglaD6V+pCOcG35P2jCqdfR7uuEhz1GIC3oy4hkUF8xA1XSXmd9hOh/a5EA==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.38.0",
         "@typescript-eslint/types": "5.38.0",
@@ -1055,8 +1029,7 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.38.0.tgz",
-      "integrity": "sha512-ByhHIuNyKD9giwkkLqzezZ9y5bALW8VNY6xXcP+VxoH4JBDKjU5WNnsiD4HJdglHECdV+lyaxhvQjTUbRboiTA==",
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "5.38.0",
         "@typescript-eslint/visitor-keys": "5.38.0"
@@ -1071,8 +1044,7 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.38.0.tgz",
-      "integrity": "sha512-iZq5USgybUcj/lfnbuelJ0j3K9dbs1I3RICAJY9NZZpDgBYXmuUlYQGzftpQA9wC8cKgtS6DASTvF3HrXwwozA==",
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/typescript-estree": "5.38.0",
         "@typescript-eslint/utils": "5.38.0",
@@ -1097,8 +1069,7 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.38.0.tgz",
-      "integrity": "sha512-HHu4yMjJ7i3Cb+8NUuRCdOGu2VMkfmKyIJsOr9PfkBVYLYrtMCK/Ap50Rpov+iKpxDTfnqvDbuPLgBE5FwUNfA==",
+      "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -1109,8 +1080,7 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.38.0.tgz",
-      "integrity": "sha512-6P0RuphkR+UuV7Avv7MU3hFoWaGcrgOdi8eTe1NwhMp2/GjUJoODBTRWzlHpZh6lFOaPmSvgxGlROa0Sg5Zbyg==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "@typescript-eslint/types": "5.38.0",
         "@typescript-eslint/visitor-keys": "5.38.0",
@@ -1135,8 +1105,7 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.38.0.tgz",
-      "integrity": "sha512-6sdeYaBgk9Fh7N2unEXGz+D+som2QCQGPAf1SxrkEr+Z32gMreQ0rparXTNGRRfYUWk/JzbGdcM8NSSd6oqnTA==",
+      "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "@typescript-eslint/scope-manager": "5.38.0",
@@ -1158,8 +1127,7 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.38.0.tgz",
-      "integrity": "sha512-MxnrdIyArnTi+XyFLR+kt/uNAcdOnmT+879os7qDRI+EYySR4crXJq9BXPfRzzLGq0wgxkwidrCJ9WCAoacm1w==",
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "5.38.0",
         "eslint-visitor-keys": "^3.3.0"
@@ -1513,6 +1481,7 @@
     },
     "node_modules/async-cache": {
       "version": "1.1.0",
+      "deprecated": "No longer maintained. Use [lru-cache](http://npm.im/lru-cache) version 7.6 or higher, and provide an asynchronous `fetchMethod` option.",
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -2070,6 +2039,7 @@
     },
     "node_modules/codecov": {
       "version": "3.8.3",
+      "deprecated": "https://about.codecov.io/blog/codecov-uploader-deprecation-plan/",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2267,6 +2237,7 @@
     },
     "node_modules/core-js-pure": {
       "version": "3.14.0",
+      "deprecated": "core-js-pure@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js-pure.",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2298,6 +2269,7 @@
     },
     "node_modules/cucumber": {
       "version": "6.0.5",
+      "deprecated": "Cucumber is publishing new releases under @cucumber/cucumber",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2338,6 +2310,7 @@
     },
     "node_modules/cucumber-expressions": {
       "version": "8.3.0",
+      "deprecated": "This package is now published under @cucumber/cucumber-expressions",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2864,8 +2837,7 @@
     },
     "node_modules/eslint": {
       "version": "8.23.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
-      "integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
+      "license": "MIT",
       "dependencies": {
         "@eslint/eslintrc": "^1.3.2",
         "@humanwhocodes/config-array": "^0.10.4",
@@ -2919,8 +2891,7 @@
     },
     "node_modules/eslint-plugin-kuzzle": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-kuzzle/-/eslint-plugin-kuzzle-0.0.6.tgz",
-      "integrity": "sha512-1tWOBxr0Fpe7yVFh3WLwrN8jgjaA39yKM0ohAkLNAN22P4HvPrN2rk0EhEUA8UFrpuRpX4wp4sF1HYUXJ2786g==",
+      "license": "Apache 2",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
@@ -2931,8 +2902,7 @@
     },
     "node_modules/eslint-plugin-prettier": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
-      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+      "license": "MIT",
       "dependencies": {
         "prettier-linter-helpers": "^1.0.0"
       },
@@ -3030,13 +3000,11 @@
     },
     "node_modules/eslint/node_modules/js-sdsl": {
       "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.4.tgz",
-      "integrity": "sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw=="
+      "license": "MIT"
     },
     "node_modules/espree": {
       "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
-      "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
@@ -3198,8 +3166,7 @@
     },
     "node_modules/fast-diff": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
+      "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
       "version": "3.2.11",
@@ -3515,6 +3482,18 @@
       "version": "1.0.0",
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "devOptional": true,
@@ -3630,6 +3609,7 @@
     },
     "node_modules/gherkin": {
       "version": "5.0.0",
+      "deprecated": "This package is now published under @cucumber/gherkin",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3666,8 +3646,7 @@
     },
     "node_modules/globals": {
       "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -3728,6 +3707,7 @@
     },
     "node_modules/har-validator": {
       "version": "5.1.5",
+      "deprecated": "this library is no longer supported",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4565,6 +4545,7 @@
     },
     "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
       "version": "3.4.0",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4713,7 +4694,10 @@
     },
     "node_modules/jsonify": {
       "version": "0.0.0",
-      "license": "Public Domain"
+      "license": "Public Domain",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/jsonwebtoken": {
       "version": "8.5.1",
@@ -4808,12 +4792,12 @@
       "license": "MIT"
     },
     "node_modules/kuzzle": {
-      "version": "2.19.5",
-      "license": "Apache-2.0",
+      "version": "2.19.7",
+      "resolved": "https://registry.npmjs.org/kuzzle/-/kuzzle-2.19.7.tgz",
+      "integrity": "sha512-cnKpaLv+STflC2hLcC9qvvpuHcrU4go78Ajztztq9b37Ro0+vf6h+qJJjBtlyddeuWfTQxTgJxgdl2lWYLqf6Q==",
       "peer": true,
       "dependencies": {
         "@elastic/elasticsearch": "https://github.com/elastic/elasticsearch-js/archive/refs/tags/v7.13.0.tar.gz",
-        "@types/js-yaml": "^4.0.5",
         "aedes": "^0.46.3",
         "bluebird": "^3.7.2",
         "cli-color": "^2.0.3",
@@ -4822,6 +4806,7 @@
         "denque": "^2.1.0",
         "didyoumean": "^1.2.2",
         "dumpme": "^1.0.3",
+        "eslint-plugin-kuzzle": "^0.0.6",
         "eventemitter3": "^4.0.7",
         "inquirer": "^9.1.1",
         "ioredis": "^5.2.3",
@@ -4832,7 +4817,7 @@
         "koncorde": "^4.0.3",
         "kuzzle-plugin-auth-passport-local": "^6.3.6",
         "kuzzle-plugin-logger": "^3.0.3",
-        "kuzzle-sdk": "^7.10.1",
+        "kuzzle-sdk": "^7.10.3",
         "kuzzle-vault": "^2.0.4",
         "lodash": "4.17.21",
         "long": "^5.2.0",
@@ -4842,7 +4827,6 @@
         "ndjson": "^2.0.0",
         "node-segfault-handler": "^1.1.0",
         "passport": "^0.6.0",
-        "prettier": "^2.7.1",
         "protobufjs": "~7.1.0",
         "rc": "1.2.8",
         "semver": "^7.3.7",
@@ -5308,8 +5292,7 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5986,6 +5969,7 @@
     },
     "node_modules/node-pre-gyp": {
       "version": "0.14.0",
+      "deprecated": "Please upgrade to @mapbox/node-pre-gyp: the non-scoped node-pre-gyp package is deprecated and only the @mapbox scoped package will recieve updates in the future",
       "license": "BSD-3-Clause",
       "dependencies": {
         "detect-libc": "^1.0.2",
@@ -6885,8 +6869,7 @@
     },
     "node_modules/prettier": {
       "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "license": "MIT",
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -6899,8 +6882,7 @@
     },
     "node_modules/prettier-linter-helpers": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "license": "MIT",
       "dependencies": {
         "fast-diff": "^1.1.2"
       },
@@ -7275,6 +7257,7 @@
     },
     "node_modules/request": {
       "version": "2.88.2",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7305,6 +7288,7 @@
     },
     "node_modules/request-promise": {
       "version": "4.2.6",
+      "deprecated": "request-promise has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7344,6 +7328,7 @@
     },
     "node_modules/request/node_modules/uuid": {
       "version": "3.4.0",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -8361,7 +8346,8 @@
       }
     },
     "node_modules/sorted-array": {
-      "version": "2.0.4"
+      "version": "2.0.4",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info."
     },
     "node_modules/source-map": {
       "version": "0.5.7",
@@ -8980,8 +8966,7 @@
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^1.8.1"
       },
@@ -8994,8 +8979,7 @@
     },
     "node_modules/tsutils/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -9037,8 +9021,7 @@
     },
     "node_modules/type-fest": {
       "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -9965,8 +9948,6 @@
     },
     "@eslint/eslintrc": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
-      "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -10204,12 +10185,11 @@
       "dev": true
     },
     "@types/js-yaml": {
-      "version": "4.0.5"
+      "version": "4.0.5",
+      "dev": true
     },
     "@types/json-schema": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
+      "version": "7.0.11"
     },
     "@types/lodash": {
       "version": "4.14.184",
@@ -10224,8 +10204,6 @@
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.38.0.tgz",
-      "integrity": "sha512-GgHi/GNuUbTOeoJiEANi0oI6fF3gBQc3bGFYj40nnAPCbhrtEDf2rjBmefFadweBmO1Du1YovHeDP2h5JLhtTQ==",
       "requires": {
         "@typescript-eslint/scope-manager": "5.38.0",
         "@typescript-eslint/type-utils": "5.38.0",
@@ -10239,8 +10217,6 @@
     },
     "@typescript-eslint/parser": {
       "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.38.0.tgz",
-      "integrity": "sha512-/F63giJGLDr0ms1Cr8utDAxP2SPiglaD6V+pCOcG35P2jCqdfR7uuEhz1GIC3oy4hkUF8xA1XSXmd9hOh/a5EA==",
       "requires": {
         "@typescript-eslint/scope-manager": "5.38.0",
         "@typescript-eslint/types": "5.38.0",
@@ -10250,8 +10226,6 @@
     },
     "@typescript-eslint/scope-manager": {
       "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.38.0.tgz",
-      "integrity": "sha512-ByhHIuNyKD9giwkkLqzezZ9y5bALW8VNY6xXcP+VxoH4JBDKjU5WNnsiD4HJdglHECdV+lyaxhvQjTUbRboiTA==",
       "requires": {
         "@typescript-eslint/types": "5.38.0",
         "@typescript-eslint/visitor-keys": "5.38.0"
@@ -10259,8 +10233,6 @@
     },
     "@typescript-eslint/type-utils": {
       "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.38.0.tgz",
-      "integrity": "sha512-iZq5USgybUcj/lfnbuelJ0j3K9dbs1I3RICAJY9NZZpDgBYXmuUlYQGzftpQA9wC8cKgtS6DASTvF3HrXwwozA==",
       "requires": {
         "@typescript-eslint/typescript-estree": "5.38.0",
         "@typescript-eslint/utils": "5.38.0",
@@ -10269,14 +10241,10 @@
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.38.0.tgz",
-      "integrity": "sha512-HHu4yMjJ7i3Cb+8NUuRCdOGu2VMkfmKyIJsOr9PfkBVYLYrtMCK/Ap50Rpov+iKpxDTfnqvDbuPLgBE5FwUNfA=="
+      "version": "5.38.0"
     },
     "@typescript-eslint/typescript-estree": {
       "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.38.0.tgz",
-      "integrity": "sha512-6P0RuphkR+UuV7Avv7MU3hFoWaGcrgOdi8eTe1NwhMp2/GjUJoODBTRWzlHpZh6lFOaPmSvgxGlROa0Sg5Zbyg==",
       "requires": {
         "@typescript-eslint/types": "5.38.0",
         "@typescript-eslint/visitor-keys": "5.38.0",
@@ -10289,8 +10257,6 @@
     },
     "@typescript-eslint/utils": {
       "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.38.0.tgz",
-      "integrity": "sha512-6sdeYaBgk9Fh7N2unEXGz+D+som2QCQGPAf1SxrkEr+Z32gMreQ0rparXTNGRRfYUWk/JzbGdcM8NSSd6oqnTA==",
       "requires": {
         "@types/json-schema": "^7.0.9",
         "@typescript-eslint/scope-manager": "5.38.0",
@@ -10302,8 +10268,6 @@
     },
     "@typescript-eslint/visitor-keys": {
       "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.38.0.tgz",
-      "integrity": "sha512-MxnrdIyArnTi+XyFLR+kt/uNAcdOnmT+879os7qDRI+EYySR4crXJq9BXPfRzzLGq0wgxkwidrCJ9WCAoacm1w==",
       "requires": {
         "@typescript-eslint/types": "5.38.0",
         "eslint-visitor-keys": "^3.3.0"
@@ -11461,8 +11425,6 @@
     },
     "eslint": {
       "version": "8.23.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
-      "integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
       "requires": {
         "@eslint/eslintrc": "^1.3.2",
         "@humanwhocodes/config-array": "^0.10.4",
@@ -11525,16 +11487,12 @@
           }
         },
         "js-sdsl": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.4.tgz",
-          "integrity": "sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw=="
+          "version": "4.1.4"
         }
       }
     },
     "eslint-plugin-kuzzle": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-kuzzle/-/eslint-plugin-kuzzle-0.0.6.tgz",
-      "integrity": "sha512-1tWOBxr0Fpe7yVFh3WLwrN8jgjaA39yKM0ohAkLNAN22P4HvPrN2rk0EhEUA8UFrpuRpX4wp4sF1HYUXJ2786g==",
       "requires": {
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
@@ -11545,8 +11503,6 @@
     },
     "eslint-plugin-prettier": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
-      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
       }
@@ -11574,8 +11530,6 @@
     },
     "espree": {
       "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
-      "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
       "requires": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
@@ -11678,9 +11632,7 @@
       "version": "3.1.3"
     },
     "fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
+      "version": "1.2.0"
     },
     "fast-glob": {
       "version": "3.2.11",
@@ -11894,6 +11846,11 @@
     "fs.realpath": {
       "version": "1.0.0"
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "dev": true,
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "devOptional": true
@@ -11996,8 +11953,6 @@
     },
     "globals": {
       "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
       "requires": {
         "type-fest": "^0.20.2"
       }
@@ -12687,11 +12642,12 @@
       "version": "2.0.0"
     },
     "kuzzle": {
-      "version": "2.19.5",
+      "version": "2.19.7",
+      "resolved": "https://registry.npmjs.org/kuzzle/-/kuzzle-2.19.7.tgz",
+      "integrity": "sha512-cnKpaLv+STflC2hLcC9qvvpuHcrU4go78Ajztztq9b37Ro0+vf6h+qJJjBtlyddeuWfTQxTgJxgdl2lWYLqf6Q==",
       "peer": true,
       "requires": {
         "@elastic/elasticsearch": "https://github.com/elastic/elasticsearch-js/archive/refs/tags/v7.13.0.tar.gz",
-        "@types/js-yaml": "^4.0.5",
         "aedes": "^0.46.3",
         "bluebird": "^3.7.2",
         "cli-color": "^2.0.3",
@@ -12700,6 +12656,7 @@
         "denque": "^2.1.0",
         "didyoumean": "^1.2.2",
         "dumpme": "^1.0.3",
+        "eslint-plugin-kuzzle": "^0.0.6",
         "eventemitter3": "^4.0.7",
         "inquirer": "^9.1.1",
         "ioredis": "^5.2.3",
@@ -12710,7 +12667,7 @@
         "koncorde": "^4.0.3",
         "kuzzle-plugin-auth-passport-local": "^6.3.6",
         "kuzzle-plugin-logger": "^3.0.3",
-        "kuzzle-sdk": "^7.10.1",
+        "kuzzle-sdk": "^7.10.3",
         "kuzzle-vault": "^2.0.4",
         "lodash": "4.17.21",
         "long": "^5.2.0",
@@ -12720,7 +12677,6 @@
         "ndjson": "^2.0.0",
         "node-segfault-handler": "^1.1.0",
         "passport": "^0.6.0",
-        "prettier": "^2.7.1",
         "protobufjs": "~7.1.0",
         "rc": "1.2.8",
         "semver": "^7.3.7",
@@ -13034,8 +12990,6 @@
     },
     "minimatch": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -14062,14 +14016,10 @@
       "version": "1.2.1"
     },
     "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
+      "version": "2.7.1"
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
       "requires": {
         "fast-diff": "^1.1.2"
       }
@@ -15454,16 +15404,12 @@
     },
     "tsutils": {
       "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
       "requires": {
         "tslib": "^1.8.1"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "version": "1.14.1"
         }
       }
     },
@@ -15492,9 +15438,7 @@
       "dev": true
     },
     "type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
+      "version": "0.20.2"
     },
     "typedarray": {
       "version": "0.0.6",

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -5036,6 +5036,29 @@ describe("Test: ElasticSearch service", () => {
 
       should(elasticsearch._client.indices.create).not.be.called();
     });
+
+    it("does create hidden collection based on global settings", async () => {
+      elasticsearch._client.indices.create.resolves({});
+      elasticsearch.config.globalSettings = {
+        number_of_shards: 42,
+        number_of_replicas: 42,
+      };
+
+      await elasticsearch._createHiddenCollection("nisantasi");
+
+      should(elasticsearch._client.indices.create).be.calledWithMatch({
+        index: hiddenIndice,
+        body: {
+          aliases: { [hiddenAlias]: {} },
+          settings: {
+            number_of_shards: 42,
+            number_of_replicas: 42,
+          },
+        },
+      });
+      should(Mutex.prototype.lock).be.called();
+      should(Mutex.prototype.unlock).be.called();
+    });
   });
 
   describe("#_checkMappings", () => {

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -2454,8 +2454,8 @@ describe("Test: ElasticSearch service", () => {
       );
     });
 
-    it("should use globalSettings if none are provided", async () => {
-      elasticsearch.config.globalSettings = {
+    it("should use defaultSettings if none are provided", async () => {
+      elasticsearch.config.defaultSettings = {
         number_of_replicas: 42,
         number_of_shards: 66,
       };
@@ -2463,11 +2463,11 @@ describe("Test: ElasticSearch service", () => {
       await elasticsearch.createCollection(index, collection);
 
       const esReq = elasticsearch._client.indices.create.firstCall.args[0];
-      should(esReq.body.settings).eql(elasticsearch.config.globalSettings);
+      should(esReq.body.settings).eql(elasticsearch.config.defaultSettings);
     });
 
     it("should use provided settings if provided", async () => {
-      elasticsearch.config.globalSettings = {
+      elasticsearch.config.defaultSettings = {
         number_of_replicas: 42,
         number_of_shards: 66,
       };
@@ -2484,7 +2484,7 @@ describe("Test: ElasticSearch service", () => {
     });
 
     it("should use partially provided settings", async () => {
-      elasticsearch.config.globalSettings = {
+      elasticsearch.config.defaultSettings = {
         number_of_replicas: 42,
         number_of_shards: 66,
       };
@@ -5039,7 +5039,7 @@ describe("Test: ElasticSearch service", () => {
 
     it("does create hidden collection based on global settings", async () => {
       elasticsearch._client.indices.create.resolves({});
-      elasticsearch.config.globalSettings = {
+      elasticsearch.config.defaultSettings = {
         number_of_shards: 42,
         number_of_replicas: 42,
       };

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -2102,7 +2102,7 @@ describe("Test: ElasticSearch service", () => {
         index,
         collection,
         "not an object",
-        () => { }
+        () => {}
       );
 
       return should(promise).be.rejectedWith({

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -2102,7 +2102,7 @@ describe("Test: ElasticSearch service", () => {
         index,
         collection,
         "not an object",
-        () => {}
+        () => { }
       );
 
       return should(promise).be.rejectedWith({
@@ -2452,6 +2452,55 @@ describe("Test: ElasticSearch service", () => {
         BadRequestError,
         { id: "services.storage.invalid_collection_name" }
       );
+    });
+
+    it("should use globalSettings if none are provided", async () => {
+      elasticsearch.config.globalSettings = {
+        number_of_replicas: 42,
+        number_of_shards: 66,
+      };
+
+      await elasticsearch.createCollection(index, collection);
+
+      const esReq = elasticsearch._client.indices.create.firstCall.args[0];
+      should(esReq.body.settings).eql(elasticsearch.config.globalSettings);
+    });
+
+    it("should use provided settings if provided", async () => {
+      elasticsearch.config.globalSettings = {
+        number_of_replicas: 42,
+        number_of_shards: 66,
+      };
+
+      const settings = {
+        number_of_replicas: 1,
+        number_of_shards: 2,
+      };
+
+      await elasticsearch.createCollection(index, collection, { settings });
+
+      const esReq = elasticsearch._client.indices.create.firstCall.args[0];
+      should(esReq.body.settings).eql(settings);
+    });
+
+    it("should use partially provided settings", async () => {
+      elasticsearch.config.globalSettings = {
+        number_of_replicas: 42,
+        number_of_shards: 66,
+      };
+
+      const settings = {
+        number_of_replicas: 1,
+      };
+
+      await elasticsearch.createCollection(index, collection, { settings });
+
+      const esReq = elasticsearch._client.indices.create.firstCall.args[0];
+
+      should(esReq.body.settings).eql({
+        number_of_replicas: 1,
+        number_of_shards: 66,
+      });
     });
   });
 


### PR DESCRIPTION
## Why ?
Because a system administrator would ensure index and collection created by users match the Elasticsearch architecture (number of nodes). This in order to provide the best Elasticsearch settings by default for the current cluster topology

## How ?

Add a field `globalSettings` in the `storageEngine` configuration of the KuzzleRC. This field could contains for now:
- `number_of_replicas`: number of replicas to use by default when creating hidden and public index/collection
- `number_of_shards`: number of shards to use by default when creating hidden and public index/collection

## How to test it?
You can start a fresh Kuzzle cluster (with a fresh Elasticsearch cluster) using these command:
```bash
kourou app:start-services
kuzzle_services__storageEngine__globalSettings__number_of_replicas=3 kuzzle_services__storageEngine__globalSettings__number_of_shards=1 npm run dev 
```

Check the number of shards and replicas for newly created hidden collections (eg: `%kuzzle.config` etc...) and try to create new ones using the Admin Console.
By default, using Admin Console regular UI, all the created collection/index will get the `globalSettings` number of shards/replicas. If you want to test to override these values, you can use the `API Action` feature and provide a complete custom request as this one:

```http
{
  "controller": "collection",
  "action": "create",
  "index": "titi",
  "collection": "tutu",
  "body": {
    "settings": {
      "number_of_replicas": 2,
      "number_of_shards" : 2
    }
  }
}
```
