### PR TITLE
docs(log): add a log to know which ES configuration is set up

### DIFF
--- a/lib/service/storage/Elasticsearch.ts
+++ b/lib/service/storage/Elasticsearch.ts
@@ -13,6 +13,8 @@ export class Elasticsearch extends Service {
   constructor(config: any, scope = storeScopeEnum.PUBLIC) {
     super("elasticsearch", config);
 
+    global.kuzzle.log.info(`[ℹ] Elasticsearch configuration is set to major version : ${config.majorVersion}`);
+
     if (config.majorVersion === "7") {
       this.client = new ES7(config, scope);
     } else if (config.majorVersion === "8") {

--- a/lib/service/storage/Elasticsearch.ts
+++ b/lib/service/storage/Elasticsearch.ts
@@ -13,7 +13,9 @@ export class Elasticsearch extends Service {
   constructor(config: any, scope = storeScopeEnum.PUBLIC) {
     super("elasticsearch", config);
 
-    global.kuzzle.log.info(`[ℹ] Elasticsearch configuration is set to major version : ${config.majorVersion}`);
+    global.kuzzle.log.info(
+      `[ℹ] Elasticsearch configuration is set to major version : ${config.majorVersion}`,
+    );
 
     if (config.majorVersion === "7") {
       this.client = new ES7(config, scope);


### PR DESCRIPTION
## What does this PR do ?

Add log to display which ES version is configured  