### PR TITLE
Fix incorrect HTTP Content-Type headers being accepted

### DIFF
--- a/lib/core/network/protocols/httpwsProtocol.js
+++ b/lib/core/network/protocols/httpwsProtocol.js
@@ -498,23 +498,30 @@ class HttpWsProtocol extends Protocol {
       return;
     }
 
-    const contentType = message.headers["content-type"];
+    const contentTypeHeader = message.headers["content-type"];
 
-    if (
-      contentType &&
-      !this.httpConfig.opts.allowedContentTypes.some((allowed) =>
-        contentType.includes(allowed)
-      )
-    ) {
-      this.httpSendError(
-        message,
-        response,
-        kerrorHTTP.get("unsupported_content", contentType)
-      );
-      return;
+    if (contentTypeHeader) {
+      const contentTypeParamIndex = contentTypeHeader.indexOf(";");
+      const contentType =
+        contentTypeParamIndex !== -1
+          ? contentTypeHeader.slice(0, contentTypeParamIndex).trim()
+          : contentTypeHeader.trim();
+
+      if (
+        !this.httpConfig.opts.allowedContentTypes.some(
+          (allowed) => contentType === allowed
+        )
+      ) {
+        this.httpSendError(
+          message,
+          response,
+          kerrorHTTP.get("unsupported_content", contentType)
+        );
+        return;
+      }
     }
 
-    const encoding = CHARSET_REGEX.exec(contentType);
+    const encoding = CHARSET_REGEX.exec(contentTypeHeader);
 
     if (encoding !== null && encoding[1].toLowerCase() !== "utf-8") {
       this.httpSendError(

--- a/test/core/network/protocols/http.test.js
+++ b/test/core/network/protocols/http.test.js
@@ -359,7 +359,7 @@ describe("core/network/protocols/http", () => {
 
     it("should reject requests with supported content types with extraneous characters", () => {
       httpWs.server._httpOnMessage("get", "/", "", {
-        "content-type": "canard application/jsoncheval",
+        "content-type": "serge application/jsoncheval",
       });
 
       should(entryPoint.newConnection).not.called();

--- a/test/core/network/protocols/http.test.js
+++ b/test/core/network/protocols/http.test.js
@@ -357,6 +357,20 @@ describe("core/network/protocols/http", () => {
         });
     });
 
+    it("should reject requests with supported content types with extraneous characters", () => {
+      httpWs.server._httpOnMessage("get", "/", "", {
+        "content-type": "canard application/jsoncheval",
+      });
+
+      should(entryPoint.newConnection).not.called();
+      should(global.kuzzle.router.http.route).not.called();
+      should(httpWs.httpSendError)
+        .calledOnce()
+        .calledWithMatch(sinon.match.object, httpWs.server._httpResponse, {
+          id: "network.http.unsupported_content",
+        });
+    });
+
     it("should reject requests with unhandled charsets", () => {
       httpWs.server._httpOnMessage("get", "/", "", {
         "content-type": "application/json; charset=utf-82",


### PR DESCRIPTION
## What does this PR do ?

This fixes successful matches of `Content-Type` headers with extraneous content.
Previously, `Content-Type: canardapplication/jsonziufhzihuchevalzef izufh` would be considered valid because it contains `application/json`.

### How should this be manually tested?

  - Step 1 : Send any request with a `Content-Type` header containing a valid Content-Type surrounded by random characters.
  - Step 2 : Verify that it is now refused.
