### PR TITLE
doc: fix typo in document:export

### DIFF
--- a/doc/2/api/controllers/document/export/index.md
+++ b/doc/2/api/controllers/document/export/index.md
@@ -84,7 +84,7 @@ Following arguments are available: `query`, `fields` and `fieldsName`.
   "index": "<index>",
   "collection": "<collection>",
   "controller": "document",
-  "action": "search",
+  "action": "export",
   "body": {
     "query": {
       // ...


### PR DESCRIPTION
search => export