### PR TITLE
fix : Typo in getting started

### DIFF
--- a/doc/2/guides/getting-started/run-kuzzle/index.md
+++ b/doc/2/guides/getting-started/run-kuzzle/index.md
@@ -50,13 +50,11 @@ First, we will initialize a new application using Kourou:
 ```bash
 kourou app:scaffold playground
 
-  🚀 Kourou - Scaffolds a new Kuzzle application
+ 🚀 Kourou - Scaffolds a new Kuzzle application
 
-  ✔ Creating "playground/" directory
   ✔ Creating and rendering application files
-  ✔ Installing latest Kuzzle version via NPM and Docker (this can take some time)
 
- [✔] Scaffolding complete! Use "npm run docker:dev" to run your application
+ [✔] Scaffolding complete! Use cd playground && npm run docker npm install install dependencies and then npm run docker:dev to run your application!
 
 ```
 

--- a/doc/2/guides/getting-started/run-kuzzle/index.md
+++ b/doc/2/guides/getting-started/run-kuzzle/index.md
@@ -56,7 +56,7 @@ kourou app:scaffold playground
   ✔ Creating and rendering application files
   ✔ Installing latest Kuzzle version via NPM and Docker (this can take some time)
 
- [✔] Scaffolding complete! Use "npm run dev:docker" to run your application
+ [✔] Scaffolding complete! Use "npm run docker:dev" to run your application
 
 ```
 


### PR DESCRIPTION
I know there's no mistakes, but I really spend a lot of time reading doc and I found another easter egg : 

comand is now npm run docker:dev and not dev:docker

ci-allow-merge-into: master
ci-no-changelog-tag