### PR TITLE
Fix koncorde exists keyword translation to ES query

### DIFF
--- a/doc/2/api/errors/error-codes/services/index.md
+++ b/doc/2/api/errors/error-codes/services/index.md
@@ -87,3 +87,12 @@ description: Error codes definitions
 | services.statistics.not_available<br/><pre>0x01040001</pre>  | [InternalError](/core/2/api/errors/error-codes#internalerror) <pre>(500)</pre> | Statistics module is not available. | The statistics module is not enabled. See "config.stats.enabled". |
 
 ---
+
+
+### Subdomain: 0x0105: koncorde
+
+| id / code | class / status | message | description |
+| --------- | -------------- | --------| ----------- |
+| services.koncorde.elastic_translation_error<br/><pre>0x01050001</pre>  | [BadRequestError](/core/2/api/errors/error-codes#badrequesterror) <pre>(400)</pre> | An error occured while translating a Koncorde filter to an Elasticsearch query: %s | An error occured while translating a Koncorde filter to an Elasticsearch query |
+
+---

--- a/jest/api/controller/document/search.test.ts
+++ b/jest/api/controller/document/search.test.ts
@@ -1,0 +1,119 @@
+import { Kuzzle, WebSocket } from 'kuzzle-sdk';
+
+const kuzzle = new Kuzzle(new WebSocket('localhost'));
+const index = 'nyc-open-data';
+const collection = 'yellow-taxi';
+
+beforeAll(async () => {
+  await kuzzle.connect();
+  await kuzzle.index.create(index);
+  await kuzzle.collection.create(index, collection, {
+    mappings: {
+      properties: {
+        foo: {
+          type: 'keyword'
+        },
+        field: {
+          properties: {
+            path: {
+              type: 'keyword'
+            }
+          }
+        }
+      }
+    }
+  });
+});
+
+afterAll(async () => {
+  await kuzzle.index.delete(index);
+  await kuzzle.disconnect();
+});
+
+describe('koncorde query', () => {
+  afterEach(async () => {
+    await kuzzle.collection.truncate(index, collection);
+  });
+
+  describe('exists', () => {
+    it('should return true if the field exists', async () => {
+      const document = { foo: 'bar' };
+
+      await kuzzle.document.create(index, collection, document, undefined, {
+        refresh: 'wait_for'
+      });
+
+      const result = await kuzzle.document.search(index, collection, {
+        query: {
+          exists: {
+            field: 'foo'
+          }
+        },
+      }, {
+        lang: 'koncorde'
+      });
+
+      expect(result.hits.length).toEqual(1);
+    });
+
+    it('should return false if the field does not exists', async () => {
+      const document = { foo: 'bar' };
+
+      await kuzzle.document.create(index, collection, document, undefined, {
+        refresh: 'wait_for'
+      });
+
+      const result = await kuzzle.document.search(index, collection, {
+        query: {
+          exists: {
+            field: 'name'
+          }
+        }
+      }, {
+        lang: 'koncorde'
+      });
+
+      expect(result.hits.length).toEqual(0);
+    });
+
+    it('should support the syntax "field.path[value]" and return document if matching', async () => {
+      const document = { field: { path: ['ALPHA','BETA'] } };
+
+      await kuzzle.document.create(index, collection, document, undefined, {
+        refresh: 'wait_for'
+      });
+
+      const result = await kuzzle.document.search(index, collection, {
+        query: {
+          exists: {
+            field: 'field.path["BETA"]'
+          }
+        }
+      }, {
+        lang: 'koncorde'
+      });
+
+      expect(result.hits.length).toEqual(1);
+    });
+
+    it('should support the syntax "field.path[value]" and return nothing if not matching', async () => {
+      const document = { field: { path: ['ALPHA','BETA'] } };
+
+      await kuzzle.document.create(index, collection, document, undefined, {
+        refresh: 'wait_for'
+      });
+
+      const result = await kuzzle.document.search(index, collection, {
+        query: {
+          exists: {
+            field: 'field.path["GAMMA"]'
+          }
+        }
+      }, {
+        lang: 'koncorde'
+      });
+
+      expect(result.hits.length).toEqual(0);
+    });
+  });
+});

--- a/lib/kerror/codes/1-services.json
+++ b/lib/kerror/codes/1-services.json
@@ -335,6 +335,17 @@
           "class": "InternalError"
         }
       }
+    },
+    "koncorde": {
+      "code": 5,
+      "errors": {
+        "elastic_translation_error": {
+          "description": "An error occured while translating a Koncorde filter to an Elasticsearch query",
+          "code": 1,
+          "message": "An error occured while translating a Koncorde filter to an Elasticsearch query: %s",
+          "class": "BadRequestError"
+        }
+      }
     }
   }
 }

--- a/lib/service/storage/queryTranslator.js
+++ b/lib/service/storage/queryTranslator.js
@@ -21,6 +21,8 @@
 
 "use strict";
 
