### PR TITLE
Allows to register realtime subscriptions from the backend

### DIFF
--- a/doc/2/framework/classes/backend-subscription/add/index.md
+++ b/doc/2/framework/classes/backend-subscription/add/index.md
@@ -1,7 +1,7 @@
 ---
 code: true
 type: page
-title: register | Framework | Core
+title: add | Framework | Core
 
 description: BackendSubscription.add method
 ---

--- a/doc/2/framework/classes/backend-subscription/add/index.md
+++ b/doc/2/framework/classes/backend-subscription/add/index.md
@@ -1,0 +1,67 @@
+---
+code: true
+type: page
+title: register | Framework | Core
+
+description: BackendSubscription.add method
+---
+
+# `add()`
+
+<SinceBadge version="auto-version" />
+
+Registers a new realtime subscription on the specified connection.
+
+This method is a backend version of the [realtime:subscribe](/core/2/api/controllers/realtime/subscribe) API action.
+
+This connection will then starts to receive realtime messages on the returned `roomId`.
+
+::: info
+This method can only be used before the application is started.
+:::
+
+```ts
+add(
+  connection: Connection,
+  index: string,
+  collection: string,
+  filters: JSONObject,
+  {
+    volatile,
+    scope,
+    users,
+  }: {
+    volatile?: JSONObject;
+    scope?: "in" | "out" | "all" | "none";
+    users?: "in" | "out" | "all" | "none";
+  }
+): Promise<{ roomId: string; channel: string }>
+```
+
+<br/>
+
+| Argument     | Type                  | Description                                            |
+| ------------ | --------------------- | ------------------------------------------------------ |
+| `connection` | <pre>Connection<pre>  | Connection to register the subscription on             |
+| `index`      | <pre>string</pre>     | Index name                                             |
+| `collection` | <pre>string</pre>     | Collection name                                        |
+| `filters`    | <pre>JSONObject</pre> | Subscription filters                                   |
+| `options`    | <pre>JSONObject</pre> | Subscription options (`volatile`, `scope` and `users`) |
+
+## Usage
+
+```js
+const { roomId, channel } = await app.subscription.add(
+  request.context.connection,
+  "lamaral",
+  "windsurf",
+  {
+    range: { wind: { gte: 20 } },
+  },
+  {
+    users: "all",
+    scope: "in",
+    volatile: { name: "Aschen" },
+  }
+);
+```

--- a/doc/2/framework/classes/backend-subscription/index.md
+++ b/doc/2/framework/classes/backend-subscription/index.md
@@ -1,0 +1,9 @@
+---
+type: branch
+title: BackendSubscription | Framework | Core
+
+description: BackendSubscription class definition
+code: true
+---
+
+<RedirectToFirstChild />

