### PR TITLE
fix(td-28): drop memoryStorageController's class-wide index signature

### DIFF
--- a/lib/api/controllers/memoryStorageController.ts
+++ b/lib/api/controllers/memoryStorageController.ts
@@ -93,21 +93,16 @@ let mapping: RedisCommandMapping;
 /**
  * @class MemoryStorageController
  */
-class MemoryStorageController extends NativeController {
-  /**
-   * Every Redis command in the table becomes an action method on the instance,
-   * installed at construction and looked up by name by the funnel. The index
-   * signature is what makes that dynamic write typeable — it is type-only, so
-   * the emitted JavaScript is unchanged.
-   */
-  [command: string]: unknown;
+/** What every Redis command in the table becomes on the instance. */
+type CommandAction = (request: KuzzleRequest) => Promise<unknown>;
 
+class MemoryStorageController extends NativeController {
   constructor() {
     super();
 
     initMapping();
 
-    const buildCommandFn = (command: string) => {
+    const buildCommandFn = (command: string): CommandAction => {
       if (command === "mexecute") {
         return async (request: KuzzleRequest) =>
           global.kuzzle.ask(
@@ -135,9 +130,15 @@ class MemoryStorageController extends NativeController {
         );
     };
 
+    // Every Redis command in the table becomes an action method on the
+    // instance, installed here and looked up by name by the funnel. `command`
+    // is a runtime-built key, so a plain `this[command] = …` cannot be typed
+    // without opening the whole class to an index signature (TD-28, #2704);
+    // `Reflect.set` is the property-write counterpart already used for the
+    // same reason in `core/shared/sdk/impersonatedSdk`.
     for (const command of Object.keys(mapping)) {
       this._actions.add(command);
-      this[command] = buildCommandFn(command);
+      Reflect.set(this, command, buildCommandFn(command));
     }
   }
 }


### PR DESCRIPTION
Closes #2704. Follow-up to #2702 (TD-22), found by the post-sprint review of 2026-09-10.

## The problem

TD-22 typed `this[command] = buildCommandFn(command)` with a **class-wide** index signature:

```ts
class MemoryStorageController extends NativeController {
  [command: string]: unknown;
```

It applies to the whole class, not to the dynamic writes: every property access reads as `unknown`, and every property *name* compiles — `this.askk(...)` included. The file scored 0 written and 0 implicit `any` while being less type-safe about its own members than before it was typed.

No ratchet charges for it: not `: any`, not `as any`, not `as unknown as`, and it *removes* `TS7xxx` diagnostics. Exactly the blind spot step 06 exists to close.

## The fix

`Reflect.set(this, command, buildCommandFn(command))` — the property-write counterpart of the `Reflect.get`/`Reflect.apply` idiom the codebase already uses for runtime-built keys, and the same call `core/shared/sdk/impersonatedSdk` makes for the same reason. No cast, no index signature, the class surface stays closed. The command shape gets a name (`CommandAction`) and `buildCommandFn` is annotated with it.

**The ratchet picked the solution.** The first attempt was the localised cast the issue proposed (`this as unknown as Record<string, CommandAction>`) — the `any` ratchet rejected it at **208 > 207**, since it counts `as unknown as`. That is what pushed this to the cast-free form; the honest price turned out to be zero.

## Validation

- `npx tsc --noEmit` clean · prettier clean · eslint 0 errors.
- Ratchets all at equality: js 50 · mocha 151 · any 207 · implicit-any 464. `test:strict` 101/101.
- **Mocha 3026** and **vitest 13 files / 183 tests** green in Docker — including the `rewire`-driven `memoryStorageController` spec, which reaches the installed actions by name.

Emitted JavaScript: `this[command] = fn` becomes `Reflect.set(this, command, fn)`, an equivalent own-property assignment.

The register entry (TD-28) is updated in #2708, which owns those docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)