### PR TITLE
Fix global types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,6 +160,7 @@ lib/kerror/errors/sizeLimitError.js
 lib/kerror/errors/tooManyRequestsError.js
 lib/kerror/errors/unauthorizedError.js
 lib/kerror/index.js
+lib/kuzzle/index.js
 lib/kuzzle/kuzzle.js
 lib/kuzzle/event/KuzzleEventEmitter.js
 lib/model/security/profile.js

--- a/.gitignore
+++ b/.gitignore
@@ -161,6 +161,7 @@ lib/kerror/errors/tooManyRequestsError.js
 lib/kerror/errors/unauthorizedError.js
 lib/kerror/index.js
 lib/kuzzle/kuzzle.js
+lib/kuzzle/event/KuzzleEventEmitter.js
 lib/model/security/profile.js
 lib/model/security/role.js
 lib/model/security/token.js

--- a/lib/core/security/tokenRepository.ts
+++ b/lib/core/security/tokenRepository.ts
@@ -494,7 +494,7 @@ export class TokenRepository extends ObjectRepository<Token> {
    *
    * So we need to override the TTL auto-refresh function to disable it
    */
-  refreshCacheTTL() {
+  async refreshCacheTTL() {
     // This comment is here to please Sonarqube. It requires a comment
     // explaining why a function is empty, but there is no sense
     // duplicating what has been just said in the JSDoc.

--- a/lib/kuzzle/event/KuzzleEventEmitter.ts
+++ b/lib/kuzzle/event/KuzzleEventEmitter.ts
@@ -80,12 +80,12 @@ class KuzzleEventEmitter extends EventEmitter {
     /**
      * Map of plugin pipe handler functions by event
      */
-    this.pluginPipes = new Map();
+    this.pluginPipes = new Map<string, PipeEventHandler[]>();
 
     /**
      * Map of plugin pipe definitions by pipeId
      */
-    this.pluginPipeDefinitions = new Map();
+    this.pluginPipeDefinitions = new Map<string, PluginPipeDefinition>();
 
     this.corePipes = new Map<string, PipeEventHandler[]>();
     this.coreAnswerers = new Map<string, AskEventHandler>();

--- a/lib/kuzzle/index.ts
+++ b/lib/kuzzle/index.ts
@@ -19,6 +19,7 @@
  * limitations under the License.
  */
 
-"use strict";
+import { Kuzzle } from "./kuzzle";
 
-module.exports = require("./kuzzle");
+export { Kuzzle };
+export default Kuzzle;

--- a/lib/kuzzle/kuzzle.ts
+++ b/lib/kuzzle/kuzzle.ts
@@ -927,4 +927,4 @@ class Kuzzle extends KuzzleEventEmitter {
 }
 
 export { Kuzzle };
-module.exports = Kuzzle;
+export default Kuzzle;

--- a/lib/types/EventHandler.ts
+++ b/lib/types/EventHandler.ts
@@ -38,11 +38,34 @@ export type EventDefinition = {
 };
 
 /**
+ * Describe an ask event with it's name and the payload and result types
+ */
+export type AskEventDefinition = {
+  /**
+   * Name of the event
+   *
+   * @example
+   * "core:document:create"
+   */
+  name: string;
+
+  /**
+   * Payload of the event
+   */
+  payload: any;
+
+  /**
+   * Result of the event
+   */
+  result: any;
+};
+
+/**
  * Handler for hook events
  */
 export type HookEventHandler<
   TEventDefinition extends EventDefinition = EventDefinition,
-> = (...args: TEventDefinition["args"]) => void;
+> = (...args: TEventDefinition["args"]) => Promise<void> | void;
 
 /**
  * Handler for pipe event.
@@ -59,6 +82,24 @@ export type PipeEventHandler<
 export type ClusterEventHandler<
   TEventDefinition extends EventDefinition = EventDefinition,
 > = (...args: TEventDefinition["args"]) => any;
+
+/**
+ * Handler for ask event.
+ */
+export type AskEventHandler<
+  TAskEventDefinition extends AskEventDefinition = AskEventDefinition,
+> = (
+  ...args: [payload?: TAskEventDefinition["payload"], ...rest: any[]]
+) => Promise<TAskEventDefinition["result"]> | TAskEventDefinition["result"];
+
+/**
+ * Handler for call event.
+ */
+export type CallEventHandler<
+  TAskEventDefinition extends AskEventDefinition = AskEventDefinition,
+> = (
+  ...args: [payload?: TAskEventDefinition["payload"], ...rest: any[]]
+) => TAskEventDefinition["result"];
 
 /**
  * @deprecated Use HookEventHandler, PipeEventHandler or ClusterEventHandler

--- a/lib/types/Global.ts
+++ b/lib/types/Global.ts
@@ -1,5 +1,5 @@
 import { Backend } from "../core/backend";
-import { Kuzzle } from "../kuzzle";
+import { Kuzzle } from "../kuzzle/kuzzle";
 
 /**
  * This file contains global type declarations for Kuzzle.

--- a/lib/types/Global.ts
+++ b/lib/types/Global.ts
@@ -1,5 +1,5 @@
 import { Backend } from "../core/backend";
-import { Kuzzle } from "../kuzzle/kuzzle";
+import { Kuzzle } from "../kuzzle";
 
 /**
  * This file contains global type declarations for Kuzzle.

--- a/lib/types/config/KuzzleConfiguration.ts
+++ b/lib/types/config/KuzzleConfiguration.ts
@@ -1,11 +1,11 @@
 import {
+  DumpConfiguration,
+  HttpConfiguration,
+  LimitsConfiguration,
+  PluginsConfiguration,
+  SecurityConfiguration,
   ServerConfiguration,
   ServicesConfiguration,
-  SecurityConfiguration,
-  HttpConfiguration,
-  PluginsConfiguration,
-  LimitsConfiguration,
-  DumpConfiguration,
 } from "../index";
 
 export interface IKuzzleConfiguration {
@@ -153,6 +153,7 @@ export interface IKuzzleConfiguration {
 
   internal: {
     hash: any;
+    notifiableProtocols: string[];
   };
 
   validation: Record<string, unknown>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "@semantic-release/commit-analyzer": "^10.0.1",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/release-notes-generator": "^11.0.4",
+        "@types/cookie": "^0.6.0",
         "@types/jest": "29.5.10",
         "@types/js-yaml": "4.0.9",
         "@types/lodash": "4.14.202",
@@ -3003,6 +3004,12 @@
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@semantic-release/commit-analyzer": "^10.0.1",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/release-notes-generator": "^11.0.4",
+    "@types/cookie": "^0.6.0",
     "@types/jest": "29.5.10",
     "@types/js-yaml": "4.0.9",
     "@types/lodash": "4.14.202",

--- a/test/kuzzle/event/kuzzleEventEmitter.test.js
+++ b/test/kuzzle/event/kuzzleEventEmitter.test.js
@@ -3,7 +3,7 @@
 const should = require("should");
 const sinon = require("sinon");
 
-const Emitter = require("../../../lib/kuzzle/event/kuzzleEventEmitter");
+const Emitter = require("../../../lib/kuzzle/event/KuzzleEventEmitter").default;
 const { InternalError: KuzzleInternalError } = require("../../../index");
 
 describe("#KuzzleEventEmitter", () => {

--- a/test/kuzzle/kuzzle.test.js
+++ b/test/kuzzle/kuzzle.test.js
@@ -45,7 +45,7 @@ describe("/lib/kuzzle/kuzzle.js", () => {
 
   function _mockKuzzle(KuzzleConstructor) {
     Reflect.deleteProperty(global, "kuzzle");
-    const k = new KuzzleConstructor(config);
+    const k = new KuzzleConstructor.default(config);
     const mock = new KuzzleMock();
 
     mockedProperties.forEach((p) => {

--- a/test/mocks/kuzzle.mock.js
+++ b/test/mocks/kuzzle.mock.js
@@ -3,7 +3,8 @@
 const sinon = require("sinon");
 const Bluebird = require("bluebird");
 
-const KuzzleEventEmitter = require("../../lib/kuzzle/event/kuzzleEventEmitter");
+const KuzzleEventEmitter =
+  require("../../lib/kuzzle/event/KuzzleEventEmitter").default;
 const kuzzleStateEnum = require("../../lib/kuzzle/kuzzleStateEnum");
 const configLoader = require("../../lib/config");
 


### PR DESCRIPTION
`global.kuzzle` typing is broken, this PR fixes it.

It also includes a conversion of the `KuzzleEventEmitter` class to TypeScript in order to provide better typings.