### PR TITLE
refactor(td-31): tighten documentController's helper signatures

### DIFF
--- a/lib/api/controllers/documentController.ts
+++ b/lib/api/controllers/documentController.ts
@@ -31,6 +31,24 @@ import {
 import { KuzzleRequest } from "../request";
 import { NativeController } from "./baseController";
 import extractFields = require("../../util/extractFields");
+
+/** One of `actionEnum`'s values — what a document notification reports. */
+type NotifyAction = (typeof actionEnum)[keyof typeof actionEnum];
+
+/** The two single-document writes `_writeDocument` serves. */
+type WriteMethod = "replace" | "createOrReplace";
+
+/** The two multi-document reads `_mFetch` serves. */
+type FetchMethod = "mGet" | "mExists";
+
+/** The five multi-document writes `_mChanges` serves. */
+type ChangeMethod =
+  | "mCreate"
+  | "mCreateOrReplace"
+  | "mUpdate"
+  | "mUpsert"
+  | "mReplace";
+
 /**
  * @description actions available on the document Controller (used by generic events)
  * @key actions
@@ -397,7 +415,7 @@ class DocumentController extends NativeController {
    * @returns {Promise<Object>}
    */
   createOrReplace(request: KuzzleRequest) {
-    return this._writeDocument(request, "createOrReplace", actionEnum.WRITE);
+    return this._writeDocument(request, "createOrReplace");
   }
 
   /**
@@ -610,7 +628,7 @@ class DocumentController extends NativeController {
    * @returns {Promise<Object>}
    */
   replace(request: KuzzleRequest) {
-    return this._writeDocument(request, "replace", actionEnum.REPLACE);
+    return this._writeDocument(request, "replace");
   }
 
   /**
@@ -879,7 +897,7 @@ class DocumentController extends NativeController {
    * @param  {String} methodName storage method to ask for
    * @returns {Promise.<Object>} { successes, errors }
    */
-  async _mFetch(request: KuzzleRequest, methodName: string) {
+  async _mFetch(request: KuzzleRequest, methodName: FetchMethod) {
     // `ids` may come either in the body or in the query string
     const ids =
       request.input.body?.ids && Object.keys(request.input.body.ids).length
@@ -920,15 +938,15 @@ class DocumentController extends NativeController {
    * the notification action, and what that notification carries.
    *
    * @param  {Request} request
-   * @param  {String} methodName storage method to ask for
-   * @param  {notifyActionEnum} action performed on the document
+   * @param  {String} methodName storage method to ask for — it also decides
+   *                  the notification action and its payload, so the two can
+   *                  no longer disagree (TD-31)
    * @returns {Promise.<Object>} the storage response
    */
-  async _writeDocument(
-    request: KuzzleRequest,
-    methodName: string,
-    action: number,
-  ) {
+  async _writeDocument(request: KuzzleRequest, methodName: WriteMethod) {
+    const action: NotifyAction =
+      methodName === "replace" ? actionEnum.REPLACE : actionEnum.WRITE;
+
     const id = request.getId();
     const content = request.getBody();
     const userId = request.getKuid();
@@ -978,7 +996,7 @@ class DocumentController extends NativeController {
         "core:realtime:document:notify",
         modifiedRequest,
         action,
-        action === actionEnum.REPLACE
+        methodName === "replace"
           ? {
               _id: modifiedRequest.input.args._id,
               _source: modifiedRequest.input.body,
@@ -999,7 +1017,11 @@ class DocumentController extends NativeController {
    * @param  {notifyActionEnum} action performed on the documents
    * @returns {Promise.<Object>} { successes, errors }
    */
-  async _mChanges(request: KuzzleRequest, methodName: string, action: number) {
+  async _mChanges(
+    request: KuzzleRequest,
+    methodName: ChangeMethod,
+    action: NotifyAction,
+  ) {
     let source = true;
     const userId = request.getKuid();
     const strict = request.getBoolean("strict");


### PR DESCRIPTION
Closes #2706. Follow-up to #2701 (TD-23), found by the post-sprint review of 2026-09-10.

## The problem

The helpers TD-23 extracted took loose parameters:

```ts
async _mFetch(request: KuzzleRequest, methodName: string)
async _writeDocument(request: KuzzleRequest, methodName: string, action: number)
```

- `methodName` is interpolated into a storage event name, so a typo fails at runtime (an `ask` on an unregistered event) instead of at compile time.
- `_writeDocument` chose the notification payload from `action === actionEnum.REPLACE`, not from the method — so the two arguments could disagree, and `("createOrReplace", actionEnum.REPLACE)` would silently get `replace`'s semantics.

## The fix

- Method names become unions: `FetchMethod` (`"mGet" | "mExists"`), `WriteMethod` (`"replace" | "createOrReplace"`), `ChangeMethod` (the five `_mChanges` serves).
- **`_writeDocument` derives the action from the method** instead of taking it, so the disagreement is removed rather than documented. Its two call sites drop the now-redundant argument.
- `_mChanges` keeps `action` — it genuinely varies over five methods — but takes `NotifyAction`, the enum's value type, instead of `number`.

`actionEnum` is already `as const`, so `(typeof actionEnum)[keyof typeof actionEnum]` gives the exact literal union with no new declaration to keep in sync.

## Validation

No behaviour change: both call sites passed exactly the pair the helper now computes.

- `npx tsc --noEmit` clean · prettier clean · eslint 0 errors.
- Ratchets at equality: js 50 · mocha 151 · any 207 · implicit-any 464.
- **Mocha 3026 passing** in Docker.

The register entry (TD-31) is updated in #2708, which owns those docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)