### PR TITLE
docs(adr): relocate ADR-0001 + type-debt register to docs/adr-001/

### DIFF
--- a/.claude/skills/wrapup/SKILL.md
+++ b/.claude/skills/wrapup/SKILL.md
@@ -37,7 +37,7 @@ say so and move on.
 
 ## 3. Maintain the governing ADR (if one exists)
 
-If the work is governed by an ADR (e.g. `adrs/ADR-*.md`), keep two **living**
+If the work is governed by an ADR (e.g. `docs/adr-*/ADR-*.md`), keep two **living**
 sections up to date:
 
 ### 3a. Progress table
@@ -73,6 +73,6 @@ next session) can find it immediately.
 
 ---
 
-> Reference implementation in this repo: `adrs/ADR-0001-migration-typescript.md`
+> Reference implementation in this repo: `docs/adr-001/ADR-0001-migration-typescript.md`
 > maintains exactly this pattern — a progress table and a "cold start" section —
 > for the ongoing TypeScript migration.

--- a/.github/workflows/pull_request.workflow.yaml
+++ b/.github/workflows/pull_request.workflow.yaml
@@ -73,7 +73,7 @@ jobs:
         shell: bash
 
       # Ratchets: the .js / mocha / explicit-any counts may only decrease.
-      # See adrs/ADR-0001-migration-typescript.md §6 and scripts/ratchet.sh.
+      # See docs/adr-001/ADR-0001-migration-typescript.md §6 and scripts/ratchet.sh.
       - name: Migration ratchets (js / mocha / any)
         run: npm run ratchet
         shell: bash

--- a/.migration/strict-adopted.txt
+++ b/.migration/strict-adopted.txt
@@ -1,4 +1,4 @@
-# Files adopted in STRICT mode — see adrs/ADR-0001 §6.2 and scripts/strict-check.sh.
+# Files adopted in STRICT mode — see docs/adr-001/ADR-0001 §6.2 and scripts/strict-check.sh.
 # A file listed here MUST pass 'strict: true'. Add more as hardening progresses;
 # 'npm run test:strict -- --candidates' lists files that are already clean.
 # Seeded 2026-07-12: lib/types files already clean under strict.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ We use most of the [NPM Coding Style](https://www.w3resource.com/npm/npm-coding-
 ## TypeScript migration
 
 Kuzzle is being migrated from JavaScript to TypeScript incrementally (see
-[`adrs/ADR-0001-migration-typescript.md`](adrs/ADR-0001-migration-typescript.md)).
+[`docs/adr-001/ADR-0001-migration-typescript.md`](docs/adr-001/ADR-0001-migration-typescript.md)).
 While the migration is in progress, a few ratcheted rules apply, enforced in CI by
 the `migration-ratchets` job:
 

