### PR TITLE
Feat : seoUpgrade for kuzzle documentation

### DIFF
--- a/doc/2/api/controllers/index.md
+++ b/doc/2/api/controllers/index.md
@@ -5,3 +5,4 @@ order: 300
 title: Controllers
 description: API controllers exhaustive list
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/abstract-classes/base-validation-type/index.md
+++ b/doc/2/framework/abstract-classes/base-validation-type/index.md
@@ -4,4 +4,4 @@ title: BaseValidationType
 description: BaseValidationType abstract class
 code: true
 ---
- 
+ <RedirectToFirstChild />

--- a/doc/2/framework/abstract-classes/controller/index.md
+++ b/doc/2/framework/abstract-classes/controller/index.md
@@ -4,3 +4,4 @@ title: Controller
 description: Controller abstract class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/abstract-classes/kuzzle-error/index.md
+++ b/doc/2/framework/abstract-classes/kuzzle-error/index.md
@@ -4,3 +4,4 @@ title: KuzzleError
 description: KuzzleError abstract class
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/abstract-classes/plugin/index.md
+++ b/doc/2/framework/abstract-classes/plugin/index.md
@@ -4,3 +4,4 @@ title: Plugin
 description: Plugin abstract class
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/backend-cluster/index.md
+++ b/doc/2/framework/classes/backend-cluster/index.md
@@ -4,3 +4,4 @@ title: BackendCluster
 description: BackendCluster class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/backend-config/index.md
+++ b/doc/2/framework/classes/backend-config/index.md
@@ -4,3 +4,4 @@ title: BackendConfig
 description: BackendConfig class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/backend-controller/index.md
+++ b/doc/2/framework/classes/backend-controller/index.md
@@ -4,3 +4,4 @@ title: BackendController
 description: BackendController class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/backend-errors/index.md
+++ b/doc/2/framework/classes/backend-errors/index.md
@@ -4,3 +4,4 @@ type: branch
 title: BackendErrors
 description: BackendErrors class documentation
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/backend-hook/index.md
+++ b/doc/2/framework/classes/backend-hook/index.md
@@ -4,3 +4,4 @@ title: BackendHook
 description: BackendHook class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/backend-import/index.md
+++ b/doc/2/framework/classes/backend-import/index.md
@@ -4,3 +4,4 @@ title: BackendImport
 description: BackendImport class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/backend-openapi/index.md
+++ b/doc/2/framework/classes/backend-openapi/index.md
@@ -4,3 +4,4 @@ title: BackendOpenApi
 description: BackendOpenApi class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/backend-pipe/index.md
+++ b/doc/2/framework/classes/backend-pipe/index.md
@@ -4,3 +4,4 @@ title: BackendPipe
 description: BackendPipe class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/backend-plugin/index.md
+++ b/doc/2/framework/classes/backend-plugin/index.md
@@ -4,3 +4,4 @@ title: BackendPlugin
 description: BackendPlugin class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/backend-storage/index.md
+++ b/doc/2/framework/classes/backend-storage/index.md
@@ -4,3 +4,4 @@ title: BackendStorage
 description: BackendStorage class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/backend-vault/index.md
+++ b/doc/2/framework/classes/backend-vault/index.md
@@ -4,3 +4,4 @@ title: BackendVault
 description: BackendVault class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/backend/index.md
+++ b/doc/2/framework/classes/backend/index.md
@@ -4,3 +4,4 @@ title: Backend
 description: Backend class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/data-validation/index.md
+++ b/doc/2/framework/classes/data-validation/index.md
@@ -4,3 +4,4 @@ title: DataValidation
 description: DataValidation class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/embedded-sdk/index.md
+++ b/doc/2/framework/classes/embedded-sdk/index.md
@@ -4,3 +4,4 @@ title: EmbeddedSDK
 description: EmbeddedSDK class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/http-stream/index.md
+++ b/doc/2/framework/classes/http-stream/index.md
@@ -4,3 +4,4 @@ title: HttpStream
 description: HttpStream class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/inflector/index.md
+++ b/doc/2/framework/classes/inflector/index.md
@@ -4,3 +4,4 @@ title: Inflector
 description: Inflector class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/internal-logger/index.md
+++ b/doc/2/framework/classes/internal-logger/index.md
@@ -4,3 +4,4 @@ title: InternalLogger
 description: InternalLogger class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/koncorde/index.md
+++ b/doc/2/framework/classes/koncorde/index.md
@@ -4,3 +4,4 @@ title: Koncorde
 description: Koncorde class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/kuzzle-request/index.md
+++ b/doc/2/framework/classes/kuzzle-request/index.md
@@ -4,3 +4,4 @@ title: KuzzleRequest
 description: KuzzleRequest class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/mutex/index.md
+++ b/doc/2/framework/classes/mutex/index.md
@@ -4,3 +4,4 @@ title: Mutex
 description: Mutex class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/name-generator/index.md
+++ b/doc/2/framework/classes/name-generator/index.md
@@ -4,3 +4,4 @@ title: NameGenerator
 description: NameGenerator class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/plugin-context-accessors/index.md
+++ b/doc/2/framework/classes/plugin-context-accessors/index.md
@@ -4,3 +4,4 @@ title: PluginContextAccessors
 description: PluginContextAccessors class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/plugin-context-constructors/index.md
+++ b/doc/2/framework/classes/plugin-context-constructors/index.md
@@ -4,3 +4,4 @@ title: PluginContextConstructors
 description: PluginContextConstructors class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/plugin-context/index.md
+++ b/doc/2/framework/classes/plugin-context/index.md
@@ -4,3 +4,4 @@ title: PluginContext
 description: PluginContext class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/plugin-storage/index.md
+++ b/doc/2/framework/classes/plugin-storage/index.md
@@ -4,3 +4,4 @@ title: PluginStorage
 description: PluginStorage class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/plugin-strategy/index.md
+++ b/doc/2/framework/classes/plugin-strategy/index.md
@@ -4,3 +4,4 @@ title: PluginStrategy
 description: PluginStrategy class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/repository/index.md
+++ b/doc/2/framework/classes/repository/index.md
@@ -4,3 +4,4 @@ title: Repository
 description: Repository class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/request-context/index.md
+++ b/doc/2/framework/classes/request-context/index.md
@@ -4,3 +4,4 @@ title: RequestContext
 description: RequestContext class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/request-input/index.md
+++ b/doc/2/framework/classes/request-input/index.md
@@ -4,3 +4,4 @@ title: RequestInput
 description: RequestInput class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/request-response/index.md
+++ b/doc/2/framework/classes/request-response/index.md
@@ -4,3 +4,4 @@ title: RequestResponse
 description: RequestResponse class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/subscription/index.md
+++ b/doc/2/framework/classes/subscription/index.md
@@ -4,3 +4,4 @@ title: Subscription
 description: Subscription class definition
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/error-classes/bad-request-error/index.md
+++ b/doc/2/framework/error-classes/bad-request-error/index.md
@@ -4,3 +4,4 @@ title: BadRequestError
 description: BadRequestError class
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/error-classes/external-service-error/index.md
+++ b/doc/2/framework/error-classes/external-service-error/index.md
@@ -4,3 +4,4 @@ title: ExternalServiceError
 description: ExternalServiceError class
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/error-classes/forbidden-error/index.md
+++ b/doc/2/framework/error-classes/forbidden-error/index.md
@@ -4,3 +4,4 @@ title: ForbiddenError
 description: ForbiddenError class
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/error-classes/gateway-timeout-error/index.md
+++ b/doc/2/framework/error-classes/gateway-timeout-error/index.md
@@ -4,3 +4,4 @@ title: GatewayTimeoutError
 description: GatewayTimeoutError class
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/error-classes/internal-error/index.md
+++ b/doc/2/framework/error-classes/internal-error/index.md
@@ -4,3 +4,4 @@ title: InternalError
 description: InternalError class
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/error-classes/not-found-error/index.md
+++ b/doc/2/framework/error-classes/not-found-error/index.md
@@ -4,3 +4,4 @@ title: NotFoundError
 description: NotFoundError class
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/error-classes/partial-error/index.md
+++ b/doc/2/framework/error-classes/partial-error/index.md
@@ -4,3 +4,4 @@ title: PartialError
 description: PartialError class
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/error-classes/plugin-implementation-error/index.md
+++ b/doc/2/framework/error-classes/plugin-implementation-error/index.md
@@ -4,3 +4,4 @@ title: PluginImplementationError
 description: PluginImplementationError class
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/error-classes/precondition-error/index.md
+++ b/doc/2/framework/error-classes/precondition-error/index.md
@@ -4,3 +4,4 @@ title: PreconditionError
 description: PreconditionError class
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/error-classes/service-unavailable-error/index.md
+++ b/doc/2/framework/error-classes/service-unavailable-error/index.md
@@ -4,3 +4,4 @@ title: ServiceUnavailableError
 description: ServiceUnavailableError class
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/framework/error-classes/size-limit-error/index.md
+++ b/doc/2/framework/error-classes/size-limit-error/index.md
@@ -4,3 +4,4 @@ title: SizeLimitError
 description: SizeLimitError class
 code: true
 ---
