### PR TITLE
fix(elasticsearch): user provided _kuzzle_info for M operations

### DIFF
--- a/lib/service/storage/7/elasticsearch.ts
+++ b/lib/service/storage/7/elasticsearch.ts
@@ -3080,6 +3080,8 @@ export class ES7 {
     extractedDocuments: JSONObject[],
     documentsToGet: JSONObject[],
   ) {
+    delete document.body._kuzzle_info;
+
     let extractedDocument;
 
     if (prepareMUpsert) {

--- a/lib/service/storage/8/elasticsearch.ts
+++ b/lib/service/storage/8/elasticsearch.ts
@@ -3080,6 +3080,8 @@ export class ES8 {
     extractedDocuments: JSONObject[],
     documentsToGet: JSONObject[],
   ) {
+    delete document.body._kuzzle_info;
+
     let extractedDocument;
 
     if (prepareMUpsert) {


### PR DESCRIPTION
## What does this PR do ?

<!--
  Please include a summary of the change, relevant motivation and context.
  Also, list any dependencies that are required for this change.
-->

### How should this be manually tested?
This PR makes the multiples operations (mCreate, mUpdate, mUpsert, etc.) ignore user provided _kuzzle_info, which should not be modified by anyone but the backend.