### PR TITLE
Fix documentation example for using `searchUsersByCredentials` action. 

### DIFF
--- a/doc/2/api/controllers/security/search-users-by-credentials/index.md
+++ b/doc/2/api/controllers/security/search-users-by-credentials/index.md
@@ -54,15 +54,17 @@ Body:
   "action": "searchUsersByCredentials",
   "strategy": "<strategy>",
   "body": {
-    "bool": {
-      "must": [
-        {
-          "match": {
-            // example with the "local" authentication strategy
-            "username":  "test@example.com"
+    "query":{
+      "bool": {
+        "must": [
+          {
+            "match": {
+              // example with the "local" authentication strategy
+              "username":  "test@example.com"
+            }
           }
-        }
-      ]
+        ]
+      }
     }
   },
 }


### PR DESCRIPTION
## What does this PR do ?

Fixes a small mistake in the documentation.

### How should this be manually tested?

Step 1: Try to do a `searchUsersBycredentials` query as the documentation states, see it fails.
Step 2: Try with my proposed changes, and it works.

