### PR TITLE
Mandatory query param in deleteByQuery

### DIFF
--- a/lib/api/controllers/documentController.js
+++ b/lib/api/controllers/documentController.js
@@ -765,7 +765,7 @@ class DocumentController extends NativeController {
    * @returns {Promise<Object>}
    */
   async deleteByQuery(request) {
-    let query = request.getBodyObject("query", {});
+    let query = request.getBodyObject("query");
     const silent = request.getBoolean("silent");
     const refresh = request.getString("refresh", "false");
     const source = request.getBoolean("source");

--- a/test/api/controllers/documentController.test.js
+++ b/test/api/controllers/documentController.test.js
@@ -1866,7 +1866,7 @@ describe("DocumentController", () => {
 
     it('should not notify with "silent" argument', async () => {
       request.input.args.silent = true;
-      request.input.body = { query: { } };
+      request.input.body = { query: {} };
 
       await documentController.deleteByQuery(request);
 

--- a/test/api/controllers/documentController.test.js
+++ b/test/api/controllers/documentController.test.js
@@ -1866,6 +1866,7 @@ describe("DocumentController", () => {
 
     it('should not notify with "silent" argument', async () => {
       request.input.args.silent = true;
+      request.input.body.query = {};
 
       await documentController.deleteByQuery(request);
 

--- a/test/api/controllers/documentController.test.js
+++ b/test/api/controllers/documentController.test.js
@@ -1866,7 +1866,7 @@ describe("DocumentController", () => {
 
     it('should not notify with "silent" argument', async () => {
       request.input.args.silent = true;
-      request.input.body.query = {};
+      request.input.body = { query: { } };
 
       await documentController.deleteByQuery(request);
 


### PR DESCRIPTION
Actually if you call deleteByQuery without query param, you can delete all documents because default query value is set to "{}" which is equals to "match_all" predicate.

Remove default value for query to avoid that.