### PR TITLE
fix(dump): check suffix against a regexp to sanitize user input

### DIFF
--- a/lib/kuzzle/dumpGenerator.js
+++ b/lib/kuzzle/dumpGenerator.js
@@ -53,6 +53,12 @@ class DumpGenerator {
 
     this._dump = true;
 
+    const suffixRegex = /^[A-Za-z0-9_-]{0,64}$/;
+    if (!suffixRegex.test(suffix)) {
+      throw new BadRequestError(
+        `Invalid suffix '${suffix}'. Suffix must be alphanumeric and can contain '-' and '_'. Max length is 64 characters.`,
+      );
+    }
     const basePath = path.normalize(global.kuzzle.config.dump.path);
     const dumpPath = path.join(
       basePath,
@@ -62,7 +68,7 @@ class DumpGenerator {
         .substring(0, 200),
     );
     const resolvedPath = path.resolve(dumpPath);
-    if (!resolvedPath.startsWith(path.resolve(basePath))) {
+    if (!resolvedPath.startsWith(path.resolve(basePath) + path.sep)) {
       throw new BadRequestError(
         `Dump path '${dumpPath}' is outside of designated dump directory '${basePath}'`,
       );

--- a/test/kuzzle/dumpGenerator.test.js
+++ b/test/kuzzle/dumpGenerator.test.js
@@ -68,7 +68,7 @@ describe("Test: kuzzle/dumpGenerator", () => {
       BadRequestError,
       {
         message: new RegExp(
-          /Dump path [A-Za-z-/.'"]* is outside of designated dump directory [A-Za-z-/."']*/,
+          /Invalid suffix [A-Za-z-/.'"]*. Suffix must be alphanumeric and can contain '-' and '_'. Max length is 64 characters.*/,
         ),
       },
     );


### PR DESCRIPTION
## What does this PR do ?
Add a regex to sanitize user input on dump api

```js

    const suffixRegex = /^[A-Za-z0-9_-]{0,64}$/;
    if (!suffixRegex.test(suffix)) {
      throw new BadRequestError(
        `Invalid suffix '${suffix}'. Suffix must be alphanumeric and can contain '-' and '_'. Max length is 64 characters.`,
      );
    }
```
