### PR TITLE
fix(triggerEvents): fix response format for request with triggerEvents

### DIFF
--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -754,7 +754,8 @@ class Funnel {
   async executePluginRequest(request) {
     try {
       if (request.input.triggerEvents) {
-        return await this.processRequest(request);
+        const response = await this.processRequest(request);
+        return { ...response.result };
       }
       return await doAction(this.getController(request), request);
     } catch (e) {

--- a/test/api/funnel/executePluginRequest.test.js
+++ b/test/api/funnel/executePluginRequest.test.js
@@ -104,13 +104,12 @@ describe("funnel.executePluginRequest", () => {
 
   it("should trigger pipes if triggerEvent is enabled", async () => {
     const request = new Request({
-      controller: "testme",
       action: "succeed",
+      controller: "testme",
       triggerEvents: true,
     });
 
-    return funnel.executePluginRequest(request).then((response) => {
-      should(response).be.exactly(request);
+    return funnel.executePluginRequest(request).then(() => {
       should(kuzzle.pipe).calledWith("testme:beforeSucceed");
       should(kuzzle.pipe).calledWith("testme:afterSucceed");
     });
@@ -118,12 +117,11 @@ describe("funnel.executePluginRequest", () => {
 
   it("should not trigger pipes if triggerEvent is disabled", async () => {
     const request = new Request({
-      controller: "testme",
       action: "succeed",
+      controller: "testme",
     });
 
-    return funnel.executePluginRequest(request).then((response) => {
-      should(response).be.exactly(request);
+    return funnel.executePluginRequest(request).then(() => {
       should(kuzzle.pipe).not.calledWith("testme:beforeSucceed");
       should(kuzzle.pipe).not.calledWith("testme:afterSucceed");
     });


### PR DESCRIPTION
## What does this PR do ?
This PR fixes the repsonse format of triggerEvents request. 
The response was formatted twice in the funnel via executePluginRequest and processRequest thus having a nested result 
such as 
```
"result": {
  "result": {
   "_id": "D-E9MZEBRAJIxXfAL6SB",
   "_source": {
    "_kuzzle_info": {
     "author": null,
     "createdAt": 1723107979136,
     "updatedAt": null,
     "updater": null
    }
   },
   ```
### How should this be manually tested?

  - Step 1 : Send a request without the triggerEvents flag
  - Step 2 : Send a request with the triggerEvents flag
  - Step 3 : Compare both results

