### PR TITLE
fix(td-27): normalize a controller's error where it is raised, not on the funnel

### DIFF
--- a/lib/api/funnel.ts
+++ b/lib/api/funnel.ts
@@ -733,7 +733,16 @@ class Funnel {
         _request,
       );
 
-      const responseData = await doAction(controller, _request);
+      let responseData: Awaited<ReturnType<typeof doAction>>;
+
+      try {
+        responseData = await doAction(controller, _request);
+      } catch (e) {
+        // Only here is the error known to come from the controller itself:
+        // `_wrapError` sits downstream of the pipes too and cannot tell the
+        // two apart (TD-27).
+        throw this._wrapControllerError(_request, e);
+      }
 
       const status = _request.status === 102 ? 200 : _request.status;
       _request.setResult(responseData, { status }); // NOSONAR: TD-20 (#2688)
@@ -1108,26 +1117,67 @@ class Funnel {
   }
 
   /**
-   * Eventually wrap an error into a PluginImplementationError
+   * Eventually wrap an error into a PluginImplementationError.
+   *
+   * Everything that reaches this method comes out of a pipe — the error pipes
+   * of `handleProcessRequestError`, or `processRequest`'s own
+   * `request:onExecution` / before / after pipes — i.e. out of plugin code. A
+   * controller's error is wrapped at its source by `_wrapControllerError` and
+   * arrives here already a KuzzleError, so there is nothing left to guard on:
+   * see TD-27 (https://github.com/kuzzleio/kuzzle/issues/2703), which is why
+   * the previous guard on the controller name is gone rather than fixed.
+   *
    * @param  {Request} request
    * @param  {Error} error
    * @returns {KuzzleError}
    */
   _wrapError(request: KuzzleRequest, error: Error): Error {
-    if (
-      !this.isNativeController(request.input.controller) &&
-      !(error instanceof KuzzleError)
-    ) {
-      return kerror.getFrom(
-        error,
-        "plugin",
-        "runtime",
-        "unexpected_error",
-        error.message,
-      );
+    if (error instanceof KuzzleError) {
+      return error;
     }
 
-    return error;
+    return kerror.getFrom(
+      error,
+      "plugin",
+      "runtime",
+      "unexpected_error",
+      error.message,
+    );
+  }
+
+  /**
+   * Normalizes an error thrown by a controller action into a KuzzleError.
+   *
+   * A native controller throwing something that is not a KuzzleError is a
+   * Kuzzle bug, and it is reported as one (`core.fatal.unexpected_error`).
+   * Reporting it as `plugin.runtime.unexpected_error` — which is what happened
+   * for as long as `_wrapError`'s guard was dead — names the wrong culprit,
+   * and letting it through raw is worse still: `KuzzleRequest.setError` then
+   * builds an InternalError with no `id` and no `code`, on a 500 sent to a
+   * client. See TD-27 (https://github.com/kuzzleio/kuzzle/issues/2703).
+   *
+   * @param  {Request} request
+   * @param  {Error} error
+   * @returns {KuzzleError}
+   */
+  _wrapControllerError(request: KuzzleRequest, error: Error): Error {
+    if (error instanceof KuzzleError) {
+      return error;
+    }
+
+    const [domain, subdomain] = this.isNativeController(
+      request.input.controller,
+    )
+      ? ["core", "fatal"]
+      : ["plugin", "runtime"];
+
+    return kerror.getFrom(
+      error,
+      domain,
+      subdomain,
+      "unexpected_error",
+      error.message,
+    );
   }
 
   /**

--- a/test/api/funnel/handleProcessRequestError.test.js
+++ b/test/api/funnel/handleProcessRequestError.test.js
@@ -73,10 +73,10 @@ describe("funnel.processRequest", () => {
     });
   });
 
-  // TD-21 (#2687): `_wrapError` guards on the controller name. It used to be
-  // handed the whole request, so the guard was always false and a native
-  // controller's internal error reached the client as a plugin error.
-  it("leaves a native controller error unwrapped", () => {
+  // TD-27 (#2703): `_wrapError` sits downstream of the error pipes, so what
+  // reaches it comes from plugin code whatever the request's controller is.
+  // A controller's own error is normalized upstream, by `_wrapControllerError`.
+  it("wraps a pipe error as a plugin error even on a native controller", () => {
     const originalError = new BadRequestError("original error"),
       internalError = new TypeError("cannot read properties of undefined"),
       request = new Request({ controller: "document", action: "fail" });
@@ -92,8 +92,27 @@ describe("funnel.processRequest", () => {
 
     return should(
       funnel.handleProcessRequestError(request, request, originalError),
-    ).rejectedWith(TypeError, {
-      message: "cannot read properties of undefined",
+    ).rejectedWith(PluginImplementationError, {
+      id: "plugin.runtime.unexpected_error",
     });
+  });
+
+  it("leaves a KuzzleError raised by a pipe alone", () => {
+    const originalError = new BadRequestError("original error"),
+      pipeError = new BadRequestError("raised by the pipe"),
+      request = new Request({ controller: "document", action: "fail" });
+
+    funnel.controllers.set("document", {});
+
+    kuzzle.pipe.onFirstCall().rejects(originalError);
+    kuzzle.pipe.onSecondCall().callsFake(() =>
+      Promise.resolve().then(() => {
+        throw pipeError;
+      }),
+    );
+
+    return should(
+      funnel.handleProcessRequestError(request, request, originalError),
+    ).rejectedWith(BadRequestError, { message: "raised by the pipe" });
   });
 });

--- a/test/api/funnel/processRequest.test.js
+++ b/test/api/funnel/processRequest.test.js
@@ -143,11 +143,62 @@ describe("funnel.processRequest", () => {
       .stub()
       .throws(new Error("incompatible sdk"));
 
-    // `fakeController` is a native controller, so the error is surfaced as-is
-    // rather than wrapped into a PluginImplementationError (TD-21, #2687).
+    // `_checkSdkVersion` is funnel code, not controller code: its error goes
+    // through `_wrapError` like a pipe's (TD-27, #2703). In production it
+    // throws a KuzzleError and is left alone; only this stub's raw Error is
+    // wrapped.
     return should(funnel.processRequest(request)).be.rejectedWith(Error, {
-      message: "incompatible sdk",
+      message:
+        "Caught an unexpected plugin error: incompatible sdk\nThis is probably not a Kuzzle error, but a problem with a plugin implementation.",
     });
+  });
+
+  // TD-27 (#2703): an error thrown by a controller action is normalized where
+  // it is raised, so a native controller's bug is reported as a Kuzzle error
+  // and a plugin controller's as a plugin error — and both keep an id.
+  it("should report a native controller's non-KuzzleError as a core error", () => {
+    const request = new Request({
+      controller: "fakeController",
+      action: "fail",
+    });
+
+    funnel.controllers
+      .get("fakeController")
+      .fail.rejects(new TypeError("cannot read properties of undefined"));
+
+    return should(funnel.processRequest(request)).be.rejectedWith(
+      KuzzleInternalError,
+      {
+        id: "core.fatal.unexpected_error",
+        status: 500,
+      },
+    );
+  });
+
+  it("should report a plugin controller's non-KuzzleError as a plugin error", () => {
+    const controller = "fakePlugin/controller",
+      request = new Request({ controller, action: "fail" });
+
+    pluginsManager.controllers
+      .get(controller)
+      .fail.rejects(new TypeError("cannot read properties of undefined"));
+
+    return should(funnel.processRequest(request)).be.rejectedWith(
+      PluginImplementationError,
+      { id: "plugin.runtime.unexpected_error" },
+    );
+  });
+
+  it("should leave a controller's KuzzleError untouched", () => {
+    const request = new Request({
+      controller: "fakeController",
+      action: "fail",
+    });
+
+    return should(funnel.processRequest(request)).be.rejectedWith(
+      KuzzleInternalError,
+      { message: "rejected action" },
+    );
   });
 
   it("should throw if a plugin action returns a non-serializable response", () => {


### PR DESCRIPTION
Closes #2703. Follow-up to #2700 (TD-21), found by the post-sprint review of 2026-09-10.

## The problem

#2700 fixed `_wrapError`'s dead guard by passing `request.input.controller`. But `_wrapError` is the common funnel for **three** error sources:

| Call site | Where the error comes from |
|---|---|
| `handleProcessRequestError`, 1st call | `processRequest`'s whole `try` — the controller action, but also `request:onExecution`, the before/after pipes and the document aliases |
| same method, 2nd | the `<controller>:error<Action>` pipe |
| same method, 3rd | the `request:onError` pipe |

A predicate on the controller name cannot separate "the native controller threw" from "a plugin pipe threw while serving a request to a native controller" — so the fix also changed plugin-pipe behaviour, which TD-21 never intended.

It also **dropped the error's identity**. An error that passes through `_wrapError` unwrapped ends in `KuzzleRequest.setError` → `new InternalError(error)`: `id` and `code` both `undefined`, on a 500 sent to a client, while Kuzzle's whole error contract is built on documented id/code pairs.

## The fix — decide at the source

- `processRequest` wraps **only** the `doAction` call, via a new `_wrapControllerError`: `core.fatal.unexpected_error` for a native controller, `plugin.runtime.unexpected_error` for a plugin one, a `KuzzleError` left alone.
- `_wrapError` returns to its pre-TD-21 rule (wrap any non-`KuzzleError`) and **the guard is deleted, not fixed**: by the time an error reaches it, it comes from a pipe — i.e. from plugin code — so there is nothing left to discriminate. That dead guard was TD-21's actual bug.

## Why this is a `fix` and not a breaking change

| | Before #2700 | After #2700 | This PR |
|---|---|---|---|
| Plugin pipe throws a raw error | `plugin.runtime.unexpected_error` | **unwrapped** on a native-controller request | `plugin.runtime.unexpected_error` |
| Plugin controller throws a raw error | `plugin.runtime.unexpected_error` | `plugin.runtime.unexpected_error` | `plugin.runtime.unexpected_error` |
| Native controller throws a raw error | `plugin.runtime.unexpected_error` | `InternalError`, **`id`/`code` undefined** | `core.fatal.unexpected_error` (`InternalError` 500) |
| Anything throws a `KuzzleError` | untouched | untouched | untouched |

Status stays 500 in every case, the source stack is preserved by `getFrom`, and **nothing a plugin sees changes**. The only client-visible delta is the `id` of a crash *inside a native controller* — which was factually wrong before (`plugin.…` for a Kuzzle bug) and identity-less after #2700. No `BREAKING CHANGE:` footer.

## Tests

`test/api/funnel/processRequest.test.js` — three cases pinning the three controller outcomes (native → `core.fatal.unexpected_error`, plugin → `plugin.runtime.unexpected_error`, `KuzzleError` → untouched). `test/api/funnel/handleProcessRequestError.test.js` — the case #2700 added is replaced by its converse (a pipe error on a native-controller request **is** a plugin error), plus a `KuzzleError`-from-a-pipe case.

The `_checkSdkVersion` case returns to the plugin wrap it had before #2700: it is funnel code, not controller code, and in production it throws a `KuzzleError` and is left alone — only the spec's raw `Error` stub is wrapped.

Both files stay in Mocha: `lib/api/funnel` is still not importable from a vitest spec (it pulls in `documentController`, which `import … = require`s the still-`.js` `util/extractFields`).

## Validation

- `npx tsc --noEmit` clean · prettier clean · eslint 0 errors (373 pre-existing warnings).
- Ratchets all at equality: js 50 · mocha 151 · any 207 · implicit-any 464. `test:strict` 101/101, `--candidates` empty.
- **Mocha 3030 passing** in Docker (was 3026: +3 in `processRequest`, +1 net in `handleProcessRequestError`); **vitest 13 files / 183 tests** green.

The register entry (TD-27) is updated in #2708, which owns those docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)