### PR TITLE
feat(csv-export) : added support for search result collapsing

### DIFF
--- a/doc/2/api/controllers/document/export/index.md
+++ b/doc/2/api/controllers/document/export/index.md
@@ -10,19 +10,19 @@ title: export | API | Core
 
 Export searched documents.
 
-This method behaves like a `document:search` except that it scrolls and formats the searched results in one of the supported format (`csv`, `jsonl`) then returns everything as an HTTP Stream,
-that can either be downloaded directly from a browser or any scripts.
+This method behaves like a `document:search`, except that it scrolls through and formats search results in one of the supported formats (`csv`, `jsonl`), then returns everything as an HTTP stream
+that can either be downloaded directly from a browser or consumed by a script.
 
 This method also supports the [Koncorde Filters DSL](/core/2/api/koncorde-filters-syntax) to match documents by passing the `lang` argument with the value `koncorde`.
 Koncorde filters will be translated into an Elasticsearch query.
 
 ::: info
 The `scroll` parameter represents the maximum time needed for the client to download a page of `size` results.
-You should try with smaller pages of results if you experienced download problems.
+Use smaller result pages if you experience download problems.
 :::
 
 ::: info
-If you want to expose the exported documents in HTTP, you will need to create a `<a>` element and add a [single use token](/core/2/api/controllers/auth/create-token) in the link `jwt` argument.
+If you want to expose exported documents over HTTP, create an `<a>` element and add a [single use token](/core/2/api/controllers/auth/create-token) in the link `jwt` argument.
 :::
 
 ::: warning
@@ -30,7 +30,7 @@ Koncorde `bool` operator and `regexp` clause are not supported for search querie
 :::
 
 ::: warning
-This method only supports the HTTP Protocol
+This method only supports the HTTP protocol.
 :::
 
 ---
@@ -50,8 +50,8 @@ Body:
   "query": {
     // ...
   },
-  "aggregations": {
-    // ...
+  "collapse": {
+    // ...collapse field
   },
   "sort": [
     // ...
@@ -89,15 +89,18 @@ Following arguments are available: `query`, `fields` and `fieldsName`.
     "query": {
       // ...
     },
-    "aggregations": {
-      // ...
+    "collapse": {
+      // ...collapse field
     },
     "sort": [
       // ...
     ],
     "fields": [
       // ["name", "age"]
-    ]
+    ],
+    "fieldsName": {
+      // "name": "Customer Name"
+    }
   },
 
   // optional:
@@ -122,8 +125,8 @@ Following arguments are available: `query`, `fields` and `fieldsName`.
 
 - `separator`: This option is only supported for the `CSV` format, it defines which character sequence will be used to format the CSV documents
 - `fields`: This option is only supported for the `CSV` format, it defines which fields should be exported
-- `fieldsName`: This option is only supported for the `CSV` format, it defines how fields path should be renamed, if not present the field path will be used.
-- `scroll`: This option must be set with a [time duration](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/common-options.html#time-units), at the end of which the cursor is destroyed.
+- `fieldsName`: This option is only supported for the `CSV` format. It defines how field paths should be renamed. If not present, field paths are used.
+- `scroll`: This option must be set with a [time duration](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/common-options.html#time-units), at the end of which the cursor is destroyed. 
 - `size`: set the maximum number of documents returned per result page. By default it's `10`.
 - `lang`: specify the query language to use. By default, it's `elasticsearch` but `koncorde` can also be used.
 - `format`: Set the format that should be used to export the documents. (`csv`, `jsonl`)
@@ -135,14 +138,18 @@ Following arguments are available: `query`, `fields` and `fieldsName`.
 ### Optional:
 
 - `query`: the search query itself, using the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-dsl.html) or the [Koncorde Filters DSL](/core/2/api/koncorde-filters-syntax) syntax.
-- `aggregations`: control how the search result should be [aggregated](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/search-aggregations.html)
+- `collapse`: keeps only the first matching document for each value of the collapse field. See [Collapsing search results](https://www.elastic.co/docs/reference/elasticsearch/rest-apis/collapse-search-results).
 - `sort`: contains a list of fields, used to [sort search results](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/search-request-sort.html), in order of importance
 - `fields`: control which field should be exported, using lodash syntax.
 
 An empty body matches all documents in the queried collection.
 
 ::: info
-Only the following fields are available in the top level of the search body: `aggregations`, `aggs`, `collapse`, `explain`, `fields`, `from`, `highlight`, `query`, `search_timeout`, `size`, `sort`, `_name`, `_source`, `_source_excludes`, `_source_includes`
+Only the following fields are available in the top level of the search body: `collapse`, `explain`, `fields`, `from`, `highlight`, `query`, `search_timeout`, `size`, `sort`, `_name`, `_source`, `_source_excludes`, `_source_includes`
+:::
+
+::: warning
+Due to an Elasticsearch limitation, `scroll` cannot be combined with the `collapse` option. As a result, `collapse` only applies to a page of up to 10000 search results.
 :::
 
 ---

--- a/lib/util/dump-collection.ts
+++ b/lib/util/dump-collection.ts
@@ -129,7 +129,7 @@ abstract class AbstractDumper {
     }
 
     if (query.collapse) {
-      global.kuzzle.log
+      globalThis.kuzzle.log
         .child("CSV-dump")
         .warn(
           "The 'collapse' option is not compatible with scrolling. Disabling scroll.",

--- a/lib/util/dump-collection.ts
+++ b/lib/util/dump-collection.ts
@@ -121,11 +121,21 @@ abstract class AbstractDumper {
       fieldsName: {},
       scroll: "5s",
       separator: ",",
-      size: 10,
+      size: 1000,
     },
   ) {
+
     if (!writeStream) {
       throw kerror.get("api", "assert", "missing_argument", "writeStream");
+    }
+
+    if (query.collapse) {
+      global.kuzzle.log
+        .child("CSV-dump")
+        .warn(
+          "The 'collapse' option is not compatible with scrolling. Disabling scroll.",
+        );
+      delete this.options.scroll;
     }
   }
 

--- a/lib/util/dump-collection.ts
+++ b/lib/util/dump-collection.ts
@@ -124,7 +124,6 @@ abstract class AbstractDumper {
       size: 1000,
     },
   ) {
-
     if (!writeStream) {
       throw kerror.get("api", "assert", "missing_argument", "writeStream");
     }


### PR DESCRIPTION
* ci(sonarqube): setup job


### How should this be manually tested?
use document:export API with collapse field and see you get only latest resulte for each possible value of the field.

```
{
	"query": {
		"bool": {
			"must": [
				{
					"exists": {
						"field": "values.reading"
					}
				},
				{
					"term": {
						"type": "waterConsumption"
					}
				}
			]
		}
	},
	"collapse": {
		"field": "origin.reference"
	},
	"sort": [
		{
			"measuredAt": "desc"
		}
	],
	"fields": [
		"values.reading",
		"origin.reference",
		"measuredAt"
	],
	"fieldsName": {
		"values.reading": "Index",
		"origin.reference": "DevEUI"
	}
}

```
KZLPRD-1330