### PR TITLE
fix(changelog): resolve leftover merge-conflict markers on 2-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -285,8 +285,6 @@
 * **updateByQuery:** kuzinfo updated after updateByQuery ([caacf9b](https://github.com/kuzzleio/kuzzle/commit/caacf9b0613a5d4b33ce1fcd99f04ea71e632502))
 * **updateByQuery:** no need to add kuzzleinfo to changes, it is updated later ([969d160](https://github.com/kuzzleio/kuzzle/commit/969d160c8d6e96ff85e0755ba3c82453608c093a))
 
-<<<<<<< HEAD
-=======
 ## [2.48.0](https://github.com/kuzzleio/kuzzle/compare/v2.47.0...v2.48.0) (2025-10-02)
 
 
@@ -325,7 +323,6 @@
 * **elasticsearch:** do not allow user to provide _kuzzle_info for M operations ([#2607](https://github.com/kuzzleio/kuzzle/issues/2607)) ([b6adb34](https://github.com/kuzzleio/kuzzle/commit/b6adb3461a213afddcc6f7c2fc92252c5204fc12))
 * revert uuid upgrade, because of ESM compat ([dbe582a](https://github.com/kuzzleio/kuzzle/commit/dbe582a241fe9d85b21c856a47a26f2d9dd6c498))
 
->>>>>>> master
 ## [2.47.0](https://github.com/kuzzleio/kuzzle/compare/v2.46.0...v2.47.0) (2025-09-16)
 
 


### PR DESCRIPTION
## What

`CHANGELOG.md` on `2-dev` contained **committed, unresolved Git merge-conflict markers** around the `2.48.0` entry:

```
<<<<<<< HEAD      (line ~288)
=======           (line ~289)
>>>>>>> master    (line ~328)
```

This was discovered incidentally while rebasing #2675 (docs relocation) — that PR does not touch `CHANGELOG.md`, so the markers were left untouched there and are fixed here instead.

## Resolution

- The `HEAD` (2-dev) side of the conflict contributed **no content** in this region.
- The `master` side carried the full `2.48.0` block (including its `2.48.0-beta.2` / `2.48.0-beta.1` entries).

Resolved by **keeping the master-side `2.48.0` block**, which belongs chronologically between `2.49.0` (above) and `2.47.0` (below). No changelog entries are dropped — only the three marker lines are removed.

Resulting order is correct reverse-chronological: `2.49.0 → 2.48.0 → 2.48.0-beta.2 → 2.48.0-beta.1 → 2.47.0`.

## Verification

```
git grep -nE '^(<{7}|={7}|>{7})( |$)'   # → no matches, repo-wide
```

The only change is the removal of the three conflict-marker lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)