### PR TITLE
Feat(funnel): allow pluginRequest to trigger events

### DIFF
--- a/doc/2/guides/develop-on-kuzzle/event-system/index.md
+++ b/doc/2/guides/develop-on-kuzzle/event-system/index.md
@@ -188,7 +188,7 @@ await app.trigger('app-name/file-available', fileUrl);
 If an internal event is triggered, the payload must be the same as the original event.
 :::
 
-**Events can be triggered** with SDK and controllers actions.
+**Events are not triggered** with SDK and controllers actions.
 
 ::: warning
 By default, actions executed through the embedded SDK or controllers won't trigger any events and thus no pipe or hooks will be called.
@@ -196,7 +196,7 @@ By default, actions executed through the embedded SDK or controllers won't trigg
 
 This behaviour is set in order to prevent an infinite loop in which a pipe calls a controller generating an event calling this same pipe again and again. 
 
-It is nonetheless possible to pass the flag `allowTrigggerEvents` to the options parameters of the controller to allow events firing :
+It is nonetheless possible to pass the flag `triggerEvents` to the options parameters of the controller to fire events :
 
 ```ts
 await this.sdk.document.create(
@@ -206,6 +206,6 @@ await this.sdk.document.create(
                 contentOfDocument: 'CREATED VIA CONTROLLER',
               },
               _idOfDocument,
-              { allowTriggerEvents: true },
+              { triggerEvents: true },
             );
 ```

--- a/doc/2/guides/develop-on-kuzzle/event-system/index.md
+++ b/doc/2/guides/develop-on-kuzzle/event-system/index.md
@@ -187,3 +187,25 @@ await app.trigger('app-name/file-available', fileUrl);
 ::: warning
 If an internal event is triggered, the payload must be the same as the original event.
 :::
+
+**Events can be triggered** with SDK and controllers actions.
+
+::: warning
+By default, actions executed through the embedded SDK or controllers won't trigger any events and thus no pipe or hooks will be called.
+:::
+
+This behaviour is set in order to prevent an infinite loop in which a pipe calls a controller generating an event calling this same pipe again and again. 
+
+It is nonetheless possible to pass the flag `allowTrigggerEvents` to the options parameters of the controller to allow events firing :
+
+```ts
+await this.sdk.document.create(
+              "index",
+              'collection',
+              {
+                contentOfDocument: 'CREATED VIA CONTROLLER',
+              },
+              _idOfDocument,
+              { allowTriggerEvents: true },
+            );
+```

--- a/doc/2/guides/develop-on-kuzzle/event-system/index.md
+++ b/doc/2/guides/develop-on-kuzzle/event-system/index.md
@@ -188,10 +188,10 @@ await app.trigger('app-name/file-available', fileUrl);
 If an internal event is triggered, the payload must be the same as the original event.
 :::
 
-**Events are not triggered** with SDK and controllers actions.
+**Events are not triggered** with the embedded SDK and controllers actions.
 
 ::: warning
-By default, actions executed through the embedded SDK or controllers won't trigger any events and thus no pipe or hooks will be called.
+By default, actions executed through the embedded SDK or controllers won't trigger any events and thus no pipe or hooks will be called. On the contrary, controllers accessed by the external SDK through HTTP or Websocket requests will always fire events.
 :::
 
 This behaviour is set in order to prevent an infinite loop in which a pipe calls a controller generating an event calling this same pipe again and again. 

