### PR TITLE
Forward errors to HTTP stream consumers

### DIFF
--- a/lib/util/dump-collection.ts
+++ b/lib/util/dump-collection.ts
@@ -195,8 +195,8 @@ abstract class AbstractDumper {
     });
 
     try {
-    await this.setup();
-    await this.writeHeader();
+      await this.setup();
+      await this.writeHeader();
 
       let results = await global.kuzzle.ask(
         "core:storage:public:document:search",
@@ -220,7 +220,6 @@ abstract class AbstractDumper {
       } while ((results = await this.scroll(results.scrollId)));
 
       await this.tearDown();
-
     } catch (e) {
       this.writeStream.write(e.toString());
     }

--- a/lib/util/dump-collection.ts
+++ b/lib/util/dump-collection.ts
@@ -194,31 +194,36 @@ abstract class AbstractDumper {
       throw error;
     });
 
+    try {
     await this.setup();
     await this.writeHeader();
 
-    let results = await global.kuzzle.ask(
-      "core:storage:public:document:search",
-      this.index,
-      this.collection,
-      this.query,
-      {
-        lang: this.options.lang,
-        scroll: this.options.scroll,
-        size: this.options.size,
-      }
-    );
+      let results = await global.kuzzle.ask(
+        "core:storage:public:document:search",
+        this.index,
+        this.collection,
+        this.query,
+        {
+          lang: this.options.lang,
+          scroll: this.options.scroll,
+          size: this.options.size,
+        }
+      );
 
-    do {
-      for (const hit of results.hits) {
-        await this.onResult({
-          _id: hit._id,
-          _source: hit._source,
-        });
-      }
-    } while ((results = await this.scroll(results.scrollId)));
+      do {
+        for (const hit of results.hits) {
+          await this.onResult({
+            _id: hit._id,
+            _source: hit._source,
+          });
+        }
+      } while ((results = await this.scroll(results.scrollId)));
 
-    await this.tearDown();
+      await this.tearDown();
+
+    } catch (e) {
+      this.writeStream.write(e.toString());
+    }
 
     this.writeStream.end();
 


### PR DESCRIPTION
## What does this PR do ?

Prevent Kuzzle from crashing when an error occurs during the export.
When an error occurs write the error to the stream, since there is no way to fail the HTTP stream, the only possibility is unfortunately to write the error to the HTTP Stream and close the stream earlier.