### PR TITLE
feat(funnel): add request:onExecution pipe

### DIFF
--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -659,6 +659,7 @@ class Funnel {
 
     try {
       await this._checkSdkVersion(_request);
+      _request = await global.kuzzle.pipe("request:onExecution", _request);
       _request = await this.performDocumentAlias(_request, "before");
       _request = await global.kuzzle.pipe(
         this.getEventName(_request, "before"),

--- a/test/api/funnel/processRequest.test.js
+++ b/test/api/funnel/processRequest.test.js
@@ -174,6 +174,7 @@ describe("funnel.processRequest", () => {
 
     return funnel.processRequest(request).then((response) => {
       should(response).be.exactly(request);
+      should(kuzzle.pipe).calledWith("request:onExecution");
       should(kuzzle.pipe).calledWith("fakeController:beforeSucceed");
       should(kuzzle.pipe).calledWith("fakeController:afterSucceed");
       should(kuzzle.pipe).calledWith("request:onSuccess", request);


### PR DESCRIPTION
## What does this PR do ?

Adds a `request:onExecution` pipe event that is triggered right before the action's own `before` pipe.
