### PR TITLE
Fix mCreate replacing documents in some cases

### DIFF
--- a/jest/api/controller/document/mCreate.test.ts
+++ b/jest/api/controller/document/mCreate.test.ts
@@ -1,0 +1,159 @@
+import { Kuzzle, WebSocket } from 'kuzzle-sdk';
+
+const kuzzle = new Kuzzle(new WebSocket('localhost'));
+const index = 'nyc-open-data';
+const collection = 'yellow-taxi';
+
+beforeAll(async () => {
+  await kuzzle.connect();
+  await kuzzle.index.create(index);
+  await kuzzle.collection.create(index, collection, {
+    mappings: {
+      properties: {
+        value: {
+          type: 'keyword'
+        },
+        field: {
+          properties: {
+            path: {
+              type: 'keyword'
+            }
+          }
+        }
+      }
+    }
+  });
+});
+
+afterAll(async () => {
+  await kuzzle.index.delete(index);
+  await kuzzle.disconnect();
+});
+
+describe('mCreate', () => {
+  afterEach(async () => {
+    await kuzzle.collection.truncate(index, collection);
+  });
+
+
+    it('It should create document if not exists', async () => {
+      const mCreateResult = await kuzzle.document.mCreate(index, collection, [
+        {
+          _id: 'A',
+          body: {
+            value: 'A'
+          }
+        }
+      ], {
+        refresh: 'wait_for'
+      });
+
+      expect(mCreateResult.successes.length).toEqual(1);
+
+      const result = await kuzzle.document.mGet(index, collection, ['A']);
+
+      expect(result.successes.length).toEqual(1);
+      expect(result.successes[0]._source).toMatchObject({
+        value: 'A'
+      });
+    });
+
+    it('It should not replace the document if not exists', async () => {
+      let mCreateResult = await kuzzle.document.mCreate(index, collection, [
+        {
+          _id: 'A',
+          body: {
+            value: 'A'
+          }
+        }
+      ], {
+        refresh: 'wait_for'
+      });
+
+      expect(mCreateResult.successes.length).toEqual(1);
+
+      mCreateResult = await kuzzle.document.mCreate(index, collection, [
+        {
+          _id: 'A',
+          body: {
+            value: 'FOO'
+          }
+        }
+      ], {
+        refresh: 'wait_for'
+      });
+
+      expect(mCreateResult.successes.length).toEqual(0);
+      expect(mCreateResult.errors.length).toEqual(1);
+
+      const result = await kuzzle.document.mGet(index, collection, ['A']);
+
+      expect(result.successes.length).toEqual(1);
+      expect(result.successes[0]._source).toMatchObject({
+        value: 'A'
+      });
+    });
+
+
+    it('It should not replace the document even if the previous document did not exist', async () => {
+      let mCreateResult = await kuzzle.document.mCreate(index, collection, [
+        {
+          _id: 'A',
+          body: {
+            value: 'A'
+          }
+        },
+        {
+          _id: 'C',
+          body: {
+            value: 'C'
+          }
+        }
+      ], {
+        refresh: 'wait_for'
+      });
+
+      expect(mCreateResult.successes.length).toEqual(2);
+
+      mCreateResult = await kuzzle.document.mCreate(index, collection, [
+        {
+          _id: 'A',
+          body: {
+            value: 'FOO'
+          }
+        },
+        {
+          _id: 'B',
+          body: {
+            value: 'B'
+          }
+        },
+        {
+          _id: 'C',
+          body: {
+            value: 'FOO'
+          }
+        }
+      ], {
+        refresh: 'wait_for'
+      });
+
+      expect(mCreateResult.successes.length).toEqual(1);
+      expect(mCreateResult.errors.length).toEqual(2);
+
+      const result = await kuzzle.document.mGet(index, collection, ['A', 'B', 'C']);
+
+      expect(result.successes.length).toEqual(3);
+      expect(result.successes[0]._source).toMatchObject({
+        value: 'A'
+      });
+      expect(result.successes[1]._source).toMatchObject({
+        value: 'B'
+      });
+      expect(result.successes[2]._source).toMatchObject({
+        value: 'C'
+      });
+    });
+
+   
+});

--- a/lib/service/storage/elasticsearch.js
+++ b/lib/service/storage/elasticsearch.js
@@ -2262,7 +2262,6 @@ class ElasticSearch extends Service {
             status: 400,
           });
 
-          idx++;
         } else {
           esRequest.body.push({
             index: {
@@ -2271,9 +2270,10 @@ class ElasticSearch extends Service {
             },
           });
           esRequest.body.push(document._source);
-
+          
           toImport.push(document);
         }
+        idx++;
       } else {
         esRequest.body.push({ index: { _index: alias } });
         esRequest.body.push(document._source);


### PR DESCRIPTION
## What does this PR do ?

There is a bug where mCreate would replace a document that was already existing in a specific scenario.
Let's say there is a document `B` that exists
```json
      {
        "_id": "B",
        "body": {
          "value": "B"
        }
      },
```
And you call `mCreate` with

```json
      {
        "_id": "A",
        "body": {
          "value": "A"
        }
      },
      {
        "_id": "B",
        "body": {
          "value": "FOO"
        }
      },
```
Internally mCreate uses mGet to know if a document exists and not replace it.
Since the document `A` does not exist it will be create but in this case the `idx` index is not incremented causing the next comparison to check if the same document exists, since `idx` was not incremented when checking if `B` exists we are checking if `A` exists which at the time it didn't, so `B` is going to be added to the list of document to replace, causing `B` to be overriden even though there was an existing document at the time.
