### PR TITLE
fix(funnel): handle errors for trigger event requests

### DIFF
--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -754,6 +754,8 @@ class Funnel {
    */
   async executePluginRequest(request) {
     if (request.input.triggerEvents) {
+      let error;
+      let res;
       try {
         const { result } = await this.processRequest(request);
         debug(
@@ -761,17 +763,17 @@ class Funnel {
           request.id,
           result,
         );
-        return global.kuzzle.pipe("request:afterExecution", {
-          request,
-          result,
-          success: true,
-        });
-      } catch (error) {
+        res = result;
+        return { ...result };
+      } catch (e) {
+        error = e;
         debug("Error processing request %s: %a", request.id, error);
-        return global.kuzzle.pipe("request:afterExecution", {
+      } finally {
+        global.kuzzle.pipe("request:afterExecution", {
           error: error,
           request: request,
-          success: false,
+          result: res,
+          success: error === undefined ? true : false,
         });
       }
     }

--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -755,8 +755,17 @@ class Funnel {
   async executePluginRequest(request) {
     if (request.input.triggerEvents) {
       try {
-        const response = await this.processRequest(request);
-        return { ...response.result };
+        const { result } = await this.processRequest(request);
+        debug(
+          "Request %s successfully executed. Result: %a",
+          request.id,
+          result,
+        );
+        return global.kuzzle.pipe("request:afterExecution", {
+          request,
+          result,
+          success: true,
+        });
       } catch (error) {
         debug("Error processing request %s: %a", request.id, error);
         return global.kuzzle.pipe("request:afterExecution", {

--- a/lib/api/funnel.js
+++ b/lib/api/funnel.js
@@ -753,11 +753,20 @@ class Funnel {
    * @returns {Promise}
    */
   async executePluginRequest(request) {
-    try {
-      if (request.input.triggerEvents) {
+    if (request.input.triggerEvents) {
+      try {
         const response = await this.processRequest(request);
         return { ...response.result };
+      } catch (error) {
+        debug("Error processing request %s: %a", request.id, error);
+        return global.kuzzle.pipe("request:afterExecution", {
+          error: error,
+          request: request,
+          success: false,
+        });
       }
+    }
+    try {
       return await doAction(this.getController(request), request);
     } catch (e) {
       this.handleErrorDump(e);

--- a/test/api/funnel/executePluginRequest.test.js
+++ b/test/api/funnel/executePluginRequest.test.js
@@ -137,6 +137,7 @@ describe("funnel.executePluginRequest", () => {
     return funnel.executePluginRequest(request).then(() => {
       should(kuzzle.pipe).calledWith("testme:beforeFail");
       should(kuzzle.pipe).calledWith("testme:errorFail");
+      should(kuzzle.pipe).not.calledWith("testme:afterFail");
     });
   });
 });

--- a/test/api/funnel/executePluginRequest.test.js
+++ b/test/api/funnel/executePluginRequest.test.js
@@ -134,7 +134,8 @@ describe("funnel.executePluginRequest", () => {
       triggerEvents: true,
     });
 
-    return funnel.executePluginRequest(request).then(() => {
+    return funnel.executePluginRequest(request).catch((e) => {
+      should(e.message).be.eql("rejected action");
       should(kuzzle.pipe).calledWith("testme:beforeFail");
       should(kuzzle.pipe).calledWith("testme:errorFail");
       should(kuzzle.pipe).not.calledWith("testme:afterFail");

--- a/test/api/funnel/executePluginRequest.test.js
+++ b/test/api/funnel/executePluginRequest.test.js
@@ -126,4 +126,17 @@ describe("funnel.executePluginRequest", () => {
       should(kuzzle.pipe).not.calledWith("testme:afterSucceed");
     });
   });
+
+  it("should catch an error and trigger error pipe if triggerEvent enabled", async () => {
+    const request = new Request({
+      action: "fail",
+      controller: "testme",
+      triggerEvents: true,
+    });
+
+    return funnel.executePluginRequest(request).then(() => {
+      should(kuzzle.pipe).calledWith("testme:beforeFail");
+      should(kuzzle.pipe).calledWith("testme:errorFail");
+    });
+  });
 });


### PR DESCRIPTION
## What does this PR do ?
This PR fix an issue where some errors thrown from a pipe triggered by a plugin request with `triggerEvents` flag weren't caught.

The error handling is the same for plugin requests with triggerEvents as for basic requests.

