### PR TITLE
Fix set-cookie header not respecting the RFC when having multiple of them

### DIFF
--- a/lib/core/network/protocols/httpwsProtocol.js
+++ b/lib/core/network/protocols/httpwsProtocol.js
@@ -81,12 +81,13 @@ const HTTP_ALLOWED_CONTENT_TYPES = [
   "application/x-www-form-urlencoded",
   "multipart/form-data",
 ];
-const HTTP_SKIPPED_HEADERS = ["content-length"];
+const HTTP_SKIPPED_HEADERS = ["content-length", "set-cookie"];
 const HTTP_HEADER_CONNECTION = Buffer.from("Connection");
 const HTTP_HEADER_CONTENT_LENGTH = Buffer.from("Content-Length");
 const HTTP_HEADER_ACCESS_CONTROL_ALLOW_ORIGIN = Buffer.from(
   "Access-Control-Allow-Origin"
 );
+const HTTP_HEADER_SET_COOKIE = Buffer.from("Set-Cookie");
 const HTTP_HEADER_VARY = Buffer.from("Vary");
 const HTTP_HEADER_TRANSFER_ENCODING = Buffer.from("Transfer-Encoding");
 const CHUNKED = Buffer.from("chunked");
@@ -700,6 +701,12 @@ class HttpWsProtocol extends Protocol {
       );
 
       response.writeHeader(HTTP_HEADER_VARY, ORIGIN);
+    }
+
+    if (request.response.headers["set-cookie"]) {
+      for (const cookie of request.response.headers["set-cookie"]) {
+        response.writeHeader(HTTP_HEADER_SET_COOKIE, Buffer.from(cookie));
+      }
     }
 
     for (const [key, value] of Object.entries(request.response.headers)) {


### PR DESCRIPTION
## What does this PR do ?

Fix the `Set-Cookie` header not respecting the RFC when there is multiple cookie to set.
When that's the case the RFC says that there should be one header per cookie to set instead of having one `Set-Cookie` with each cookie separated by a comma