### PR TITLE
feat: setup claude

### DIFF
--- a/.ci/scripts/docker-test.sh
+++ b/.ci/scripts/docker-test.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# Run Kuzzle's unit or functional test suites fully inside Docker.
+# No local Node.js/npm install is required: dependencies, build and test
+# execution all happen inside the project's Docker images.
+#
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+ES_VERSION="${ES_VERSION:-7}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  .ci/scripts/docker-test.sh unit <vitest|mocha>
+  .ci/scripts/docker-test.sh functional <http|websocket|legacy:http|legacy:mqtt|legacy:websocket> [-- <cucumber-js args>]
+
+Env vars:
+  ES_VERSION   Elasticsearch major version for functional tests: 7 or 8 (default: 7)
+
+Examples:
+  .ci/scripts/docker-test.sh unit vitest
+  .ci/scripts/docker-test.sh unit mocha
+  .ci/scripts/docker-test.sh functional websocket
+  ES_VERSION=8 .ci/scripts/docker-test.sh functional http
+
+  # Target a single feature file or a tag instead of the whole suite:
+  .ci/scripts/docker-test.sh functional websocket -- features/api/document.feature
+  .ci/scripts/docker-test.sh functional http -- --tags "@security"
+EOF
+}
+
+run_unit() {
+  local suite="$1"
+
+  case "$suite" in
+    vitest|mocha) ;;
+    *)
+      echo "Unknown unit suite: '$suite' (expected 'vitest' or 'mocha')" >&2
+      exit 1
+      ;;
+  esac
+
+  docker compose -f docker-compose.yml run --rm --no-deps \
+    -e NODE_ENV=test \
+    node bash -lc "npm ci && npm run build && npm run test:unit:${suite}"
+}
+
+run_functional() {
+  local suite="$1"
+  shift
+  local test_script="test:functional:${suite}"
+  local yml_file
+  local extra_args=("$@")
+
+  case "$ES_VERSION" in
+    7) yml_file=".ci/test-cluster-7.yml" ;;
+    8) yml_file=".ci/test-cluster-8.yml" ;;
+    *)
+      echo "Invalid ES_VERSION '$ES_VERSION' (expected 7 or 8)" >&2
+      exit 1
+      ;;
+  esac
+
+  trap 'docker compose -f "$yml_file" logs --tail=200' ERR
+
+  docker compose -f "$yml_file" down -v
+
+  echo "Installing dependencies..."
+  docker compose -f "$yml_file" run --rm --no-deps kuzzle_node_1 npm ci
+
+  echo "Starting Kuzzle cluster..."
+  docker compose -f "$yml_file" up -d
+
+  echo "Waiting for the cluster to be reachable..."
+  docker compose -f "$yml_file" run --rm --no-deps \
+    -e KUZZLE_HOST=kuzzle_node_1 -e KUZZLE_PORT=7512 kuzzle_node_1 node bin/wait-kuzzle
+  docker compose -f "$yml_file" run --rm --no-deps \
+    -e KUZZLE_HOST=kuzzle_node_2 -e KUZZLE_PORT=7512 kuzzle_node_1 node bin/wait-kuzzle
+  docker compose -f "$yml_file" run --rm --no-deps \
+    -e KUZZLE_HOST=kuzzle_node_3 -e KUZZLE_PORT=7512 kuzzle_node_1 node bin/wait-kuzzle
+  docker compose -f "$yml_file" run --rm --no-deps \
+    -e KUZZLE_HOST=nginx -e KUZZLE_PORT=7512 kuzzle_node_1 node bin/wait-kuzzle
+
+  trap - ERR
+
+  if [ "${#extra_args[@]}" -gt 0 ] && [ "${extra_args[0]}" = "--" ]; then
+    extra_args=("${extra_args[@]:1}")
+  fi
+
+  if [ "${#extra_args[@]}" -gt 0 ]; then
+    echo "Running functional tests: ${test_script} -- ${extra_args[*]}"
+    docker compose -f "$yml_file" run --rm --no-deps \
+      -e KUZZLE_HOST=nginx \
+      kuzzle_node_1 npm run "$test_script" -- "${extra_args[@]}"
+  else
+    echo "Running functional tests: ${test_script}"
+    docker compose -f "$yml_file" run --rm --no-deps \
+      -e KUZZLE_HOST=nginx \
+      kuzzle_node_1 npm run "$test_script"
+  fi
+}
+
+case "${1:-}" in
+  unit)
+    run_unit "${2:?Missing unit suite: vitest|mocha}"
+    ;;
+  functional)
+    suite="${2:?Missing functional suite: e.g. http, websocket, legacy:http}"
+    shift 2
+    run_functional "$suite" "$@"
+    ;;
+  -h|--help|"")
+    usage
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/.ci/scripts/pr-preflight.sh
+++ b/.ci/scripts/pr-preflight.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Run the local checks most likely to fail in CI before pushing:
+#   - lint (matches the `lint` job in pull_request.workflow.yaml)
+#   - error codes documentation (matches the `error-codes-check` job)
+#   - a heuristic reminder about test/doc coverage (CONTRIBUTING.md)
+#
+# Requires local Node.js/npm (same as `npm run test:lint` would).
+#
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+status=0
+
+echo "==> Lint (npm run test:lint)"
+if npm run test:lint; then
+  echo "[OK] lint"
+else
+  echo "[FAIL] lint"
+  status=1
+fi
+
+echo
+echo "==> Error codes documentation"
+tmp_codes_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_codes_dir"' EXIT
+
+if npm run doc-error-codes -- --output "$tmp_codes_dir" > /dev/null; then
+  mismatch=0
+  for domain_dir in doc/2/api/errors/error-codes/*/; do
+    [ -d "$domain_dir" ] || continue
+    domain="$(basename "$domain_dir")"
+    if ! diff -q "$domain_dir" "$tmp_codes_dir/$domain" > /dev/null 2>&1; then
+      echo "[FAIL] error codes docs out of date for domain '$domain' — run: npm run doc-error-codes"
+      mismatch=1
+    fi
+  done
+  if [ "$mismatch" -eq 0 ]; then
+    echo "[OK] error codes docs"
+  else
+    status=1
+  fi
+else
+  echo "[FAIL] npm run doc-error-codes failed to generate docs"
+  status=1
+fi
+
+echo
+echo "==> Test & doc coverage reminder (heuristic, not a hard gate)"
+base_ref="$(git merge-base HEAD origin/master 2>/dev/null || git merge-base HEAD master 2>/dev/null || true)"
+if [ -n "$base_ref" ]; then
+  changed="$(git diff --name-only "$base_ref"...HEAD; git diff --name-only; git diff --name-only --cached)"
+else
+  changed="$(git diff --name-only; git diff --name-only --cached)"
+fi
+changed="$(echo "$changed" | sort -u)"
+
+lib_changed="$(echo "$changed" | grep -E '^lib/' || true)"
+test_changed="$(echo "$changed" | grep -E '^(test|tests|features|features-legacy)/' || true)"
+
+if [ -n "$lib_changed" ] && [ -z "$test_changed" ]; then
+  echo "[WARN] lib/ changed with no test/tests/features file changed — CONTRIBUTING.md:"
+  echo "       \"Always add/update the corresponding unit and/or functional tests.\""
+  echo "$lib_changed" | sed 's/^/    /'
+elif [ -n "$lib_changed" ]; then
+  echo "[OK] lib/ changes have matching test/feature changes"
+else
+  echo "[OK] no lib/ changes"
+fi
+
+echo
+if [ "$status" -eq 0 ]; then
+  echo "Preflight passed."
+else
+  echo "Preflight FAILED — fix the issues above before pushing."
+fi
+
+exit "$status"

--- a/.claude/skills/docker-tests/SKILL.md
+++ b/.claude/skills/docker-tests/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: docker-tests
+description: Run Kuzzle's unit (vitest/mocha) or functional (cucumber) test suites entirely inside Docker, with no local Node.js/npm install required, including targeting a single feature file or tag for fast iteration. Use when the user asks to run/launch tests, unit tests, functional tests, or "les tests" for this repo, especially when they want it done "via Docker" or without setting up a local toolchain.
+---
+
+# Docker Tests
+
+Runs Kuzzle's test suites using only Docker, via `.ci/scripts/docker-test.sh`.
+Dependencies install, TypeScript build, and test execution all happen inside
+the project's `kuzzle-runner` container images — the host only needs Docker.
+
+## Unit tests
+
+```bash
+.ci/scripts/docker-test.sh unit vitest
+.ci/scripts/docker-test.sh unit mocha
+```
+
+Each command runs `npm ci && npm run build && npm run test:unit:<suite>` inside
+a one-off container based on the `node` service from `docker-compose.yml`
+(`--no-deps`, so Elasticsearch/Redis are not started — unit tests don't need them).
+
+## Functional tests
+
+```bash
+.ci/scripts/docker-test.sh functional http
+.ci/scripts/docker-test.sh functional websocket
+.ci/scripts/docker-test.sh functional legacy:http
+.ci/scripts/docker-test.sh functional legacy:mqtt
+.ci/scripts/docker-test.sh functional legacy:websocket
+
+# Against Elasticsearch 8 instead of the default 7:
+ES_VERSION=8 .ci/scripts/docker-test.sh functional websocket
+```
+
+This spins up the 3-node Kuzzle cluster + nginx + Elasticsearch + Redis defined
+in `.ci/test-cluster-7.yml` (or `-8.yml`), waits for every node to be reachable,
+then runs the matching `test:functional:*` npm script (Cucumber) inside a
+container attached to that same cluster network — nothing runs on the host.
+
+First run pulls the Elasticsearch image and can take a few minutes; subsequent
+runs are faster. On failure, the last 200 lines of every service's logs are
+printed automatically.
+
+### Targeting a single feature file or tag
+
+Running the whole suite for a quick iteration is slow. Pass extra Cucumber
+args after `--` to target just what you're working on — they're forwarded
+straight to `cucumber-js`, overriding the profile's default `paths`/`tags`:
+
+```bash
+.ci/scripts/docker-test.sh functional websocket -- features/api/document.feature
+.ci/scripts/docker-test.sh functional http -- --tags "@security"
+```
+
+The cluster is still brought up fully (Cucumber needs a real Kuzzle to run
+against); only the test selection is narrowed.
+
+## Notes
+
+- These commands are for local development. CI (`.github/workflows/pull_request.workflow.yaml`)
+  runs unit tests directly on the runner and functional tests via
+  `.ci/scripts/run-test-cluster.sh` — `docker-test.sh` is a local-only convenience
+  wrapper and intentionally does not replace either.
+- If a dev stack is already running (`docker compose up`), unit test runs are
+  unaffected (`--no-deps`, separate one-off container).

--- a/.claude/skills/pr-preflight/SKILL.md
+++ b/.claude/skills/pr-preflight/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: pr-preflight
+description: Run the local checks most likely to fail in CI before pushing or opening a PR on this repo — lint, error-codes documentation sync, and a test/doc coverage reminder. Use when the user asks if a PR/change is ready, wants to check before pushing, or asks to run the same checks as CI locally.
+---
+
+# PR Preflight
+
+Runs `.ci/scripts/pr-preflight.sh`, which mirrors the two CI gates that most
+commonly fail on a first push, plus a lightweight coverage reminder:
+
+```bash
+.ci/scripts/pr-preflight.sh
+```
+
+1. **Lint** — `npm run test:lint`, same as the `lint` job in
+   `.github/workflows/pull_request.workflow.yaml`.
+2. **Error codes documentation** — regenerates `doc/2/api/errors/error-codes/`
+   into a temp dir via `npm run doc-error-codes` and diffs it against the
+   committed docs, same as the `error-codes-check` job. Any `lib/kerror/codes/*.json`
+   change without a regenerated doc fails here, before CI. Fix with:
+   `npm run doc-error-codes`, then commit the updated `doc/2/api/errors/error-codes/`.
+3. **Test/doc coverage reminder** — a heuristic (not a hard gate): warns if
+   `lib/` files changed (against `origin/master`, or working-tree diff if that's
+   unavailable) with no matching change under `test/`, `tests/`, `features/`
+   or `features-legacy/`. CONTRIBUTING.md is explicit that untested or
+   undocumented pull requests won't be accepted — this just flags the
+   omission before a human reviewer does.
+
+Requires local Node.js/npm (same prerequisite as `npm run test:lint`) — this
+does not run in Docker, matching how lint and the error-codes check run
+directly on the CI runner rather than in a container.
+
+Exit code is non-zero if lint or the error-codes check fails; the coverage
+reminder never fails the run on its own.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,78 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository. Humans should read
+[CONTRIBUTING.md](./CONTRIBUTING.md) instead.
+
+## What this is
+
+Kuzzle is a generic backend server (Node.js/TypeScript). Source lives in `lib/`
+(`api`, `cluster`, `config`, `core`, `kerror`, `kuzzle`, `model`, `service`,
+`types`, `util`), the public entrypoint is `index.ts`, and it compiles to
+`dist/` via `tsc`.
+
+## Build & run
+
+```bash
+npm run build      # tsc -> dist/
+npm run dev        # tsx watch start-kuzzle-dev.ts (requires ES + Redis, see docker-compose.yml)
+```
+
+Local dev stack (Elasticsearch, Redis, Kuzzle with hot reload):
+`docker compose up` (ES8) or `docker compose -f docker-compose.yml up` (ES7).
+
+## Tests — always run these before considering a change done
+
+```bash
+npm run test:lint          # eslint ./lib ./test ./bin ./features
+npm run test:unit:vitest   # unit tests under tests/
+npm run test:unit:mocha    # unit tests under test/ (needs `npm run build` first)
+```
+
+Functional tests (Cucumber) need a running Kuzzle cluster:
+```bash
+ES_VERSION=8 KUZZLE_FUNCTIONAL_TESTS="test:functional:websocket" ./.ci/scripts/run-test-cluster.sh
+```
+
+**Prefer the Docker-only path** — no local Node/ES/Redis setup needed, see the
+`docker-tests` skill or run directly:
+```bash
+.ci/scripts/docker-test.sh unit vitest
+.ci/scripts/docker-test.sh unit mocha
+.ci/scripts/docker-test.sh functional websocket   # or http, legacy:http, legacy:mqtt, legacy:websocket
+```
+
+A PR without corresponding unit/functional test coverage will not be accepted
+(see CONTRIBUTING.md) — do not skip writing tests for behavior changes.
+
+Before pushing, run the `pr-preflight` skill (`.ci/scripts/pr-preflight.sh`):
+lint + error-codes doc sync + a test-coverage reminder, mirroring the CI checks
+most likely to fail on a first push.
+
+## Code style
+
+- ESLint config: `.eslintrc.json` (`eslint-plugin-kuzzle`, stricter TS ruleset for `*.ts`).
+- Prettier: `.prettierrc` (semicolons on).
+- Async/await or promises over callbacks — **except** for code invoked before
+  the funnel module (network connection handling), which must use callbacks
+  to avoid event loop saturation.
+- Follow KISS and the Boy Scout Rule; keep changes minimal and self-documented
+  (see [CONTRIBUTING.md](./CONTRIBUTING.md) for the full rationale).
+
+## Key config files
+
+- `.kuzzlerc.sample.jsonc` — full annotated config reference.
+- `docker-compose.yml` + `docker-compose.override.yml` — local dev stack (ES7 vs ES8).
+- `.ci/test-cluster-7.yml` / `.ci/test-cluster-8.yml` — 3-node cluster used by functional tests.
+- `cucumber.config.cjs` — functional test profiles (http/websocket/mqtt, legacy vs current).
+- `vitest.config.ts` / `.mocharc.json` — unit test runners (two suites coexist during migration).
+
+## Things to know before making changes
+
+- Two unit test frameworks are active side by side (`test/` → mocha,
+  `tests/` → vitest). Check which directory your change belongs to; don't move
+  tests between them as part of an unrelated change.
+- `test:unit:mocha` runs against **compiled** output (`dist/test/**/*.test.js`)
+  — rebuild (`npm run build`) after editing source or tests before running it.
+- Error codes are documented and checked: `npm run doc-error-codes` and
+  `.ci/scripts/check-error-codes-documentation.sh`. New error codes need docs.
+- Don't commit changes to `dist/`, `coverage/`, or `node_modules/`.


### PR DESCRIPTION
# Summary

Add configuration so AI agents (Claude Code) can work efficiently on this repo, **without changing any application code** — tooling and documentation only.

## AGENTS.md

Context file for AI agents (the equivalent of a dedicated README):

- Project overview
- Build / dev commands
- How to run the tests: lint, unit (vitest / mocha), functional (cucumber)
- Code conventions: ESLint / Prettier, async/await except where noted before the funnel
- Key config files
- Gotchas to be aware of:
  - Two unit-testing frameworks coexist
  - mocha runs against compiled code
  - Error codes must be documented
  - Never commit anything into `dist/`, `coverage/`, or `node_modules/`

## .ci/scripts/docker-test.sh + `docker-tests` skill

Wrapper to run the entire test suite 100% through Docker, with no local install of Node / ES / Redis:

- **unit vitest / unit mocha** — build + unit tests in an isolated node container (`--no-deps`)
- **functional `<http|websocket|legacy:http|legacy:mqtt|legacy:websocket>`** — spins up the 3-node Kuzzle cluster + nginx + ES + Redis, waits until everything is up, then runs Cucumber
- Supports `ES_VERSION=7|8`
- Can target a single `.feature` file or a tag (e.g. `-- features/api/document.feature`, `-- --tags "@security"`)
- Does **not** affect CI (which keeps its own path via `run-test-cluster.sh`) — this is a purely local convenience

## .ci/scripts/pr-preflight.sh + `pr-preflight` skill

Script to run before pushing / opening a PR, reproducing the CI checks that most often fail on the first push:

1. **Lint** (`npm run test:lint`)
2. **Error-codes doc sync** (`npm run doc-error-codes`, then diff against `doc/2/api/errors/error-codes/`)
3. **Heuristic reminder** (non-blocking): if `lib/` changed without a corresponding change in `test/`, `tests/`, or `features*/`, warn that a PR without tests won't be accepted (see `CONTRIBUTING.md`)