### PR TITLE
feat(elasticsearch): add post_filter to whitelist of body terms

### DIFF
--- a/lib/service/storage/7/elasticsearch.ts
+++ b/lib/service/storage/7/elasticsearch.ts
@@ -122,6 +122,7 @@ export class ES7 {
       "fields",
       "from",
       "highlight",
+      "post_filter",
       "query",
       "search_after",
       "search_timeout",

--- a/lib/service/storage/8/elasticsearch.ts
+++ b/lib/service/storage/8/elasticsearch.ts
@@ -124,6 +124,7 @@ export class ES8 {
       "fields",
       "from",
       "highlight",
+      "post_filter",
       "query",
       "search_after",
       "search_timeout",


### PR DESCRIPTION
## What does this PR do ?
This PR adds the term "post_filter" to the whitelist of allowed body terms for Elasticsearch queries. (for V7 and v8).

For information, this keyword allows to filter the result of a query after an aggregation for example. 
