### PR TITLE
fix : Typo replace app by Backend

### DIFF
--- a/doc/2/guides/develop-on-kuzzle/api-controllers/index.md
+++ b/doc/2/guides/develop-on-kuzzle/api-controllers/index.md
@@ -304,7 +304,7 @@ Then Kuzzle will inject the http route specification as shown in the example bel
 
 <SinceBadge version="2.17.0" />
 
-The complete OpenAPI definition is accessible and customizable with the [app.openapi.definition](/core/2/framework/classes/backend-openapi) property.
+The complete OpenAPI definition is accessible and customizable with the [Backend.openapi.definition](/core/2/framework/classes/backend-openapi) property.
 
 **Example:** _Register an OpenAPI schema_
 


### PR DESCRIPTION
I made this PR to harmonize this with the rest of the documentation

app -> Backend

ci-allow-merge-into: master
ci-no-changelog-tag