+<RedirectToFirstChild />

--- a/doc/2/guides/advanced/api-keys/index.md
+++ b/doc/2/guides/advanced/api-keys/index.md
@@ -1,11 +1,14 @@
 ---
 code: false
 type: page
-title: API Keys
-description: Manage API keys 
 order: 200
+title: API Keys | Kuzzle Advanced | Guide | Core
+meta:
+  - name: description
+    content: Manage kuzzle API keys 
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, opensource, API Keys 
 ---
-
 # API Keys
 
 Kuzzle allows to create API keys to **authenticate users without using an authentication strategy** and the [auth:login](/core/2/api/controllers/auth/login) action.

--- a/doc/2/guides/advanced/cluster-scalability/index.md
+++ b/doc/2/guides/advanced/cluster-scalability/index.md
@@ -1,11 +1,14 @@
 ---
 code: false
 type: page
-title: Cluster and Scalability
-description: Understand how a Kuzzle cluster works
 order: 700
+title: Cluster and Scalability | Kuzzle Advanced | Guide | Core
+meta:
+  - name: description
+    content: Understand how a Kuzzle cluster works
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, opensource,  Cluster and Scalability 
 ---
-
 :::info
 This documentation page applies to Kuzzle versions 2.11 and above.  
 

--- a/doc/2/guides/advanced/configuration/index.md
+++ b/doc/2/guides/advanced/configuration/index.md
@@ -1,9 +1,13 @@
 ---
 code: false
 type: page
-title: Configuration
-description: Configure Kuzzle
 order: 100
+title: Configuration | Kuzzle Advanced | Guide | Core
+meta:
+  - name: description
+    content: Configure Kuzzle
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, opensource,  Configuration 
 ---
 
 # Configuring Kuzzle

--- a/doc/2/guides/advanced/data-validation/index.md
+++ b/doc/2/guides/advanced/data-validation/index.md
@@ -1,9 +1,13 @@
 ---
 code: false
 type: page
-title: Data Validation
-description: Ensure data quality rules
 order: 600
+title: Data Validation | Kuzzle Advanced | Guide | Core
+meta:
+  - name: description
+    content: Ensure data quality rules
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, opensource,  Data Validation
 ---
 
 # Data Validation

--- a/doc/2/guides/advanced/debugging/index.md
+++ b/doc/2/guides/advanced/debugging/index.md
@@ -1,11 +1,14 @@
 ---
 code: false
 type: page
-title: Debugging
-description: Debug Kuzzle
 order: 800
+title: Debugging kuzzle | Kuzzle Advanced | Guide | Core
+meta:
+  - name: description
+    content:  Debug Kuzzle
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, opensource, Debugging
 ---
-
 ## Introduction
 
 Kuzzle gives the possibility to debug a Kuzzle instance using the [Debug Controller](/core/2/api/controllers/debug) actions.

--- a/doc/2/guides/advanced/export-import-data/index.md
+++ b/doc/2/guides/advanced/export-import-data/index.md
@@ -1,11 +1,14 @@
 ---
 code: false
 type: page
-title: Export and Import Data
-description: Export and import data from Kuzzle. Backup and restore Kuzzle cluster.
 order: 400
+title: Export and Import Data | Kuzzle Advanced | Guide | Core
+meta:
+  - name: description
+    content: Export and import data from Kuzzle. Backup and restore Kuzzle cluster.
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, opensource, Export and Import Data
 ---
-
 # Export and import data
 
 All Kuzzle data are contained in Elasticsearch and separated into two categories:

--- a/doc/2/guides/advanced/index.md
+++ b/doc/2/guides/advanced/index.md
@@ -1,9 +1,13 @@
 ---
 code: false
 type: branch
-title: Advanced
-description: Kuzzle API advanced features and concepts
 order: 500
+title:  Kuzzle Advanced | Guide | Core
+meta:
+  - name: description
+    content: Kuzzle API advanced features and concepts
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, opensource, advanced
 ---
 
 <Redirect to="configuration" />

--- a/doc/2/guides/advanced/index.md
+++ b/doc/2/guides/advanced/index.md
@@ -2,7 +2,7 @@
 code: false
 type: branch
 order: 500
-title:  Kuzzle Advanced | Guide | Core
+title: Kuzzle Advanced | Guide | Core
 meta:
   - name: description
     content: Kuzzle API advanced features and concepts

--- a/doc/2/guides/advanced/internal-logger/index.md
+++ b/doc/2/guides/advanced/internal-logger/index.md
@@ -1,11 +1,14 @@
 ---
 code: false
 type: page
-title: Internal Logger
-description: Internal Logger usage and configuration
 order: 500
+title: Internal Logger | Kuzzle Advanced | Guide | Core
+meta:
+  - name: description
+    content: Internal Logger usage and configuration
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, opensource, Internal Logger
 ---
