### PR TITLE
Allow plugins to imports defaults (rights, users, mappings) 

### DIFF
--- a/doc/2/guides/write-plugins/plugins-features/index.md
+++ b/doc/2/guides/write-plugins/plugins-features/index.md
@@ -76,3 +76,16 @@ class MyPlugin extends Plugin {
   }
 }
 ```
+
+## Default imports
+
+Plugins can declare defaults documents to be loaded before Kuzzle open it's API.
+
+The following imports are available:
+ - `users`
+ - `roles`
+ - `profiles`
+ - `mappings` (indexes and collections)
+ - `usersMappings`
+
+See also [Backend.import](/core/2/framework/classes/backend-import).

--- a/jest/helpers/useSdk.ts
+++ b/jest/helpers/useSdk.ts
@@ -1,0 +1,5 @@
+import { Kuzzle, WebSocket } from "kuzzle-sdk";
+
+export function useSdk(): Kuzzle {
+  return new Kuzzle(new WebSocket("localhost", { port: 7512 }));
+}

--- a/jest/plugins/default-imports.test.ts
+++ b/jest/plugins/default-imports.test.ts
@@ -1,0 +1,28 @@
+import { useSdk } from "../helpers/useSdk";
+
+describe("Default loading of plugin's imports", () => {
+  const sdk = useSdk();
+
+  beforeAll(async () => {
+    await sdk.connect();
+  });
+
+  it("shoud load roles and collections", async () => {
+    const role = await sdk.security.getRole('imported-role');
+
+    expect(role.controllers).toMatchObject({
+      auth: {
+        actions: {
+          login: true,
+        }
+      }
+    });
+
+    const collection = await sdk.collection.getMapping('imported-index', 'imported-collection');
+
+    expect(collection.properties).toMatchObject({
+      name: { type: 'keyword' }
+    });
+  });
+});
+

--- a/lib/core/plugin/plugin.js
+++ b/lib/core/plugin/plugin.js
@@ -116,15 +116,20 @@ class Plugin {
     }
 
     const description = {
+      version: this.version,
       controllers: [],
       hooks: [],
       manifest: this.manifest,
       pipes: [],
       routes: [],
       strategies: [],
-      version: this.version,
+      imports: {},
     };
     /* eslint-enable sort-keys */
+
+    if (has(this.instance, "imports")) {
+      description.imports = Object.keys(this.instance.imports);
+    }
 
     if (has(this.instance, "hooks")) {
       description.hooks = Object.keys(this.instance.hooks);

--- a/lib/core/plugin/pluginsManager.js
+++ b/lib/core/plugin/pluginsManager.js
@@ -207,7 +207,7 @@ class PluginsManager {
    *
    * @throws PluginImplementationError - Throws when an error occurs when registering a plugin
    */
-  init(plugins = {}) {
+  async init(plugins = {}) {
     this._plugins = new Map([...this.loadPlugins(plugins), ...this._plugins]);
 
     global.kuzzle.on("plugin:hook:loop-error", ({ error, pluginName }) => {
@@ -224,6 +224,7 @@ class PluginsManager {
 
     // register regular plugins features
     const loadPlugins = [];
+    const defaultImports = {};
 
     for (const plugin of this._plugins.values()) {
       if (
@@ -301,13 +302,19 @@ class PluginsManager {
             this.loadedPlugins.push(plugin.name);
           }
 
+          if (!_.isEmpty(plugin.instance.imports)) {
+            _.merge(defaultImports, plugin.instance.imports);
+          }
+
           return null;
         });
 
       loadPlugins.push(promise);
     }
 
-    return Promise.all(loadPlugins);
+    await Promise.all(loadPlugins);
+
+    return defaultImports;
   }
 
   /**

--- a/lib/kuzzle/kuzzle.ts
+++ b/lib/kuzzle/kuzzle.ts
@@ -272,16 +272,18 @@ class Kuzzle extends KuzzleEventEmitter {
       await this.entryPoint.init();
 
       this.pluginsManager.application = application;
-      await this.pluginsManager.init(options.plugins);
+      const pluginImports = await this.pluginsManager.init(options.plugins);
       this.log.info(
         `[✔] Successfully loaded ${
           this.pluginsManager.loadedPlugins.length
         } plugins: ${this.pluginsManager.loadedPlugins.join(", ")}`
       );
 
+      const imports = _.merge({}, pluginImports, options.import);
+
       // Authentification plugins must be loaded before users import to avoid
       // credentials related error which would prevent Kuzzle from starting
-      await this.loadInitialState(options.import, options.support);
+      await this.loadInitialState(imports, options.support);
 
       await this.ask("core:security:verify");
 

--- a/lib/types/Plugin.ts
+++ b/lib/types/Plugin.ts
@@ -27,6 +27,7 @@ import { PipeEventHandler, HookEventHandler } from "./EventHandler";
 import { JSONObject } from "../../index";
 import * as kerror from "../kerror";
 import { has } from "../util/safeObject";
+import { ImportConfig } from "./Kuzzle";
 
 /**
  * Allows to define plugins controllers and actions
@@ -136,6 +137,11 @@ export abstract class Plugin {
    * @see https://docs.kuzzle.io/core/2/plugins/guides/strategies/overview
    */
   public strategies?: StrategyDefinition;
+
+  /**
+   * Define default imports
+   */
+  public imports?: ImportConfig;
 
   /**
    * Plugin initialization method.

--- a/plugins/available/functional-test-plugin/functionalTestPlugin.js
+++ b/plugins/available/functional-test-plugin/functionalTestPlugin.js
@@ -12,6 +12,31 @@ class FunctionalTestPlugin {
     this.pipes = {};
     this.hooks = {};
 
+    this.imports = {
+      mappings: {
+        "imported-index": {
+          "imported-collection": {
+            mappings: {
+              properties: {
+                name: { type: "keyword" },
+              },
+            },
+          },
+        },
+      },
+      roles: {
+        "imported-role": {
+          controllers: {
+            auth: {
+              actions: {
+                login: true,
+              },
+            },
+          },
+        },
+      },
+    };
+
     // context.constructor.ESClient related declarations =======================
 
     this.controllers.constructors = { ESClient: "testConstructorsESClient" };


### PR DESCRIPTION
## What does this PR do ?

Allows the plugins to define defaults documents to be loaded before Kuzzle open it's API7

You can import:
 - `users`
 - `roles`
 - `profiles`
 - `mappings` (indexes and collections)
 - `usersMappings`

### How should this be manually tested?

In the plugin definition:
```
this.imports = {
  mappings: {
    "imported-index": {
      "imported-collection": {
        mappings: {
          properties: {
            name: { type: "keyword" },
          },
        },
      },
    },
  },
  roles: {
    "imported-role": {
      controllers: {
        auth: {
          actions: {
            login: true,
          },
        },
      },
    },
  },
};
```