### PR TITLE
Ensure the ID Card Renewer is killed when the main process exit or is killed with a signal

### DIFF
--- a/lib/cluster/idCardHandler.ts
+++ b/lib/cluster/idCardHandler.ts
@@ -181,9 +181,13 @@ export class ClusterIdCardHandler {
       }
     });
 
-    this.refreshWorker.on("close", () => {
-      this.disposed = true;
+    this.refreshWorker.on("close", async () => {
+      if (!this.disposed) {
+        this.disposed = true;
+        await this.node.evictSelf('ID Card renewer worker closed unexpectedly');
+      }
     });
+
 
     // Transfer informations to the worker
     this.refreshWorker.send({
@@ -209,7 +213,18 @@ export class ClusterIdCardHandler {
    * Helper method to mock worker instantiation in unit tests
    */
   private constructWorker(path: string): ChildProcess {
-    return fork(path);
+    const childProcess = fork(path);
+
+    const exitHandler = () => {
+      if (!childProcess.killed || childProcess.connected) {
+        childProcess.kill();
+      }
+    };
+
+    process.on("exit", exitHandler);
+    process.on("SIGINT", exitHandler);
+    process.on("SIGTERM", exitHandler);
+    return childProcess;
   }
 
   /**

--- a/lib/cluster/idCardHandler.ts
+++ b/lib/cluster/idCardHandler.ts
@@ -184,10 +184,9 @@ export class ClusterIdCardHandler {
     this.refreshWorker.on("close", async () => {
       if (!this.disposed) {
         this.disposed = true;
-        await this.node.evictSelf('ID Card renewer worker closed unexpectedly');
+        await this.node.evictSelf("ID Card renewer worker closed unexpectedly");
       }
     });
-
 
     // Transfer informations to the worker
     this.refreshWorker.send({

--- a/lib/cluster/idCardHandler.ts
+++ b/lib/cluster/idCardHandler.ts
@@ -219,6 +219,7 @@ export class ClusterIdCardHandler {
       if (!childProcess.killed || childProcess.connected) {
         childProcess.kill();
       }
+      process.exit();
     };
 
     process.on("exit", exitHandler);

--- a/lib/cluster/workers/IDCardRenewer.js
+++ b/lib/cluster/workers/IDCardRenewer.js
@@ -135,4 +135,9 @@ process.on("message", async (message) => {
   }
 });
 
+// When the IPC is closed on the main process side
+process.on('disconnect', () => {
+  process.exit();
+});
+
 module.exports = { IDCardRenewer };

--- a/lib/cluster/workers/IDCardRenewer.js
+++ b/lib/cluster/workers/IDCardRenewer.js
@@ -136,7 +136,7 @@ process.on("message", async (message) => {
 });
 
 // When the IPC is closed on the main process side
-process.on('disconnect', () => {
+process.on("disconnect", () => {
   process.exit();
 });
 


### PR DESCRIPTION
## What does this PR do ?

Ensure the ID Card Renewer is killed when the main process exit or is killed with a signal.

Especially when using the Ergol to hot restart Kuzzle when developing.