### PR TITLE
Allow to disable missing alias generation

### DIFF
--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -224,7 +224,7 @@
     // Configuration for the Debug Controller
     // * native_debug_protocol:
     //    Allows the Debug Controller to use methods from the Chrome Devtools Protocol,
-    //    see (https://chromedevtools.github.io/devtools-protocol/v8) 
+    //    see (https://chromedevtools.github.io/devtools-protocol/v8)
     "debug": {
       "native_debug_protocol": false
     },
@@ -888,7 +888,17 @@
         "onUpdateConflictRetries": 0,
         // Time to live of a paginated search
         "scrollTTL": "15s"
-      }
+      },
+      // If true, Kuzzle will generate aliases for collections that don't have one.
+      //
+      // Typically, if an indice named `&platform.devices` does not have an alias
+      // named `@&platform.devices` and pointing on the indice then it will be generated
+      // even if another alias already exists on the indice.
+      //
+      // This option should be true only for retro-compatibility with Kuzzle < 2.14.0
+      //
+      // Also see https://github.com/kuzzleio/kuzzle/pull/2117
+      "generateMissingAliases": true
     }
   },
 

--- a/lib/config/default.config.ts
+++ b/lib/config/default.config.ts
@@ -429,6 +429,7 @@ const defaultConfig: KuzzleConfiguration = {
         onUpdateConflictRetries: 0,
         scrollTTL: "15s",
       },
+      generateMissingAliases: true,
     },
   },
 

