### PR TITLE
fix : documentation typo

### DIFF
--- a/doc/2/guides/main-concepts/querying/index.md
+++ b/doc/2/guides/main-concepts/querying/index.md
@@ -444,7 +444,7 @@ while (result != null) {
 
 ::: tab Kotlin
 
-Using the Javascript SDK [SearchResult.next](/sdk/jvm/1/core-classes/search-result/next) method:
+Using the Java SDK [SearchResult.next](/sdk/jvm/1/core-classes/search-result/next) method:
 
 ```kotlin
 val term: ConcurrentHashMap<String, Any?> =


### PR DESCRIPTION
I found a misstake in kuzzle documentation : 

Replace "Javascript" with "Java" 
ci-allow-merge-into: master
ci-no-changelog-tag