### PR TITLE
Delete ID Card directly from Redis when Kuzzle is shutting down

### DIFF
--- a/lib/cluster/idCardHandler.ts
+++ b/lib/cluster/idCardHandler.ts
@@ -216,7 +216,11 @@ export class ClusterIdCardHandler {
 
     const exitHandler = () => {
       if (!childProcess.killed || childProcess.connected) {
-        childProcess.kill();
+        try {
+          childProcess.disconnect();
+        } catch (e) {
+          // It could happens that the worker has been killed before the dispose causing disconnect to fail
+        }
       }
       process.exit();
     };

--- a/lib/cluster/workers/IDCardRenewer.js
+++ b/lib/cluster/workers/IDCardRenewer.js
@@ -136,7 +136,8 @@ process.on("message", async (message) => {
 });
 
 // When the IPC is closed on the main process side
-process.on("disconnect", () => {
+process.on("disconnect", async () => {
+  await idCardRenewer.dispose();
   process.exit();
 });
 


### PR DESCRIPTION
## What does this PR do ?

This PR forces the ID Card Renewer process to delete the node ID Card from Redis when Kuzzle is shutting down for whatever reason, this will allow nodes to be restarted much faster and avoid the error `[CLUSTER] Another node share the same IP address as this one (10.84.65.9): knode-regular-greer-69286. Shutting down.` because of the ID Card not being expired before the node had restarted.

