### PR TITLE
Fix ProfileDefinition type

### DIFF
--- a/lib/types/ProfileDefinition.ts
+++ b/lib/types/ProfileDefinition.ts
@@ -45,7 +45,7 @@ export type ProfileDefinition = {
       /**
        * Collection names.
        */
-      collections: string[];
+      collections?: string[];
     }>;
   }>;
 };


### PR DESCRIPTION
## What does this PR do ?

When definining a profile, you can restrict each policy (containing a role) to a specific set of indexes and collections. If the `collections` property is not defined then the policy applies to the whole index.

The `collections` property is now optional.