--- a/doc/2/framework/classes/backend-subscription/properties/index.md
+++ b/doc/2/framework/classes/backend-subscription/properties/index.md
@@ -1,0 +1,21 @@
+---
+code: false
+type: page
+title: Properties | Framework | Core
+
+description: BackendSubscription class properties
+---
+
+# BackendSubscription
+
+<SinceBadge version="auto-version" />
+
+The `BackendSubscription` class handles subscriptions to the realtime engine for a specific connection.
+
+It is accessible from the [Backend.subscription](/core/2/framework/classes/backend/properties#subscription) property.
+
+See the [Realtime Engine](/core/2/guides/main-concepts/realtime-engine) guide.
+
+::: info
+This class does not have any properties.
+:::

--- a/doc/2/framework/classes/backend-subscription/remove/index.md
+++ b/doc/2/framework/classes/backend-subscription/remove/index.md
@@ -1,0 +1,42 @@
+---
+code: true
+type: page
+title: remove | Framework | Core
+
+description: BackendSubscription.remove method
+---
+
+# `remove()`
+
+<SinceBadge version="auto-version" />
+
+Removes a realtime subscription on the specified connection.
+
+This method is a backend version of the [realtime:unsubscribe](/core/2/api/controllers/realtime/unsubscribe) API action.
+
+::: info
+This method can only be used before the application is started.
+:::
+
+```ts
+remove(
+  connection: Connection,
+  roomId: string,
+): Promise<void>
+```
+
+<br/>
+
+| Argument     | Type                 | Description                                |
+| ------------ | -------------------- | ------------------------------------------ |
+| `connection` | <pre>Connection<pre> | Connection to remove the subscription from |
+| `roomId`     | <pre>string</pre>    | Room identifier                            |
+
+## Usage
+
+```js
+await app.subscription.remove(
+  request.context.connection,
+  "<unique Kuzzle room identifier>"
+);
+```

--- a/doc/2/framework/classes/backend/properties/index.md
+++ b/doc/2/framework/classes/backend/properties/index.md
@@ -18,7 +18,6 @@ This property is an instance of the [BackendCluster](/core/2/framework/classes/b
 | ---------------------------------------------------------------------- | ----------------------- |
 | <pre>[BackendCluster](/core/2/framework/classes/backend-cluster)</pre> | BackendCluster instance |
 
-
 ## `commit`
 
 | Type              | Description                       |
@@ -147,6 +146,16 @@ This property is an instance of the [BackendStorage](/core/2/framework/classes/b
 | <pre>[BackendStorage](/core/2/framework/classes/backend-storage)</pre> | BackendStorage instance |
 
 See also the [Data Storage](/core/2/guides/main-concepts/data-storage#integrated-elasticsearch-client) guide.
+
+## `subscription`
+
+This property is an instance of the [BackendSubscription](/core/2/framework/classes/backend-subscription) class that allows to manage subscriptions to the realtime engine for a specific connection.
+
+| Type                                                                             | Description                  |
+| -------------------------------------------------------------------------------- | ---------------------------- |
+| <pre>[BackendSubscription](/core/2/framework/classes/backend-subscription)</pre> | BackendSubscription instance |
+
+See also the [Realtime Engine](/core/2/guides/main-concepts/realtime-engine) guide.
 
 ## `vault`
 

--- a/doc/2/guides/main-concepts/realtime-engine/index.md
+++ b/doc/2/guides/main-concepts/realtime-engine/index.md
@@ -523,9 +523,22 @@ async customSubscribe (request: Kuzzle Request) {
     }
   );
 
-  return { roomId };
+  return { roomId, channel };
 }
 
 ```
 
 Then, the specified connection will start to receive realtime notifications about the subscription. In the SDKs, those messages need to be listened.
+
+For example, with the Javascript SDK:
+
+```js
+const { result } = await sdk.query({
+  controller: "custom",
+  action: "subscribe",
+});
+
+sdk.protocol.on(result.channel, (notification) => {
+  console.log(notification);
+});
+```

--- a/doc/2/guides/main-concepts/realtime-engine/index.md
+++ b/doc/2/guides/main-concepts/realtime-engine/index.md
@@ -9,6 +9,7 @@ meta:
   - name: keywords
     content: Kuzzle, Documentation, Kuzzle API main concepts, Realtime Engine
 ---
+
 # Realtime Engine
 
 Kuzzle is shipped with its own **high-performance Realtime Engine** for sending notifications to clients connected through the API.
@@ -16,24 +17,27 @@ Kuzzle is shipped with its own **high-performance Realtime Engine** for sending 
 Realtime capabilities require the use of a **persistent communication protocol** such as WebSocket or MQTT.
 
 Kuzzle offers 2 different ways of doing realtime:
- - Volatile Pub/Sub System (see example on [Kuzzle tech blog](https://blog.kuzzle.io/pub-sub-for-real-time-applications))
- - Realtime Database Notifications (see example on [Kuzzle tech blog](https://blog.kuzzle.io/develop-a-new-generation-of-apps-with-kuzzle-real-time-engine))
+
+- Volatile Pub/Sub System (see example on [Kuzzle tech blog](https://blog.kuzzle.io/pub-sub-for-real-time-applications))
+- Realtime Database Notifications (see example on [Kuzzle tech blog](https://blog.kuzzle.io/develop-a-new-generation-of-apps-with-kuzzle-real-time-engine))
 
 ## Pub/Sub
 
 Kuzzle's Realtime Engine allows you to do **Pub/Sub in dedicated communication channels called rooms**.
 
 The process is as follows:
- - A first client subscribes to a particular room,
- - A second client posts a message in that room,
- - The first client receives a notification.
+
+- A first client subscribes to a particular room,
+- A second client posts a message in that room,
+- The first client receives a notification.
 
 ![kuzzle-pub-sub image description ](./pub-sub.png)
 
 Subscription to a room is done via the [realtime:subscribe](/core/2/api/controllers/realtime/subscribe) method. It takes 3 parameters, used to **describe a specific room**:
- - Name of an index,
- - Name of a collection,
- - Subscription filters contained in the `body` of the request.
+
+- Name of an index,
+- Name of a collection,
+- Subscription filters contained in the `body` of the request.
 
 ::: info
 In order to use Kuzzle in Pub/Sub mode only, the index and collection do not need to physically exist in the database (e.g. created in Kuzzle via the [index:create](/core/2/api/controllers/index/create) and [collection:create](/core/2/api/controllers/collection/create) methods of the API).
@@ -71,7 +75,8 @@ kourou realtime:subscribe nyc-open-data yellow-taxi
 
 Then clients wishing to post messages in this room must use the [realtime:publish](/core/2/api/controllers/realtime/publish) method by specifying the same index and collection names:
 
-Then you can also use Kourou in another terminal to publish a message:  
+Then you can also use Kourou in another terminal to publish a message:
+
 ```bash
 kourou realtime:publish nyc-open-data yellow-taxi '{
   name: "Manwë",
@@ -142,9 +147,10 @@ You can bypass notifications from being triggered by using actions from the [bul
 :::
 
 Subscription to a database changes is done via the [realtime:subscribe](/core/2/api/controllers/realtime/subscribe) method, taking 3 parameters:
- - Name of the index,
- - Name of the collection you want to watch,
- - Subscription filters contained in the `body` of the request.
+
+- Name of the index,
+- Name of the collection you want to watch,
+- Subscription filters contained in the `body` of the request.
 
 ::: info
 The specified index and collection **must exist in the database** to receive database notifications.
@@ -170,8 +176,8 @@ npx wscat -c ws://localhost:7512 --wait 300 --execute '{
 
 Creating a document with the [document:create](/core/2/api/controllers/document/create) method corresponds to a change in the database, so **clients subscribing to notifications in this collection will be notified**.
 
-
 Create a document with Kourou to trigger a Database Notification:
+
 ```bash
 kourou document:create nyc-open-data yellow-taxi '{
   controller: "document",
@@ -243,6 +249,7 @@ They are sent in the body of the request [realtime:subscribe](/core/2/api/contro
 A filter is composed of [clauses](core/2/api/koncorde-filters-syntax/clauses) that can be composed with [operators](/core/2/api/koncorde-filters-syntax/operators).
 
 For example if I want to receive only drivers with the `B` license:
+
 ```json
 {
   "controller": "realtime",
@@ -331,11 +338,13 @@ In addition to filters, it is possible to **specify options** to the [realtime:s
 The [scope](/core/2/api/controllers/realtime/subscribe#arguments) option allows you to specify whether you want to receive notifications regarding **documents entering or leaving the scope only**.
 
 This parameter can take 3 values:
- - `in`: receive only notifications about documents entering the scope
- - `out`: receive only notifications about documents exiting the scope
- - `all`: (default) receive everything
+
+- `in`: receive only notifications about documents entering the scope
+- `out`: receive only notifications about documents exiting the scope
+- `all`: (default) receive everything
 
 For example, to be informed of taxis arriving at central park:
+
 ```json
 {
   "controller": "realtime",
@@ -359,24 +368,25 @@ For example, to be informed of taxis arriving at central park:
 The [users](/core/2/api/controllers/realtime/subscribe#arguments) option allows you to receive additional notifications when **another client joins or leaves the same room**.
 
 This parameter can take 4 values:
- - `in`: only receive notifications when a client joins the room
- - `out`: only receive notifications when a client leaves the room
- - `all`: receive everything
- - `none`: (default) receive nothing
+
+- `in`: only receive notifications when a client joins the room
+- `out`: only receive notifications when a client leaves the room
+- `all`: receive everything
+- `none`: (default) receive nothing
 
 ```json
- {
-   "controller": "realtime",
-   "action": "subscribe",
-   "index": "nyc-open-data",
-   "collection": "yellow-taxi",
-   "body": {
-   },
-   "user": "all" 
- }
+{
+  "controller": "realtime",
+  "action": "subscribe",
+  "index": "nyc-open-data",
+  "collection": "yellow-taxi",
+  "body": {},
+  "user": "all"
+}
 ```
 
 Payload to send with wscat:
+
 ```bash
 # Use the "users" option to receive notification when a user enters or exits the room
 npx wscat -c ws://localhost:7512 --wait 300 --execute '{
@@ -385,7 +395,7 @@ npx wscat -c ws://localhost:7512 --wait 300 --execute '{
   "index": "nyc-open-data",
   "collection": "yellow-taxi",
   "body": {},
-  "users": "all" 
+  "users": "all"
 }'
 ```
 
@@ -421,6 +431,7 @@ More information about the [User Notification format](/core/2/api/payloads/notif
 When a request containing volatile data triggers a realtime notification, these **volatile data are included in the notification that will be sent** to the subscribing clients.
 
 First, subscribe to realtime notifications:
+
 ```bash
 npx wscat -c ws://localhost:7512 --wait 300 --execute '{
   "controller": "realtime",
@@ -432,6 +443,7 @@ npx wscat -c ws://localhost:7512 --wait 300 --execute '{
 ```
 
 Then, in another terminal you can publish a message in the room specifying volatile data:
+
 ```bash
 npx wscat -c ws://localhost:7512 --wait 300 --execute ' {
    "controller": "realtime",
@@ -486,3 +498,34 @@ Each client subscribing to the room will receive the following notification:
 ::: info
 SDKs and Kourou use volatile data to send additional information like the client name or version.
 :::
+
+## Subscribe a connection from the backend
+
+Realtime subscription can be added on a connection directly from the backend. This allows to restrict the usage of the [realtime:subscribe](/core/2/api/controllers/realtime/subscribe) and to add realtime subscription from a custom API action.
+
+The [Backend.subscription.add](/core/2/framework/classes/backend-subscription/add) method takes the same arguments as the [realtime:subscribe](/core/2/api/controllers/realtime/subscribe) API action but allows to register the subscription on any connection.
+
+**Example: _Subscribe to a room from a custom API action_**
+
+```js
+async customSubscribe (request: Kuzzle Request) {
+  const { roomId, channel } = await app.subscription.add(
+    request.context.connection,
+    "lamaral",
+    "windsurf",
+    {
+      range: { wind: { gte: 20 } },
+    },
+    {
+      users: "all",
+      scope: "in",
+      volatile: { name: "Aschen" },
+    }
+  );
+
+  return { roomId };
+}
+
+```
+
+Then, the specified connection will start to receive realtime notifications about the subscription. In the SDKs, those messages need to be listened.

--- a/docker/scripts/start-kuzzle-dev.ts
+++ b/docker/scripts/start-kuzzle-dev.ts
@@ -1,24 +1,33 @@
-'use strict';
+"use strict";
 
 // Starts a Kuzzle Backend application tailored for development
 // This loads a special plugin dedicated to functional tests
 
-import should from 'should/as-function';
-import { omit } from 'lodash';
+import should from "should/as-function";
+import { omit } from "lodash";
 
-import { Backend, KDocument, KDocumentContent, EventGenericDocumentBeforeUpdate, KuzzleRequest, Mutex, HttpStream } from '../../index';
-import { FunctionalTestsController } from './functional-tests-controller';
-import functionalFixtures from '../../features/fixtures/imports.json';
-import { PassThrough } from 'stream';
-import { EventGenericDocumentInjectMetadata } from '../../lib/types/events/EventGenericDocument';
+import {
+  Backend,
+  KDocument,
+  KDocumentContent,
+  EventGenericDocumentBeforeUpdate,
+  KuzzleRequest,
+  Mutex,
+  HttpStream,
+} from "../../index";
+import { FunctionalTestsController } from "./functional-tests-controller";
+import functionalFixtures from "../../features/fixtures/imports.json";
+import { PassThrough } from "stream";
+import { EventGenericDocumentInjectMetadata } from "../../lib/types/events/EventGenericDocument";
 
-const app = new Backend('functional-tests-app');
+const app = new Backend("functional-tests-app");
 
 async function loadAdditionalPlugins() {
-  const additionalPluginsIndex = process.argv.indexOf('--enable-plugins');
-  const additionalPlugins = additionalPluginsIndex > -1
-    ? process.argv[additionalPluginsIndex + 1].split(',')
-    : [];
+  const additionalPluginsIndex = process.argv.indexOf("--enable-plugins");
+  const additionalPlugins =
+    additionalPluginsIndex > -1
+      ? process.argv[additionalPluginsIndex + 1].split(",")
+      : [];
 
   for (const name of additionalPlugins) {
     const path = `../../plugins/available/${name}`;
@@ -28,12 +37,12 @@ async function loadAdditionalPlugins() {
 
     try {
       manifest = require(`${path}/manifest.json`);
-    }
-    catch (e) {
+    } catch (e) {
       // do nothing
     }
 
-    const options = manifest !== null ? { manifest, name: manifest.name } : null;
+    const options =
+      manifest !== null ? { manifest, name: manifest.name } : null;
 
     app.plugin.use(new Plugin(), options);
   }
@@ -41,49 +50,52 @@ async function loadAdditionalPlugins() {
 
 if (!process.env.CI) {
   // Easier debug
-  app.hook.register('request:onError', async (request: KuzzleRequest) => {
+  app.hook.register("request:onError", async (request: KuzzleRequest) => {
     app.log.error(request.error);
   });
 
-  app.hook.register('hook:onError', async (request: KuzzleRequest) => {
+  app.hook.register("hook:onError", async (request: KuzzleRequest) => {
     app.log.error(request.error);
   });
 }
 
-app.pipe.register<EventGenericDocumentInjectMetadata>('generic:document:injectMetadata', async (event) => {
-  const metadata = {
-    ...event.metadata,
-  };
+app.pipe.register<EventGenericDocumentInjectMetadata>(
+  "generic:document:injectMetadata",
+  async (event) => {
+    const metadata = {
+      ...event.metadata,
+    };
 
-  if (
-    event.request.getBody().addCustomMetadata ||
-    (event.request.getController() === 'document' &&
-      event.request.getAction() === 'upsert' &&
-      event.request.getBodyObject("changes", {}).addCustomMetadata)
-  ) {
-    metadata.customMetadata = 'customized';
-  }
+    if (
+      event.request.getBody().addCustomMetadata ||
+      (event.request.getController() === "document" &&
+        event.request.getAction() === "upsert" &&
+        event.request.getBodyObject("changes", {}).addCustomMetadata)
+    ) {
+      metadata.customMetadata = "customized";
+    }
 
-  return {
-    request: event.request,
-    metadata: metadata,
-    defaultMetadata: event.defaultMetadata,
+    return {
+      request: event.request,
+      metadata: metadata,
+      defaultMetadata: event.defaultMetadata,
+    };
   }
-});
+);
 
 // Controller class usage
 app.controller.use(new FunctionalTestsController(app));
 
 // Pipe management
-app.controller.register('pipes', {
+app.controller.register("pipes", {
   actions: {
     deactivateAll: {
       handler: async () => {
-        const names: any = await app.sdk.ms.keys('app:pipes:*');
+        const names: any = await app.sdk.ms.keys("app:pipes:*");
 
         for (const name of names) {
           const pipe = JSON.parse(await app.sdk.ms.get(name));
-          pipe.state = 'off';
+          pipe.state = "off";
           await app.sdk.ms.set(name, JSON.stringify(pipe));
         }
 
@@ -96,12 +108,40 @@ app.controller.register('pipes', {
         const state = request.input.args.state;
         const event = request.input.args.event;
 
-        await app.sdk.ms.set(`app:pipes:${event}`, JSON.stringify({
-          payload,
-          state,
-        }));
+        await app.sdk.ms.set(
+          `app:pipes:${event}`,
+          JSON.stringify({
+            payload,
+            state,
+          })
+        );
 
         return null;
+      },
+    },
+  },
+});
+
+app.controller.register("customSubscription", {
+  actions: {
+    subscribe: {
+      handler: async (request: KuzzleRequest) => {
+        const { roomId, channel } = await app.subscription.add(
+          request.context.connection,
+          "lamaral",
+          "windsurf",
+          {}
+        );
+
+        return { roomId, channel };
+      },
+    },
+    unsubscribe: {
+      handler: async (request: KuzzleRequest) => {
+        await app.subscription.remove(
+          request.context.connection,
+          request.input.args.roomId
+        );
       },
     },
   },
@@ -114,34 +154,46 @@ app.controller.register('pipes', {
  */
 function ensureEventDefinitionTypes() {
   type EventFoobar = {
-    name: 'event:foobar';
+    name: "event:foobar";
 
     args: [number, string];
-  }
+  };
 
-  app.pipe.register<EventFoobar>('event:foobar', async (age: number, name: string) => {
-    return age;
-  });
+  app.pipe.register<EventFoobar>(
+    "event:foobar",
+    async (age: number, name: string) => {
+      return age;
+    }
+  );
 
-  app.hook.register<EventFoobar>('event:foobar', (age: number, name: string) => {
-  });
+  app.hook.register<EventFoobar>(
+    "event:foobar",
+    (age: number, name: string) => {}
+  );
 
-  app.cluster.on<EventFoobar>('event:foobar', async (age: number, name: string) => {
-  });
+  app.cluster.on<EventFoobar>(
+    "event:foobar",
+    async (age: number, name: string) => {}
+  );
 
-  app.cluster.broadcast<EventFoobar>('event:foobar', 30);
+  app.cluster.broadcast<EventFoobar>("event:foobar", 30);
 
-  const promise: Promise<number> = app.trigger<EventFoobar>('event:foobar', 30, 'Tuan');
+  const promise: Promise<number> = app.trigger<EventFoobar>(
+    "event:foobar",
+    30,
+    "Tuan"
+  );
 
   interface PersonContent extends KDocumentContent {
     name: string;
   }
 
   app.pipe.register<EventGenericDocumentBeforeUpdate<PersonContent>>(
-    'generic:document:beforeUpdate',
+    "generic:document:beforeUpdate",
     async (documents: KDocument<PersonContent>[], request: KuzzleRequest) => {
-      return documents
-    });
+      return documents;
+    }
+  );
 }
 
 /**
@@ -149,81 +201,81 @@ function ensureEventDefinitionTypes() {
  */
 async function ensureQueryDefinitionTypes() {
   type Req = {
-    controller: 'engine';
-    action: 'create';
+    controller: "engine";
+    action: "create";
     engineId: string;
     body: {
       name: string;
-    }
-  }
+    };
+  };
 
   type Res = {
     age: number;
-  }
+  };
 
   const response = await app.sdk.query<Req, Res>({
-    controller: 'engine',
-    action: 'create',
-    engineId: 'test',
+    controller: "engine",
+    action: "create",
+    engineId: "test",
     body: {
-      name: 'test'
-    }
+      name: "test",
+    },
   });
 
   const age = response.result.age;
 }
 
 // Pipe registration
-app.pipe.register('server:afterNow', async (request) => {
-  const pipe = JSON.parse(await app.sdk.ms.get('app:pipes:server:afterNow'));
+app.pipe.register("server:afterNow", async (request) => {
+  const pipe = JSON.parse(await app.sdk.ms.get("app:pipes:server:afterNow"));
 
-  if (pipe && pipe.state !== 'off') {
-    request.response.result = { coworking: 'Spiced' };
+  if (pipe && pipe.state !== "off") {
+    request.response.result = { coworking: "Spiced" };
   }
 
   return request;
 });
 
 // Hook registration and embedded SDK realtime publish
-app.hook.register('custom:event', async (name) => {
-  await app.sdk.realtime.publish('app-functional-test', 'hooks', {
-    event: 'custom:event',
+app.hook.register("custom:event", async (name) => {
+  await app.sdk.realtime.publish("app-functional-test", "hooks", {
+    event: "custom:event",
     name,
   });
 });
 
-let syncedHello = 'World';
+let syncedHello = "World";
 let dynamicPipeId;
 
 app.openApi.definition.components.LogisticObjects = {
   Item: {
-    type: 'object',
+    type: "object",
     properties: {
-      name: { type: 'string' },
-      age: { type: 'integer' },
-    }
-  }
+      name: { type: "string" },
+      age: { type: "integer" },
+    },
+  },
 };
 
-app.controller.register('openapi-test', {
+app.controller.register("openapi-test", {
   actions: {
     hello: {
-      handler: async () => ({ hello: 'world' }),
+      handler: async () => ({ hello: "world" }),
       http: [
         {
-          verb: 'post',
-          path: '/openapi-test/:company/:objectType/:_id',
+          verb: "post",
+          path: "/openapi-test/:company/:objectType/:_id",
           openapi: {
-            description: 'Creates a new Logistic Object',
+            description: "Creates a new Logistic Object",
             parameters: [
               {
-                in: 'body',
-                description: 'Content of the Logistic Object',
+                in: "body",
+                description: "Content of the Logistic Object",
                 required: true,
                 schema: {
-                  $ref: '#/components/LogisticObjects/Item'
+                  $ref: "#/components/LogisticObjects/Item",
                 },
-              }
+              },
             ],
             responses: {
               200: {
@@ -232,77 +284,79 @@ app.controller.register('openapi-test', {
                   "application/json": {
                     schema: {
                       type: "string",
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      ]
-    }
-  }
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
 });
 
-app.controller.register('stream-test', {
+app.controller.register("stream-test", {
   actions: {
     downloadChunked: {
       handler: async () => {
         const stream = new PassThrough();
-        stream.write('Hello');
-        stream.write('World');
+        stream.write("Hello");
+        stream.write("World");
         stream.end();
 
         return new HttpStream(stream);
       },
       http: [
         {
-          verb: 'get',
-          path: '/stream-test/download-chunked',
-        }
-      ]
+          verb: "get",
+          path: "/stream-test/download-chunked",
+        },
+      ],
     },
     downloadFixed: {
       handler: async () => {
         const stream = new PassThrough();
-        stream.write('Hello');
-        stream.write('World');
+        stream.write("Hello");
+        stream.write("World");
         stream.end();
 
         return new HttpStream(stream, { totalBytes: 10 });
       },
       http: [
         {
-          verb: 'get',
-          path: '/stream-test/download-fixed',
-        }
-      ]
-    }
-  }
+          verb: "get",
+          path: "/stream-test/download-fixed",
+        },
+      ],
+    },
+  },
 });
 
-app.errors.register('app', 'api', 'custom', {
-  class: 'BadRequestError',
-  description: 'This is a custom error from API subdomain',
-  message: 'Custom %s error',
+app.errors.register("app", "api", "custom", {
+  class: "BadRequestError",
+  description: "This is a custom error from API subdomain",
+  message: "Custom %s error",
 });
 
 app.hook.register(
-  'generic:document:afterUpdate',
+  "generic:document:afterUpdate",
   async (documents, request: KuzzleRequest) => {
     await app.sdk.document.createOrReplace(
       request.getIndex(),
       request.getCollection(),
-      'generic:document:afterUpdate',
-      {});
-  });
+      "generic:document:afterUpdate",
+      {}
+    );
+  }
+);
 
-app.controller.register('tests', {
+app.controller.register("tests", {
   actions: {
     customError: {
       handler: async () => {
-        throw app.errors.get('app', 'api', 'custom', 'Tbilisi');
-      }
+        throw app.errors.get("app", "api", "custom", "Tbilisi");
+      },
     },
 
     // Controller registration and http route definition
@@ -310,29 +364,29 @@ app.controller.register('tests', {
       handler: async (request: KuzzleRequest) => {
         return { greeting: `Hello, ${request.input.args.name}` };
       },
-      http: [{ verb: 'post', path: '/hello/:name' }],
+      http: [{ verb: "post", path: "/hello/:name" }],
     },
 
     getSyncedHello: {
       handler: async () => `Hello, ${syncedHello}`,
-      http: [{ verb: 'get', path: '/hello' }],
+      http: [{ verb: "get", path: "/hello" }],
     },
 
     syncHello: {
       handler: async (request: KuzzleRequest) => {
         syncedHello = request.input.args.name;
-        await app.cluster.broadcast('sync:hello', { name: syncedHello });
-        return 'OK';
+        await app.cluster.broadcast("sync:hello", { name: syncedHello });
+        return "OK";
       },
-      http: [{ verb: 'put', path: '/syncHello/:name' }],
+      http: [{ verb: "put", path: "/syncHello/:name" }],
     },
 
     // Trigger custom event
     triggerEvent: {
       handler: async (request: KuzzleRequest) => {
-        await app.trigger('custom:event', request.input.args.name);
+        await app.trigger("custom:event", request.input.args.name);
 
-        return { trigger: 'custom:event', payload: request.input.args.name };
+        return { trigger: "custom:event", payload: request.input.args.name };
       },
     },
 
@@ -354,20 +408,20 @@ app.controller.register('tests', {
         const response = await client.index(esRequest);
         const response2 = await app.storage.storageClient.index(esRequest);
 
-        should(omit(response.body, ['_version', 'result', '_seq_no'])).match(
-          omit(response2.body, ['_version', 'result', '_seq_no'])
+        should(omit(response.body, ["_version", "result", "_seq_no"])).match(
+          omit(response2.body, ["_version", "result", "_seq_no"])
         );
 
         return response.body;
       },
-      http: [{ verb: 'post', path: '/tests/storage-client/:index' }],
+      http: [{ verb: "post", path: "/tests/storage-client/:index" }],
     },
 
     // Mutex class
     mutex: {
       handler: async (request: KuzzleRequest) => {
         const ttl = 5000;
-        const mutex = new Mutex('functionalTestMutexHandler', {
+        const mutex = new Mutex("functionalTestMutexHandler", {
           timeout: 0,
           ttl,
         });
@@ -376,57 +430,58 @@ app.controller.register('tests', {
 
         return { locked };
       },
-      http: [{ verb: 'get', path: '/tests/mutex/acquire' }],
+      http: [{ verb: "get", path: "/tests/mutex/acquire" }],
     },
 
     // Dynamic pipe registration
-    'register-pipe': {
+    "register-pipe": {
       handler: async () => {
         dynamicPipeId = app.pipe.register(
-          'server:afterNow',
-          async request => {
-            request.result.name = 'Ugo';
+          "server:afterNow",
+          async (request) => {
+            request.result.name = "Ugo";
 
             return request;
           },
-          { dynamic: true });
+          { dynamic: true }
+        );
 
         return dynamicPipeId;
-      }
+      },
     },
-    'unregister-pipe': {
+    "unregister-pipe": {
       handler: async () => {
         app.pipe.unregister(dynamicPipeId);
-      }
+      },
     },
     sendBodyHeaders: {
-      http: [{ verb: 'get', path: '/tests/body/sendeaders' }],
+      http: [{ verb: "get", path: "/tests/body/sendeaders" }],
       handler: async (request: KuzzleRequest) => {
         request.response.configure({
           headers: {
-            'set-cookie': 'foo=bar',
-            'foo': 'bar',
-            'alpha': 'beta',
-          }
+            "set-cookie": "foo=bar",
+            foo: "bar",
+            alpha: "beta",
+          },
         });
-      }
-    }
+      },
+    },
   },
 });
 
-let vaultfile = 'features/fixtures/secrets.enc.json';
+let vaultfile = "features/fixtures/secrets.enc.json";
 if (process.env.SECRETS_FILE_PREFIX) {
   vaultfile = process.env.SECRETS_FILE_PREFIX + vaultfile;
 }
 app.vault.file = vaultfile;
-app.vault.key = 'secret-password';
+app.vault.key = "secret-password";
 
 // Ensure imports before startup are working
-app.import.mappings(functionalFixtures.mappings)
-app.import.profiles(functionalFixtures.profiles)
-app.import.roles(functionalFixtures.roles)
-app.import.userMappings(functionalFixtures.userMappings)
-app.import.users(functionalFixtures.users, { onExistingUsers: 'overwrite' })
+app.import.mappings(functionalFixtures.mappings);
+app.import.profiles(functionalFixtures.profiles);
+app.import.roles(functionalFixtures.roles);
+app.import.userMappings(functionalFixtures.userMappings);
+app.import.users(functionalFixtures.users, { onExistingUsers: "overwrite" });
 
 loadAdditionalPlugins()
   .then(() => app.start())
@@ -434,11 +489,11 @@ loadAdditionalPlugins()
     // post-start methods here
 
     // Cluster synchronization
-    await app.cluster.on('sync:hello', (payload) => {
+    await app.cluster.on("sync:hello", (payload) => {
       syncedHello = payload.name;
     });
   })
-  .catch(error => {
+  .catch((error) => {
     console.error(error);
     process.exit(1);
   });

--- a/lib/core/backend/backend.ts
+++ b/lib/core/backend/backend.ts
@@ -24,7 +24,11 @@ import fs from "fs";
 import Kuzzle from "../../kuzzle";
 import { EmbeddedSDK } from "../shared/sdk/embeddedSdk";
 import * as kerror from "../../kerror";
-import { EventDefinition, JSONObject } from "../../../index";
+import {
+  BackendSubscription,
+  EventDefinition,
+  JSONObject,
+} from "../../../index";
 import {
   BackendCluster,
   BackendConfig,
@@ -207,6 +211,8 @@ export class Backend {
    */
   public errors: BackendErrors;
 
+  public subscription: BackendSubscription;
+
   /**
    * @deprecated
    *
@@ -276,6 +282,7 @@ export class Backend {
     this.cluster = new BackendCluster();
     this.openApi = new BackendOpenApi(this);
     this.errors = new BackendErrors(this);
+    this.subscription = new BackendSubscription(this);
 
     this.kerror = kerror;
 

--- a/lib/core/backend/backendSubscription.ts
+++ b/lib/core/backend/backendSubscription.ts
@@ -1,0 +1,94 @@
+/*
+ * Kuzzle, a backend software, self-hostable and ready to use
+ * to power modern apps
+ *
+ * Copyright 2015-2022 Kuzzle
+ * mailto: support AT kuzzle.io
+ * website: http://kuzzle.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { JSONObject } from "kuzzle-sdk";
+import { Connection, KuzzleRequest } from "../../api/request";
+import * as kerror from "../../kerror";
+import { ApplicationManager } from "./index";
+
+const runtimeError = kerror.wrap("plugin", "runtime");
+
+export class BackendSubscription extends ApplicationManager {
+  /**
+   * Registers a new realtime subscription on the specified connection
+   *
+   * @param connection Connection to register the subscription on
+   * @param index Index name
+   * @param collection Collection name
+   * @param filters Subscription filters
+   * @param options.volatile Volatile data
+   * @param options.scope Subscription scope
+   * @param options.users Option for users notifications
+   */
+  async add(
+    connection: Connection,
+    index: string,
+    collection: string,
+    filters: JSONObject,
+    {
+      volatile,
+      scope,
+      users,
+    }: {
+      volatile?: JSONObject;
+      scope?: "in" | "out" | "all" | "none";
+      users?: "in" | "out" | "all" | "none";
+    }
+  ): Promise<{ roomId: string; channel: string }> {
+    if (!this._application.started) {
+      throw runtimeError.get("unavailable_before_start", "subscriptions.add");
+    }
+
+    const subscriptionRequest = new KuzzleRequest(
+      {
+        action: "subscribe",
+        body: filters,
+        collection,
+        controller: "realtime",
+        index,
+        scope,
+        users,
+      },
+      {
+        volatile,
+        connectionId: connection.id,
+      }
+    );
+
+    const { result } = await global.kuzzle.ask(
+      "core:realtime:subscribe",
+      subscriptionRequest
+    );
+
+    return { roomId: result.roomId, channel: result.channel };
+  }
+
+  async remove(connection: Connection, roomId: string): Promise<void> {
+    if (!this._application.started) {
+      throw runtimeError.get(
+        "unavailable_before_start",
+        "subscriptions.remove"
+      );
+    }
+
+    await global.kuzzle.ask("core:realtime:unsubscribe", connection.id, roomId);
+  }
+}

--- a/lib/core/backend/backendSubscription.ts
+++ b/lib/core/backend/backendSubscription.ts
@@ -51,7 +51,7 @@ export class BackendSubscription extends ApplicationManager {
       volatile?: JSONObject;
       scope?: "in" | "out" | "all" | "none";
       users?: "in" | "out" | "all" | "none";
-    }
+    } = {}
   ): Promise<{ roomId: string; channel: string }> {
     if (!this._application.started) {
       throw runtimeError.get("unavailable_before_start", "subscriptions.add");
@@ -68,17 +68,17 @@ export class BackendSubscription extends ApplicationManager {
         users,
       },
       {
-        volatile,
         connectionId: connection.id,
+        volatile,
       }
     );
 
-    const { result } = await global.kuzzle.ask(
+    const { channel, roomId } = await global.kuzzle.ask(
       "core:realtime:subscribe",
       subscriptionRequest
     );
 
-    return { roomId: result.roomId, channel: result.channel };
+    return { channel, roomId };
   }
 
   async remove(connection: Connection, roomId: string): Promise<void> {

--- a/lib/core/backend/index.ts
+++ b/lib/core/backend/index.ts
@@ -25,3 +25,5 @@ export * from "./backendOpenApi";
 export * from "./internalLogger";
 
 export * from "./backendErrors";
+
+export * from "./backendSubscription";

--- a/package-lock.json
+++ b/package-lock.json
@@ -13590,29 +13590,12 @@
         "es6-iterator": "^2.0.3",
         "memoizee": "^0.4.15",
         "timers-ext": "^0.1.7"
-      },
-      "dependencies": {
-        "es5-ext": {
-          "version": "0.10.62",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-          "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-          "requires": {
-            "es6-iterator": "^2.0.3",
-            "es6-symbol": "^3.1.3",
-            "next-tick": "^1.1.0"
-          }
-        },
-        "next-tick": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-          "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-        }
       }
     },
     "cli-cursor": {
       "version": "4.0.0",
       "requires": {
-        "restore-cursor": "^3.1.0"
+        "restore-cursor": "^4.0.0"
       }
     },
     "cli-spinners": {
@@ -13638,11 +13621,6 @@
         "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-        },
         "is-fullwidth-code-point": {
           "version": "3.0.0"
         },
@@ -13652,16 +13630,6 @@
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
             "strip-ansi": "^6.0.1"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "6.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-              "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-              "requires": {
-                "ansi-regex": "^5.0.1"
-              }
-            }
           }
         },
         "wrap-ansi": {
@@ -14125,8 +14093,6 @@
         },
         "source-map": {
           "version": "0.8.0-beta.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-          "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
           "optional": true,
           "requires": {
             "whatwg-url": "^7.0.0"
@@ -14292,9 +14258,9 @@
     "es5-ext": {
       "version": "0.10.62",
       "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
       }
     },
     "es6-error": {
@@ -14376,12 +14342,6 @@
         "text-table": "^0.2.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        },
         "escape-string-regexp": {
           "version": "4.0.0"
         },
@@ -14752,7 +14712,7 @@
     "from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
@@ -15194,32 +15154,11 @@
         "wrap-ansi": "^8.0.1"
       },
       "dependencies": {
-        "ansi-escapes": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
-          "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
-          "requires": {
-            "type-fest": "^1.0.2"
-          }
-        },
         "ansi-regex": {
           "version": "6.0.1"
         },
         "chalk": {
           "version": "5.2.0"
-        },
-        "cli-cursor": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-          "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
-          "requires": {
-            "restore-cursor": "^4.0.0"
-          }
-        },
-        "cli-width": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.0.0.tgz",
-          "integrity": "sha512-ZksGS2xpa/bYkNzN3BAw1wEjsLV/ZKOf/CCrJ/QOBsxx6fOARIkwTutxp1XIOIohi6HKmOFjMoK/XaqDVUpEEw=="
         },
         "emoji-regex": {
           "version": "9.2.2"
@@ -16365,8 +16304,6 @@
     },
     "lodash.sortby": {
       "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "optional": true
     },
     "log-symbols": {
@@ -16492,13 +16429,6 @@
         "lru-queue": "^0.1.0",
         "next-tick": "^1.1.0",
         "timers-ext": "^0.1.7"
-      },
-      "dependencies": {
-        "next-tick": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-          "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-        }
       }
     },
     "merge-stream": {
@@ -16694,12 +16624,6 @@
             }
           }
         },
-        "nanoid": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-          "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
-          "dev": true
-        },
         "string-width": {
           "version": "4.2.3",
           "dev": true,
@@ -16708,21 +16632,6 @@
             "is-fullwidth-code-point": "^3.0.0",
             "strip-ansi": "^6.0.1"
           }
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-          "dev": true
         },
         "supports-color": {
           "version": "8.1.1",
@@ -16986,11 +16895,6 @@
         "which": "^2.0.2"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-        },
         "are-we-there-yet": {
           "version": "3.0.1",
           "requires": {
@@ -17044,14 +16948,6 @@
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
             "strip-ansi": "^6.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "requires": {
-            "ansi-regex": "^5.0.1"
           }
         },
         "tar": {
@@ -17458,14 +17354,6 @@
         "chalk": {
           "version": "5.2.0"
         },
-        "cli-cursor": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-          "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
-          "requires": {
-            "restore-cursor": "^4.0.0"
-          }
-        },
         "is-unicode-supported": {
           "version": "1.3.0"
         },
@@ -17474,15 +17362,6 @@
           "requires": {
             "chalk": "^5.0.0",
             "is-unicode-supported": "^1.1.0"
-          }
-        },
-        "restore-cursor": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-          "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
-          "requires": {
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2"
           }
         },
         "strip-ansi": {
@@ -18288,15 +18167,6 @@
               "version": "4.0.0",
               "dev": true
             },
-            "strip-ansi": {
-              "version": "6.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-              "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^5.0.1"
-              }
-            },
             "supports-color": {
               "version": "7.2.0",
               "dev": true,
@@ -18394,41 +18264,7 @@
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
             "strip-ansi": "^6.0.1"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "6.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-              "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^5.0.1"
-              }
-            }
           }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-              "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-              "dev": true
-            }
-          }
-        },
-        "strip-json-comments": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-          "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
@@ -18483,15 +18319,7 @@
     "rxjs": {
       "version": "7.8.0",
       "requires": {
-        "tslib": "^1.9.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
-        }
+        "tslib": "^2.1.0"
       }
     },
     "safe-buffer": {
@@ -19285,10 +19113,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
     },
-    "uWebSockets.js": {
-      "version": "https://github.com/uNetworking/uWebSockets.js/archive/refs/tags/v20.0.0.tar.gz",
-      "integrity": "sha1-uixCeYYVB2NktqHxRuifGx5CSp0="
-    },
     "unbox-primitive": {
       "version": "1.0.2",
       "optional": true,
@@ -19377,6 +19201,10 @@
     },
     "uuid-parse": {
       "version": "1.1.0"
+    },
+    "uWebSockets.js": {
+      "version": "https://github.com/uNetworking/uWebSockets.js/archive/refs/tags/v20.0.0.tar.gz",
+      "integrity": "sha1-uixCeYYVB2NktqHxRuifGx5CSp0="
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -19639,11 +19467,6 @@
         "yargs-parser": "^21.1.1"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-        },
         "get-caller-file": {
           "version": "2.0.5"
         },


### PR DESCRIPTION
## What does this PR do ?

Realtime subscription can be added on a connection directly from the backend. This allows to restrict the usage of the [realtime:subscribe](/core/2/api/controllers/realtime/subscribe) and to add realtime subscription from a custom API action.

The [Backend.subscription.add](/core/2/framework/classes/backend-subscription/add) method takes the same arguments as the [realtime:subscribe](/core/2/api/controllers/realtime/subscribe) API action but allows to register the subscription on any connection.

**Example: _Subscribe to a room from a custom API action_**

```js
async customSubscribe (request: Kuzzle Request) {
  const { roomId, channel } = await app.subscription.add(
    request.context.connection,
    "lamaral",
    "windsurf",
    {
      range: { wind: { gte: 20 } },
    },
    {
      users: "all",
      scope: "in",
      volatile: { name: "Aschen" },
    }
  );

  return { roomId, channel };
}

```

Then, the specified connection will start to receive realtime notifications about the subscription. In the SDKs, those messages need to be listened.

For example, with the Javascript SDK:

```js
const { result } = await sdk.query({
  controller: "custom",
  action: "subscribe",
});

sdk.protocol.on(result.channel, (notification) => {
  console.log(notification);
});
```