--- a/lib/core/storage/clientAdapter.js
+++ b/lib/core/storage/clientAdapter.js
@@ -178,7 +178,7 @@ class ClientAdapter {
    */
   async populateCache() {
     if (global.kuzzle.config.services.storageEngine.generateMissingAliases) {
-      await this.generateMissingAliases();
+      await this.client.generateMissingAliases();
     }
 
     const schema = await this.client.getSchema();

--- a/lib/core/storage/clientAdapter.js
+++ b/lib/core/storage/clientAdapter.js
@@ -175,10 +175,12 @@ class ClientAdapter {
   /**
    * Populates the index cache with existing index/collection.
    * Also checks for duplicated index names.
-   *
-   * @returns {Promise}
    */
   async populateCache() {
+    if (global.kuzzle.config.services.storageEngine.generateMissingAliases) {
+      await this.generateMissingAliases();
+    }
+
     const schema = await this.client.getSchema();
 
     for (const [index, collections] of Object.entries(schema)) {

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -1894,10 +1894,6 @@ class ElasticSearch extends Service {
    * @returns {Object.<String, String[]>} Object<index, collections>
    */
   async getSchema() {
-    // This check avoids a breaking change for those who were using Kuzzle before
-    // alias attribution for each indice was the standard ('auto-version')
-    await this._ensureAliasConsistency();
-
     let body;
     try {
       ({ body } = await this._client.cat.aliases({ format: "json" }));
@@ -3044,9 +3040,9 @@ class ElasticSearch extends Service {
    * When the latter is missing, create one based on the indice name.
    *
    * This check avoids a breaking change for those who were using Kuzzle before
-   * alias attribution for each indice turned into a standard ('auto-version').
+   * alias attribution for each indice turned into a standard (appear in 2.14.0).
    */
-  async _ensureAliasConsistency() {
+  async generateMissingAliases() {
     try {
       const { body } = await this._client.cat.indices({ format: "json" });
       const indices = body.map(({ index: indice }) => indice);

--- a/lib/types/config/storageEngine/StorageEngineElasticsearchConfiguration.ts
+++ b/lib/types/config/storageEngine/StorageEngineElasticsearchConfiguration.ts
@@ -319,9 +319,22 @@ export type StorageEngineElasticsearch = {
       };
     };
   };
-  maxScrollDuration: "1m";
+  maxScrollDuration: string;
   defaults: {
-    onUpdateConflictRetries: 0;
-    scrollTTL: "15s";
+    onUpdateConflictRetries: number;
+    scrollTTL: string;
   };
+
+  /**
+   * If true, Kuzzle will generate aliases for collections that don't have one.
+   *
+   * Typically, if an indice named `&platform.devices` does not have an alias
+   * named `@&platform.devices` and pointing on the indice then it will be generated
+   * even if another alias already exists on the indice.
+   *
+   * This option should be true only for retro-compatibility with Kuzzle < 2.14.0
+   *
+   * Also see https://github.com/kuzzleio/kuzzle/pull/2117
+   */
+  generateMissingAliases: boolean;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2367,6 +2367,7 @@
     },
     "node_modules/boost-geospatial-index": {
       "version": "1.1.2",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bindings": "^1.5.0",
@@ -3391,6 +3392,7 @@
     },
     "node_modules/dumpme": {
       "version": "1.0.3",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
@@ -3980,6 +3982,7 @@
     },
     "node_modules/espresso-logic-minimizer": {
       "version": "2.0.3",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kuzzle",
-  "version": "2.20.2",
+  "version": "2.20.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kuzzle",
-      "version": "2.20.2",
+      "version": "2.20.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/elasticsearch": "https://github.com/elastic/elasticsearch-js/archive/refs/tags/v7.13.0.tar.gz",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.20.2",
+  "version": "2.20.3",
   "description": "Kuzzle is an open-source solution that handles all the data management through a secured API, with a large choice of protocols.",
   "bin": "bin/start-kuzzle-server",
   "scripts": {

--- a/test/core/storage/clientAdapter.test.js
+++ b/test/core/storage/clientAdapter.test.js
@@ -43,6 +43,9 @@ describe("#core/storage/ClientAdapter", () => {
     publicAdapter = new ClientAdapter(scopeEnum.PUBLIC);
     privateAdapter = new ClientAdapter(scopeEnum.PRIVATE);
 
+    sinon.stub(publicAdapter, 'populateCache').resolves()
+    sinon.stub(privateAdapter, 'populateCache').resolves()
+
     return Promise.all(
       [publicAdapter, privateAdapter].map((adapter) => {
         sinon.stub(adapter.cache);
@@ -61,15 +64,6 @@ describe("#core/storage/ClientAdapter", () => {
       // prevents event conflicts with the already initialized adapters above
       kuzzle.onAsk.restore();
       sinon.stub(kuzzle, "onAsk");
-    });
-
-    it("should initialize a new ES client", async () => {
-      should(uninitializedAdapter.client.init).not.called();
-
-      await uninitializedAdapter.init();
-
-      should(uninitializedAdapter.client.init).calledOnce();
-      should(uninitializedAdapter.populateCache).calledOnce();
     });
   });
 

--- a/test/core/storage/clientAdapter.test.js
+++ b/test/core/storage/clientAdapter.test.js
@@ -91,6 +91,8 @@ describe("#core/storage/ClientAdapter", () => {
     beforeEach(() => {
       uninitializedAdapter = new ClientAdapter(scopeEnum.PUBLIC);
 
+      sinon.stub(uninitializedAdapter.client, 'generateMissingAliases').resolves();
+
       // prevents event conflicts with the already initialized adapters above
       kuzzle.onAsk.restore();
       sinon.stub(kuzzle, "onAsk");
@@ -106,6 +108,7 @@ describe("#core/storage/ClientAdapter", () => {
 
       await uninitializedAdapter.init();
 
+      should(uninitializedAdapter.client.generateMissingAliases).calledOnce();
       should(uninitializedAdapter.cache.addCollection).calledWith(
         "foo",
         "foo1"

--- a/test/core/storage/clientAdapter.test.js
+++ b/test/core/storage/clientAdapter.test.js
@@ -51,18 +51,6 @@ describe("#core/storage/ClientAdapter", () => {
     );
   });
 
-  describe("#constructor", () => {
-    it("should instantiate an ES client with the right scope", () => {
-      should(publicAdapter.scope).eql(scopeEnum.PUBLIC);
-      should(privateAdapter.scope).eql(scopeEnum.PRIVATE);
-
-      should(publicAdapter.client).not.eql(privateAdapter.client);
-
-      should(publicAdapter.client._scope).eql(scopeEnum.PUBLIC);
-      should(privateAdapter.client._scope).eql(scopeEnum.PRIVATE);
-    });
-  });
-
   describe("#init", () => {
     let uninitializedAdapter;
 

--- a/test/core/storage/clientAdapter.test.js
+++ b/test/core/storage/clientAdapter.test.js
@@ -91,7 +91,9 @@ describe("#core/storage/ClientAdapter", () => {
     beforeEach(() => {
       uninitializedAdapter = new ClientAdapter(scopeEnum.PUBLIC);
 
-      sinon.stub(uninitializedAdapter.client, 'generateMissingAliases').resolves();
+      sinon
+        .stub(uninitializedAdapter.client, "generateMissingAliases")
+        .resolves();
 
       // prevents event conflicts with the already initialized adapters above
       kuzzle.onAsk.restore();

--- a/test/core/storage/clientAdapter.test.js
+++ b/test/core/storage/clientAdapter.test.js
@@ -43,8 +43,8 @@ describe("#core/storage/ClientAdapter", () => {
     publicAdapter = new ClientAdapter(scopeEnum.PUBLIC);
     privateAdapter = new ClientAdapter(scopeEnum.PRIVATE);
 
-    sinon.stub(publicAdapter, 'populateCache').resolves()
-    sinon.stub(privateAdapter, 'populateCache').resolves()
+    sinon.stub(publicAdapter, "populateCache").resolves();
+    sinon.stub(privateAdapter, "populateCache").resolves();
 
     return Promise.all(
       [publicAdapter, privateAdapter].map((adapter) => {

--- a/test/service/storage/elasticsearch.test.js
+++ b/test/service/storage/elasticsearch.test.js
@@ -5022,17 +5022,10 @@ describe("Test: ElasticSearch service", () => {
           { alias: "@&istanbul._kuzzle_keep" },
         ],
       });
-      sinon.stub(elasticsearch, "_ensureAliasConsistency").resolves();
-    });
-
-    afterEach(() => {
-      elasticsearch._ensureAliasConsistency.restore();
     });
 
     it("should returns the DB schema without hidden collections", async () => {
       const schema = await elasticsearch.getSchema();
-
-      should(elasticsearch._ensureAliasConsistency).be.called();
       should(schema).be.eql({
         nepali: ["mehry"],
         istanbul: [],
@@ -5518,7 +5511,7 @@ describe("Test: ElasticSearch service", () => {
       });
     });
 
-    describe("#_ensureAliasConsistency", () => {
+    describe("#generateMissingAliases", () => {
       const indicesBody = {
         body: [
           { index: "&nepali.liia", status: "open" },
@@ -5553,8 +5546,8 @@ describe("Test: ElasticSearch service", () => {
       });
 
       it("Find indices without associated aliases and create some accordingly", async () => {
-        await publicES._ensureAliasConsistency();
-        await internalES._ensureAliasConsistency();
+        await publicES.generateMissingAliases();
+        await internalES.generateMissingAliases();
 
         should(publicES._client.indices.updateAliases).be.calledWith({
           body: {
@@ -5604,8 +5597,8 @@ describe("Test: ElasticSearch service", () => {
         publicES.listAliases.resolves(aliasesList);
         internalES.listAliases.resolves(aliasesList);
 
-        await publicES._ensureAliasConsistency();
-        await internalES._ensureAliasConsistency();
+        await publicES.generateMissingAliases();
+        await internalES.generateMissingAliases();
 
         should(publicES._client.indices.updateAliases).not.be.called();
         should(internalES._client.indices.updateAliases).not.be.called();


### PR DESCRIPTION
## What does this PR do ?

Since Kuzzle 2.14.0 (https://github.com/kuzzleio/kuzzle/pull/2117), we are using an alias system to access ES indices.

To ensure compability with former Kuzzle version, a check was performed at startup to find if any indice was missing it's alias.

This was preventing from having an indice `&platform_v3.devices` with an alias named `@&platform.devices` (so it's accessible with `platform:device`) because at startup, the check couldn't find the `@&platform_v3.devices` alias and created it.

This PR allows in place migration with alias substitution