### PR TITLE
fix(npm): fix ES7 sdk pulled from Github instead of NPM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "passport": "0.7.0",
         "protobufjs": "7.2.5",
         "rc": "1.2.8",
-        "sdk-es7": "https://github.com/elastic/elasticsearch-js/archive/refs/tags/v7.13.0.tar.gz",
+        "sdk-es7": "npm:@elastic/elasticsearch@7.13.0",
         "sdk-es8": "npm:@elastic/elasticsearch@8.12.1",
         "semver": "7.6.0",
         "sorted-array": "2.0.4",
@@ -8247,7 +8247,8 @@
     "node_modules/hpagent": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-0.1.2.tgz",
-      "integrity": "sha512-ePqFXHtSQWAFXYmj+JtOTHr84iNrII4/QRlAAPPE+zqnKy4xJo7Ie1Y4kC7AdB+LxLxSTTzBMASsEcy0q8YyvQ=="
+      "integrity": "sha512-ePqFXHtSQWAFXYmj+JtOTHr84iNrII4/QRlAAPPE+zqnKy4xJo7Ie1Y4kC7AdB+LxLxSTTzBMASsEcy0q8YyvQ==",
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -17880,8 +17881,8 @@
     "node_modules/sdk-es7": {
       "name": "@elastic/elasticsearch",
       "version": "7.13.0",
-      "resolved": "https://github.com/elastic/elasticsearch-js/archive/refs/tags/v7.13.0.tar.gz",
-      "integrity": "sha1-KH2HuyhOIkuGAit0KRVmPxI43So=",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.13.0.tgz",
+      "integrity": "sha512-WgwLWo2p9P2tdqzBGX9fHeG8p5IOTXprXNTECQG2mJ7z9n93N5AFBJpEw4d35tWWeCWi9jI13A2wzQZH7XZ/xw==",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "passport": "0.7.0",
     "protobufjs": "7.2.5",
     "rc": "1.2.8",
-    "sdk-es7": "https://github.com/elastic/elasticsearch-js/archive/refs/tags/v7.13.0.tar.gz",
+    "sdk-es7": "npm:@elastic/elasticsearch@7.13.0",
     "sdk-es8": "npm:@elastic/elasticsearch@8.12.1",
     "semver": "7.6.0",
     "sorted-array": "2.0.4",


### PR DESCRIPTION
## What does this PR do ?

Fixes ES7 SDK being pulled from Github instead of NPM.