### PR TITLE
Feat/seo upgrade fix meta title override and error while compiling

### DIFF
--- a/doc/2/.vuepress
+++ b/doc/2/.vuepress
@@ -1,1 +1,1 @@
-../framework/src/.vuepress
+/home/thomas/Bureau/documentationUpdate/documentation/src/.vuepress

--- a/doc/2/.vuepress
+++ b/doc/2/.vuepress
@@ -1,1 +1,1 @@
-/home/thomas/Bureau/documentationUpdate/documentation/src/.vuepress
+../framework/src/.vuepress

--- a/doc/2/guides/advanced/secrets-vault/index.md
+++ b/doc/2/guides/advanced/secrets-vault/index.md
@@ -8,7 +8,6 @@ meta:
     content: Securely store your application secrets
   - name: keywords
     content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, opensource, d-shrinkwrap This version of npm is compatible with lockfileVersion@1, but package-lock.json was generated for lockfileVersion@2. I'll try to do my best with it!
-npm WARN deprecated docsearch.js@2.6.3: This package has been deprecated and is no lonSecrets Vault
 ---
 # Secrets Vault
 

--- a/doc/2/index.md
+++ b/doc/2/index.md
@@ -3,7 +3,6 @@ code: false
 type: root
 order: 0
 title: Core v2.x
-description: Kuzzle Core v2.x Documentation
 ---
 
 <Redirect to="guides/introduction/what-is-kuzzle" />


### PR DESCRIPTION

## Feat/seo upgrade fix to build the repo with github action

The problem was comming from a key "npm WARN deprecated docsearch.js@2.6.3" in the header section