### PR TITLE
fix(elasticsearch): allow bulk updateByQuery without changes

### DIFF
--- a/lib/service/storage/7/elasticsearch.ts
+++ b/lib/service/storage/7/elasticsearch.ts
@@ -1298,6 +1298,14 @@ export class ES7 {
       refresh?: boolean;
     } = {},
   ) {
+    const esRequest: RequestParams.UpdateByQuery<KRequestBody<JSONObject>> = {
+      body: {
+        query: this._sanitizeSearchBody({ query }).query,
+      },
+      index: this._getAlias(index, collection),
+      refresh,
+    };
+
     const script = {
       params: {},
       source: "",
@@ -1310,14 +1318,9 @@ export class ES7 {
       script.params[key] = value;
     }
 
-    const esRequest: RequestParams.UpdateByQuery<KRequestBody<JSONObject>> = {
-      body: {
-        query: this._sanitizeSearchBody({ query }).query,
-        script,
-      },
-      index: this._getAlias(index, collection),
-      refresh,
-    };
+    if (script.source !== "") {
+      esRequest.body.script = script;
+    }
 
     debug("Bulk Update by query: %o", esRequest);
 

--- a/lib/service/storage/8/elasticsearch.ts
+++ b/lib/service/storage/8/elasticsearch.ts
@@ -1328,6 +1328,12 @@ export class ES8 {
       refresh?: boolean;
     } = {},
   ) {
+    const esRequest: estypes.UpdateByQueryRequest = {
+      index: this._getAlias(index, collection),
+      query: this._sanitizeSearchBody({ query }).query,
+      refresh,
+    };
+
     const script = {
       params: {},
       source: "",
@@ -1340,12 +1346,9 @@ export class ES8 {
       script.params[key] = value;
     }
 
-    const esRequest: estypes.UpdateByQueryRequest = {
-      index: this._getAlias(index, collection),
-      query: this._sanitizeSearchBody({ query }).query,
-      refresh,
-      script,
-    };
+    if (script.source !== "") {
+      esRequest.script = script;
+    }
 
     debug("Bulk Update by query: %o", esRequest);
 

--- a/test/service/storage/elasticsearch-7.test.js
+++ b/test/service/storage/elasticsearch-7.test.js
@@ -1814,6 +1814,27 @@ describe("Test: ElasticSearch service", () => {
           "2 documents were successfully updated before an error occured",
       });
     });
+
+    it("should not generate a script if there are no changes", async () => {
+      const requestWithoutChanges = {
+        body: {
+          query,
+        },
+        index: alias,
+        refresh: false,
+      };
+
+      await elasticsearch.client.bulkUpdateByQuery(
+        index,
+        collection,
+        query,
+        {},
+      );
+
+      should(elasticsearch.client._client.updateByQuery).be.calledWithMatch(
+        requestWithoutChanges,
+      );
+    });
   });
 
   describe("#deleteByQuery", () => {

--- a/test/service/storage/elasticsearch-8.test.js
+++ b/test/service/storage/elasticsearch-8.test.js
@@ -1747,6 +1747,25 @@ describe("Test: ElasticSearch service", () => {
           "2 documents were successfully updated before an error occured",
       });
     });
+
+    it("should not generate a script if there are no changes", async () => {
+      const requestWithoutChanges = {
+        query,
+        index: alias,
+        refresh: false,
+      };
+
+      await elasticsearch.client.bulkUpdateByQuery(
+        index,
+        collection,
+        query,
+        {},
+      );
+
+      should(elasticsearch.client._client.updateByQuery).be.calledWithMatch(
+        requestWithoutChanges,
+      );
+    });
   });
 
   describe("#deleteByQuery", () => {


### PR DESCRIPTION
## What does this PR do ?

Allows calling `bulk:updateByQuery` with an empty `changes` object in order to trigger a reindex.
Also added a test to ensure no script is generated when an empty `changes` object is passed.

### How should this be manually tested?

  - Step 1 : call `bulk:updateByQuery` with an empty `changes` object.
  - Step 2 : ensure the call returned a 200 code with the right updated document count
