### PR TITLE
feat: do not store clear api keys in internal storage

### DIFF
--- a/.ci/scripts/run-test-cluster.sh
+++ b/.ci/scripts/run-test-cluster.sh
@@ -37,10 +37,10 @@ trap 'docker compose -f $YML_FILE logs' err
 
 docker compose -f $YML_FILE up -d
 
-# don't wait on 7512: nginx will accept connections far before Kuzzle does
 KUZZLE_PORT=17510 ./bin/wait-kuzzle
 KUZZLE_PORT=17511 ./bin/wait-kuzzle
 KUZZLE_PORT=17512 ./bin/wait-kuzzle
+KUZZLE_PORT=7512 ./bin/wait-kuzzle
 
 trap - err
 

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,9 @@
 {
   "plugins": ["kuzzle"],
   "extends": ["plugin:kuzzle/default", "plugin:kuzzle/node"],
+  "parserOptions": {
+    "ecmaVersion": 2020
+  },
   "rules": {
     "sort-keys": "warn",
     "kuzzle/array-foreach": "warn"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,5 +123,5 @@ npm run test:unit
 ### Functional tests
 
 ```bash
-KUZZLE_FUNCTIONAL_TESTS="test:functional:websocket" NODE_VERSION="20" ./.ci/scripts/run-test-cluster.sh
+KUZZLE_FUNCTIONAL_TESTS="test:functional:websocket" NODE_VERSION="20" ES_VERSION=8 ./.ci/scripts/run-test-cluster.sh
 ```

--- a/doc/2/guides/getting-started/deploy-your-application/index.md
+++ b/doc/2/guides/getting-started/deploy-your-application/index.md
@@ -51,7 +51,7 @@ A production deployment must include a reverse proxy to securize the connection 
 ::: warning
 #### Production Deployment: Auth Token Secret
 
-For every production deployment of Kuzzle, it is essential to set the kuzzle_security__authToken__secret environment variable. This ensures that the JWT secrets used for authenticating requests are generated externally and not stored in Elasticsearch. By managing the secret through an environment variable, you enhance security, prevent potential data exposure, and ensure tokens remain valid only as long as the secret remains unchanged.
+For every production deployment of Kuzzle, it is essential to set the `kuzzle_security__authToken__secret` environment variable. This ensures that the JWT secrets used for authenticating requests are generated externally and not stored in Elasticsearch. By managing the secret through an environment variable, you enhance security, prevent potential data exposure, and ensure tokens remain valid only as long as the secret remains unchanged.
 
 Important: If the `kuzzle_security__authToken__secret` value is changed when Kuzzle restarts, all existing tokens will be invalidated. This ensures that only tokens signed with the current secret remain valid, adding an extra layer of security.
 

--- a/doc/2/guides/getting-started/deploy-your-application/index.md
+++ b/doc/2/guides/getting-started/deploy-your-application/index.md
@@ -49,17 +49,25 @@ A production deployment must include a reverse proxy to securize the connection 
 :::
 
 ::: warning
-#### Production Deployment: Auth Token Secret
+# Authentication Security in Production
 
-For every production deployment of Kuzzle, it is essential to set the `kuzzle_security__authToken__secret` environment variable. This ensures that the JWT secrets used for authenticating requests are generated externally and not stored in Elasticsearch. By managing the secret through an environment variable, you enhance security, prevent potential data exposure, and ensure tokens remain valid only as long as the secret remains unchanged.
+## ⚠️ Important Security Requirement
 
-Important: If the `kuzzle_security__authToken__secret` value is changed when Kuzzle restarts, all existing tokens will be invalidated. This ensures that only tokens signed with the current secret remain valid, adding an extra layer of security.
+You must set the `kuzzle_security__authToken__secret` environment variable before deploying Kuzzle to production. This secret is used to sign and verify JSON Web Tokens (JWTs) for user authentication.
 
-For default configuration values, you can refer to [the sample Kuzzle configuration file](https://github.com/kuzzleio/kuzzle/blob/master/.kuzzlerc.sample.jsonc).
+## Why This Matters
+- Prevents tokens from being stored in Elasticsearch
+- Improves overall security
+- Gives you direct control over token management
 
-Note: If the secret is not set, Kuzzle will fallback to a less secure method of generating and storing the secret, which is not recommended for production environments.
+## Security Notes
+1. **Fallback Warning**: If you don't set this variable, Kuzzle will use a less secure fallback method (not recommended for production)
+2. **Token Invalidation**: Changing the secret value will immediately invalidate all existing authentication tokens
+3. **User Impact**: Users will need to log in again if the secret changes
+
+## Additional Resources
+For other configuration options, see the [sample configuration file](https://github.com/kuzzleio/kuzzle/blob/master/.kuzzlerc.sample.jsonc).
 :::
-
 ## Prepare our Docker Compose deployment
 
 We are going to write a `docker-compose.yml` file that describes our services.  

--- a/doc/2/guides/getting-started/deploy-your-application/index.md
+++ b/doc/2/guides/getting-started/deploy-your-application/index.md
@@ -48,6 +48,18 @@ This deployment does not use any SSL encryption (HTTPS).
 A production deployment must include a reverse proxy to securize the connection with SSL.
 :::
 
+::: warning
+#### Production Deployment: Auth Token Secret
+
+For every production deployment of Kuzzle, it is essential to set the kuzzle_security__authToken__secret environment variable. This ensures that the JWT secrets used for authenticating requests are generated externally and not stored in Elasticsearch. By managing the secret through an environment variable, you enhance security, prevent potential data exposure, and ensure tokens remain valid only as long as the secret remains unchanged.
+
+Important: If the `kuzzle_security__authToken__secret` value is changed when Kuzzle restarts, all existing tokens will be invalidated. This ensures that only tokens signed with the current secret remain valid, adding an extra layer of security.
+
+For default configuration values, you can refer to [the sample Kuzzle configuration file](https://github.com/kuzzleio/kuzzle/blob/master/.kuzzlerc.sample.jsonc).
+
+Note: If the secret is not set, Kuzzle will fallback to a less secure method of generating and storing the secret, which is not recommended for production environments.
+:::
+
 ## Prepare our Docker Compose deployment
 
 We are going to write a `docker-compose.yml` file that describes our services.  

--- a/features/step_definitions/auth-steps.js
+++ b/features/step_definitions/auth-steps.js
@@ -24,14 +24,14 @@ Given(
     const previousToken = this.sdk.jwt;
     const token = _.get(this.props, "result._source.token") || this.props.token;
 
-    should(token).not.be.undefined();
-
-    this.sdk.jwt = token;
     if (not) {
       should(await this.sdk.auth.checkToken()).throwError({
         id: "services.storage.not_found",
       });
     } else {
+      should(token).not.be.undefined();
+  
+      this.sdk.jwt = token;
       const { valid } = await this.sdk.auth.checkToken();
       this.sdk.jwt = previousToken;
       should(valid).be.true("Provided token is invalid");

--- a/features/step_definitions/auth-steps.js
+++ b/features/step_definitions/auth-steps.js
@@ -27,21 +27,20 @@ Given(
     should(token).not.be.undefined();
 
     this.sdk.jwt = token;
-
-    const { valid } = await this.sdk.auth.checkToken();
-
-    this.sdk.jwt = previousToken;
-
     if (not) {
-      should(valid).be.false("Provided token is valid");
+      should(await this.sdk.auth.checkToken()).throwError({
+        id: "services.storage.not_found",
+      });
     } else {
+      const { valid } = await this.sdk.auth.checkToken();
+      this.sdk.jwt = previousToken;
       should(valid).be.true("Provided token is invalid");
     }
   },
 );
 
 Given("I save the created API key", function () {
-  this.props.token = this.props.result._source.token;
+  this.props.token = this.props.result.token;
 });
 
 Given(

--- a/features/step_definitions/auth-steps.js
+++ b/features/step_definitions/auth-steps.js
@@ -24,23 +24,24 @@ Given(
     const previousToken = this.sdk.jwt;
     const token = _.get(this.props, "result._source.token") || this.props.token;
 
+    should(token).not.be.undefined();
+
+    this.sdk.jwt = token;
+
+    const { valid } = await this.sdk.auth.checkToken();
+
+    this.sdk.jwt = previousToken;
+
     if (not) {
-      should(await this.sdk.auth.checkToken()).throwError({
-        id: "services.storage.not_found",
-      });
+      should(valid).be.false("Provided token is valid");
     } else {
-      should(token).not.be.undefined();
-  
-      this.sdk.jwt = token;
-      const { valid } = await this.sdk.auth.checkToken();
-      this.sdk.jwt = previousToken;
       should(valid).be.true("Provided token is invalid");
     }
   },
 );
 
 Given("I save the created API key", function () {
-  this.props.token = this.props.result.token;
+  this.props.token = this.props.result._source.token;
 });
 
 Given(

--- a/lib/core/security/tokenRepository.ts
+++ b/lib/core/security/tokenRepository.ts
@@ -363,20 +363,24 @@ export class TokenRepository extends ObjectRepository<Token> {
 
     if (isApiKey) {
       const fingerprint = sha256(token);
-      
-      const userApiKeys = await ApiKey.search({ query : {
-        term: {
-          userId: decoded._id,
+
+      const userApiKeys = await ApiKey.search({
+        query: {
+          term: {
+            userId: decoded._id,
+          },
         },
-      } });
+      });
 
       if (userApiKeys.length === 0) {
         throw securityError.get("invalid");
       }
 
-      const targetApiKey = userApiKeys.find((apiKey) => apiKey.fingerprint === fingerprint);
-      
-      if(!targetApiKey) {
+      const targetApiKey = userApiKeys.find(
+        (apiKey) => apiKey.fingerprint === fingerprint,
+      );
+
+      if (!targetApiKey) {
         throw securityError.get("invalid");
       }
 

--- a/lib/core/security/tokenRepository.ts
+++ b/lib/core/security/tokenRepository.ts
@@ -135,7 +135,7 @@ export class TokenRepository extends ObjectRepository<Token> {
       this.verifyToken(hash),
     );
 
-    // ? those checks are necessary to detect JWT seed changes and delete existing token if necessary
+    // ? those checks are necessary to detect JWT seed changes and delete existing tokens if necessary
     const existingTokens = await global.kuzzle.ask(
       "core:cache:internal:searchKeys",
       "repos/kuzzle/token/*",

--- a/lib/core/security/tokenRepository.ts
+++ b/lib/core/security/tokenRepository.ts
@@ -362,7 +362,7 @@ export class TokenRepository extends ObjectRepository<Token> {
     }
 
     if (isApiKey) {
-      return this._verifyApiKey(decoded, token)
+      return this._verifyApiKey(decoded, token);
     }
 
     let userToken;
@@ -390,33 +390,33 @@ export class TokenRepository extends ObjectRepository<Token> {
   async _verifyApiKey(decoded, token: string) {
     const fingerprint = sha256(token);
 
-      const userApiKeys = await ApiKey.search({
-        query: {
-          term: {
-            userId: decoded._id,
-          },
+    const userApiKeys = await ApiKey.search({
+      query: {
+        term: {
+          userId: decoded._id,
         },
-      });
+      },
+    });
 
-      const targetApiKey = userApiKeys?.find(
-        (apiKey) => apiKey.fingerprint === fingerprint,
-      );
+    const targetApiKey = userApiKeys?.find(
+      (apiKey) => apiKey.fingerprint === fingerprint,
+    );
 
-      if (!targetApiKey) {
-        throw securityError.get("invalid");
-      }
+    if (!targetApiKey) {
+      throw securityError.get("invalid");
+    }
 
-      const apiKey = await ApiKey.load(decoded._id, targetApiKey._id);
+    const apiKey = await ApiKey.load(decoded._id, targetApiKey._id);
 
-      const userToken = new Token({
-        _id: `${decoded._id}#${token}`,
-        expiresAt: apiKey.expiresAt,
-        jwt: token,
-        ttl: apiKey.ttl,
-        userId: decoded._id,
-      });
+    const userToken = new Token({
+      _id: `${decoded._id}#${token}`,
+      expiresAt: apiKey.expiresAt,
+      jwt: token,
+      ttl: apiKey.ttl,
+      userId: decoded._id,
+    });
 
-      return userToken;
+    return userToken;
   }
 
   removeTokenPrefix(token: string) {

--- a/lib/core/security/tokenRepository.ts
+++ b/lib/core/security/tokenRepository.ts
@@ -363,8 +363,24 @@ export class TokenRepository extends ObjectRepository<Token> {
 
     if (isApiKey) {
       const fingerprint = sha256(token);
+      
+      const userApiKeys = await ApiKey.search({ query : {
+        term: {
+          userId: decoded._id,
+        },
+      } });
 
-      const apiKey = await ApiKey.load(decoded._id, fingerprint);
+      if (userApiKeys.length === 0) {
+        throw securityError.get("invalid");
+      }
+
+      const targetApiKey = userApiKeys.find((apiKey) => apiKey.fingerprint === fingerprint);
+      
+      if(!targetApiKey) {
+        throw securityError.get("invalid");
+      }
+
+      const apiKey = await ApiKey.load(decoded._id, targetApiKey._id);
 
       const userToken = new Token({
         _id: `${decoded._id}#${token}`,

--- a/lib/kuzzle/internalIndexHandler.js
+++ b/lib/kuzzle/internalIndexHandler.js
@@ -205,8 +205,7 @@ class InternalIndexHandler extends Store {
 
   async _initSecret() {
     const { authToken, jwt } = global.kuzzle.config.security;
-    const configSeed =
-      authToken && authToken.secret ? authToken.secret : jwt && jwt.secret;
+    const configSeed = authToken?.secret ?? jwt?.secret;
 
     let storedSeed = await this.exists("config", this._JWT_SECRET_ID);
 

--- a/lib/kuzzle/internalIndexHandler.js
+++ b/lib/kuzzle/internalIndexHandler.js
@@ -220,7 +220,7 @@ class InternalIndexHandler extends Store {
       }
 
       global.kuzzle.log.warn(
-        "[!] Kuzzle is using generated seed for authentication. This is suitable for development but should NEVER be use in Production. See https://docs.kuzzle.io/core/2/guides/getting-started/deploy-your-application/",
+        "[!] Kuzzle is using a generated seed for authentication. This is suitable for development but should NEVER be used in production. See https://docs.kuzzle.io/core/2/guides/getting-started/deploy-your-application/",
       );
     }
     global.kuzzle.secret = configSeed

--- a/lib/kuzzle/internalIndexHandler.js
+++ b/lib/kuzzle/internalIndexHandler.js
@@ -209,12 +209,18 @@ class InternalIndexHandler extends Store {
 
     let storedSeed = await this.exists("config", this._JWT_SECRET_ID);
 
-    if (!configSeed && !storedSeed) {
-      storedSeed = crypto.randomBytes(512).toString("hex");
-      await this.create(
-        "config",
-        { seed: storedSeed },
-        { id: this._JWT_SECRET_ID },
+    if (!configSeed) {
+      if (!storedSeed) {
+        storedSeed = crypto.randomBytes(512).toString("hex");
+        await this.create(
+          "config",
+          { seed: storedSeed },
+          { id: this._JWT_SECRET_ID },
+        );
+      }
+
+      global.kuzzle.log.warn(
+        "[!] Kuzzle is using generated seed for authentication. This is suitable for development but should NEVER be use in Production. See https://docs.kuzzle.io/core/2/guides/getting-started/deploy-your-application/",
       );
     }
     global.kuzzle.secret = configSeed

--- a/lib/kuzzle/internalIndexHandler.js
+++ b/lib/kuzzle/internalIndexHandler.js
@@ -111,6 +111,7 @@ class InternalIndexHandler extends Store {
       const bootstrapped = await this.exists("config", this._BOOTSTRAP_DONE_ID);
 
       if (bootstrapped) {
+        await this._initSecret();
         return;
       }
 
@@ -150,7 +151,7 @@ class InternalIndexHandler extends Store {
     await this.createInitialValidations();
 
     debug("Bootstrapping JWT secret");
-    await this._persistSecret();
+    await this._initSecret();
 
     // Create datamodel version
     await this.create(
@@ -202,24 +203,24 @@ class InternalIndexHandler extends Store {
     await Bluebird.all(promises);
   }
 
-  async getSecret() {
-    const response = await this.get("config", this._JWT_SECRET_ID);
+  async _initSecret() {
+    const { authToken, jwt } = global.kuzzle.config.security;
+    const configSeed =
+      authToken && authToken.secret ? authToken.secret : jwt && jwt.secret;
 
-    return response._source.seed;
-  }
+    let storedSeed = await this.exists("config", this._JWT_SECRET_ID);
 
-  async _persistSecret() {
-    const seed =
-      global.kuzzle.config.security.jwt.secret ||
-      crypto.randomBytes(512).toString("hex");
-
-    await this.create(
-      "config",
-      { seed },
-      {
-        id: this._JWT_SECRET_ID,
-      },
-    );
+    if (!configSeed && !storedSeed) {
+      storedSeed = crypto.randomBytes(512).toString("hex");
+      await this.create(
+        "config",
+        { seed: storedSeed },
+        { id: this._JWT_SECRET_ID },
+      );
+    }
+    global.kuzzle.secret = configSeed
+      ? configSeed
+      : (await this.get("config", this._JWT_SECRET_ID))._source.seed;
   }
 }
 

--- a/lib/kuzzle/kuzzle.ts
+++ b/lib/kuzzle/kuzzle.ts
@@ -259,9 +259,6 @@ class Kuzzle extends KuzzleEventEmitter {
       // This will init the cluster module if enabled
       this.id = await this.initKuzzleNode();
 
-      // Secret used to generate JWTs
-      this.secret = await this.internalIndex.getSecret();
-
       this.vault = vault.load(options.vaultKey, options.secretsFile);
 
       await this.validation.init();

--- a/lib/model/storage/apiKey.js
+++ b/lib/model/storage/apiKey.js
@@ -49,7 +49,7 @@ class ApiKey extends BaseModel {
   serialize({ includeToken = false } = {}) {
     const serialized = super.serialize();
 
-    if (!includeToken) {
+    if (!includeToken && this.token) {
       delete serialized._source.token;
     }
 
@@ -107,7 +107,6 @@ class ApiKey extends BaseModel {
         description,
         expiresAt: token.expiresAt,
         fingerprint,
-        token: token.jwt,
         ttl: token.ttl,
         userId: user._id,
       },
@@ -115,6 +114,8 @@ class ApiKey extends BaseModel {
     );
 
     await apiKey.save({ refresh, userId: creatorId });
+
+    apiKey.token = token.jwt;
 
     return apiKey;
   }
@@ -127,16 +128,27 @@ class ApiKey extends BaseModel {
    *
    * @returns {ApiKey}
    */
-  static async load(userId, id) {
-    const apiKey = await super.load(id);
+  static async load(userId, fingerprint) {
+    const query = {
+      term: {
+        userId,
+      },
+    };
 
-    if (userId !== apiKey.userId) {
-      throw kerror.get("services", "storage", "not_found", id, {
-        message: `ApiKey "${id}" not found for user "${userId}".`,
-      });
+    const apiKeys = await super.search({ query });
+    if (apiKeys.length > 0) {
+      const apiKey = apiKeys.find((a) => a.fingerprint === fingerprint);
+      if (userId !== apiKey.userId) {
+        throw kerror.get("services", "storage", "not_found", fingerprint, {
+          message: `ApiKey "${fingerprint}" not found for user "${userId}".`,
+        });
+      }
+
+      return apiKey;
     }
-
-    return apiKey;
+    throw kerror.get("services", "storage", "not_found", fingerprint, {
+      message: `ApiKey "${fingerprint}" not found for user "${userId}".`,
+    });
   }
 
   /**

--- a/lib/model/storage/apiKey.js
+++ b/lib/model/storage/apiKey.js
@@ -112,7 +112,7 @@ class ApiKey extends BaseModel {
       },
       apiKeyId || fingerprint,
     );
-
+    console.log(apiKey)
     await apiKey.save({ refresh, userId: creatorId });
 
     apiKey.token = token.jwt;
@@ -128,29 +128,18 @@ class ApiKey extends BaseModel {
    *
    * @returns {ApiKey}
    */
-  static async load(userId, fingerprint) {
-    const query = {
-      term: {
-        userId,
-      },
-    };
+  static async load(userId, id) {
+    const apiKey = await super.load(id);
 
-    const apiKeys = await super.search({ query });
-    if (apiKeys.length > 0) {
-      const apiKey = apiKeys.find((a) => a.fingerprint === fingerprint);
-      if (userId !== apiKey.userId) {
-        throw kerror.get("services", "storage", "not_found", fingerprint, {
-          message: `ApiKey "${fingerprint}" not found for user "${userId}".`,
-        });
-      }
-
-      return apiKey;
+    if (userId !== apiKey.userId) {
+      throw kerror.get("services", "storage", "not_found", id, {
+        message: `ApiKey "${id}" not found for user "${userId}".`,
+      });
     }
-    throw kerror.get("services", "storage", "not_found", fingerprint, {
-      message: `ApiKey "${fingerprint}" not found for user "${userId}".`,
-    });
-  }
 
+    return apiKey;
+  }
+  
   /**
    * Deletes API keys for an user
    *

--- a/lib/model/storage/apiKey.js
+++ b/lib/model/storage/apiKey.js
@@ -112,7 +112,6 @@ class ApiKey extends BaseModel {
       },
       apiKeyId || fingerprint,
     );
-    console.log(apiKey)
     await apiKey.save({ refresh, userId: creatorId });
 
     apiKey.token = token.jwt;
@@ -139,7 +138,7 @@ class ApiKey extends BaseModel {
 
     return apiKey;
   }
-  
+
   /**
    * Deletes API keys for an user
    *

--- a/lib/model/storage/baseModel.js
+++ b/lib/model/storage/baseModel.js
@@ -218,7 +218,6 @@ class BaseModel {
       searchBody,
       options,
     );
-
     return resp.hits.map((hit) => this._instantiateFromDb(hit));
   }
 
@@ -232,7 +231,7 @@ class BaseModel {
   static truncate({ refresh } = {}) {
     return this.deleteByQuery({ match_all: {} }, { refresh });
   }
-
+  // ? This looks not in use anymore ?
   static batchExecute(query, callback) {
     return global.kuzzle.internalIndex.mExecute(
       this.collection,

--- a/test/mocks/internalIndexHandler.mock.js
+++ b/test/mocks/internalIndexHandler.mock.js
@@ -11,7 +11,6 @@ class InternalIndexHandlerMock extends InternalIndexHandler {
     sinon.stub(this, "init");
     sinon.stub(this, "createInitialSecurities").resolves();
     sinon.stub(this, "createInitialValidations").resolves();
-    sinon.stub(this, "getSecret").resolves();
   }
 }
 

--- a/test/model/storage/apiKey.test.js
+++ b/test/model/storage/apiKey.test.js
@@ -116,23 +116,16 @@ describe("ApiKey", () => {
 
   describe("ApiKey.load", () => {
     it("should throw if the key does not belong to the provided user", async () => {
-      const searchStub = sinon
-        .stub(BaseModel, "search")
+      const loadStub = sinon
+        .stub(BaseModel, "load")
         .resolves({ userId: "mylehuong" });
 
       const promise = ApiKey.load("aschen", "api-key-id");
-
       await should(promise).be.rejectedWith({
         id: "services.storage.not_found",
       });
 
-      should(searchStub).be.calledWith({
-        query: {
-          term: {
-            userId: "aschen",
-          },
-        },
-      });
+      should(loadStub).be.calledWith("api-key-id");
     });
   });
 

--- a/test/model/storage/apiKey.test.js
+++ b/test/model/storage/apiKey.test.js
@@ -116,8 +116,8 @@ describe("ApiKey", () => {
 
   describe("ApiKey.load", () => {
     it("should throw if the key does not belong to the provided user", async () => {
-      const loadStub = sinon
-        .stub(BaseModel, "load")
+      const searchStub = sinon
+        .stub(BaseModel, "search")
         .resolves({ userId: "mylehuong" });
 
       const promise = ApiKey.load("aschen", "api-key-id");
@@ -126,7 +126,13 @@ describe("ApiKey", () => {
         id: "services.storage.not_found",
       });
 
-      should(loadStub).be.calledWith("api-key-id");
+      should(searchStub).be.calledWith({
+        query: {
+          term: {
+            userId: "aschen",
+          },
+        },
+      });
     });
   });
 


### PR DESCRIPTION
KUZSUPPORT-68

# Goals: 
- remove the seed from internal storage in case we have secret provided by config :heavy_check_mark: 
  - removed `_persistSecret` method to use a `_initSecret` that will load secret at backend start
  - set some changes in `TokenRepository` `init` method to detect seed changes and invalidate all tokens
  - refactor validation errors throw order to avoid sending `expired` if token is invalid && expired _(not fully sure it is possible but hey, costs nothing)_
  - Warn users at start when using generated seed ![image](https://github.com/user-attachments/assets/33adc1a5-49a0-4f21-878d-23822e9fdf6c)
  - add `authToken` config support because `jwt` is deprecated but `authToken` is not usable 
  - Updated tests to reflect new uses cases.
  - remove test  `_getSecret` wich is not necessary anymore.
  - add documentation warning to encourage use a custom seed when deploying to production using `ENV`
- do not store clear api keys in internal storage :heavy_check_mark: 
  - ensure no breaking changes
  - ensure old api keys still works 


review point of interest : 
- I decided to remove apikeys from cache at it was stored in clear as in the database. It could be kept using fingerprint as a part of the key instead of api key itself ? May need some refactor
