### PR TITLE
fix(securityController): token revocation

### DIFF
--- a/lib/api/controllers/securityController.ts
+++ b/lib/api/controllers/securityController.ts
@@ -1332,8 +1332,11 @@ export default class SecurityController extends NativeController {
    */
   async revokeTokens(request: KuzzleRequest) {
     const id = request.getId();
+    const refresh = request.getRefresh("wait_for");
 
     await this.ask("core:security:token:deleteByKuid", id);
+
+    await ApiKey.deleteByUser({ _id: id } as any, { refresh });
 
     return null;
   }

--- a/test/api/controllers/securityController/users.test.js
+++ b/test/api/controllers/securityController/users.test.js
@@ -1262,8 +1262,16 @@ describe("Test: security controller - users", () => {
   });
 
   describe("#revokeTokens", () => {
+    let ApiKey;
+
     beforeEach(() => {
+      ApiKey = require("../../../../lib/model/storage/apiKey");
+      sinon.stub(ApiKey, "deleteByUser").resolves();
       request.input.args._id = "test";
+    });
+
+    afterEach(() => {
+      ApiKey.deleteByUser.restore();
     });
 
     it("should revoke all tokens related to a given user", async () => {
@@ -1272,6 +1280,11 @@ describe("Test: security controller - users", () => {
       should(kuzzle.ask).calledWithMatch(
         "core:security:token:deleteByKuid",
         request.input.args._id,
+      );
+
+      should(ApiKey.deleteByUser).calledWithMatch(
+        { _id: request.input.args._id },
+        { refresh: "wait_for" },
       );
     });
 


### PR DESCRIPTION
## What does this PR do ?

Fixes an issue where `revokeTokens` only deleted session tokens (JWTs) from the cache, leaving persistent API keys fully intact and visible when calling `searchAPIKeys`. 

### How should this be manually tested?

  - Step 1: Create a new user in Kuzzle.
  - Step 2: Create a new API key for this user.
  - Step 3: Run `searchAPIKeys` for the user and verify the key is present in the list.
  - Step 4: Revoke the user's tokens using `revokeTokens`.
  - Step 5: Run `searchAPIKeys` again and verify that the API key is no longer present in the list.