### PR TITLE
fix(getting started): update node version to support 18

### DIFF
--- a/doc/2/guides/getting-started/run-kuzzle/index.md
+++ b/doc/2/guides/getting-started/run-kuzzle/index.md
@@ -20,7 +20,7 @@ In this guide we will use Docker and Docker Compose to run those services.
 
 ### Prerequisites
 
-- [Node.js <= 16](https://nodejs.org/en/download/)
+- [Node.js <= 18](https://nodejs.org/en/download/)
 - [Docker](https://docs.docker.com/engine/install/)
 - [Docker Compose](https://docs.docker.com/compose/install/)
 - [Kourou](https://github.com/kuzzleio/kourou)


### PR DESCRIPTION
## Update the node version in the doc
kuzzle now accepts node 18 :tada: 

https://github.com/kuzzleio/kuzzle/releases/tag/2.24.0

### How should this be manually tested?

  - Step 1 : kourou app:scaffold test
  - Step 2 : cd test && npm run docker npm install
  - Step 3 : npm run docker:dev
  - Step 4: check the admin console
