### PR TITLE
Fix missing parameters in deployment workflow call

### DIFF
--- a/.github/workflows/workflow-deployments.yaml
+++ b/.github/workflows/workflow-deployments.yaml
@@ -2,6 +2,22 @@ name: Workflow Deployments
 
 on:
   workflow_call:
+    inputs:
+      node_lts_current_version:
+        description: "Current Node LTS Version"
+        required: true
+        default: "18"
+        type: string
+      node_lts_active_version:
+        description: "Active Node LTS Version"
+        required: true
+        default: "16"
+        type: string
+      docker_platforms:
+        description: "Docker platforms"
+        required: true
+        default: "linux/amd64,linux/arm64"
+        type: string
   workflow_dispatch:
     inputs:
       doc_deploy:
@@ -19,6 +35,21 @@ on:
         required: true
         default: true
         type: boolean
+      node_lts_current_version:
+        description: "Current Node LTS Version"
+        required: true
+        default: "18"
+        type: string
+      node_lts_active_version:
+        description: "Active Node LTS Version"
+        required: true
+        default: "16"
+        type: string
+      docker_platforms:
+        description: "Docker platforms"
+        required: true
+        default: "linux/amd64,linux/arm64"
+        type: string
 
 jobs:
   # -----------------------------------------------------------------------------
@@ -56,7 +87,7 @@ jobs:
       - uses: ./.github/actions/install-packages
       - uses: actions/setup-node@v2
         with:
-          node-version: ${{ env.NODE_LTS_CURRENT_VERSION }}
+          node-version: ${{ inputs.node_lts_current_version }}
       - uses: actions/cache@v2
         with:
           path: "**/node_modules"
@@ -87,7 +118,7 @@ jobs:
           context: .
           file: ./docker/images/kuzzle/Dockerfile
           push: true
-          platforms: ${{ env.DOCKER_PLATFORMS }}
+          platforms: ${{ inputs.docker_platforms }}
           tags: kuzzleio/kuzzle:${{ steps.get-version.outputs.major-version }},kuzzleio/kuzzle:latest,kuzzleio/kuzzle:${{ steps.get-version.outputs.version }}
 
   npm-deploy:
@@ -99,7 +130,7 @@ jobs:
       - uses: ./.github/actions/install-packages
       - uses: actions/setup-node@v2
         with:
-          node-version: ${{ env.NODE_LTS_ACTIVE_VERSION }}
+          node-version: ${{ inputs.node_lts_active_version }}
           registry-url: "https://registry.npmjs.org"
       - run: npm install
       - run: npm publish

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -23,6 +23,9 @@ jobs:
           echo "::set-output name=matrix::{\"node-version\": [\"$NODE_LTS_MAINTENANCE_VERSION\", \"$NODE_LTS_ACTIVE_VERSION\"]}"
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      node_lts_active_version: ${{ env.NODE_LTS_ACTIVE_VERSION }}
+      node_lts_current_version: ${{ env.NODE_LTS_CURRENT_VERSION }}
+      docker_platforms: ${{ env.DOCKER_PLATFORMS }}
 
   danger-js:
     name: Danger JS
@@ -199,6 +202,10 @@ jobs:
 
   deploy-workflow:
     name: Deployment Workflow
-    needs: [cluster-monkey-tests]
+    needs: [cluster-monkey-tests, prepare-matrix]
     uses: ./.github/workflows/workflow-deployments.yaml
     secrets: inherit
+    with:
+      node_lts_active_version: ${{ needs.prepare-matrix.outputs.node_lts_active_version }}
+      node_lts_current_version: ${{ needs.prepare-matrix.outputs.node_lts_current_version }}
+      docker_platforms: ${{ needs.prepare-matrix.outputs.docker_platforms }}


### PR DESCRIPTION
## What does this PR do ?

This PR fixes missing parameters in the deployment workflow call.
Those parameters are declared in the main workflow as an `env` context, but according to [this page](https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations) `env` context from the caller workflow is not propagated to the called workflow.
This PR works around this limitation by passing parameters as `inputs`.