+const kerror = require("../../kerror");
+
 class KeywordError extends Error {
   constructor(type, name) {
     super(
@@ -33,17 +35,79 @@ class KeywordError extends Error {
 
 const KONCORDE_OPERATORS = ["and", "or", "not", "bool"];
 
+
+
+/**
+ * Parse the Koncorde path to extract the path and the value
+ * path have the form "path.to.field[json_value]"
+ * 
+ * @param {string} path 
+ * @returns 
+ */
+function parseKoncordePath(path) {
+  const firstBracket = path.indexOf('[');
+
+  if (firstBracket < 0) {
+    return {
+      path,
+    }
+  }
+
+  const lastBracket = path.lastIndexOf(']');
+
+  if (lastBracket < 0) {
+    throw kerror.get('services', 'koncorde', 'elastic_translation_error', `Invalid exists path "${path}": missing closing bracket`);
+  }
+
+  return {
+    path: path.slice(0, firstBracket),
+    value: JSON.parse(path.slice(firstBracket + 1, lastBracket)),
+  }
+}
+
+
 const KONCORDE_CLAUSES_TO_ES = {
   equals: (content) => ({
     term: {
       ...content,
     },
   }),
-  exists: (field) => ({
-    exists: {
-      field,
-    },
-  }),
+  exists: (field) => {
+    if (!field || !field.field) {
+      throw kerror.get('services', 'koncorde', 'elastic_translation_error', 'Invalid "exists" clause: field is missing');
+    }
+
+    const parsedInfo = parseKoncordePath(field.field);
+
+    // If we have a value, we need to use a range query to be sure that the value is the same
+    if (parsedInfo.value) {
+      return {
+        bool: {
+          filter: [
+            {
+              exists: {
+                field: parsedInfo.path,
+              }
+            },
+            {
+              range: {
+                [parsedInfo.path]: {
+                  gte: parsedInfo.value,
+                  lte: parsedInfo.value,
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+
+    return {
+      exists: {
+        field: parsedInfo.path,
+      },
+    }
+  },
   geoBoundingBox: (content) => ({
     geo_bounding_box: {
       ...content,

--- a/lib/service/storage/queryTranslator.js
+++ b/lib/service/storage/queryTranslator.js
@@ -75,16 +75,8 @@ const KONCORDE_CLAUSES_TO_ES = {
     },
   }),
   exists: (field) => {
-    if (!field || !field.field) {
-      throw kerror.get(
-        "services",
-        "koncorde",
-        "elastic_translation_error",
-        'Invalid "exists" clause: field is missing'
-      );
-    }
-
-    const parsedInfo = parseKoncordePath(field.field);
+    // Support old syntax { exists: { field: "path" } } and { exists: "path" }
+    const parsedInfo = parseKoncordePath(field.field || field);
 
     // If we have a value, we need to use a range query to be sure that the value is the same
     if (parsedInfo.value) {

--- a/lib/service/storage/queryTranslator.js
+++ b/lib/service/storage/queryTranslator.js
@@ -35,36 +35,38 @@ class KeywordError extends Error {
 
 const KONCORDE_OPERATORS = ["and", "or", "not", "bool"];
 
-
-
 /**
  * Parse the Koncorde path to extract the path and the value
  * path have the form "path.to.field[json_value]"
- * 
- * @param {string} path 
- * @returns 
+ *
+ * @param {string} path
+ * @returns
  */
 function parseKoncordePath(path) {
-  const firstBracket = path.indexOf('[');
+  const firstBracket = path.indexOf("[");
 
   if (firstBracket < 0) {
     return {
       path,
-    }
+    };
   }
 
-  const lastBracket = path.lastIndexOf(']');
+  const lastBracket = path.lastIndexOf("]");
 
   if (lastBracket < 0) {
-    throw kerror.get('services', 'koncorde', 'elastic_translation_error', `Invalid exists path "${path}": missing closing bracket`);
+    throw kerror.get(
+      "services",
+      "koncorde",
+      "elastic_translation_error",
+      `Invalid exists path "${path}": missing closing bracket`
+    );
   }
 
   return {
     path: path.slice(0, firstBracket),
     value: JSON.parse(path.slice(firstBracket + 1, lastBracket)),
-  }
+  };
 }
-
 
 const KONCORDE_CLAUSES_TO_ES = {
   equals: (content) => ({
@@ -74,7 +76,12 @@ const KONCORDE_CLAUSES_TO_ES = {
   }),
   exists: (field) => {
     if (!field || !field.field) {
-      throw kerror.get('services', 'koncorde', 'elastic_translation_error', 'Invalid "exists" clause: field is missing');
+      throw kerror.get(
+        "services",
+        "koncorde",
+        "elastic_translation_error",
+        'Invalid "exists" clause: field is missing'
+      );
     }
 
     const parsedInfo = parseKoncordePath(field.field);
@@ -87,26 +94,26 @@ const KONCORDE_CLAUSES_TO_ES = {
             {
               exists: {
                 field: parsedInfo.path,
-              }
+              },
             },
             {
               range: {
                 [parsedInfo.path]: {
                   gte: parsedInfo.value,
                   lte: parsedInfo.value,
-                }
-              }
-            }
-          ]
-        }
-      }
+                },
+              },
+            },
+          ],
+        },
+      };
     }
 
     return {
       exists: {
         field: parsedInfo.path,
       },
-    }
+    };
   },
   geoBoundingBox: (content) => ({
     geo_bounding_box: {


### PR DESCRIPTION
## What does this PR do ?

This PR fixes an issue that was occuring with the translation of the Koncorde query to the Elasticsearch query.
the full [syntax of the `exists` keyword](https://github.com/kuzzleio/koncorde/wiki/Filter-Syntax#exists) (`path.to.field[json_value]`) that was supported by the Koncorde DSL was not fully translated to the Elastic DSL.

closes #2347

### How should this be manually tested?

Tests have been implemented with Jest to ensure the syntax work properly