--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -753,6 +753,9 @@ class Funnel {
    */
   async executePluginRequest(request) {
     try {
+      if (request.input.allowTriggerEvents) {
+        return await this.processRequest(request);
+      }
       return await doAction(this.getController(request), request);
     } catch (e) {
       this.handleErrorDump(e);

--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -753,7 +753,7 @@ class Funnel {
    */
   async executePluginRequest(request) {
     try {
-      if (request.input.allowTriggerEvents) {
+      if (request.input.triggerEvents) {
         return await this.processRequest(request);
       }
       return await doAction(this.getController(request), request);

--- a/lib/api/request/requestInput.ts
+++ b/lib/api/request/requestInput.ts
@@ -32,6 +32,7 @@ const _body = "body\u200b";
 const _headers = "headers\u200b";
 const _controller = "controller\u200b";
 const _action = "action\u200b";
+const _allowTriggerEvents = "allowTriggerEvents\u200b";
 
 // any property not listed here will be copied into
 // RequestInput.args
@@ -155,6 +156,7 @@ export class RequestInput {
     this[_body] = null;
     this[_controller] = null;
     this[_action] = null;
+    this[_allowTriggerEvents] = null;
 
     // default value to null for former "resources" to avoid breaking
     this.args = {};
@@ -181,6 +183,7 @@ export class RequestInput {
     this.body = data.body;
     this.controller = data.controller;
     this.action = data.action;
+    this.allowTriggerEvents = data.allowTriggerEvents;
   }
 
   /**
@@ -263,7 +266,12 @@ export class RequestInput {
       this[_action] = assert.assertString("action", str);
     }
   }
-
+  get allowTriggerEvents(): boolean | undefined {
+    return this[_allowTriggerEvents];
+  }
+  set allowTriggerEvents(bool: boolean) {
+    this[_allowTriggerEvents] = bool === true ? true : undefined;
+  }
   /**
    * Request body.
    * In Http it's the request body parsed.

--- a/lib/api/request/requestInput.ts
+++ b/lib/api/request/requestInput.ts
@@ -32,7 +32,7 @@ const _body = "body\u200b";
 const _headers = "headers\u200b";
 const _controller = "controller\u200b";
 const _action = "action\u200b";
-const _allowTriggerEvents = "allowTriggerEvents\u200b";
+const _triggerEvents = "triggerEvents\u200b";
 
 // any property not listed here will be copied into
 // RequestInput.args
@@ -156,7 +156,7 @@ export class RequestInput {
     this[_body] = null;
     this[_controller] = null;
     this[_action] = null;
-    this[_allowTriggerEvents] = null;
+    this[_triggerEvents] = null;
 
     // default value to null for former "resources" to avoid breaking
     this.args = {};
@@ -183,7 +183,7 @@ export class RequestInput {
     this.body = data.body;
     this.controller = data.controller;
     this.action = data.action;
-    this.allowTriggerEvents = data.allowTriggerEvents;
+    this.triggerEvents = data.triggerEvents;
   }
 
   /**
@@ -266,11 +266,11 @@ export class RequestInput {
       this[_action] = assert.assertString("action", str);
     }
   }
-  get allowTriggerEvents(): boolean | undefined {
-    return this[_allowTriggerEvents];
+  get triggerEvents(): boolean | undefined {
+    return this[_triggerEvents];
   }
-  set allowTriggerEvents(bool: boolean) {
-    this[_allowTriggerEvents] = bool === true ? true : undefined;
+  set triggerEvents(bool: boolean) {
+    this[_triggerEvents] = bool === true ? true : undefined;
   }
   /**
    * Request body.

--- a/test/api/funnel/executePluginRequest.test.js
+++ b/test/api/funnel/executePluginRequest.test.js
@@ -2,7 +2,6 @@
 
 const should = require("should");
 const sinon = require("sinon");
-
 const KuzzleMock = require("../../mocks/kuzzle.mock");
 const { MockNativeController } = require("../../mocks/controller.mock");
 const FunnelController = require("../../../lib/api/funnel");
@@ -101,5 +100,32 @@ describe("funnel.executePluginRequest", () => {
         }
         done(e);
       });
+  });
+
+  it("should trigger pipes if allowTriggerEvent is enabled", async () => {
+    const request = new Request({
+      controller: "testme",
+      action: "succeed",
+      allowTriggerEvents: true,
+    });
+
+    return funnel.executePluginRequest(request).then((response) => {
+      should(response).be.exactly(request);
+      should(kuzzle.pipe).calledWith("testme:beforeSucceed");
+      should(kuzzle.pipe).calledWith("testme:afterSucceed");
+    });
+  });
+
+  it("should not trigger pipes if allowTriggerEvent is disabled", async () => {
+    const request = new Request({
+      controller: "testme",
+      action: "succeed",
+    });
+
+    return funnel.executePluginRequest(request).then((response) => {
+      should(response).be.exactly(request);
+      should(kuzzle.pipe).not.calledWith("testme:beforeSucceed");
+      should(kuzzle.pipe).not.calledWith("testme:afterSucceed");
+    });
   });
 });

--- a/test/api/funnel/executePluginRequest.test.js
+++ b/test/api/funnel/executePluginRequest.test.js
@@ -102,11 +102,11 @@ describe("funnel.executePluginRequest", () => {
       });
   });
 
-  it("should trigger pipes if allowTriggerEvent is enabled", async () => {
+  it("should trigger pipes if triggerEvent is enabled", async () => {
     const request = new Request({
       controller: "testme",
       action: "succeed",
-      allowTriggerEvents: true,
+      triggerEvents: true,
     });
 
     return funnel.executePluginRequest(request).then((response) => {
@@ -116,7 +116,7 @@ describe("funnel.executePluginRequest", () => {
     });
   });
 
-  it("should not trigger pipes if allowTriggerEvent is disabled", async () => {
+  it("should not trigger pipes if triggerEvent is disabled", async () => {
     const request = new Request({
       controller: "testme",
       action: "succeed",


### PR DESCRIPTION

## What does this PR do ?
This PR introduces an optional parameter "allowTriggerEvents" in KuzzleRequest to allow or not API actions to trigger events and pipes.
In the funnel if a pluginRequest holds this parameter, the request is processed as a normal request otherwise it is treated as usally without triggering events.

### How should this be manually tested?
In a project using Kuzzle:
-Set up a custom controller creating a document for example
-Set up a pipe that triggers on the creation of document ('document:beforeCreate/document:afterCreate)
-Send a request to your controller without "allowTriggerEvents": the pipe shouldn't trigger
-Send a request to your controller with  allowTriggerEvents:true  the pipe should trigger.


### Other changes
With this process the request also triggers statistic counts which it wouldn't have in the normal pluginRequest execution
