### PR TITLE
fix(export-csv): use sort args when provided in the query

### DIFF
--- a/lib/api/controllers/documentController.js
+++ b/lib/api/controllers/documentController.js
@@ -245,11 +245,16 @@ class DocumentController extends NativeController {
     const format = request.getString("format", "jsonl");
     const separator = request.getString("separator", ",");
     const query = request.getObjectFromBodyOrArgs("query", {});
+    const sort = request.getObjectFromBodyOrArgs("sort", null);
     const collapse = request.getObjectFromBodyOrArgs("collapse", {});
     const fields = request.getArrayFromBodyOrArgs("fields", []);
     const fieldsName = request.getObjectFromBodyOrArgs("fieldsName", {});
 
     const searchBody = { query };
+
+    if (sort !== null) {
+      searchBody.sort = sort;
+    }
 
     if (Object.keys(collapse).length > 0) {
       searchBody.collapse = collapse;

--- a/lib/api/controllers/documentController.js
+++ b/lib/api/controllers/documentController.js
@@ -252,10 +252,6 @@ class DocumentController extends NativeController {
 
     const searchBody = { query };
 
-    if (sort !== null) {
-      searchBody.sort = sort;
-    }
-
     if (Object.keys(collapse).length > 0) {
       searchBody.collapse = collapse;
     }
@@ -273,7 +269,9 @@ class DocumentController extends NativeController {
     if (lang === "koncorde") {
       searchBody.query = await this.translateKoncorde(searchBody.query || {});
     }
-
+    if (sort !== null) {
+      searchBody.sort = sort;
+    }
     let mimeType = "html/text";
 
     if (format.toLowerCase() === "csv") {

--- a/lib/api/controllers/documentController.js
+++ b/lib/api/controllers/documentController.js
@@ -245,7 +245,7 @@ class DocumentController extends NativeController {
     const format = request.getString("format", "jsonl");
     const separator = request.getString("separator", ",");
     const query = request.getObjectFromBodyOrArgs("query", {});
-    const sort = request.getObjectFromBodyOrArgs("sort", null);
+    const sort = request.getObjectFromBodyOrArgs("sort", {});
     const collapse = request.getObjectFromBodyOrArgs("collapse", {});
     const fields = request.getArrayFromBodyOrArgs("fields", []);
     const fieldsName = request.getObjectFromBodyOrArgs("fieldsName", {});
@@ -269,7 +269,8 @@ class DocumentController extends NativeController {
     if (lang === "koncorde") {
       searchBody.query = await this.translateKoncorde(searchBody.query || {});
     }
-    if (sort !== null) {
+
+    if (Object.keys(sort).length > 0) {
       searchBody.sort = sort;
     }
     let mimeType = "html/text";

--- a/test/api/controllers/documentController.test.js
+++ b/test/api/controllers/documentController.test.js
@@ -417,6 +417,7 @@ describe("DocumentController", () => {
       response.stream.resume();
       await new Promise((resolve) => response.stream.on("end", resolve));
 
+      //eslint-disable-next-line no-console
       console.dir(kuzzle.ask.firstCall.args, { depth: null });
 
       should(kuzzle.ask).be.calledWithMatch(

--- a/test/api/controllers/documentController.test.js
+++ b/test/api/controllers/documentController.test.js
@@ -417,22 +417,12 @@ describe("DocumentController", () => {
       response.stream.resume();
       await new Promise((resolve) => response.stream.on("end", resolve));
 
-      //eslint-disable-next-line no-console
-      console.dir(kuzzle.ask.firstCall.args, { depth: null });
-
       should(kuzzle.ask).be.calledWithMatch(
         "core:storage:public:document:search",
         index,
         collection,
         sinon.match.hasNested("collapse.field", "category"),
-        /*{
-          query: {
-            term: { category: "books" },
-          },
-          collapse: {
-            field: "category",
-          },
-        }*/ {
+        {
           lang: "elasticsearch",
           scroll: undefined,
           size: 10,

--- a/test/api/controllers/documentController.test.js
+++ b/test/api/controllers/documentController.test.js
@@ -417,19 +417,21 @@ describe("DocumentController", () => {
       response.stream.resume();
       await new Promise((resolve) => response.stream.on("end", resolve));
 
+      console.dir(kuzzle.ask.firstCall.args, { depth: null });
+
       should(kuzzle.ask).be.calledWithMatch(
         "core:storage:public:document:search",
         index,
         collection,
-        {
+        sinon.match.hasNested("collapse.field", "category"),
+        /*{
           query: {
             term: { category: "books" },
           },
           collapse: {
             field: "category",
           },
-        },
-        {
+        }*/ {
           lang: "elasticsearch",
           scroll: undefined,
           size: 10,


### PR DESCRIPTION


## What does this PR do ?

fix this kind of query:
``` JSON
{
	"query": {
		"bool": {
			"must": [
				{
					"range" : {
						"measuredAt" : {
							"lte" : "now",
							"gt" : "now-7d"
						}
					}
				},
				
				{
					"exists": {
						"field": "values.reading"
					}
				},
				{
					"term": {
						"type": "waterConsumption"
					}
				}
			]
		}
	},
	"sort": [
		{
			"measuredAt": "asc"
		}
	],
	"fields": [
		"values.reading",
		"origin.reference",
		"measuredAt"
	],
	"fieldsName": {
		"values.reading": "Index",
		"origin.reference": "DevEUI"
	}
}
```
