### PR TITLE
Fix/unsubscribe cleanup

### DIFF
--- a/lib/core/realtime/hotelClerk.ts
+++ b/lib/core/realtime/hotelClerk.ts
@@ -544,7 +544,7 @@ export class HotelClerk {
       throw realtimeError.get("room_not_found", roomId);
     }
 
-    for (const channel of Object.keys(room.channels)) {
+    for (const channel of room.channels.keys()) {
       global.kuzzle.entryPoint.leaveChannel(channel, connectionId);
     }
 


### PR DESCRIPTION
# Overview

## Realtime Unsubscribe Bug: Root Cause and Impact

### What the bug was
In hotelClerk.ts (line 547), unsubscribe logic iterated channels with:

`Object.keys(room.channels)`

But room.channels is a Map (see room.ts), and Object.keys on a Map returns an empty array.

That means leaveChannel(...) was not executed for actual realtime channels during unsubscribe.

### Correct behavior

The fix is to iterate the Map keys directly:

```js
for (const channel of room.channels.keys()) {
  global.kuzzle.entryPoint.leaveChannel(channel, connectionId);
}
```

Technical consequence of the bug

Unsubscribe removed internal subscription bookkeeping, but did not consistently remove protocol-level channel membership.

This created a potential mismatch between:

Internal realtime state (hotel clerk, rooms, subscriptions)
Effective websocket channel attachment in the network layer

### Why this matters
Realtime delivery depends on coherent channel lifecycle. If channel leave operations are skipped, long-running systems can accumulate stale membership state and drift over time.

Possible effects include:

### Inconsistent notification routing

Partial or unexpected realtime delivery behavior while socket remains connected
Issues that appear only after long uptime and are difficult to reproduce in short-lived environments
Validation

