### PR TITLE
fix(plugin): fix allowAdditionalActionProperties config accessing

### DIFF
--- a/lib/core/plugin/plugin.js
+++ b/lib/core/plugin/plugin.js
@@ -31,6 +31,7 @@ const kerror = require("../../kerror");
 const errorCodes = require("../../kerror/codes");
 const Manifest = require("./pluginManifest");
 const { has, isPlainObject } = require("../../util/safeObject");
+const defaultConfig = require("../../config/default.config");
 
 const assertionError = kerror.wrap("plugin", "assert");
 const runtimeError = kerror.wrap("plugin", "runtime");
@@ -334,8 +335,9 @@ class Plugin {
       definition.actions,
     )) {
       if (
-        !global.app.config.content.controllers.definition
-          .allowAdditionalActionProperties
+        !global.app.config.content.controllers?.definition
+          ?.allowAdditionalActionProperties ??
+        defaultConfig.controllers.definition.allowAdditionalActionProperties
       ) {
         const actionProperties = Object.keys(actionDefinition).filter(
           (prop) => prop !== "handler" && prop !== "http",


### PR DESCRIPTION
## What does this PR do ?
Fixes `allowAdditionalActionProperties` config accessing in `plugin.js`.

The default config is not merged in at the time this function is first called so we manually
fallback on the default config
