### PR TITLE
fix: update es version to avoid anyController error

### DIFF
--- a/docker/images/elasticsearch/Dockerfile
+++ b/docker/images/elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-ARG ELASTICSEARCH_VERSION="7.17.25"
+ARG ELASTICSEARCH_VERSION="7.17.26"
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ELASTICSEARCH_VERSION}
 
 LABEL maintainer="kuzzle" contact="<support@kuzzle.io>"


### PR DESCRIPTION
# overview


With newer versions of docker desktop an error started to occur. This update the Elasticsearch image to fix this issue