### PR TITLE
fix(td-26): drop the five awaits of a non-Promise

### DIFF
--- a/docs/adr-001/type-debt-register.md
+++ b/docs/adr-001/type-debt-register.md
@@ -34,7 +34,7 @@
 | [TD-23](#td-23) | 🟡 low | Duplication | `sonar.cpd.exclusions` growing into permanent, untracked debt (5 files) — [#2691](https://github.com/kuzzleio/kuzzle/issues/2691) | M | 🟦 |
 | [TD-24](#td-24) | 🟠 med | Enforcement | SonarCloud measures **no coverage on `.ts`** — every conversion voids its own coverage gate — [#2692](https://github.com/kuzzleio/kuzzle/issues/2692) | S | ✅ |
 | [TD-25](#td-25) | 🟡 low | Dependencies | `@types/debug` is narrower than `debug`'s runtime — adopting it costs 3 casts, so `util/debug.ts` stays out of strict | S | ⬜ |
-| [TD-26](#td-26) | 🟡 low | Correctness | 5 `await`s of a non-Promise, kept for timing parity across conversions (`NOSONAR: TD-26`) | XS | ⬜ |
+| [TD-26](#td-26) | 🟡 low | Correctness | 5 `await`s of a non-Promise, kept for timing parity across conversions (`NOSONAR: TD-26`) | XS | ✅ |
 
 **Quick wins (handled first, cf. ADR step 01 — type quick wins):** TD-01, TD-04, TD-05, TD-06.
 
@@ -84,6 +84,7 @@ They are individually trivial and collectively worth one pass: the markers are a
 
 - **Reco:** a single behaviour-change PR that drops all five `await`s (and the markers), with a note that the only observable effect is one microtask of resolution timing per site. `grep -rn "NOSONAR: TD-26" lib/` lists them.
 - **Trigger:** independent of the migration sprints; a good companion to [TD-20](#td-20)'s deprecated-API cleanup, which is the same shape of "conversion found it, conversion must not fix it".
+- **✅ Done (2026-09-09, #2697):** all five `await`s and their `NOSONAR: TD-26` markers dropped. The only observable effect is one microtask of resolution timing per site; `funnel._checkSdkVersion` still throws inside the same `try`, and `SecurityModule.init` stays `async` (its four remaining `await`s keep the ordering the loader depends on).
 
 ---
 

--- a/lib/api/funnel.ts
+++ b/lib/api/funnel.ts
@@ -725,11 +725,7 @@ class Funnel {
     let _request = request;
 
     try {
-      // `_checkSdkVersion` is synchronous, so this `await` only costs a
-      // microtask hop. Removing it is very likely unobservable — but "very
-      // likely" is not the bar for a conversion PR (ADR-0001: no behaviour
-      // change). Drop the `await` in a follow-up.
-      await this._checkSdkVersion(_request); // NOSONAR
+      this._checkSdkVersion(_request);
       _request = await global.kuzzle.pipe("request:onExecution", _request);
       _request = await this.performDocumentAlias(_request, "before");
       _request = await global.kuzzle.pipe(

--- a/lib/core/security/index.ts
+++ b/lib/core/security/index.ts
@@ -48,12 +48,10 @@ class SecurityModule {
   }
 
   async init() {
-    // `role.init()` and `profile.init()` are synchronous (they only register
-    // `onAsk` handlers), so awaiting them is pointless — but dropping the
-    // `await` shifts this method's resolution by a microtask, which a
-    // conversion must not do. Tracked in TD-26.
-    await this.role.init(); // NOSONAR: TD-26
-    await this.profile.init(); // NOSONAR: TD-26
+    // `role.init()` and `profile.init()` are synchronous: they only register
+    // `onAsk` handlers.
+    this.role.init();
+    this.profile.init();
     await this.token.init();
     await this.user.init();
     // Last: the loader replays security fixtures through the API, so every

--- a/lib/core/security/roleRepository.ts
+++ b/lib/core/security/roleRepository.ts
@@ -329,7 +329,7 @@ class RoleRepository extends ObjectRepository<Role> {
 
     const role = await this.loadOneFromDatabase(id);
 
-    await this.roles.set(role._id, role); // NOSONAR: TD-26
+    this.roles.set(role._id, role);
 
     return role;
   }
@@ -404,7 +404,7 @@ class RoleRepository extends ObjectRepository<Role> {
     await this.persistToDatabase(role, options);
 
     const updatedRole = await this.loadOneFromDatabase(role._id);
-    await this.roles.set(role._id, updatedRole); // NOSONAR: TD-26
+    this.roles.set(role._id, updatedRole);
 
     return updatedRole;
   }

--- a/test/api/funnel/processRequest.test.js
+++ b/test/api/funnel/processRequest.test.js
@@ -137,9 +137,11 @@ describe("funnel.processRequest", () => {
       controller: "fakeController",
       action: "succeed",
     });
+    // `_checkSdkVersion` is synchronous and throws: it is no longer awaited
+    // (TD-26), so the stub has to throw rather than return a rejected promise.
     funnel._checkSdkVersion = sinon
       .stub()
-      .rejects(new Error("incompatible sdk"));
+      .throws(new Error("incompatible sdk"));
 
     return should(funnel.processRequest(request)).be.rejectedWith(Error, {
       message:

--- a/tests/core/security/index.test.ts
+++ b/tests/core/security/index.test.ts
@@ -117,7 +117,11 @@ describe("#core/security/SecurityModule", () => {
     });
 
     it("rejects and stops at the first failure", async () => {
-      mock(module.profile).init = vi.fn().mockRejectedValue(new Error("nope"));
+      // `profile.init()` is synchronous and no longer awaited (TD-26), so the
+      // failure has to be thrown, not returned as a rejected promise.
+      mock(module.profile).init = vi.fn().mockImplementation(() => {
+        throw new Error("nope");
+      });
 
       await expect(module.init()).rejects.toThrow("nope");
       expect(mock(module.token).init).not.toHaveBeenCalled();


### PR DESCRIPTION
Closes #2697 — type-debt register [TD-26](https://github.com/kuzzleio/kuzzle/blob/2-dev/docs/adr-001/type-debt-register.md#td-26).

## What

The five sites listed in TD-26 `await` a value that is not thenable (`typescript:S4123`, Critical). Each predates the TS migration and each was **kept** across its conversion PR, because dropping an `await` shifts the enclosing async function's resolution by a microtask — a behaviour change, which a conversion PR must not make. This is the single behaviour-change pass the register recommends.

| Site | Awaited value |
|------|---------------|
| `funnel.processRequest` → `_checkSdkVersion()` | a synchronous method (it throws) |
| `roleRepository.load` → `this.roles.set(...)` | `Map.set` returns the Map |
| `roleRepository.validateAndSaveRole` → `this.roles.set(...)` | idem |
| `security/index.init` → `this.role.init()` | `RoleRepository.init()` is not `async` |
| `security/index.init` → `this.profile.init()` | `ProfileRepository.init()` is not `async` |

All five `NOSONAR: TD-26` markers are gone with them.

## Observable effect

One microtask of resolution timing per site, and nothing else:

- `funnel._checkSdkVersion` still throws inside the same `try`, so `processRequest` still rejects with the same wrapped error.
- `SecurityModule.init` stays `async`; its four remaining `await`s keep the ordering the loader depends on (role → profile → token → user → loader).

## Specs re-baselined

Two specs encoded the `await` by stubbing a **synchronous** method with a *rejected promise* — which, unawaited, resolves nowhere:

- `test/api/funnel/processRequest.test.js` — `_checkSdkVersion` stub now `throws()`.
- `tests/core/security/index.test.ts` — `profile.init` mock now throws synchronously.

Both now match the real signatures.

## Validation

- mocha: **3025 passing**, 0 failing
- vitest: **166 passing** (12 files)
- `npm run ratchet`: js / mocha / any / implicit-any all at baseline
- `npm run test:strict`: 101 adopted files pass
- lint: 0 errors
- `tsc --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)