### PR TITLE
Fix ZeroMQ version to avoid npm install errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kuzzle",
-  "version": "2.19.8",
+  "version": "2.19.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kuzzle",
-      "version": "2.19.8",
+      "version": "2.19.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/elasticsearch": "https://github.com/elastic/elasticsearch-js/archive/refs/tags/v7.13.0.tar.gz",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.19.8",
+  "version": "2.19.9",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "bin": "bin/start-kuzzle-server",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "winston-syslog": "^2.6.0",
     "winston-transport": "^4.5.0",
     "yargs": "^17.5.1",
-    "zeromq": "^6.0.0-beta.6"
+    "zeromq": "6.0.0-beta.6"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- ZeroMQ introduce bug in 6.0.0-beta.7 and break "npm install". This PR fix the version to 6.0.0-beta.6.
ci-allow-merge-into: master
