### PR TITLE
update node version to <= 16 instead of >= 12

### DIFF
--- a/doc/2/guides/getting-started/run-kuzzle/index.md
+++ b/doc/2/guides/getting-started/run-kuzzle/index.md
@@ -20,7 +20,7 @@ In this guide we will use Docker and Docker Compose to run those services.
 
 ### Prerequisites
 
-- [Node.js >= 12](https://nodejs.org/en/download/)
+- [Node.js <= 16](https://nodejs.org/en/download/)
 - [Docker](https://docs.docker.com/engine/install/)
 - [Docker Compose](https://docs.docker.com/compose/install/)
 - [Kourou](https://github.com/kuzzleio/kourou)


### PR DESCRIPTION
## Just update the node version to avoid any mistakes for new users

By doing this we can reduce frustration for new users who try to run kuzzle for the first time and deal with an error. 