### PR TITLE
Fix document:search error response when index or collection are missing

### DIFF
--- a/lib/api/controllers/documentController.js
+++ b/lib/api/controllers/documentController.js
@@ -131,6 +131,14 @@ class DocumentController extends NativeController {
         { from, scroll: scrollTTL, size }
       );
     } else {
+      if (!index) {
+        throw kerror.get("api", "assert", "missing_argument", "index");
+      }
+
+      if (!collection) {
+        throw kerror.get("api", "assert", "missing_argument", "collection");
+      }
+
       result = await this.ask(
         "core:storage:public:document:search",
         index,

--- a/test/api/controllers/documentController.test.js
+++ b/test/api/controllers/documentController.test.js
@@ -111,6 +111,30 @@ describe("DocumentController", () => {
       );
     });
 
+    it("should reject if no index is provided and there is no target", async () => {
+      request.input.args.index = undefined;
+      request.input.args.collection = 'foo';
+      request.input.args.targets = undefined;
+      request.input.action = "search";
+
+      await should(documentController.search(request)).rejectedWith(
+        BadRequestError,
+        { id: "api.assert.missing_argument", message: 'Missing argument "index".' }
+      );
+    });
+
+    it("should reject if no collection is provided and there is no target", async () => {
+      request.input.args.index = "foo";
+      request.input.args.collection = undefined;
+      request.input.args.targets = undefined;
+      request.input.action = "search";
+
+      await should(documentController.search(request)).rejectedWith(
+        BadRequestError,
+        { id: "api.assert.missing_argument", message: 'Missing argument "collection".' }
+      );
+    });
+
     it("should verify that targets are valid", async () => {
       request.input.args.index = null;
       request.input.args.collection = null;

--- a/test/api/controllers/documentController.test.js
+++ b/test/api/controllers/documentController.test.js
@@ -113,13 +113,16 @@ describe("DocumentController", () => {
 
     it("should reject if no index is provided and there is no target", async () => {
       request.input.args.index = undefined;
-      request.input.args.collection = 'foo';
+      request.input.args.collection = "foo";
       request.input.args.targets = undefined;
       request.input.action = "search";
 
       await should(documentController.search(request)).rejectedWith(
         BadRequestError,
-        { id: "api.assert.missing_argument", message: 'Missing argument "index".' }
+        {
+          id: "api.assert.missing_argument",
+          message: 'Missing argument "index".',
+        }
       );
     });
 
@@ -131,7 +134,10 @@ describe("DocumentController", () => {
 
       await should(documentController.search(request)).rejectedWith(
         BadRequestError,
-        { id: "api.assert.missing_argument", message: 'Missing argument "collection".' }
+        {
+          id: "api.assert.missing_argument",
+          message: 'Missing argument "collection".',
+        }
       );
     });
 


### PR DESCRIPTION
## What does this PR do ?

Fixes an issue where `document:search` was not returning the proper `missing_argument` error when index or collection was missing