--- a/docs/adr-001/ADR-0001-migration-typescript.md
+++ b/docs/adr-001/ADR-0001-migration-typescript.md
@@ -31,7 +31,7 @@ Counters (baselines in `.migration/`): **js = 79**, **mocha = 151**, **any = 200
 
 **Where we are:** the foundation is in place (ADR, register, 3 CI ratchets, progressive strict, ESLint). **Sprint 1 done** (`lib/util` 100% TS, merged into `2-dev`) and **Sprint 3 done** (`lib/model` + `lib/service` now 100% TS — PR #2676). The migration advances one layer-PR at a time off `2-dev`.
 
-**Open PRs (both → `2-dev`, independent):** #2675 (ADR docs relocation `adrs/` → `docs/adr-001/`) · #2676 (Sprint 3 — models & services). Both edit this Progress section, so whichever merges **second** needs a trivial conflict resolution here.
+**Doc location (2026-07-15):** the ADR and its register were moved from `adrs/` to `docs/adr-001/` (`git mv`, history preserved; all references updated); ADRs now live under `docs/adr-<n>/`.
 
 **Next actions:**
 1. **Sprint 4 — `lib/api`** (13 files, incl. controllers + `funnel.js`), now unblocked by Sprint 3, under the cucumber net. *(Sprint 2 — real `bin/` entrypoints — is deprioritized for now.)*
@@ -80,20 +80,20 @@ The largest files in the repo are still in JS and concentrate the risk:
 
 | File | LOC | Role |
 |------|-----|------|
-| [`lib/api/httpRoutes.js`](../lib/api/httpRoutes.js) | 1554 | HTTP routes table |
-| [`lib/core/network/protocols/httpwsProtocol.js`](../lib/core/network/protocols/httpwsProtocol.js) | 1254 | HTTP/WS protocol (uWebSockets) |
-| [`lib/core/plugin/pluginsManager.js`](../lib/core/plugin/pluginsManager.js) | 1244 | Plugin management |
-| [`lib/cluster/node.js`](../lib/cluster/node.js) | 1203 | Cluster node |
-| [`lib/core/validation/validation.js`](../lib/core/validation/validation.js) | 1180 | Document validation |
-| [`lib/api/controllers/documentController.js`](../lib/api/controllers/documentController.js) | 1165 | Document controller |
-| [`lib/api/funnel.js`](../lib/api/funnel.js) | 1143 | API request routing/execution |
+| [`lib/api/httpRoutes.js`](../../lib/api/httpRoutes.js) | 1554 | HTTP routes table |
+| [`lib/core/network/protocols/httpwsProtocol.js`](../../lib/core/network/protocols/httpwsProtocol.js) | 1254 | HTTP/WS protocol (uWebSockets) |
+| [`lib/core/plugin/pluginsManager.js`](../../lib/core/plugin/pluginsManager.js) | 1244 | Plugin management |
+| [`lib/cluster/node.js`](../../lib/cluster/node.js) | 1203 | Cluster node |
+| [`lib/core/validation/validation.js`](../../lib/core/validation/validation.js) | 1180 | Document validation |
+| [`lib/api/controllers/documentController.js`](../../lib/api/controllers/documentController.js) | 1165 | Document controller |
+| [`lib/api/funnel.js`](../../lib/api/funnel.js) | 1143 | API request routing/execution |
 
 ### Constraints and forces at play
 
 - **`allowJs: true`** is enabled: JS and TS coexist natively in the `tsc` build. **0 hard `require('./x.js')` imports** in the existing TS → interop is clean, file-by-file conversion does not break import chains.
 - **Existing safety net:** functional tests (cucumber) are already in TS and cover the critical paths — they protect refactors of the big files.
 - **Double test debt:** the language migration is *blocked by* the runner question. Converting a Mocha test to `.ts` without moving it to vitest only shifts the debt.
-- **No prior ADR convention:** this document initialises the `adrs/` folder at the repo root (distinct from `doc/`, reserved for the Kuzzle documentation tool).
+- **No prior ADR convention:** this document initialises the ADR practice for the repo, stored under `docs/adr-<n>/` (distinct from `doc/`, reserved for the Kuzzle documentation tool).
 - **Why finish now?** A durable hybrid state costs more than either extreme: double tooling (Mocha + vitest), partial typing that gives a false sense of safety, confusing onboarding — and the remaining files are exactly the most critical ones (hence the riskiest to leave untyped).
 
 ---
@@ -238,9 +238,9 @@ Keep `tsconfig.json` in its current mode for the build; add a `tsconfig.strict.j
 > ⚠️ **You cannot isolate strict to a subset via `include`** — tsc pulls the entire import graph into the program and checks all of it. Empirical finding (2026-07-12): a `tsconfig.strict.json` with `include: ["lib/types/**/*.ts"]` still reports **1164 errors**, all located in the *imported* files (services, controllers, core…), not in `lib/types`. The progressive scope is therefore managed **by filtering tsc output**, not via `include`.
 
 **Shipped mechanism (Sprint 0):**
-- [`tsconfig.strict.json`](../tsconfig.strict.json): `extends` the base config + `strict: true`, `include` = all of `lib/` + `index.ts`.
-- [`.migration/strict-adopted.txt`](../.migration/strict-adopted.txt): a **growing list** of files that MUST pass strict (seeded with the **41 already-clean `lib/types` files**).
-- [`scripts/strict-check.sh`](../scripts/strict-check.sh) (`npm run test:strict`): compiles in strict but **only fails** on errors located in an adopted file. Harden a file → add it to the list → it is guaranteed forever. `npm run test:strict -- --candidates` lists clean files not yet adopted (**35 at start**).
+- [`tsconfig.strict.json`](../../tsconfig.strict.json): `extends` the base config + `strict: true`, `include` = all of `lib/` + `index.ts`.
+- [`.migration/strict-adopted.txt`](../../.migration/strict-adopted.txt): a **growing list** of files that MUST pass strict (seeded with the **41 already-clean `lib/types` files**).
+- [`scripts/strict-check.sh`](../../scripts/strict-check.sh) (`npm run test:strict`): compiles in strict but **only fails** on errors located in an adopted file. Harden a file → add it to the list → it is guaranteed forever. `npm run test:strict -- --candidates` lists clean files not yet adopted (**35 at start**).
 - **Final goal:** the list covers all of `lib/`, then flip `strict` in `tsconfig.json` and remove this machinery.
 
 Recommended flag activation order (least to most painful), if you prefer to enable flags one by one rather than by file list:
@@ -256,7 +256,7 @@ Two actions, complementary to the strict ratchet:
 1. **Re-enable the rule** via a local override (the `*.ts` block of `.eslintrc.json`) — or by bumping `eslint-plugin-kuzzle` — first as `warn` so as not to block immediately.
 2. **3rd CI ratchet** `no-explicit-any` as *baseline-and-decrement* (same mechanics as the JS ratchet): the number of explicit `any` may only decrease.
 
-**Shipped implementation (Sprint 0):** the three count ratchets (JS, mocha, any) are a single parameterised script [`scripts/ratchet.sh`](../scripts/ratchet.sh) `<js|mocha|any>`, exposed via `npm run ratchet` (all three) and `npm run ratchet:{js,mocha,any}`. Baselines in [`.migration/`](../.migration/): `js=111`, `mocha=151`, `any=200`. A metric may only decrease; any improvement must update its baseline in the same PR (`npm run ratchet:any -- --update`).
+**Shipped implementation (Sprint 0):** the three count ratchets (JS, mocha, any) are a single parameterised script [`scripts/ratchet.sh`](../../scripts/ratchet.sh) `<js|mocha|any>`, exposed via `npm run ratchet` (all three) and `npm run ratchet:{js,mocha,any}`. Baselines in [`.migration/`](../../.migration/): `js=111`, `mocha=151`, `any=200`. A metric may only decrease; any improvement must update its baseline in the same PR (`npm run ratchet:any -- --update`).
 
 > **Priority targets (measured concentration):** `lib/core` holds ~48% of the `any`, and **4 files** — `core/shared/store.ts`, `core/plugin/pluginContext.ts`, `service/storage/7/elasticsearch.ts`, `service/storage/8/elasticsearch.ts` — concentrate ~40% of the `: any` and ~55% of the `as any`. Handling them first clears most of the debt. Most of this `any` is **recoverable** (lazy); the genuinely justified `any` is confined to the Elasticsearch client boundary.
 

--- a/docs/adr-001/type-debt-register.md
+++ b/docs/adr-001/type-debt-register.md
@@ -201,7 +201,9 @@ The audit **rejected** 2 findings as non-reproducible or redundant:
 - **2026-07-12** — Quick wins delivered in PR #2668 (3 isolated commits, `tsc --noEmit` green at each step): TD-06, TD-04 + partial TD-05, partial TD-01.
 - **2026-07-12** — ADR + register committed on the migration branch. Sprint 0 tooling delivered in PR #2669: 3 count ratchets (js/mocha/any), `strict-check.sh` + adopted list (41 files), ESLint `no-explicit-any` re-enabled, CI job wired. TD-03 ✅, TD-02 🟦.
 - **2026-07-12** — Sprint 1 (warm-up) delivered in PR #2670: 5 `lib/util` modules (safeObject, bytes, wildcard, memoize, extractFields) converted JS→TS; JS baseline 111→106; strict 41→46 adopted files; tsc + build + unit tests (7/7) green. `bin/` scope adjusted (see ADR §6.4): `.upgrades` to be deleted (separate PR).
+- **2026-07-14** — Sprint 1 finished in PR #2674 (merged into `2-dev`): the remaining 7 `lib/util` files converted → `lib/util` is now 100% TS. Counters: js=86, mocha=151, any=200, strict adopted=51.
 - **2026-07-15** — Sprint 3 delivered in PR #2676: `lib/model` (baseModel, apiKey, rights) + `lib/service` (service, redis, esWrapper 7/8) converted JS→TS → both layers now 100% TS. JS baseline 86→79; `any` unchanged (200), no `@ts-ignore` (one documented `@ts-expect-error` for `ApiKey.load`'s static-signature divergence). tsc clean; full mocha suite (3025) green in Docker. Sprint 2 (`bin/`) deprioritized.
+- **2026-07-15** — ADR docs relocated from `adrs/` to `docs/adr-001/` (`git mv`, history preserved); all references updated (CONTRIBUTING, CI workflow, `scripts/`, `tsconfig.strict.json`, `/wrapup` skill). New convention: ADRs live under `docs/adr-<n>/`.
 
 ---
 

--- a/scripts/ratchet.sh
+++ b/scripts/ratchet.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# TypeScript-migration ratchets — see adrs/ADR-0001-migration-typescript.md (§6.1, §6.2, §6.3).
+# TypeScript-migration ratchets — see docs/adr-001/ADR-0001-migration-typescript.md (§6.1, §6.2, §6.3).
 #
 # A tracked metric may only DECREASE. The baseline file (.migration/*-baseline.txt)
 # records the EXACT current value; every migration PR that improves a metric must

--- a/scripts/strict-check.sh
+++ b/scripts/strict-check.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Progressive strict check — see adrs/ADR-0001-migration-typescript.md §6.2.
+# Progressive strict check — see docs/adr-001/ADR-0001-migration-typescript.md §6.2.
 #
 # Runs tsc with `strict: true` over all production .ts (tsconfig.strict.json), but only
 # FAILS on strict errors located in files listed in .migration/strict-adopted.txt.

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -1,5 +1,5 @@
 {
-  // STRICT compilation of all production code — see adrs/ADR-0001 §6.2.
+  // STRICT compilation of all production code — see docs/adr-001/ADR-0001 §6.2.
   //
   // NB: strict cannot be isolated to a subset via `include` — tsc pulls the whole
   // import graph into the program and checks all of it. So we compile all of lib/ in


### PR DESCRIPTION
## What

Relocate the ADR-0001 TypeScript-migration ADR and its companion type-debt
register from `adrs/` to **`docs/adr-001/`** (`git mv`, history preserved), and
update every reference to the old path.

## Why

Adopt a per-ADR folder layout under `docs/adr-<n>/` (distinct from `doc/`, which
is reserved for the Kuzzle documentation tool).

## Changes

- `git mv adrs/{ADR-0001-migration-typescript.md,type-debt-register.md}` → `docs/adr-001/`
- Fix the ADR's intra-doc relative links (`../` → `../../` for the deeper folder)
- Update references in `CONTRIBUTING.md`, the CI workflow, `scripts/ratchet.sh`,
  `scripts/strict-check.sh`, the `tsconfig.strict.json` comment, and the `/wrapup` skill
- Refresh the ADR progress table / cold-start (Sprint 1 #2674 now merged into `2-dev`)
  and add register journal entries

## Notes

Docs-only: no production code, error codes, or tests are touched. All 12 relative
links were verified to resolve after the move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
