### PR TITLE
chore(docker): bump base version of elasticsearch for docker image

### DIFF
--- a/.github/workflows/elasticsearch.yml
+++ b/.github/workflows/elasticsearch.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
-  ELASTICSEARCH_VERSION: "7.16.2"
+  ELASTICSEARCH_VERSION: "7.17.25"
 
 jobs:
   build-and-push:

--- a/docker/images/elasticsearch/Dockerfile
+++ b/docker/images/elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-ARG ELASTICSEARCH_VERSION="7.16.2"
+ARG ELASTICSEARCH_VERSION="7.17.25"
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ELASTICSEARCH_VERSION}
 
 LABEL maintainer="kuzzle" contact="<support@kuzzle.io>"

--- a/docker/images/elasticsearch/README.md
+++ b/docker/images/elasticsearch/README.md
@@ -1,7 +1,7 @@
 # Elasticsearch
 
-This container is built from [Elasticsearch official 7.10 image](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html) with a few modifications:
+This container is built from [Elasticsearch official 7.17 image](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/docker.html) with a few modifications:
 
-* All xpack plugins are disabled by default
-* `jvm.options` file is modified to remove the jvm heap size settings, thus allowing to set them with `ES_JAVA_OPTS` environment variable (default to 512m).
-* The GeoIP downloader is disabled by default
+- All xpack plugins are disabled by default
+- `jvm.options` file is modified to remove the jvm heap size settings, thus allowing to set them with `ES_JAVA_OPTS` environment variable (default to 512m).
+- The GeoIP downloader is disabled by default


### PR DESCRIPTION
## What does this PR do ?

Bumps base image version of our docker elasticsearch image to the latest 7.x version available.