### PR TITLE
refactor: import hash

### DIFF
--- a/lib/config/default.config.ts
+++ b/lib/config/default.config.ts
@@ -425,6 +425,19 @@ const defaultConfig: KuzzleConfiguration = {
               },
             },
           },
+          imports: {
+            settings: {
+              // @deprecated : replace undefined by 1
+              number_of_shards: undefined,
+              number_of_replicas: undefined,
+            },
+            mappings: {
+              dynamic: "strict",
+              properties: {
+                hash: { type: "keyword" },
+              },
+            },
+          },
         },
       },
       maxScrollDuration: "1m",

--- a/lib/config/default.config.ts
+++ b/lib/config/default.config.ts
@@ -428,8 +428,8 @@ const defaultConfig: KuzzleConfiguration = {
           imports: {
             settings: {
               // @deprecated : replace undefined by 1
-              number_of_shards: undefined,
-              number_of_replicas: undefined,
+              number_of_shards: 1,
+              number_of_replicas: 1,
             },
             mappings: {
               dynamic: "strict",

--- a/lib/types/config/storageEngine/StorageEngineElasticsearchConfiguration.ts
+++ b/lib/types/config/storageEngine/StorageEngineElasticsearchConfiguration.ts
@@ -317,6 +317,26 @@ export type StorageEngineElasticsearch = {
           };
         };
       };
+      imports: {
+        settings: {
+          /**
+           * @default 1
+           */
+          number_of_shards: number;
+
+          /**
+           * @default 1
+           */
+          number_of_replicas: number;
+        };
+
+        mappings: {
+          dynamic: "strict";
+          properties: {
+            hash: { type: "keyword" };
+          };
+        };
+      };
     };
   };
   maxScrollDuration: string;


### PR DESCRIPTION
## What does this PR do ?

This pr improves the current import hash import storage system. Currently when kuzzle starts it checks in redis for each type of imports if the key is different to the generated hash. If a redis doesn't have persistent storage and dies the redis keys will not be here and kuzzle will re import the roles which will override the existing ones. To avoid this reimport we also store the imported hash in elasticsearch under %kuzzle.imports. This way when kuzzle starts, if the key is not stored in redis it checks in elastic search and if it's not in elastic search or different from the hash we reimport the roles.