-
 # Internal Logger
 
 Kuzzle uses [Winston](https://github.com/winstonjs/winston) to log messages.  

--- a/doc/2/guides/advanced/secrets-vault/index.md
+++ b/doc/2/guides/advanced/secrets-vault/index.md
@@ -1,11 +1,16 @@
 ---
 code: false
 type: page
-title: Secrets Vault
-description: Securely store your application secrets
+title: 
+description: 
 order: 300
+title: Secrets Vault | Kuzzle Advanced | Guide | Core
+meta:
+  - name: description
+    content: Securely store your application secrets
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, opensource, Secrets Vault
 ---
-
 # Secrets Vault
 
 When you develop an application with Kuzzle, you may **need to use secrets** such as API keys or authentication information.

--- a/doc/2/guides/develop-on-kuzzle/api-controllers/index.md
+++ b/doc/2/guides/develop-on-kuzzle/api-controllers/index.md
@@ -1,11 +1,14 @@
 ---
 code: false
 type: page
-title: API Controllers
-description: Extend Kuzzle API with controllers and actions
 order: 300
+title: API Controllers | Develop on Kuzzle | Guide | Core
+meta:
+  - name: description
+    content: Extend Kuzzle API with controllers and actions
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, iot, backend, opensource,  API Controllers
 ---
-
 # API Controllers
 
 Kuzzle allows to extend its existing API using Controllers. Controllers are **logical containers of actions**.

--- a/doc/2/guides/develop-on-kuzzle/customize-api-errors/index.md
+++ b/doc/2/guides/develop-on-kuzzle/customize-api-errors/index.md
@@ -1,11 +1,14 @@
 ---
 code: false
 type: page
-title: Customize API Errors
-description: Returns custom errors in API responses
 order: 600
+title: Customize API Errors | Develop on Kuzzle | Guide | Core
+meta:
+  - name: description
+    content: Returns custom errors in API responses
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, iot, backend, opensource,  Customize API Errors
 ---
-
 # Customize API Errors
 
 It is possible to customize the errors that we want to return in case of failure of an API request.

--- a/doc/2/guides/develop-on-kuzzle/embedded-sdk/index.md
+++ b/doc/2/guides/develop-on-kuzzle/embedded-sdk/index.md
@@ -1,11 +1,14 @@
 ---
 code: false
 type: page
-title: Embedded SDK
-description: Execute API action from backend code
 order: 200
+title: Embedded SDK | Develop on Kuzzle | Guide | Core
+meta:
+  - name: description
+    content:  Execute API action from backend code
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, iot, backend, opensource,  Embedded SDK
 ---
-
 # Embedded SDK
 
 ::: info

--- a/doc/2/guides/develop-on-kuzzle/event-system/index.md
+++ b/doc/2/guides/develop-on-kuzzle/event-system/index.md
@@ -1,11 +1,14 @@
 ---
 code: false
 type: page
-title: Event System
-description: Interact with Internal Events
 order: 300
+title:  Event System | Develop on Kuzzle | Guide | Core
+meta:
+  - name: description
+    content: Interact with Internal Events
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, iot, backend, opensource, Event System
 ---
-
 # Event System
 
 Most of the **internal tasks performed by Kuzzle trigger events**.

--- a/doc/2/guides/develop-on-kuzzle/event-system/index.md
+++ b/doc/2/guides/develop-on-kuzzle/event-system/index.md
@@ -2,7 +2,7 @@
 code: false
 type: page
 order: 300
-title:  Event System | Develop on Kuzzle | Guide | Core
+title: Event System | Develop on Kuzzle | Guide | Core
 meta:
   - name: description
     content: Interact with Internal Events

--- a/doc/2/guides/develop-on-kuzzle/external-plugins/index.md
+++ b/doc/2/guides/develop-on-kuzzle/external-plugins/index.md
@@ -2,7 +2,7 @@
 code: false
 type: page
 order: 500
-title:  External Plugins | Develop on Kuzzle | Guide | Core
+title: External Plugins | Develop on Kuzzle | Guide | Core
 meta:
   - name: description
     content: Use External Plugins to add whole sets of features

--- a/doc/2/guides/develop-on-kuzzle/external-plugins/index.md
+++ b/doc/2/guides/develop-on-kuzzle/external-plugins/index.md
@@ -1,11 +1,14 @@
 ---
 code: false
 type: page
-title: External Plugins
-description: Use External Plugins to add whole sets of features
 order: 500
+title:  External Plugins | Develop on Kuzzle | Guide | Core
+meta:
+  - name: description
+    content: Use External Plugins to add whole sets of features
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, iot, backend, opensource, External Plugins 
 ---
-
 # External Plugins
 
 You can **extend Kuzzle's features** via plugins.

--- a/doc/2/guides/develop-on-kuzzle/index.md
+++ b/doc/2/guides/develop-on-kuzzle/index.md
@@ -2,7 +2,7 @@
 code: false
 type: branch
 order: 400
-title:  Develop on Kuzzle | Guide | Core
+title: Develop on Kuzzle | Guide | Core
 meta:
   - name: description
     content: Write custom backend code for Kuzzle

--- a/doc/2/guides/develop-on-kuzzle/index.md
+++ b/doc/2/guides/develop-on-kuzzle/index.md
@@ -1,11 +1,14 @@
 ---
 code: false
 type: branch
-title: Develop on Kuzzle
-description: Write custom backend code for Kuzzle
 order: 400
+title:  Develop on Kuzzle | Guide | Core
+meta:
+  - name: description
+    content: Write custom backend code for Kuzzle
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, opensource, Develop on Kuzzle
 ---
-
 <Redirect to="embedded-sdk" />
 
 

--- a/doc/2/guides/getting-started/authenticate-users/index.md
+++ b/doc/2/guides/getting-started/authenticate-users/index.md
@@ -1,9 +1,13 @@
 ---
 code: false
 type: page
-title: Authenticate Users
-description: Use the multi-authentication system
 order: 400
+title: Authenticate Users | Kuzzle Getting Started | Guide | Core
+meta:
+  - name: description
+    content: Use the multi-authentication system
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, Write an Application, iot, backend, opensource, realtime, Authenticate Users
 ---
 
 # Authenticate Users

--- a/doc/2/guides/getting-started/create-new-controllers/index.md
+++ b/doc/2/guides/getting-started/create-new-controllers/index.md
@@ -1,9 +1,13 @@
 ---
 code: false
 type: page
-title: Create new Controllers
-description: Extends Kuzzle API with new actions
 order: 700
+title: Create new Controllers | Kuzzle Getting Started | Guide | Core
+meta:
+  - name: description
+    content: Extends Kuzzle API with new actions
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, Write an Application, iot, backend, opensource, realtime, Create new controllers
 ---
 
 # Create new Controllers

--- a/doc/2/guides/getting-started/customize-api-behavior/index.md
+++ b/doc/2/guides/getting-started/customize-api-behavior/index.md
@@ -1,10 +1,15 @@
 ---
 code: false
 type: page
-title: Customize the API Behavior
-description: Use the fine-grained middleware-like system
 order: 800
+title:  Customize the API Behavior | Kuzzle Getting Started | Guide | Core
+meta:
+  - name: description
+    content: Use the fine-grained middleware-like system
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, Write an Application, iot, backend, opensource, realtime, Customize the API Behavior 
 ---
+
 
 # Customize the API Behavior
 

--- a/doc/2/guides/getting-started/customize-api-behavior/index.md
+++ b/doc/2/guides/getting-started/customize-api-behavior/index.md
@@ -2,7 +2,7 @@
 code: false
 type: page
 order: 800
-title:  Customize the API Behavior | Kuzzle Getting Started | Guide | Core
+title: Customize the API Behavior | Kuzzle Getting Started | Guide | Core
 meta:
   - name: description
     content: Use the fine-grained middleware-like system

--- a/doc/2/guides/getting-started/deploy-your-application/index.md
+++ b/doc/2/guides/getting-started/deploy-your-application/index.md
@@ -2,7 +2,7 @@
 code: false
 type: page
 order: 900
-title:  Deploy your Application | Kuzzle Getting Started | Guide | Core
+title: Deploy your Application | Kuzzle Getting Started | Guide | Core
 meta:
   - name: description
     content: Deploy your Kuzzle application on a remote server

--- a/doc/2/guides/getting-started/deploy-your-application/index.md
+++ b/doc/2/guides/getting-started/deploy-your-application/index.md
@@ -1,9 +1,13 @@
 ---
 code: false
 type: page
-title: Deploy your Application
-description: Deploy your Kuzzle application on a remote server
 order: 900
+title:  Deploy your Application | Kuzzle Getting Started | Guide | Core
+meta:
+  - name: description
+    content: Deploy your Kuzzle application on a remote server
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, Write an Application, iot, backend, opensource, realtime, Deploy your application
 ---
 
 # Deploy your Application

--- a/doc/2/guides/getting-started/index.md
+++ b/doc/2/guides/getting-started/index.md
@@ -1,10 +1,13 @@
 ---
 code: false
 type: branch
-title: Getting Started
-description: Learn how to use Kuzzle to develop your backend application
 order: 200
+title:  Kuzzle Getting Started | Guide | Core
+meta:
+  - name: description
+    content: Learn how to use Kuzzle to develop your backend application
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend
 ---
-
 <Redirect to="run-kuzzle" />
 

--- a/doc/2/guides/getting-started/index.md
+++ b/doc/2/guides/getting-started/index.md
@@ -2,7 +2,7 @@
 code: false
 type: branch
 order: 200
-title:  Kuzzle Getting Started | Guide | Core
+title: Kuzzle Getting Started | Guide | Core
 meta:
   - name: description
     content: Learn how to use Kuzzle to develop your backend application

--- a/doc/2/guides/getting-started/run-kuzzle/index.md
+++ b/doc/2/guides/getting-started/run-kuzzle/index.md
@@ -2,7 +2,7 @@
 code: false
 type: page
 order: 100
-title:  Run Kuzzle | Kuzzle Getting Started | Guide | Core
+title: Run Kuzzle | Kuzzle Getting Started | Guide | Core
 meta:
   - name: description
     content: Run your first Kuzzle application

--- a/doc/2/guides/getting-started/run-kuzzle/index.md
+++ b/doc/2/guides/getting-started/run-kuzzle/index.md
@@ -1,9 +1,13 @@
 ---
 code: false
 type: page
-title: Run Kuzzle
-description: Run your first Kuzzle application
 order: 100
+title:  Run Kuzzle | Kuzzle Getting Started | Guide | Core
+meta:
+  - name: description
+    content: Run your first Kuzzle application
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, Write an Application, iot, backend, opensource, realtime, run kuzzle
 ---
 
 # Run Kuzzle

--- a/doc/2/guides/getting-started/set-up-permissions/index.md
+++ b/doc/2/guides/getting-started/set-up-permissions/index.md
@@ -2,7 +2,7 @@
 code: false
 type: page
 order: 300
-title:  Set up Permissions | Kuzzle Getting Started | Guide | Core
+title: Set up Permissions | Kuzzle Getting Started | Guide | Core
 meta:
   - name: description
     content: Define kuzzle user rights and permissions 

--- a/doc/2/guides/getting-started/set-up-permissions/index.md
+++ b/doc/2/guides/getting-started/set-up-permissions/index.md
@@ -1,10 +1,15 @@
 ---
 code: false
 type: page
-title: Set up Permissions
-description: Define user rights
 order: 300
+title:  Set up Permissions | Kuzzle Getting Started | Guide | Core
+meta:
+  - name: description
+    content: Define kuzzle user rights and permissions 
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, Write an Application, iot, backend, opensource, realtime, Set up Permissions
 ---
+
 
 # Set up Permissions
 
@@ -15,7 +20,7 @@ The permissions system is designed following a standard model and is structured 
  - **profile**: combination of one or more roles
  - **user**: combination of one or more profiles
 
-![roles, profiles and users](./role-profile-user.png)
+![roles, profiles and users diagram image](./role-profile-user.png)
 
 ## Role
 
@@ -42,7 +47,7 @@ kourou security:createRole '{
 
 You should see your newly created role in the `Security > Roles` section of the [Admin Console](http://next-console.kuzzle.io)
 
-![Admin Console roles display](./admin-console-roles.png)
+![Admin Console roles display screenshot](./admin-console-roles.png)
 
 ## Profile
 
@@ -60,7 +65,7 @@ Now we have a `dummy` profile which gives access to the API actions allowed by t
 
 You should see your newly created profile in the `Security > Profiles` section of the [Admin Console](http://next-console.kuzzle.io)
 
-![Admin Console profiles display](./admin-console-profiles.png)
+![Admin Console profiles display screenshot](./admin-console-profiles.png)
 
 ## User
 
@@ -85,7 +90,7 @@ kourou security:createUser '{
 
 You should see your newly created role in the `Security > Users` section of the [Admin Console](http://next-console.kuzzle.io)
 
-![Admin Console users display](./admin-console-users.png)
+![Admin Console users display screenshot](./admin-console-users.png)
 
 ## Creating an administrator account, and restricting anonymous user rights
 

--- a/doc/2/guides/getting-started/store-and-access-data/index.md
+++ b/doc/2/guides/getting-started/store-and-access-data/index.md
@@ -1,9 +1,13 @@
 ---
 code: false
 type: page
-title: Store and Access Data
-description: Create and retrieve documents
 order: 200
+title: Store and Access Data | Kuzzle Getting Started | Guide | Core
+meta:
+  - name: description
+    content: Create and retrieve documents
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, Write an Application, iot, backend, opensource, realtime, Store and Access Data
 ---
 
 # Store and Access Data
@@ -101,7 +105,7 @@ Finally, we are going to use the [Admin Console](http://next-console.kuzzle.io) 
 
 Select the `nyc-open-data` index and then the `yellow-taxi` collection. You should see one document in this collection.
 
-![admin console show document](./admin-console-show-document.gif)
+![admin console show document gif](./admin-console-show-document.gif)
 
 ### Search for documents
 

--- a/doc/2/guides/getting-started/subscribe-realtime-notifications/index.md
+++ b/doc/2/guides/getting-started/subscribe-realtime-notifications/index.md
@@ -1,11 +1,14 @@
 ---
 code: false
 type: page
-title: Subscribe to Realtime Notifications
-description: Use the Realtime Engine to subscribe to database change
 order: 500
+title:  Subscribe to Realtime Notifications | Kuzzle Getting Started | Guide | Core
+meta:
+  - name: description
+    content: Use the Realtime Engine to subscribe to database change
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, Write an Application, iot, backend, opensource, realtime 
 ---
-
 # Subscribe to Realtime Notifications
 
 Kuzzle integrates an **advanced realtime engine**. It can work in a classic pub/sub mode but also as a realtime database notification engine.

--- a/doc/2/guides/getting-started/subscribe-realtime-notifications/index.md
+++ b/doc/2/guides/getting-started/subscribe-realtime-notifications/index.md
@@ -2,7 +2,7 @@
 code: false
 type: page
 order: 500
-title:  Subscribe to Realtime Notifications | Kuzzle Getting Started | Guide | Core
+title: Subscribe to Realtime Notifications | Kuzzle Getting Started | Guide | Core
 meta:
   - name: description
     content: Use the Realtime Engine to subscribe to database change

--- a/doc/2/guides/getting-started/write-application/index.md
+++ b/doc/2/guides/getting-started/write-application/index.md
@@ -2,7 +2,7 @@
 code: false
 type: page
 order: 600
-title:  Write an Application | Kuzzle Getting Started | Guide | Core
+title: Write an Application | Kuzzle Getting Started | Guide | Core
 meta:
   - name: description
     content: Discover the framework capabilities

--- a/doc/2/guides/getting-started/write-application/index.md
+++ b/doc/2/guides/getting-started/write-application/index.md
@@ -1,9 +1,13 @@
 ---
 code: false
 type: page
-title: Write an Application
-description: Discover the framework capabilities
 order: 600
+title:  Write an Application | Kuzzle Getting Started | Guide | Core
+meta:
+  - name: description
+    content: Discover the framework capabilities
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, Write an Application, iot, backend, opensource
 ---
 
 # Write an Application

--- a/doc/2/guides/index.md
+++ b/doc/2/guides/index.md
@@ -2,8 +2,11 @@
 code: false
 type: root
 order: 0
-title: Guides
-description: Kuzzle v2.x Guides
+title:  What is kuzzle | Guides | Core
+meta:
+  - name: description
+    content: Kuzzle v2.x Guides
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle v2, HTTP, MQTT
 ---
-
 <Redirect to="introduction/what-is-kuzzle" />

--- a/doc/2/guides/index.md
+++ b/doc/2/guides/index.md
@@ -2,7 +2,7 @@
 code: false
 type: root
 order: 0
-title:  What is kuzzle | Guides | Core
+title: What is kuzzle | Guides | Core
 meta:
   - name: description
     content: Kuzzle v2.x Guides

--- a/doc/2/guides/introduction/general-purpose-backend/index.md
+++ b/doc/2/guides/introduction/general-purpose-backend/index.md
@@ -2,7 +2,7 @@
 code: false
 type: page
 order: 200
-title:  General Purpose Backend | Kuzzle Introduction | Guide | Core
+title: General Purpose Backend | Kuzzle Introduction | Guide | Core
 meta:
   - name: description
     content: Kuzzle main concepts and features overview

--- a/doc/2/guides/introduction/general-purpose-backend/index.md
+++ b/doc/2/guides/introduction/general-purpose-backend/index.md
@@ -1,9 +1,13 @@
 ---
 code: false
 type: page
-title: General Purpose Backend
-description: Kuzzle main concepts and features overview
 order: 200
+title:  General Purpose Backend | Kuzzle Introduction | Guide | Core
+meta:
+  - name: description
+    content: Kuzzle main concepts and features overview
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend
 ---
 
 # General Purpose Backend
@@ -87,7 +91,7 @@ Kuzzle fits perfectly in a **context of SSO and centralization of authentication
 
 Kuzzle has a **standard system with 3 dimensions**. Roles control access to API actions, profiles are a composition of roles and finally users are a composition of profiles.
 
-[Users, Profiles and Roles](./profiles-roles.png)
+[Users, Profiles and Roles diagram](./profiles-roles.png)
 
 This system allows to manage the majority of access control rights situations. For the most advanced cases, Kuzzle **allows to dynamically restrict access rights** via its event system and its pipe mechanism.
 

--- a/doc/2/guides/introduction/index.md
+++ b/doc/2/guides/introduction/index.md
@@ -1,9 +1,14 @@
 ---
 code: false
 type: branch
-title: Introduction
-description: Kuzzle presentation and key concepts
 order: 100
+title: Kuzzle Introduction | Guide | Core
+meta:
+  - name: description
+    content: Kuzzle presentation and key concepts
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins
 ---
+
 
 <Redirect to="what-is-kuzzle" />

--- a/doc/2/guides/introduction/what-is-kuzzle/index.md
+++ b/doc/2/guides/introduction/what-is-kuzzle/index.md
@@ -1,11 +1,14 @@
 ---
 code: false
 type: page
-title: What is Kuzzle
-description: Why are we spending so much time developing our backend?
 order: 100
+title: What is Kuzzle | Kuzzle Introduction | Guide | Core
+meta:
+  - name: description
+    content: Why are we spending so much time developing our backend?
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, What is kuzzle
 ---
-
 # What is Kuzzle
 
 If you're on this page it's probably because **you need a backend** for your mobile, web or IoT application.
@@ -47,42 +50,42 @@ When you start Kuzzle, you automatically have access to an API exposing a wide r
 <div class="IconTable">
   <div class="IconTable-item">
     <div class="IconTable-item-icon">
-      <img src="./feature-data-storage.svg"/>
+      <img src="./feature-data-storage.svg" alt="database illustration"/>
     </div>
     <div class="IconTable-item-text">
       <a target="_blank" href="/core/2/guides/main-concepts/data-storage">Data storage and access</a>
     </div>
   </div><div class="IconTable-item">
     <div class="IconTable-item-icon">
-      <img src="./feature-acl.svg"/>
+      <img src="./feature-acl.svg" alt="Advanced permission system illustration"/>
     </div>
     <div class="IconTable-item-text">
       <a target="_blank" href="/core/2/guides/main-concepts/permissions">Advanced permission system</a>
     </div>
   </div><div class="IconTable-item">
     <div class="IconTable-item-icon">
-      <img src="./feature-auth.svg"/>
+      <img src="./feature-auth.svg" alt="authentification illustration"/>
     </div>
     <div class="IconTable-item-text">
       <a target="_blank" href="/core/2/guides/main-concepts/authentication">Multi authentication</a>
     </div>
   </div><div class="IconTable-item">
     <div class="IconTable-item-icon">
-      <img src="./feature-api.svg"/>
+      <img src="./feature-api.svg" alt="api illustration"/>
     </div>
     <div class="IconTable-item-text">
       <a target="_blank" href="/core/2/guides/main-concepts/api">Multi protocol API (Http, WebSocket, MQTT)</a>
     </div>
   </div><div class="IconTable-item">
     <div class="IconTable-item-icon">
-      <img src="./feature-realtime.svg"/>
+      <img src="./feature-realtime.svg" alt="realtime engine illustration"/>
     </div>
     <div class="IconTable-item-text">
       <a target="_blank" href="/core/2/guides/main-concepts/realtime-engine">Realtime engine</a>
     </div>
   </div><div class="IconTable-item">
     <div class="IconTable-item-icon">
-      <img src="./feature-cluster.svg"/>
+      <img src="./feature-cluster.svg" alt="cluster interconnected illustration"/>
     </div>
     <div class="IconTable-item-text">
       <a target="_blank" href="/core/2/guides/advanced/cluster-scalability">Integrated cluster mode</a>
@@ -131,7 +134,7 @@ It is used to manage its data and the user permissions system.
 
 As it is a single-page application (SPA), no data related to your Kuzzle application will pass through our servers, so you can use the online version available at [http://next-console.kuzzle.io](http://next-console.kuzzle.io).
 
-![admin console](./ecosystem-admin-console.png)
+![Screenshot of the admin console interface](./ecosystem-admin-console.png)
 
 ### SDKs
 
@@ -143,7 +146,7 @@ These SDKs are available for the most common languages and the majority of front
  - [Csharp](/sdk/csharp/2) : Xamarin, [.NET](/sdk/csharp/2/getting-started/standalone)
  - [Java / Kotlin](/sdk/jvm/1) : Android, JVM
 
-![sdks and platforms](./ecosystem-sdk-platforms.png)
+![List of sdk (js java, c#, kotln dart, go) and platforms (react / react native, android studio, flutter, xamarin, angular, node, vuejs, microsoft.net)](./ecosystem-sdk-platforms.png)
 
 ### Kourou
 
@@ -161,7 +164,7 @@ These plugins allow you to use the functionalities of other services such as [Am
 
 The community is also able to develop and distribute its own plugins to enrich the ecosystem.
 
-![business plugins](./ecosystem-business-plugins.png)
+![List of business plugins](./ecosystem-business-plugins.png)
 
 
 ### Expert Professional Support

--- a/doc/2/guides/main-concepts/api/index.md
+++ b/doc/2/guides/main-concepts/api/index.md
@@ -2,7 +2,7 @@
 code: false
 type: page
 order: 100
-title:  Kuzzle API | Main Concepts | Guide | Core
+title: Kuzzle API | Main Concepts | Guide | Core
 meta:
   - name: description
     content: Discover Kuzzle API usage and formats

--- a/doc/2/guides/main-concepts/api/index.md
+++ b/doc/2/guides/main-concepts/api/index.md
@@ -1,9 +1,13 @@
 ---
 code: false
 type: page
-title: API
-description: Discover Kuzzle API usage and formats
 order: 100
+title:  Kuzzle API | Main Concepts | Guide | Core
+meta:
+  - name: description
+    content: Discover Kuzzle API usage and formats
+  - name: keywords
+    content: Kuzzle, Documentation, Kuzzle API main concepts, Authentication
 ---
 
 # API

--- a/doc/2/guides/main-concepts/authentication/index.md
+++ b/doc/2/guides/main-concepts/authentication/index.md
@@ -1,9 +1,13 @@
 ---
 code: false
 type: page
-title: Authentication
-description: Authenticate your users through the multi-strategy system
 order: 500
+title:  Authentication | Main Concepts | Guide | Core
+meta:
+  - name: description
+    content: Authenticate your users through the multi-strategy system
+  - name: keywords
+    content: Kuzzle, Documentation, Kuzzle API main concepts, Authentication
 ---
 
 # Authentication

--- a/doc/2/guides/main-concepts/authentication/index.md
+++ b/doc/2/guides/main-concepts/authentication/index.md
@@ -2,7 +2,7 @@
 code: false
 type: page
 order: 500
-title:  Authentication | Main Concepts | Guide | Core
+title: Authentication | Main Concepts | Guide | Core
 meta:
   - name: description
     content: Authenticate your users through the multi-strategy system

--- a/doc/2/guides/main-concepts/data-storage/index.md
+++ b/doc/2/guides/main-concepts/data-storage/index.md
@@ -2,7 +2,7 @@
 code: false
 type: page
 order: 200
-title:  Data Storage | Main Concepts | Guide | Core
+title: Data Storage | Main Concepts | Guide | Core
 meta:
   - name: description
     content: Understand how works the underlying document storage engine

--- a/doc/2/guides/main-concepts/data-storage/index.md
+++ b/doc/2/guides/main-concepts/data-storage/index.md
@@ -1,9 +1,13 @@
 ---
 code: false
 type: page
-title: Data Storage
-description: Understand how works the underlying document storage engine
 order: 200
+title:  Data Storage | Main Concepts | Guide | Core
+meta:
+  - name: description
+    content: Understand how works the underlying document storage engine
+  - name: keywords
+    content: Kuzzle, Documentation, Kuzzle API main concepts, Permissions
 ---
 
 # Data Storage

--- a/doc/2/guides/main-concepts/index.md
+++ b/doc/2/guides/main-concepts/index.md
@@ -1,10 +1,15 @@
 ---
 code: false
 type: branch
-title: Main Concepts
-description: Kuzzle API main features and concepts
 order: 300
+title: Main Concepts | Guide | Core
+meta:
+  - name: description
+    content:  Kuzzle API main features and concepts
+  - name: keywords
+    content: Kuzzle, Documentation, Kuzzle API main features and concepts 
 ---
+
 
 <Redirect to="api" />
 

--- a/doc/2/guides/main-concepts/permissions/index.md
+++ b/doc/2/guides/main-concepts/permissions/index.md
@@ -1,11 +1,14 @@
 ---
 code: false
 type: page
-title: Permissions
-description: Configure fine-grained permissions to your data and features
 order: 400
+title: Permissions | Main Concepts | Guide | Core
+meta:
+  - name: description
+    content:  Configure fine-grained permissions to your data and features
+  - name: keywords
+    content: Kuzzle, Documentation, Kuzzle API main concepts, Permissions
 ---
-
 # Permissions
 
 Kuzzle provides a full set of functionalities to configure fine-grained permissions to your data and features.
@@ -18,7 +21,7 @@ The **profiles** themselves are made of **different groups of permissions**, the
 A profile is linked to a set of roles, and each role defines a set of permissions.  
 For example, in the diagram below, the `editor` profile has all permissions, the `contributor` has fewer permissions, and the `default` profile has only default permissions:
 
-![Users, Profiles and Roles](./profiles-roles.png)
+![Users, Profiles and Roles image diagram](./profiles-roles.png)
 
 Roles, profiles and users can be edited in the [Admin Console](http://console.kuzzle.io).
 

--- a/doc/2/guides/main-concepts/querying/index.md
+++ b/doc/2/guides/main-concepts/querying/index.md
@@ -1,11 +1,14 @@
 ---
 code: false
 type: page
-title: Querying
-description: Learn how to search for your data with Elasticsearch Query Language
 order: 300
+title: Querying | Main Concepts | Guide | Core
+meta:
+  - name: description
+    content:  Learn how to search for your data with Elasticsearch Query Language
+  - name: keywords
+    content: Kuzzle, Documentation, Kuzzle API main concepts, Querying
 ---
-
 # Querying
 
 Kuzzle directly exposes [Elasticsearch's query language](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-dsl.html) in a secure way.

--- a/doc/2/guides/main-concepts/realtime-engine/index.md
+++ b/doc/2/guides/main-concepts/realtime-engine/index.md
@@ -1,11 +1,14 @@
 ---
 code: false
 type: page
-title: Realtime Engine
-description: Subscribe to realtime notifications from database and use pub/sub engine
 order: 600
+title: Realtime Engine| Main Concepts | Guide | Core
+meta:
+  - name: description
+    content: Subscribe to realtime notifications from database and use pub/sub engine
+  - name: keywords
+    content: Kuzzle, Documentation, Kuzzle API main concepts, Realtime Engine
 ---
-
 # Realtime Engine
 
 Kuzzle is shipped with its own **high-performance Realtime Engine** for sending notifications to clients connected through the API.
@@ -25,7 +28,7 @@ The process is as follows:
  - A second client posts a message in that room,
  - The first client receives a notification.
 
-![kuzzle-pub-sub](./pub-sub.png)
+![kuzzle-pub-sub image description ](./pub-sub.png)
 
 Subscription to a room is done via the [realtime:subscribe](/core/2/api/controllers/realtime/subscribe) method. It takes 3 parameters, used to **describe a specific room**:
  - Name of an index,
@@ -277,7 +280,7 @@ Each subscription filter **defines a scope**. All documents in the collection ca
 
 Once a client has subscribed to notifications with filters, they will receive notifications each time a document **enters or exits the scope** defined by the filters.
 
-![subscription-filter-scope](./subscription-filter-scope.png)
+![subscription-filter-scope image description](./subscription-filter-scope.png)
 
 ::: warning
 Notification about document exiting the scope will only be received for documents that previously entered the scope.

--- a/doc/2/guides/migrate-from-v1/changes/index.md
+++ b/doc/2/guides/migrate-from-v1/changes/index.md
@@ -1,10 +1,14 @@
 ---
 code: false
 type: branch
-title: Breaking changes
 order: 100
+title: Breaking changes | Migrate from Kuzzle 1.x | Guide | Core
+meta:
+  - name: description
+    content: Here's the list of breaking changes for kuzzle
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, Breaking changes
 ---
-
 
 # Breaking changes
 

--- a/doc/2/guides/migrate-from-v1/index.md
+++ b/doc/2/guides/migrate-from-v1/index.md
@@ -1,6 +1,13 @@
 ---
 code: false
 type: branch
-title: Migrate from Kuzzle 1.x
 order: 700
+title: Migrate from Kuzzle 1.x | Guide | Core
+meta:
+  - name: description
+    content:  Migrate from Kuzzle 1.x
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins
 ---
+
+<Redirect to="changes" />

--- a/doc/2/guides/migrate-from-v1/upgrade/index.md
+++ b/doc/2/guides/migrate-from-v1/upgrade/index.md
@@ -1,8 +1,13 @@
 ---
 code: false
 type: branch
-title: Upgrading Kuzzle
 order: 100
+title: Upgrading Kuzzle | Migrate from Kuzzle 1.x | Guide | Core
+meta:
+  - name: description
+    content: Kuzzle can either be made in place, or by importing data from a Kuzzle v1 instance into a fresh v2 infrastucture.
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, Upgrading kuzzle
 ---
 
 # Upgrading Kuzzle

--- a/doc/2/guides/write-plugins/index.md
+++ b/doc/2/guides/write-plugins/index.md
@@ -1,9 +1,13 @@
 ---
 code: false
 type: branch
-title: Write Plugins
-description: Write and distribute generic plugins to extend Kuzzle
 order: 600
+title: Write plugins | Guide | Core
+meta:
+  - name: description
+    content:  Write and distribute generic plugins to extend Kuzzle
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins
 ---
 
 <Redirect to="start-writing-plugins" />

--- a/doc/2/guides/write-plugins/integrate-authentication-strategy/index.md
+++ b/doc/2/guides/write-plugins/integrate-authentication-strategy/index.md
@@ -1,9 +1,13 @@
 ---
 code: false
 type: page
-title: Authentication Strategy
-description: Learn how to integrate new authentication strategy
 order: 300
+title: Authentication Strategy | Write plugins | Guide | Core
+meta:
+  - name: description
+    content: Learn how to integrate new authentication strategy
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, Authentication Strategy 
 ---
 
 # Authentication Strategy

--- a/doc/2/guides/write-plugins/old-guides/controllers/index.md
+++ b/doc/2/guides/write-plugins/old-guides/controllers/index.md
@@ -3,6 +3,12 @@ code: false
 type: page
 title: Controllers
 order: 400
+title: Controllers | Old Guides | Write plugins | Guide 
+meta:
+  - name: description
+    content: Kuzzle's API is divided into controllers, each exposing executable actions (see API reference).
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, old guides, Controllers
 ---
 
 <DeprecatedBadge version="2.8.0" />

--- a/doc/2/guides/write-plugins/old-guides/hooks/index.md
+++ b/doc/2/guides/write-plugins/old-guides/hooks/index.md
@@ -1,8 +1,13 @@
 ---
 code: false
 type: page
-title: Hooks
 order: 200
+title: Hooks | Old Guides | Write plugins | Guide 
+meta:
+  - name: description
+    content: Hooks are asynchronous listeners, plugged to events, and receiving information regarding that event.
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, old guides, Hooks
 ---
 
 <DeprecatedBadge version="2.8.0" />

--- a/doc/2/guides/write-plugins/old-guides/index.md
+++ b/doc/2/guides/write-plugins/old-guides/index.md
@@ -2,6 +2,14 @@
 code: false
 type: branch
 order: 400
-title: Old Guides
-description: Kuzzle Old Plugins guides
+title: 
+description: 
+title: Old Guides | Write plugins | Guide 
+meta:
+  - name: description
+    content:  Kuzzle Old Plugins guides
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, old guides
 ---
+
+<Redirect to="hooks" />

--- a/doc/2/guides/write-plugins/old-guides/pipes/index.md
+++ b/doc/2/guides/write-plugins/old-guides/pipes/index.md
@@ -1,10 +1,14 @@
 ---
 code: false
 type: page
-title: Pipes
 order: 300
+title: Pipes | Old Guides | Write plugins | Guide 
+meta:
+  - name: description
+    content: Pipes are functions plugged to events, called synchronously by Kuzzle, and receiving information regarding that event.
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, old guides, pipes
 ---
-
 <DeprecatedBadge version="2.8.0" />
 
 ::: warning

--- a/doc/2/guides/write-plugins/plugins-features/index.md
+++ b/doc/2/guides/write-plugins/plugins-features/index.md
@@ -1,11 +1,14 @@
 ---
 code: false
 type: page
-title: Plugins Features
-description: Available features in plugins development
 order: 200
+title: Plugins Features | Write plugins | Guide | Core
+meta:
+  - name: description
+    content: Available features in plugins development
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, Plugins Features
 ---
-
 # Plugins Features
 
 ## Embedded SDK

--- a/doc/2/guides/write-plugins/start-writing-plugins/index.md
+++ b/doc/2/guides/write-plugins/start-writing-plugins/index.md
@@ -1,9 +1,14 @@
 ---
 code: false
 type: page
-title: Start Writing a Plugin
-description: Setup environment for plugin development
+
 order: 100
+title: Start Writing a Plugin | Write plugins | Guide | Core
+meta:
+  - name: description
+    content: Setup environment for plugin development
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, Plugins Features
 ---
 
 # Start Writing a Plugin

--- a/doc/2/guides/write-protocols/context/clientconnection/index.md
+++ b/doc/2/guides/write-protocols/context/clientconnection/index.md
@@ -1,7 +1,12 @@
 ---
 code: true
 type: page
-title: ClientConnection
+title: ClientConnection | Protocol Framework | Write protocols | Guide
+meta:
+  - name: description
+    content: The ClientConnection class must be instantiated whenever a new client connection is created, and that instance must be provided to the entryPoint.newConnection method.
+  - name: keywords
+    content: Kuzzle, Documentation, write protocols, start, HTTP, MQTT, protocol framework, ClientConnection
 ---
 
 # ClientConnection

--- a/doc/2/guides/write-protocols/context/debug/index.md
+++ b/doc/2/guides/write-protocols/context/debug/index.md
@@ -1,7 +1,12 @@
 ---
 code: true
 type: page
-title: debug
+title: debug | Protocol Framework | Write protocols | Guide
+meta:
+  - name: description
+    content: All debug messages are sent to the following namespace kuzzle:entry-point:protocols
+  - name: keywords
+    content: Kuzzle, Documentation, write protocols, start, HTTP, MQTT, protocol framework, debug
 ---
 
 # debug

--- a/doc/2/guides/write-protocols/context/errors/index.md
+++ b/doc/2/guides/write-protocols/context/errors/index.md
@@ -1,7 +1,12 @@
 ---
 code: true
 type: page
-title: errors
+title: errors | Protocol Framework | Write protocols | Guide
+meta:
+  - name: description
+    content: The context.errors object regroups all error objects, used in request responses, or to be used by the protocol if needs be.
+  - name: keywords
+    content: Kuzzle, Documentation, write protocols, start, HTTP, MQTT, protocol framework, errors
 ---
 
 # errors

--- a/doc/2/guides/write-protocols/context/index.md
+++ b/doc/2/guides/write-protocols/context/index.md
@@ -2,7 +2,7 @@
 code: false
 type: branch
 order: 200
-title:  Protocol Framework | Write protocols | Guides | Core
+title: Protocol Framework | Write protocols | Guides | Core
 meta:
   - name: description
     content: Protocol Framework Reference

--- a/doc/2/guides/write-protocols/context/index.md
+++ b/doc/2/guides/write-protocols/context/index.md
@@ -2,6 +2,12 @@
 code: false
 type: branch
 order: 200
-title: Protocol Framework
-description: Protocol Framework Reference
+title:  Protocol Framework | Write protocols | Guides | Core
+meta:
+  - name: description
+    content: Protocol Framework Reference
+  - name: keywords
+    content: Kuzzle, Documentation, write protocols, start, HTTP, MQTT, protocol framework
 ---
+
+<Redirect to="./intro" />

--- a/doc/2/guides/write-protocols/context/intro/index.md
+++ b/doc/2/guides/write-protocols/context/intro/index.md
@@ -1,8 +1,13 @@
 ---
 type: page
 code: false
-title: Introduction
 order: 0
+title: Introduction | Protocol Entrypoint | Write protocols | Guide
+meta:
+  - name: description
+    content: This is the class used to build the input property of any KuzzleRequest object.
+  - name: keywords
+    content: Kuzzle, Documentation, write protocols, start, HTTP, MQTT, protocol framework, RequestInput
 ---
 
 # Introduction

--- a/doc/2/guides/write-protocols/context/log/index.md
+++ b/doc/2/guides/write-protocols/context/log/index.md
@@ -1,7 +1,12 @@
 ---
 code: true
 type: page
-title: log
+title: log | Protocol Framework | Write protocols | Guide
+meta:
+  - name: description
+    content: The context.log object exposes functions used to send messages to Kuzzle's logging system.
+  - name: keywords
+    content: Kuzzle, Documentation, write protocols, start, HTTP, MQTT, protocol framework, log
 ---
 
 # log

--- a/doc/2/guides/write-protocols/context/request/index.md
+++ b/doc/2/guides/write-protocols/context/request/index.md
@@ -1,9 +1,13 @@
 ---
 code: true
 type: page
-title: KuzzleRequest
+title: Response headers | Protocol Framework | Write protocols | Guide
+meta:
+  - name: description
+    content: Network protocol specific headers can be added to the response. If the protocol supports it, these headers are forwarded in the response sent to the client.
+  - name: keywords
+    content: Kuzzle, Documentation, write protocols, start, HTTP, MQTT, protocol framework, Response headers
 ---
-
 # KuzzleRequest
 
 

--- a/doc/2/guides/write-protocols/context/requestcontext/index.md
+++ b/doc/2/guides/write-protocols/context/requestcontext/index.md
@@ -1,7 +1,12 @@
 ---
 code: true
 type: page
-title: RequestContext
+title: RequestContext | Protocol Framework | Write protocols | Guide
+meta:
+  - name: description
+    content: This is the class used to build the context property of any KuzzleRequest object.
+  - name: keywords
+    content: Kuzzle, Documentation, write protocols, start, HTTP, MQTT, protocol framework, RequestContext
 ---
 
 # RequestContext

--- a/doc/2/guides/write-protocols/context/requestinput/index.md
+++ b/doc/2/guides/write-protocols/context/requestinput/index.md
@@ -1,7 +1,12 @@
 ---
 code: true
 type: page
-title: RequestInput
+title: RequestInput | Protocol Framework | Write protocols | Guide
+meta:
+  - name: description
+    content: This is the class used to build the input property of any KuzzleRequest object.
+  - name: keywords
+    content: Kuzzle, Documentation, write protocols, start, HTTP, MQTT, protocol framework, RequestInput
 ---
 
 # RequestInput

--- a/doc/2/guides/write-protocols/entrypoint/execute/index.md
+++ b/doc/2/guides/write-protocols/entrypoint/execute/index.md
@@ -1,9 +1,13 @@
 ---
 code: true
 type: page
-title: execute
+title: execute | Protocol Entrypoint | Write protocols | Guide
+meta:
+  - name: description
+    content: The execute function main usage is to forward users API requests to Kuzzle.
+  - name: keywords
+    content: Kuzzle, Documentation, write protocols, start, HTTP, MQTT, protocol entrypoint, execute
 ---
-
 # execute
 
 

--- a/doc/2/guides/write-protocols/entrypoint/index.md
+++ b/doc/2/guides/write-protocols/entrypoint/index.md
@@ -2,7 +2,7 @@
 code: false
 type: branch
 order: 300
-title:  Protocol Entrypoint | Write protocols | Guides | Core
+title: Protocol Entrypoint | Write protocols | Guides | Core
 meta:
   - name: description
     content: Protocol Entrypoint Reference

--- a/doc/2/guides/write-protocols/entrypoint/index.md
+++ b/doc/2/guides/write-protocols/entrypoint/index.md
@@ -2,6 +2,12 @@
 code: false
 type: branch
 order: 300
-title: Protocol Entrypoint
-description: Protocol Entrypoint Reference
+title:  Protocol Entrypoint | Write protocols | Guides | Core
+meta:
+  - name: description
+    content: Protocol Entrypoint Reference
+  - name: keywords
+    content: Kuzzle, Documentation, write protocols, start, HTTP, MQTT, protocol entrypoint
 ---
+
+<Redirect to="./intro" />

--- a/doc/2/guides/write-protocols/entrypoint/intro/index.md
+++ b/doc/2/guides/write-protocols/entrypoint/intro/index.md
@@ -1,8 +1,13 @@
 ---
 type: page
 code: false
-title: Properties
 order: 0
+title: Properties | Protocol Entrypoint | Write protocols | Guide
+meta:
+  - name: description
+    content: An instance of the EntryPoint class is provided as an argument to the protocol's required init function.
+  - name: keywords
+    content: Kuzzle, Documentation, write protocols, start, HTTP, MQTT, protocol entrypoint, properties
 ---
 
 # Properties

--- a/doc/2/guides/write-protocols/entrypoint/newconnection/index.md
+++ b/doc/2/guides/write-protocols/entrypoint/newconnection/index.md
@@ -1,7 +1,12 @@
 ---
 code: true
 type: page
-title: newConnection
+title: newConnection | Protocol Entrypoint | Write protocols | Guide
+meta:
+  - name: description
+    content: Declares a new client connection to Kuzzle.
+  - name: keywords
+    content: Kuzzle, Documentation, write protocols, start, HTTP, MQTT, protocol entrypoint, newConnection 
 ---
 
 # newConnection

--- a/doc/2/guides/write-protocols/entrypoint/removeconnection/index.md
+++ b/doc/2/guides/write-protocols/entrypoint/removeconnection/index.md
@@ -1,9 +1,13 @@
 ---
 code: true
 type: page
-title: removeConnection
+title: removeConnection | Protocol Entrypoint | Write protocols | Guide
+meta:
+  - name: description
+    content: Removes a client connection from Kuzzle.
+  - name: keywords
+    content: Kuzzle, Documentation, write protocols, start, HTTP, MQTT, protocol entrypoint, removeConnection
 ---
-
 # removeConnection
 
 

--- a/doc/2/guides/write-protocols/index.md
+++ b/doc/2/guides/write-protocols/index.md
@@ -1,9 +1,14 @@
 ---
 code: false
 type: branch
-title: Write Protocols
-description: Write communication protocols for Kuzzle API
 order: 700
+
+title:  Write protocols | Guide
+meta:
+  - name: description
+    content: Write communication protocols for Kuzzle API
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write protocols, HTTP, MQTT
 ---
 
-
+<Redirect to="./start-writing-protocols/" />

--- a/doc/2/guides/write-protocols/index.md
+++ b/doc/2/guides/write-protocols/index.md
@@ -3,7 +3,7 @@ code: false
 type: branch
 order: 700
 
-title:  Write protocols | Guide
+title: Write protocols | Guide
 meta:
   - name: description
     content: Write communication protocols for Kuzzle API

--- a/doc/2/guides/write-protocols/methods/broadcast/index.md
+++ b/doc/2/guides/write-protocols/methods/broadcast/index.md
@@ -1,7 +1,7 @@
 ---
 code: true
 type: page
-title:  broadcast | Write protocols | Guide
+title: broadcast | Write protocols | Guide
 meta:
   - name: description
     content: Asks the protocol to emit a payload to channels.

--- a/doc/2/guides/write-protocols/methods/broadcast/index.md
+++ b/doc/2/guides/write-protocols/methods/broadcast/index.md
@@ -1,9 +1,13 @@
 ---
 code: true
 type: page
-title: broadcast
+title:  broadcast | Write protocols | Guide
+meta:
+  - name: description
+    content: Asks the protocol to emit a payload to channels.
+  - name: keywords
+    content: Kuzzle, Documentation, write protocols, start, HTTP, MQTT, broadcast
 ---
-
 # broadcast
 
 Asks the protocol to emit a payload to [channels](/core/2/guides/write-protocols/start-writing-protocols#channels).

--- a/doc/2/guides/write-protocols/methods/disconnect/index.md
+++ b/doc/2/guides/write-protocols/methods/disconnect/index.md
@@ -1,7 +1,7 @@
 ---
 code: true
 type: page
-title:  disconnect | Write protocols | Guide
+title: disconnect | Write protocols | Guide
 meta:
   - name: description
     content: Asks the protocol to force-close a connection.

--- a/doc/2/guides/write-protocols/methods/disconnect/index.md
+++ b/doc/2/guides/write-protocols/methods/disconnect/index.md
@@ -1,9 +1,13 @@
 ---
 code: true
 type: page
-title: disconnect
+title:  disconnect | Write protocols | Guide
+meta:
+  - name: description
+    content: Asks the protocol to force-close a connection.
+  - name: keywords
+    content: Kuzzle, Documentation, write protocols, start, HTTP, MQTT, disconnect
 ---
-
 # disconnect
 
 Asks the protocol to force-close a connection.

--- a/doc/2/guides/write-protocols/methods/index.md
+++ b/doc/2/guides/write-protocols/methods/index.md
@@ -2,7 +2,7 @@
 code: false
 type: branch
 order: 200
-title:  Write protocols | Guide
+title: Write protocols | Guide
 meta:
   - name: description
     content: Setup environment for protocol development

--- a/doc/2/guides/write-protocols/methods/index.md
+++ b/doc/2/guides/write-protocols/methods/index.md
@@ -2,6 +2,10 @@
 code: false
 type: branch
 order: 200
-title: Protocol Methods
-description: Protocol Methods Reference
+title:  Write protocols | Guide
+meta:
+  - name: description
+    content: Setup environment for protocol development
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write protocols, start, HTTP, MQTT
 ---

--- a/doc/2/guides/write-protocols/methods/init/index.md
+++ b/doc/2/guides/write-protocols/methods/init/index.md
@@ -1,7 +1,7 @@
 ---
 code: true
 type: page
-title:  init | Write protocols | Guide 
+title: init | Write protocols | Guide 
 meta:
   - name: description
     content: Initializes the protocol.

--- a/doc/2/guides/write-protocols/methods/init/index.md
+++ b/doc/2/guides/write-protocols/methods/init/index.md
@@ -1,7 +1,12 @@
 ---
 code: true
 type: page
-title: init
+title:  init | Write protocols | Guide 
+meta:
+  - name: description
+    content: Initializes the protocol.
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write protocols, start, HTTP, MQTT, init
 ---
 
 # init

--- a/doc/2/guides/write-protocols/methods/joinchannel/index.md
+++ b/doc/2/guides/write-protocols/methods/joinchannel/index.md
@@ -1,7 +1,7 @@
 ---
 code: true
 type: page
-title:  joinChannel | Write protocols | Guide
+title: joinChannel | Write protocols | Guide
 meta:
   - name: description
     content: Informs the protocol that one of its connected users joined a channel.

--- a/doc/2/guides/write-protocols/methods/joinchannel/index.md
+++ b/doc/2/guides/write-protocols/methods/joinchannel/index.md
@@ -1,7 +1,12 @@
 ---
 code: true
 type: page
-title: joinChannel
+title:  joinChannel | Write protocols | Guide
+meta:
+  - name: description
+    content: Informs the protocol that one of its connected users joined a channel.
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write protocols, start, HTTP, MQTT, joinChannel
 ---
 
 # joinChannel

--- a/doc/2/guides/write-protocols/methods/leavechannel/index.md
+++ b/doc/2/guides/write-protocols/methods/leavechannel/index.md
@@ -1,7 +1,12 @@
 ---
 code: true
 type: page
-title: leaveChannel
+title:  leaveChannel | Write protocols | Guide
+meta:
+  - name: description
+    content: Informs the protocol that one of its connected users left a channel.
+  - name: keywords
+    content: Kuzzle, Documentation, write protocols, start, HTTP, MQTT, leaveChannel
 ---
 
 # leaveChannel

--- a/doc/2/guides/write-protocols/methods/leavechannel/index.md
+++ b/doc/2/guides/write-protocols/methods/leavechannel/index.md
@@ -1,7 +1,7 @@
 ---
 code: true
 type: page
-title:  leaveChannel | Write protocols | Guide
+title: leaveChannel | Write protocols | Guide
 meta:
   - name: description
     content: Informs the protocol that one of its connected users left a channel.

--- a/doc/2/guides/write-protocols/methods/notify/index.md
+++ b/doc/2/guides/write-protocols/methods/notify/index.md
@@ -1,7 +1,12 @@
 ---
 code: true
 type: page
-title: notify
+title:  Notify | Protocol Methods | Write protocols | Guide
+meta:
+  - name: description
+    content: Asks the protocol to send data to a specific connection, on some of its channels.
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write protocols, start, notify
 ---
 
 # notify

--- a/doc/2/guides/write-protocols/methods/notify/index.md
+++ b/doc/2/guides/write-protocols/methods/notify/index.md
@@ -1,7 +1,7 @@
 ---
 code: true
 type: page
-title:  Notify | Protocol Methods | Write protocols | Guide
+title: Notify | Protocol Methods | Write protocols | Guide
 meta:
   - name: description
     content: Asks the protocol to send data to a specific connection, on some of its channels.

--- a/doc/2/guides/write-protocols/start-writing-protocols/index.md
+++ b/doc/2/guides/write-protocols/start-writing-protocols/index.md
@@ -1,11 +1,14 @@
 ---
 code: false
 type: page
-title: Start Writing a protocol
-description: Setup environment for protocol development
 order: 100
+title:  Start Writing a protocol | Write protocols | Guide
+meta:
+  - name: description
+    content: Setup environment for protocol development
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write protocoles, start, HTTP, MQTT
 ---
-
 # Start Writing a Protocol
 
 Kuzzle has native support for the following network protocols: [HTTP](/core/2/api/protocols/http), [MQTT](/core/2/api/protocols/mqtt) (disabled by default), and [Websocket](/core/2/api/protocols/websocket).

--- a/doc/2/guides/write-protocols/start-writing-protocols/index.md
+++ b/doc/2/guides/write-protocols/start-writing-protocols/index.md
@@ -2,7 +2,7 @@
 code: false
 type: page
 order: 100
-title:  Start Writing a protocol | Write protocols | Guide
+title: Start Writing a protocol | Write protocols | Guide
 meta:
   - name: description
     content: Setup environment for protocol development


### PR DESCRIPTION
##  Metadata decription title and keywords update to get better google SEO. 


Adding this to most of the markdown doc headers with this type of header example :
```
title:  General Purpose Backend | Kuzzle Introduction | Guide | Core
meta:
  name: description
    content: Kuzzle main concepts and features overview
  name: keywords
    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend
```


### How should this be manually tested?

  - Step 1 : after the merge check if the metadatas and title are updated on the documentation pages using a web browser extention
  - Step 2 : if updates aren't applied try to reindex the website using google search console
  - Step 3 : if it's good but v1 is still on top need to find new solutions (maybe around s3, google console or canonicals)

### Other changes

added the following on type: 'branch' to avoid those type of blank links : https://docs.kuzzle.io/paas-console/1/api/
```
<Redirect to="folder" />
```
