### PR TITLE
Replace wrong dev:docker command with docker:dev in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,15 +52,14 @@ npx kourou app:scaffold playground
 
  🚀 Kourou - Scaffolds a new Kuzzle application
 
-  ✔ Creating playground/ directory
   ✔ Creating and rendering application files
-  ✔ Installing latest Kuzzle version via NPM and Docker (this can take some time)
- [✔] Scaffolding complete! Use "npm run dev:docker" to run your application
+
+ [✔] Scaffolding complete! Use cd playground && npm run docker npm install install dependencies and then npm run docker:dev to run your application!
 ```
 
 Then you need to run Kuzzle services, Elasticsearch and Redis: `kourou app:start-services`
 
-Finally you can run your application inside Docker with `npm run dev:docker`
+Finally you can run your application inside Docker with `npm run docker:dev`
 
 Kuzzle is now listening for requests on the port `7512`!
 

--- a/doc/2/guides/getting-started/customize-api-behavior/index.md
+++ b/doc/2/guides/getting-started/customize-api-behavior/index.md
@@ -33,7 +33,7 @@ The format of those events is the following:
  - `<controller>:before<Action>`: emitted before processing
  - `<controller>:after<Action>`: emitted after processing, before sending back the response
 
-Restarts your application with the following command to display events: `DEBUG=kuzzle:events npm run dev:docker`
+Restarts your application with the following command to display events: `DEBUG=kuzzle:events npm run docker:dev`
 
 ::: info
 Kuzzle uses the [debug](https://www.npmjs.com/package/debug) package to display messages.  

--- a/doc/2/guides/getting-started/run-kuzzle/index.md
+++ b/doc/2/guides/getting-started/run-kuzzle/index.md
@@ -91,10 +91,10 @@ app
   .catch(console.error);
 ```
 
-We can now run our first application with `npm run dev:docker`
+We can now run our first application with `npm run docker:dev`
 
 ::: info
-Under the hood, the command `npm run dev:docker` uses [nodemon](https://nodemon.io/) and [ts-node](https://www.npmjs.com/package/ts-node) inside the Docker container to run the application.
+Under the hood, the command `npm run docker:dev` uses [nodemon](https://nodemon.io/) and [ts-node](https://www.npmjs.com/package/ts-node) inside the Docker container to run the application.
 :::
 
 Now visit [http://localhost:7512](http://localhost:7512) with your browser. You should see the result of the [server:info](/core/2/api/controllers/server/info) action.


### PR DESCRIPTION
## What does this PR do ?

This PR replace the command `npm run dev:docker` (which doesn't exist anymore) with the right one: `npm run docker:dev`.
It also updates the output of `kourou app:scaffold`.