### PR TITLE
2.19.7 - Add default type to EmbeddedSDK.query

### DIFF
--- a/lib/core/shared/sdk/embeddedSdk.ts
+++ b/lib/core/shared/sdk/embeddedSdk.ts
@@ -149,7 +149,10 @@ export class EmbeddedSDK extends Kuzzle {
    * @param request - API request (https://docs.kuzzle.io/core/2/guides/main-concepts/1-api#other-protocols)
    * @param options - Optional arguments
    */
-  query<TRequest extends BaseRequest = BaseRequest, TResult extends JSONObject = JSONObject>(
+  query<
+    TRequest extends BaseRequest = BaseRequest,
+    TResult extends JSONObject = JSONObject
+  >(
     request: TRequest,
     options: { propagate?: boolean } = {}
   ): Promise<ResponsePayload<TResult>> {

--- a/lib/core/shared/sdk/embeddedSdk.ts
+++ b/lib/core/shared/sdk/embeddedSdk.ts
@@ -149,7 +149,7 @@ export class EmbeddedSDK extends Kuzzle {
    * @param request - API request (https://docs.kuzzle.io/core/2/guides/main-concepts/1-api#other-protocols)
    * @param options - Optional arguments
    */
-  query<TRequest extends BaseRequest, TResult>(
+  query<TRequest extends BaseRequest = BaseRequest, TResult extends JSONObject = JSONObject>(
     request: TRequest,
     options: { propagate?: boolean } = {}
   ): Promise<ResponsePayload<TResult>> {

--- a/lib/kerror/index.ts
+++ b/lib/kerror/index.ts
@@ -206,7 +206,7 @@ export function rawGetFrom(
 
   // If a stacktrace is present, we need to modify the first line because it
   // still contains the original error message
-  if (derivedError.stack && derivedError.stack.length) {
+  if (derivedError.stack && derivedError.stack.length && source.stack) {
     const stackArray = source.stack.split("\n");
     stackArray.shift();
     derivedError.stack = [

--- a/lib/service/storage/esWrapper.js
+++ b/lib/service/storage/esWrapper.js
@@ -232,7 +232,7 @@ class ESWrapper {
   _handleNotFoundError(error, message) {
     let errorMessage = message;
 
-    if (! error.body._index) {
+    if (!error.body._index) {
       return kerror.get("unexpected_not_found", errorMessage);
     }
 

--- a/lib/service/storage/esWrapper.js
+++ b/lib/service/storage/esWrapper.js
@@ -232,6 +232,10 @@ class ESWrapper {
   _handleNotFoundError(error, message) {
     let errorMessage = message;
 
+    if (! error.body._index) {
+      return kerror.get("unexpected_not_found", errorMessage);
+    }
+
     // _index= "&nyc-open-data.yellow-taxi"
     const index = error.body._index.split(".")[0].slice(1);
     const collection = error.body._index.split(".")[1];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kuzzle",
-  "version": "2.19.6",
+  "version": "2.19.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kuzzle",
-      "version": "2.19.6",
+      "version": "2.19.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/elasticsearch": "https://github.com/elastic/elasticsearch-js/archive/refs/tags/v7.13.0.tar.gz",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.19.6",
+  "version": "2.19.7",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "bin": "bin/start-kuzzle-server",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:functional:legacy:mqtt": "npx cucumber-js --format progress-bar --profile mqtt ./features-legacy",
     "cucumber": "cucumber.js --fail-fast",
     "codecov": "codecov",
+    "prettier": "npx prettier ./lib ./test ./bin ./features ./plugins/available/functional-test-plugin --write",
     "test:lint": "npm run test:lint:js && npm run test:lint:ts",
     "test:lint:ts": "eslint --max-warnings=0 ./lib --ext .ts --config .eslintc-ts.json",
     "test:lint:ts:fix": "eslint --max-warnings=0 --fix ./lib --ext .ts --config .eslintc-ts.json",

--- a/test/service/storage/esWrapper.test.js
+++ b/test/service/storage/esWrapper.test.js
@@ -98,7 +98,7 @@ describe("Test: ElasticSearch Wrapper", () => {
       const formatted = esWrapper.formatESError(error);
 
       should(formatted).be.match({
-        message: 'test',
+        message: "test",
         id: "services.storage.unexpected_not_found",
       });
     });

--- a/test/service/storage/esWrapper.test.js
+++ b/test/service/storage/esWrapper.test.js
@@ -83,6 +83,26 @@ describe("Test: ElasticSearch Wrapper", () => {
       });
     });
 
+    it("should handle unexpected not found", () => {
+      const error = new Error("test");
+      error.meta = { statusCode: 404 };
+      error.body = {
+        found: false,
+        _id: "mehry",
+        error: {
+          reason: "foo",
+          "resource.id": "bar",
+        },
+      };
+
+      const formatted = esWrapper.formatESError(error);
+
+      should(formatted).be.match({
+        message: 'test',
+        id: "services.storage.unexpected_not_found",
+      });
+    });
+
     it("should handle unknown DSL keyword", () => {
       const error = new Error("");
       error.meta = {


### PR DESCRIPTION
## What does this PR do ?

Add default types to `EmbeddedSDK.query` otherwise this result in an error:

```js
const { result } = await app.sdk.query(...);

result.anything; // error since "result" is of type "unknown"
```

### Other changes

 - fix bug happening when ES cannot find a resource who is not an index
 - fix bug when wrapping an error without stacktrace
 
ci-allow-merge-into: master