### PR TITLE
feat(logger): create logger child instances for plugins 

### DIFF
--- a/.github/workflows/workflow-deployments.yml
+++ b/.github/workflows/workflow-deployments.yml
@@ -21,6 +21,16 @@ on:
         default: "22"
         type: string
 
+    secrets:
+      ACCESS_TOKEN_CI:
+        required: true
+      SEMANTIC_RELEASE_GHP:
+        required: true
+      NPM_TOKEN:
+        required: true
+      SEMANTIC_RELEASE_SLACK_WEBHOOK:
+        required: true
+
   workflow_dispatch:
     inputs:
       doc_deploy:

--- a/lib/core/plugin/pluginContext.ts
+++ b/lib/core/plugin/pluginContext.ts
@@ -56,6 +56,7 @@ import { EmbeddedSDK } from "../shared/sdk/embeddedSdk";
 import { Store } from "../shared/store";
 import { storeScopeEnum } from "../storage/storeScopeEnum";
 import PluginRepository from "./pluginRepository";
+import { KuzzleLogger } from "kuzzle-logger/dist";
 
 const contextError = kerror.wrap("plugin", "context");
 
@@ -229,6 +230,11 @@ export class PluginContext {
   public secrets: JSONObject;
 
   /**
+   * Logger instance
+   */
+  public logger: KuzzleLogger;
+
+  /**
    * Internal Logger
    */
   public log: {
@@ -327,15 +333,17 @@ export class PluginContext {
 
     Object.freeze(this.constructors);
 
-    /* context.log ======================================================== */
+    this.logger = global.kuzzle.log.child(`${pluginName}`);
 
+    /* context.log ======================================================== */
+    // @deprecated backward compatibility only
     this.log = {
-      debug: (msg) => global.kuzzle.log.debug(`[${pluginName}] ${msg}`),
-      error: (msg) => global.kuzzle.log.error(`[${pluginName}] ${msg}`),
-      info: (msg) => global.kuzzle.log.info(`[${pluginName}] ${msg}`),
-      silly: (msg) => global.kuzzle.log.silly(`[${pluginName}] ${msg}`),
-      verbose: (msg) => global.kuzzle.log.verbose(`[${pluginName}] ${msg}`),
-      warn: (msg) => global.kuzzle.log.warn(`[${pluginName}] ${msg}`),
+      debug: (msg) => this.logger.debug(`[${pluginName}] ${msg}`),
+      error: (msg) => this.logger.error(`[${pluginName}] ${msg}`),
+      info: (msg) => this.logger.info(`[${pluginName}] ${msg}`),
+      silly: (msg) => this.logger.trace(`[${pluginName}] ${msg}`),
+      verbose: (msg) => this.logger.trace(`[${pluginName}] ${msg}`),
+      warn: (msg) => this.logger.warn(`[${pluginName}] ${msg}`),
     };
 
     Object.freeze(this.log);

--- a/lib/core/plugin/pluginContext.ts
+++ b/lib/core/plugin/pluginContext.ts
@@ -333,7 +333,7 @@ export class PluginContext {
 
     Object.freeze(this.constructors);
 
-    this.logger = global.kuzzle.log.child(`${pluginName}`);
+    this.logger = globalThis.kuzzle.log.child(`${pluginName}`);
 
     /* context.log ======================================================== */
     // @deprecated backward compatibility only

--- a/test/core/plugin/context/context.test.js
+++ b/test/core/plugin/context/context.test.js
@@ -258,12 +258,22 @@ describe("Plugin Context", () => {
     });
 
     it("should expose the right accessors", () => {
+      const pinoLevelMap = {
+        silly: "trace",
+        verbose: "trace",
+        info: "info",
+        debug: "debug",
+        warn: "warn",
+        error: "error",
+      };
+
       for (const level of ["verbose", "info", "debug", "warn", "error"]) {
         should(context.log[level]).be.an.instanceOf(Function);
+        should(context.logger[pinoLevelMap[level]]).be.an.instanceOf(Function);
 
         context.log[level]("test");
 
-        should(kuzzle.log[level])
+        should(context.logger[pinoLevelMap[level]])
           .calledOnce()
           .calledWithExactly("[pluginName] test");
       }
@@ -285,7 +295,7 @@ describe("Plugin Context", () => {
 
       process.nextTick(() => {
         try {
-          should(kuzzle.log.info)
+          should(context.logger.info)
             .be.calledOnce()
             .be.calledWith("[pluginName] foobar");
 


### PR DESCRIPTION
This allow kuzzle to automatically create a child logeur for plugins.
This child plugin is used by historical accessors for backward compat

<img width="1657" height="1011" alt="image" src="https://github.com/user-attachments/assets/1ad4cb55-ed22-4a3a-a2d0-dfcb03c9b002" />

