### PR TITLE
feat(controllers): add a config to allow additional properties in actions definitions

### DIFF
--- a/.kuzzlerc.sample.jsonc
+++ b/.kuzzlerc.sample.jsonc
@@ -1117,5 +1117,18 @@
       "sync": 7511
     },
     "syncTimeout": 5000
+  },
+  // [controllers]
+  // Controllers configuration
+  //   * definition:
+  //      Options to manage controllers definition behavior
+  //       * allowAdditionalActionProperties:
+  //          If set to true, Kuzzle will allow additional properties in
+  //          actions definitions. If set to false, Kuzzle will throw an error
+  //          if an action definition contains additional properties.
+  "controllers": {
+    "definition": {
+      "allowAdditionalActionProperties": false
+    }
   }
 }

--- a/lib/config/default.config.ts
+++ b/lib/config/default.config.ts
@@ -473,6 +473,12 @@ const defaultConfig: KuzzleConfiguration = {
   },
   /** @type {DocumentSpecification} */
   validation: {},
+
+  controllers: {
+    definition: {
+      allowAdditionalActionProperties: false,
+    },
+  },
 };
 
 export default defaultConfig;

--- a/lib/core/plugin/plugin.js
+++ b/lib/core/plugin/plugin.js
@@ -333,19 +333,23 @@ class Plugin {
     for (const [action, actionDefinition] of Object.entries(
       definition.actions,
     )) {
-      const actionProperties = Object.keys(actionDefinition);
-
-      if (actionProperties.length > 2) {
-        actionProperties.splice(actionProperties.indexOf("handler"), 1);
-        actionProperties.splice(actionProperties.indexOf("http"), 1);
-
-        throw assertionError.get(
-          "invalid_controller_definition",
-          name,
-          `action "${action}" has invalid properties: ${actionProperties.join(
-            ", ",
-          )}`,
+      if (
+        !global.app.config.content.controllers.definition
+          .allowAdditionalActionProperties
+      ) {
+        const actionProperties = Object.keys(actionDefinition).filter(
+          (prop) => prop !== "handler" && prop !== "http",
         );
+
+        if (actionProperties.length > 0) {
+          throw assertionError.get(
+            "invalid_controller_definition",
+            name,
+            `action "${action}" has invalid properties: ${actionProperties.join(
+              ", ",
+            )}`,
+          );
+        }
       }
 
       if (typeof action !== "string") {

--- a/lib/types/config/KuzzleConfiguration.ts
+++ b/lib/types/config/KuzzleConfiguration.ts
@@ -157,6 +157,17 @@ export interface IKuzzleConfiguration {
   };
 
   validation: Record<string, unknown>;
+
+  controllers: {
+    definition: {
+      /**
+       * Allow additional properties in action definitions.
+       *
+       * @default false
+       */
+      allowAdditionalActionProperties: boolean;
+    };
+  };
 }
 
 export type KuzzleConfiguration = Partial<IKuzzleConfiguration>;

--- a/test/core/backend/BackendController.test.js
+++ b/test/core/backend/BackendController.test.js
@@ -66,6 +66,7 @@ describe("Backend", () => {
 
     beforeEach(() => {
       definition = getDefinition();
+      global.app.config.content.controllers.definition.allowAdditionalActionProperties = false;
     });
 
     it("should registers a new controller definition", () => {
@@ -89,8 +90,25 @@ describe("Backend", () => {
       delete definition.actions;
 
       should(() => {
-        application.controller.register(definition);
+        application.controller.register("greeting", definition);
       }).throwError({ id: "plugin.assert.invalid_controller_definition" });
+    });
+
+    it("should reject additional properties", () => {
+      definition.actions.sayHello.foo = "bar";
+
+      should(() => {
+        application.controller.register("greeting", definition);
+      }).throwError({ id: "plugin.assert.invalid_controller_definition" });
+    });
+
+    it("should accept additional properties if config allows it", () => {
+      global.app.config.content.controllers.definition.allowAdditionalActionProperties = true;
+      definition.actions.sayHello.foo = "bar";
+
+      should(() => {
+        application.controller.register("greeting", definition);
+      }).not.throwError({ id: "plugin.assert.invalid_controller_definition" });
     });
   });
 
@@ -113,6 +131,7 @@ describe("Backend", () => {
 
     beforeEach(() => {
       controller = new GreetingController();
+      global.app.config.content.controllers.definition.allowAdditionalActionProperties = false;
     });
 
     it("should uses a new controller instance", () => {
@@ -154,6 +173,23 @@ describe("Backend", () => {
       should(() => {
         application.controller.use(controller);
       }).throwError({ id: "plugin.assert.invalid_controller_definition" });
+    });
+
+    it("should reject additional properties", () => {
+      controller.definition.actions.sayHello.foo = "bar";
+
+      should(() => {
+        application.controller.use(controller);
+      }).throwError({ id: "plugin.assert.invalid_controller_definition" });
+    });
+
+    it("should accept additional properties if config allows it", () => {
+      global.app.config.content.controllers.definition.allowAdditionalActionProperties = true;
+      controller.definition.actions.sayHello.foo = "bar";
+
+      should(() => {
+        application.controller.use(controller);
+      }).not.throwError({ id: "plugin.assert.invalid_controller_definition" });
     });
   });
 });


### PR DESCRIPTION
## What does this PR do ?

Adds a configuration that allow specifying additional properties in the actions definitions of a controller.

### How should this be manually tested?

  - Step 1 : Set config `controllers.definition.allowAdditionalActionProperties` to `true`
  - Step 2 : Add additional properties to an action definition (other than `handler` and `http`)
  - Step 3 : Registering this controller with the backend shouldn't result in a exception being thrown

### Other changes

- Fixed the test of the presence of additional properties
- Fixed missing parameter in a test that didn't result in a failure because thrown error was the same