### PR TITLE
Allows to pass arguments for GET `document:export`

### DIFF
--- a/doc/2/api/controllers/document/export/index.md
+++ b/doc/2/api/controllers/document/export/index.md
@@ -57,17 +57,25 @@ Body:
     // ...
   ],
   "fields": [
-    // ...
-  ]
+    // ["name", "age"]
+  ],
+  "fieldsName": {
+    // "name": "Customer Name"
+  }
 }
 ```
 
 You can also access this route with the `GET` verb:
 
 ```http
-URL: http://kuzzle:7512/<index>/<collection>/_export[?format=<export format>][&size=<int>][&scroll=<time to live>][&lang=<query language>]
+URL: http://kuzzle:7512/<index>/<collection>/_export[?format=<export format>][&size=<int>][&scroll=<time to live>][&lang=<query language>][&searchBody=<query, sort>][&fields=<fields to export>][&fieldsName=<header of each exported field>]
 Method: GET
 ```
+
+::: info
+It's possible to pass arguments that are usually in the body into the query string in JSON format.
+Following arguments are available: `query`, `fields` and `fieldsName`.
+:::
 
 ### Other protocols
 
@@ -88,7 +96,7 @@ Method: GET
       // ...
     ],
     "fields": [
-    // ...
+      // ["name", "age"]
     ]
   },
 
@@ -98,7 +106,7 @@ Method: GET
   "lang": "<query language>",
   "format": "<export format>",
   "fieldsName": {
-    "<field path>": "<field name>"
+    "name": "Customer Name"
   }
 }
 ```
@@ -113,6 +121,7 @@ Method: GET
 ### Optional:
 
 - `separator`: This option is only supported for the `CSV` format, it defines which character sequence will be used to format the CSV documents
