### PR TITLE
build: no strict version for kuzzle-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "koncorde": "4.3.0",
         "kuzzle-plugin-auth-passport-local": "6.4.0",
         "kuzzle-plugin-logger": "3.0.3",
-        "kuzzle-sdk": "7.11.1",
+        "kuzzle-sdk": "^7.11.3",
         "kuzzle-vault": "2.0.4",
         "lodash": "4.17.21",
         "long": "5.2.3",
@@ -10325,9 +10325,9 @@
       }
     },
     "node_modules/kuzzle-sdk": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/kuzzle-sdk/-/kuzzle-sdk-7.11.1.tgz",
-      "integrity": "sha512-1nPZmekFE2Q1gNhPisn9kg1/LsDRzDnl4GIYGdjIHISK5BhiAICMEsmMMyTiYqja42/mdMqm+M5bFx4p3wMJdQ==",
+      "version": "7.11.3",
+      "resolved": "https://registry.npmjs.org/kuzzle-sdk/-/kuzzle-sdk-7.11.3.tgz",
+      "integrity": "sha512-YHPSE99GRg1GT9UD5hOuJnt5vc/Gqmp705id4sCjyRJNRaq9uf3j3OzM6bvD+4YPZB7LTim53z66CFQP7IV7Qg==",
       "dependencies": {
         "min-req-promise": "^1.0.1",
         "ws": "^8.13.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "koncorde": "4.3.0",
     "kuzzle-plugin-auth-passport-local": "6.4.0",
     "kuzzle-plugin-logger": "3.0.3",
-    "kuzzle-sdk": "7.11.1",
+    "kuzzle-sdk": "^7.11.3",
     "kuzzle-vault": "2.0.4",
     "lodash": "4.17.21",
     "long": "5.2.3",


### PR DESCRIPTION
## What does this PR do ?

Change `kuzzle-sdk` version restriction to allow npm to dedup the package when it's required in other package.

## Explanation
Currently, Kuzzle require strictly `kuzzle-sdk@7.11.1`, if a package like plugin require `kuzzle` and `kuzzle-sdk@7.11.3`

With strict restriction, NPM produce this install

- kuzzle-sdk@7.11.3
- kuzzle
  - kuzzle-sdk@7.11.1
  
With package restriction like `kuzzle-sdk@^7.11.3` (so accept greater than `7.11.3` but less than `8`), NPM produce this install

- kuzzle-sdk@7.11.3
- kuzzle

Here, kuzzle-sdk is not installed in kuzzle directory because `kuzzle-sdk@7.11.3` satisfy the restriction.
Also, normally in future if I want to install `kuzzle-sdk@8.0.0` in my package, npm will throw an error for incompatibility (need to verify, because npm haven't consistent behavior through the versions)