### PR TITLE
Add http protocol parameter additionalContentTypes

### DIFF
--- a/.ci/test-cluster.yml
+++ b/.ci/test-cluster.yml
@@ -26,6 +26,7 @@ x-kuzzle-config: &kuzzle-config
     - kuzzle_server__protocols__mqtt__developmentMode=false
     - kuzzle_http__accessControlAllowOrigin=localhost
     - kuzzle_limits__loginsPerSecond=50
+    - kuzzle_server__protocols__http__additionalContentTypes=*json:["application/x-yaml"]
     - NODE_ENV=development
     - NODE_VERSION=${NODE_VERSION:-}
     - DEBUG=none

--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -405,14 +405,14 @@
     "protocols": {
       "http": {
         // * additionalContentTypes:
-        //    Allows additional Content-Types to be accepted by Kuzzle.
+        //    Enables Kuzzle to accept additional Content-Types.
+        //    Note: This relies on the implementation of a
+        //    "protocol:http:beforeParsingPayload" pipe that implements
+        //    the formatting of the additional content types to JSON.
         //    The default content types are:
         //      * application/json
         //      * application/x-www-form-urlencoded
         //      * multipart/form-data
-        //    Note: This relies on the implementation of a
-        //    "protocol:http:beforeParsingPayload" pipe that implements
-        //    the formatting of the additional content types to JSON.
         // * allowCompression:
         //    Enable support for compressed requests, using the
         //    Content-Encoding header

--- a/.kuzzlerc.sample
+++ b/.kuzzlerc.sample
@@ -404,6 +404,15 @@
     // protocols can be extended and configured in this section.
     "protocols": {
       "http": {
+        // * additionalContentTypes:
+        //    Allows additional Content-Types to be accepted by Kuzzle.
+        //    The default content types are:
+        //      * application/json
+        //      * application/x-www-form-urlencoded
+        //      * multipart/form-data
+        //    Note: This relies on the implementation of a
+        //    "protocol:http:beforeParsingPayload" pipe that implements
+        //    the formatting of the additional content types to JSON.
         // * allowCompression:
         //    Enable support for compressed requests, using the
         //    Content-Encoding header
@@ -421,6 +430,7 @@
         //    allocate as many decoders to handle the incoming request.
         // * maxFormFileSize:
         //    Maximum size of requests sent via http forms
+        "additionalContentTypes": [],
         "allowCompression": true,
         "enabled": true,
         "maxEncodingLayers": 3,

--- a/doc/2/api/protocols/http/index.md
+++ b/doc/2/api/protocols/http/index.md
@@ -58,14 +58,14 @@ The listening port can be modified under the `server.port` section of the [confi
         // compression support is disabled
         "allowCompression": true,
 
-        // Allows additional Content-Types to be accepted by Kuzzle.
+        // Enables Kuzzle to accept additional Content-Types.
+        // Note: This relies on the implementation of a
+        // "protocol:http:beforeParsingPayload" pipe that implements
+        // the formatting of the additional content types to JSON.
         // The default content types are:
         //  * application/json
         //  * application/x-www-form-urlencoded
         //  * multipart/form-data
-        // Note: This relies on the implementation of a
-        // "protocol:http:beforeParsingPayload" pipe that implements
-        // the formatting of the additional content types to JSON.
         "additionalContentTypes": [],
       },
   }

--- a/doc/2/api/protocols/http/index.md
+++ b/doc/2/api/protocols/http/index.md
@@ -56,10 +56,21 @@ The listening port can be modified under the `server.port` section of the [confi
         //   gzip, deflate, identity
         // Note: "identity" is always an accepted value, even if
         // compression support is disabled
-        "allowCompression": true
+        "allowCompression": true,
+
+        // Allows additional Content-Types to be accepted by Kuzzle.
+        // The default content types are:
+        //  * application/json
+        //  * application/x-www-form-urlencoded
+        //  * multipart/form-data
+        // Note: This relies on the implementation of a
+        // "protocol:http:beforeParsingPayload" pipe that implements
+        // the formatting of the additional content types to JSON.
+        "additionalContentTypes": [],
       },
   }
 ```
+
 ::: warning
 HTTP and WebSocket protocols share the same underlying server instance.
 Modifying the listening port will impact these two protocols.

--- a/doc/2/guides/advanced/content-types/index.md
+++ b/doc/2/guides/advanced/content-types/index.md
@@ -1,0 +1,90 @@
+---
+code: false
+type: page
+order: 900
+title: Additional Content Types | Kuzzle Advanced | Guide | Core
+meta:
+  - name: description
+    content: Support additional content types
+  - name: keywords
+    content: Kuzzle, Documentation, kuzzle write pluggins, General purpose backend, opensource, content-type, iot, backend
+---
+
+# Additional Content Types
+
+<SinceBadge version="2.25.0" />
+
+By default, Kuzzle supports common HTTP content types like JSON and form data.
+
+However, there may be cases where you need to support additional content types such as YAML.
+
+This documentation guide will explain how to extend Kuzzle's capabilities to handle custom content types.
+
+## Configuring Kuzzle
+
+The `server.protocols.http.additionalContentTypes` configuration setting in the [kuzzlerc configuration file](/core/2/guides/advanced/configuration) allows you to specify additional content types that Kuzzle should support.
+
+It takes an array of strings, where each string represents a content type.
+
+```javascript
+"server": {
+  "protocols": {
+    "http": {
+      // Enables Kuzzle to accept additional Content-Types.
+      // Note: This relies on the implementation of a
+      // "protocol:http:beforeParsingPayload" pipe that implements
+      // the formatting of the additional content types to JSON.
+      "additionalContentTypes": [
+        "application/x-yaml"
+      ]
+    }
+  }
+}
+```
+
+:::info
+The default content types are:
+
+- application/json
+- application/x-www-form-urlencoded
+- multipart/form-data
+:::
+
+## Implementing the `protocol:http:beforeParsingPayload` pipe
+
+To convert the payload of the custom content type to a format that Kuzzle can handle (e.g., JSON), you need to implement the `protocol:http:beforeParsingPayload` pipe.
+
+This pipe intercepts the incoming HTTP request, allowing you to modify the payload before Kuzzle parses it.
+
+The `protocol:http:beforeParsingPayload` pipe is a function that takes an object as an argument, containing two properties:
+
+- `message`: An object of type HttpMessage, containing information about the HTTP request.
+- `payload`: A Buffer containing the raw payload data.
+
+Your implementation should return an object containing a single `payload` property, which holds the converted payload.
+
+Here's an example implementation of the `protocol:http:beforeParsingPayload` pipe, converting YAML to JSON:
+
+```typescript
+const yamlToJsonPipe = ({
+  message,
+  payload,
+}: {
+  message: HttpMessage;
+  payload: Buffer;
+}): { payload: string } => {
+  if (message.headers["content-type"] !== "application/x-yaml") {
+    return { payload };
+  }
+
+  const convertedPayload = YAML.parse(payload.toString());
+
+  return { payload: JSON.stringify(convertedPayload) };
+};
+```
+
+That pipe can then be registered in your backend:
+
+```typescript
+app.pipe.register("protocol:http:beforeParsingPayload", yamlToJsonPipe);
+```

--- a/docker/scripts/functional-tests-controller.ts
+++ b/docker/scripts/functional-tests-controller.ts
@@ -11,6 +11,10 @@ export class FunctionalTestsController extends Controller {
         },
         byeWorld: {
           handler: this.byeWorld
+        },
+        postHelloWorld: {
+          handler: this.postHelloWorld,
+          http: [{path: 'functional-tests/hello-world', verb: 'post'}]
         }
       }
     };
@@ -23,5 +27,9 @@ export class FunctionalTestsController extends Controller {
   async byeWorld () {
     // ensure the "app" property is usable
     return this.app.sdk.document.create('test', 'test', { message: 'bye' });
+  }
+
+  async postHelloWorld (request: Request) {
+    return { greeting: `Hello, ${request.getBodyString("name")}` };
   }
 }

--- a/jest/network/http/http-additional-content-types.test.ts
+++ b/jest/network/http/http-additional-content-types.test.ts
@@ -1,0 +1,20 @@
+import rp from 'request-promise';
+import YAML from 'yaml';
+
+test('Check additional content type', async () => {
+  const postData = YAML.stringify({ name: 'Martial' });
+
+  const response = rp.post({
+    uri: "http://localhost:17510/_/functional-tests/hello-world",
+    headers: {
+      'Content-Type': 'application/x-yaml',
+      'Content-Length': Buffer.byteLength(postData),
+    },
+    body: postData,
+    transform: (body) => JSON.parse(body)
+  });
+    
+  await expect(response).resolves.toMatchObject({
+    result: { greeting: "Hello, Martial" }
+  });
+});

--- a/lib/config/default.config.ts
+++ b/lib/config/default.config.ts
@@ -218,6 +218,7 @@ const defaultConfig: KuzzleConfiguration = {
     port: 7512,
     protocols: {
       http: {
+        additionalContentTypes: [],
         allowCompression: true,
         enabled: true,
         maxEncodingLayers: 3,

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -236,9 +236,15 @@ function checkHttpOptions(config) {
     `[http] "maxFormFileSize" parameter: cannot parse "${cfg.maxFormFileSize}"`
   );
   cfg.maxFormFileSize = maxFormFileSize;
+
   assert(
     typeof config.http.cookieAuthentication === "boolean",
     `[http] "cookieAuthentication" parameter: invalid value "${config.http.cookieAuthentication}" (boolean expected)`
+  );
+  assert(
+    Array.isArray(cfg.additionalContentTypes) &&
+      cfg.additionalContentTypes.every((ct) => typeof ct === "string"),
+    `[http] "additionalContentTypes" parameter: invalid value "${cfg.additionalContentTypes}" (array of strings expected)`
   );
 }
 

--- a/lib/core/network/protocols/httpwsProtocol.js
+++ b/lib/core/network/protocols/httpwsProtocol.js
@@ -502,7 +502,7 @@ class HttpWsProtocol extends Protocol {
 
     if (
       contentType &&
-      !HTTP_ALLOWED_CONTENT_TYPES.some((allowed) =>
+      !this.httpConfig.opts.allowedContentTypes.some((allowed) =>
         contentType.includes(allowed)
       )
     ) {
@@ -1194,6 +1194,10 @@ class HttpWsProtocol extends Protocol {
       headers,
       opts: {
         allowCompression: cfg.allowCompression,
+        allowedContentTypes: [
+          ...HTTP_ALLOWED_CONTENT_TYPES,
+          ...cfg.additionalContentTypes,
+        ],
         maxEncodingLayers: cfg.maxEncodingLayers,
         maxFormFileSize: cfg.maxFormFileSize,
       },

--- a/lib/types/config/ServerConfiguration.ts
+++ b/lib/types/config/ServerConfiguration.ts
@@ -75,6 +75,19 @@ export type ServerConfiguration = {
   protocols: {
     http: {
       /**
+       * Allows additional Content-Types to be accepted by Kuzzle.
+       * The default content types are:
+       *   * application/json
+       *   * application/x-www-form-urlencoded
+       *   * multipart/form-data
+       * Note: This relies on the implementation of a
+       * "protocol:http:beforeParsingPayload" pipe that implements
+       * the formatting of the additional content types to JSON.
+       * @default []
+       */
+      additionalContentTypes: string[];
+
+      /**
        * Enable support for compressed requests, using the Content-Encoding header
        * Currently supported compression algorithms:  gzip, deflate, identity
        * Note: "identity" is always an accepted value, even if compression support is disabled

--- a/lib/types/config/ServerConfiguration.ts
+++ b/lib/types/config/ServerConfiguration.ts
@@ -75,14 +75,14 @@ export type ServerConfiguration = {
   protocols: {
     http: {
       /**
-       * Allows additional Content-Types to be accepted by Kuzzle.
+       * Enables Kuzzle to accept additional Content-Types.
+       * Note: This relies on the implementation of a
+       * "protocol:http:beforeParsingPayload" pipe that implements
+       * the formatting of the additional content types to JSON.
        * The default content types are:
        *   * application/json
        *   * application/x-www-form-urlencoded
        *   * multipart/form-data
-       * Note: This relies on the implementation of a
-       * "protocol:http:beforeParsingPayload" pipe that implements
-       * the formatting of the additional content types to JSON.
        * @default []
        */
       additionalContentTypes: string[];

--- a/test/core/network/protocols/http.test.js
+++ b/test/core/network/protocols/http.test.js
@@ -44,6 +44,7 @@ describe("core/network/protocols/http", () => {
       },
       protocols: {
         http: {
+          additionalContentTypes: [],
           allowCompression: true,
           enabled: true,
           maxEncodingLayers: 3,

--- a/test/core/network/protocols/websocket.test.js
+++ b/test/core/network/protocols/websocket.test.js
@@ -40,6 +40,7 @@ describe("core/network/protocols/websocket", () => {
       port: 7512,
       protocols: {
         http: {
+          additionalContentTypes: [],
           allowCompression: true,
           enabled: true,
           maxEncodingLayers: 3,


### PR DESCRIPTION
## What does this PR do ?
Implements a new `kuzzlerc` settings for the http protocol, that allows specifying additional accepted `Content-Type`s.
Note: This requires the matching implementation of a `protocol:http:beforeParsingPayload` pipe that is able to convert to JSON the payloads received with those new Content-Types.