+- `fields`: This option is only supported for the `CSV` format, it defines which fields should be exported
 - `fieldsName`: This option is only supported for the `CSV` format, it defines how fields path should be renamed, if not present the field path will be used.
 - `scroll`: This option must be set with a [time duration](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/common-options.html#time-units), at the end of which the cursor is destroyed.
 - `size`: set the maximum number of documents returned per result page. By default it's `10`.

--- a/features/DocumentController.feature
+++ b/features/DocumentController.feature
@@ -233,7 +233,6 @@ Feature: Document Controller
     When I search documents with the following search body:
       """
       {
-
         "query": {
           "range": {
             "age": {
@@ -254,7 +253,7 @@ Feature: Document Controller
       | "nyc-open-data" | ["yellow-taxi"] |
       | "mtp-open-data" | ["green-taxi"]  |
     Then I should receive a "hits" array of objects matching:
-      | _id          | index           | collection |
+      | _id          | index           | collection    |
       | "document-3" | "mtp-open-data" | "green-taxi"  |
       | "document-1" | "nyc-open-data" | "yellow-taxi" |
 
@@ -275,7 +274,7 @@ Feature: Document Controller
       | _id     | "document-1"  |
       | _source | { "age": 42 } |
     And The document "document-1" content match:
-      | age  | 42 |
+      | age | 42 |
 
   # document:exists ============================================================
 
@@ -303,10 +302,10 @@ Feature: Document Controller
       | "document-2" | { "name": "document2" } |
       | "document-3" | { "name": "document3" } |
     When I execute the action "document":"mExists" with args:
-      | index      | "nyc-open-data"                          |
-      | collection | "yellow-taxi"                            |
-      | strict     | true                                     |
-      | body       | { ids: [ "document-1", "document-2" ] }  |
+      | index      | "nyc-open-data"                         |
+      | collection | "yellow-taxi"                           |
+      | strict     | true                                    |
+      | body       | { ids: [ "document-1", "document-2" ] } |
     Then I should receive a "successes" array matching:
       | "document-1" |
       | "document-2" |
@@ -321,10 +320,10 @@ Feature: Document Controller
       | "document-2" | { "name": "document2" } |
       | "document-3" | { "name": "document3" } |
     When I execute the action "document":"mExists" with args:
-      | index      | "nyc-open-data"                                     |
-      | collection | "yellow-taxi"                                       |
-      | strict     | false                                               |
-      | body       | { ids: [ "document-1", "214284", "document-42" ] }  |
+      | index      | "nyc-open-data"                                    |
+      | collection | "yellow-taxi"                                      |
+      | strict     | false                                              |
+      | body       | { ids: [ "document-1", "214284", "document-42" ] } |
     Then I should receive a "successes" array matching:
       | "document-1" |
     And I should receive a "errors" array matching:
@@ -340,10 +339,10 @@ Feature: Document Controller
       | "document-2" | { "name": "document2" } |
       | "document-3" | { "name": "document3" } |
     When I execute the action "document":"mExists" with args:
-      | index      | "nyc-open-data"                                                        |
-      | collection | "yellow-taxi"                                                          |
-      | strict     | false                                                                  |
-      | body       | { ids: [ "document-1", "document-2", "document-42", "document-21" ] }  |
+      | index      | "nyc-open-data"                                                       |
+      | collection | "yellow-taxi"                                                         |
+      | strict     | false                                                                 |
+      | body       | { ids: [ "document-1", "document-2", "document-42", "document-21" ] } |
     Then I should receive a "successes" array matching:
       | "document-1" |
       | "document-2" |
@@ -364,7 +363,7 @@ Feature: Document Controller
       | strict     | true                                     |
       | body       | { ids: [ "document-1", "document-42" ] } |
     Then I should receive an error matching:
-      | id     | "api.process.incomplete_multiple_request" |
+      | id | "api.process.incomplete_multiple_request" |
 
   # document:export ============================================================
 
@@ -375,8 +374,8 @@ Feature: Document Controller
     Then The document "document-1" should not exist
     And The document "document-2" should not exist
     When I "create" the following multiple documents:
-      | _id          | body                               |
-      | "document-1" | { "name": "document1", "age": 42 } |
+      | _id          | body                                |
+      | "document-1" | { "name": "document1", "age": 42 }  |
       | "document-2" | { "name": "document2", "age": 666 } |
     And I refresh the collection
     When I export the collection "nyc-open-data":"yellow-taxi" in the format "jsonl"
@@ -392,15 +391,22 @@ Feature: Document Controller
     Then The document "document-1" should not exist
     And The document "document-2" should not exist
     When I "create" the following multiple documents:
-      | _id          | body                               |
-      | "document-1" | { "name": "document1", "age": 42 } |
+      | _id          | body                                |
+      | "document-1" | { "name": "document1", "age": 42 }  |
       | "document-2" | { "name": "document2", "age": 666 } |
     And I refresh the collection
-    When I export the collection "nyc-open-data":"yellow-taxi" in the format "csv"
+    When I export the collection "nyc-open-data":"yellow-taxi" in the format "csv" with GET:
+      | fields | ["age", "name"]        |
+      | query  | { term: { age: 666 } } |
     Then the streamed data should be equal to:
-      | _id,age,city,job,name      |
-      | document-1,42,,,document1  |
-      | document-2,666,,,document2 |
+      | _id,age,name             |
+      | document-2,666,document2 |
+    When I export the collection "nyc-open-data":"yellow-taxi" in the format "csv" with POST:
+      | fields | ["age", "name"]        |
+      | query  | { term: { age: 666 } } |
+    Then the streamed data should be equal to:
+      | _id,age,name             |
+      | document-2,666,document2 |
 
   @mappings
   @http
@@ -409,11 +415,11 @@ Feature: Document Controller
     Then The document "document-1" should not exist
     And The document "document-2" should not exist
     When I "create" the following multiple documents:
-      | _id          | body                               |
-      | "document-1" | { "name": "document1", "age": 42 } |
+      | _id          | body                                |
+      | "document-1" | { "name": "document1", "age": 42 }  |
       | "document-2" | { "name": "document2", "age": 666 } |
     And I refresh the collection
-    When I export the collection "nyc-open-data":"yellow-taxi" in the format "csv":
+    When I export the collection "nyc-open-data":"yellow-taxi" in the format "csv" with GET:
       | fields | ["age","name"] |
     Then the streamed data should be equal to:
       | _id,age,name             |
@@ -427,11 +433,11 @@ Feature: Document Controller
     Then The document "document-1" should not exist
     And The document "document-2" should not exist
     When I "create" the following multiple documents:
-      | _id          | body                               |
-      | "document-1" | { "name": "document1", "age": 42 } |
+      | _id          | body                                |
+      | "document-1" | { "name": "document1", "age": 42 }  |
       | "document-2" | { "name": "document2", "age": 666 } |
     And I refresh the collection
-    When I export the collection "nyc-open-data":"yellow-taxi" in the format "csv":
+    When I export the collection "nyc-open-data":"yellow-taxi" in the format "csv" with GET:
       | fields     | [ "age", "name" ]                                         |
       | fieldsName | { "age": "cityAge", "name": "documentName", "_id": "id" } |
     Then the streamed data should be equal to:
@@ -492,9 +498,9 @@ Feature: Document Controller
       | _id        | "document-1"            |
       | body       | { "name": "document1" } |
     Then I should receive a result matching:
-      | _id     | "document-1"             |
-      | _source | { "name": "document1" }  |
-      | created | true                     |
+      | _id     | "document-1"            |
+      | _source | { "name": "document1" } |
+      | created | true                    |
     And I refresh the collection
     And I count 1 documents
     And The document "document-1" content match:
@@ -512,9 +518,9 @@ Feature: Document Controller
       | _id        | "document-1"            |
       | body       | { "name": "replaced1" } |
     Then I should receive a result matching:
-      | _id     | "document-1"             |
-      | _source | { "name": "replaced1" }  |
-      | created | false                    |
+      | _id     | "document-1"            |
+      | _source | { "name": "replaced1" } |
+      | created | false                   |
     And I refresh the collection
     And I count 1 documents
     And The document "document-1" content match:
@@ -545,10 +551,10 @@ Feature: Document Controller
       | _id          | body                               |
       | "document-1" | { "name": "document1", "age": 42 } |
     When I successfully execute the action "document":"mCreateOrReplace" with args:
-      | index      | "nyc-open-data"        |
-      | collection | "yellow-taxi"          |
+      | index      | "nyc-open-data"                                                               |
+      | collection | "yellow-taxi"                                                                 |
       | body       | { "documents": [ { "_id": "document-1", "body": { "name": "replaced1" } } ] } |
-      | source     | true                   |
+      | source     | true                                                                          |
     Then I should receive a "successes" array of objects matching:
       | _id          | _source                 | status | result    | created |
       | "document-1" | { "name": "replaced1" } | 200    | "updated" | false   |
@@ -565,10 +571,10 @@ Feature: Document Controller
       | _id          | body                               |
       | "document-1" | { "name": "document1", "age": 42 } |
     When I successfully execute the action "document":"mCreateOrReplace" with args:
-      | index      | "nyc-open-data"        |
-      | collection | "yellow-taxi"          |
+      | index      | "nyc-open-data"                                                               |
+      | collection | "yellow-taxi"                                                                 |
       | body       | { "documents": [ { "_id": "document-1", "body": { "name": "replaced1" } } ] } |
-      | source     | "false"                |
+      | source     | "false"                                                                       |
     Then I should receive a "successes" array of objects matching:
       | _id          | _source       | status | result    | created |
       | "document-1" | "_UNDEFINED_" | 200    | "updated" | false   |
@@ -671,16 +677,16 @@ Feature: Document Controller
       | "document-1" | { "name": "updated1" } | -                      |
       | "document-2" | { "age": 21 }          | { "name": "created2" } |
     Then I should receive a "successes" array of objects matching:
-      | _id          | _source                            | _version | status | created |
-      | "document-1" | { "name": "updated1", "age": 42 }  | 2        | 200    | false   |
-      | "document-2" | { "name": "created2", "age": 21 }  | 1        | 201    | true    |
+      | _id          | _source                           | _version | status | created |
+      | "document-1" | { "name": "updated1", "age": 42 } | 2        | 200    | false   |
+      | "document-2" | { "name": "created2", "age": 21 } | 1        | 201    | true    |
     And I should receive a empty "errors" array
     And The document "document-1" content match:
       | name | "updated1" |
       | age  | 42         |
     And The document "document-2" content match:
       | name | "created2" |
-      | age  | 21          |
+      | age  | 21         |
 
   @mappings
   Scenario: Upsert multiple documents with errors
@@ -699,13 +705,13 @@ Feature: Document Controller
       | _id           | _source                 | _version | status | created |
       | "document-42" | { "name": "created42" } | 1        | 201    | true    |
     And I should receive a "errors" array of objects matching:
-      | reason                               | status | document                                                    |
-      | "document _id must be a string"      | 400    | { "changes": { "name": "updated0" } }                       |
-      | "document default must be an object" | 400    | { "_id": "document-1", "changes": { "name": "updated1" } }  |
-      | "document changes must be an object" | 400    | { "_id": "document-2", "changes": "not an object" }         |
+      | reason                               | status | document                                                   |
+      | "document _id must be a string"      | 400    | { "changes": { "name": "updated0" } }                      |
+      | "document default must be an object" | 400    | { "_id": "document-1", "changes": { "name": "updated1" } } |
+      | "document changes must be an object" | 400    | { "_id": "document-2", "changes": "not an object" }        |
     And The document "document-1" content match:
       | name | "document1" |
-      | age  | 42         |
+      | age  | 42          |
     And The document "document-2" content match:
       | name | "document2" |
     And The document "document-42" content match:
@@ -864,7 +870,7 @@ Feature: Document Controller
       | strict     | true                                     |
       | body       | { ids: [ "document-1", "document-42" ] } |
     Then I should receive an error matching:
-      | id     | "api.process.incomplete_multiple_request" |
+      | id | "api.process.incomplete_multiple_request" |
 
   # document:count =============================================================
 
@@ -891,10 +897,10 @@ Feature: Document Controller
       | -   | { "job": "cto" }       |
     And I refresh the collection
     When I successfully execute the action "document":"count" with args:
-      | index      | "nyc-open-data"                                   |
-      | collection | "yellow-taxi"                                     |
-      | body       | { "query": { "equals": {"job": "developer" } } }  |
-      | lang       | "koncorde"                                        |
+      | index      | "nyc-open-data"                                  |
+      | collection | "yellow-taxi"                                    |
+      | body       | { "query": { "equals": {"job": "developer" } } } |
+      | lang       | "koncorde"                                       |
     Then I should receive a result matching:
       | count | 2 |
 
@@ -1044,22 +1050,22 @@ Feature: Document Controller
   Scenario: Upsert document with and without returning updated document
     Given an existing collection "nyc-open-data":"yellow-taxi"
     When I successfully execute the action "document":"upsert" with args:
-      | index      | "nyc-open-data"        |
-      | collection | "yellow-taxi"          |
-      | _id        | "document-1"           |
+      | index      | "nyc-open-data"                                                                 |
+      | collection | "yellow-taxi"                                                                   |
+      | _id        | "document-1"                                                                    |
       | body       | { "changes": { "name": "document-1", "age": 42 }, "default": { "foo": "bar" } } |
-      | source     | true                   |
+      | source     | true                                                                            |
     Then I should receive a result matching:
-      | _id      | "document-1"                      |
+      | _id      | "document-1"                                      |
       | _source  | { "name": "document-1", "age": 42, "foo": "bar" } |
       | _version | 1                                                 |
       | created  | true                                              |
     When I successfully execute the action "document":"upsert" with args:
-      | index      | "nyc-open-data"        |
-      | collection | "yellow-taxi"          |
-      | _id        | "document-1"           |
+      | index      | "nyc-open-data"                                                        |
+      | collection | "yellow-taxi"                                                          |
+      | _id        | "document-1"                                                           |
       | body       | { "changes": { "name": "updated1" }, "default": { "foo": "oh noes" } } |
-      | source     | true                   |
+      | source     | true                                                                   |
     Then I should receive a result matching:
       | _id      | "document-1"                                    |
       | _source  | { "name": "updated1", "age": 42, "foo": "bar" } |

--- a/lib/api/controllers/documentController.js
+++ b/lib/api/controllers/documentController.js
@@ -232,17 +232,15 @@ class DocumentController extends NativeController {
 
   async export(request) {
     const { index, collection } = request.getIndexAndCollection();
-    const { size, scrollTTL, searchBody } = request.getSearchParams();
-    const format = request.getString("format", "jsonl");
-    const fields = request.getBodyArray("fields", []);
+    const { size, scrollTTL } = request.getSearchParams();
     const lang = request.getLangParam();
+    const format = request.getString("format", "jsonl");
     const separator = request.getString("separator", ",");
-    const fieldsName = request.getBodyObject("fieldsName", {});
+    const query = request.getObjectFromBodyOrArgs("query", {});
+    const fields = request.getArrayFromBodyOrArgs("fields", []);
+    const fieldsName = request.getObjectFromBodyOrArgs("fieldsName", {});
 
-    // Remove "fields" and "fieldsName" from searchBody to avoid ES throwing an error
-    // since those properties are not allowed in the searchBody
-    searchBody.fields = undefined;
-    searchBody.fieldsName = undefined;
+    const searchBody = { query };
 
     if (request.context.connection.protocol !== "http") {
       throw kerror.get(

--- a/lib/api/request/kuzzleRequest.ts
+++ b/lib/api/request/kuzzleRequest.ts
@@ -851,6 +851,48 @@ export class KuzzleRequest {
     return this.getObject("searchBody", {});
   }
 
+  getObjectFromBodyOrArgs(name: string, def?: JSONObject): JSONObject {
+    if (
+      this.context.connection.protocol !== "http" ||
+      this.context.connection.misc.verb !== "GET"
+    ) {
+      return this.getBodyObject(name, def);
+    }
+
+    const rawObject = this.getString(name, JSON.stringify(def));
+
+    try {
+      return JSON.parse(rawObject);
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        throw assertionError.get("invalid_type", name, "JSON string");
+      }
+
+      throw error;
+    }
+  }
+
+  getArrayFromBodyOrArgs(name: string, def?: any): JSONObject {
+    if (
+      this.context.connection.protocol !== "http" ||
+      this.context.connection.misc.verb !== "GET"
+    ) {
+      return this.getBodyArray(name, def);
+    }
+
+    const rawObject = this.getString(name, JSON.stringify(def));
+
+    try {
+      return JSON.parse(rawObject);
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        throw assertionError.get("invalid_type", name, "JSON string");
+      }
+
+      throw error;
+    }
+  }
+
   /**
    * Returns the search params.
    */


### PR DESCRIPTION
## What does this PR do ?

The `document:export` action is meant to be used as a `a href` link to benefits from the HTTP Stream.

Thus, it is not possible to pass body arguments with the `GET` method. This PR fix that by allowing passing those arguments in the query string in JSON format.

Example: `http://localhost:7512/iot/measures/_export?format=csv&query={}&fields=[%22date%22,%22temperature%22]`