### PR TITLE
chore(td-29): ban @ts-ignore, and clear the three undocumented suppressions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,11 @@
 {
-  "plugins": ["kuzzle"],
-  "extends": ["plugin:kuzzle/default", "plugin:kuzzle/node"],
+  "plugins": [
+    "kuzzle"
+  ],
+  "extends": [
+    "plugin:kuzzle/default",
+    "plugin:kuzzle/node"
+  ],
   "parserOptions": {
     "ecmaVersion": 2020
   },
@@ -10,10 +15,24 @@
   },
   "overrides": [
     {
-      "files": ["*.ts"],
-      "extends": ["plugin:kuzzle/typescript"],
+      "files": [
+        "*.ts"
+      ],
+      "extends": [
+        "plugin:kuzzle/typescript"
+      ],
       "rules": {
-        "@typescript-eslint/no-explicit-any": "warn"
+        "@typescript-eslint/no-explicit-any": "warn",
+        "@typescript-eslint/ban-ts-comment": [
+          "error",
+          {
+            "ts-expect-error": "allow-with-description",
+            "ts-ignore": true,
+            "ts-nocheck": true,
+            "ts-check": false,
+            "minimumDescriptionLength": 20
+          }
+        ]
       }
     }
   ]

--- a/lib/core/shared/sdk/embeddedSdk.ts
+++ b/lib/core/shared/sdk/embeddedSdk.ts
@@ -162,11 +162,16 @@ export class EmbeddedSDK extends Kuzzle {
       request.controller === "realtime" &&
       request.action === "subscribe"
     ) {
-      // @ts-expect-error
-      request.propagate =
+      // `propagate` is not part of BaseRequest: it is a Kuzzle-internal flag
+      // read back by the realtime controller. Written with `Reflect.set`, like
+      // `__kuid__` and `__checkRights__` below, rather than suppressed.
+      Reflect.set(
+        request,
+        "propagate",
         options.propagate === undefined || options.propagate === null
           ? false
-          : options.propagate;
+          : options.propagate,
+      );
     }
 
     if (

--- a/lib/model/security/profile.ts
+++ b/lib/model/security/profile.ts
@@ -305,9 +305,12 @@ export class Profile {
                 value: actionRights,
               };
               const rightsObject = {
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                [this.constructor._hash(rightsItem)]: rightsItem,
+                // `String()` is what the computed key does implicitly anyway,
+                // and it is what makes the `string | false` return type legal
+                // here — see `_hash` below.
+                [String(
+                  (this.constructor as typeof Profile)._hash(rightsItem),
+                )]: rightsItem,
               };
 
               _.assignWith(profileRights, rightsObject, Rights.merge);
@@ -320,9 +323,15 @@ export class Profile {
     return profileRights;
   }
 
-  static _hash() {
-    return false;
-  }
+  /**
+   * Hashes a rights item into the key it is stored under.
+   *
+   * Placeholder on purpose: `profileRepository` replaces it with
+   * `global.kuzzle.hash` at startup, and the `false` returned here is exactly
+   * how that patching detects an un-patched class. The signature describes the
+   * patched function, not this stub.
+   */
+  static _hash: (rightsItem?: unknown) => string | false = () => false;
 
   validateRateLimit() {
     if (this.rateLimit === null || this.rateLimit === undefined) {

--- a/lib/model/security/profile.ts
+++ b/lib/model/security/profile.ts
@@ -331,7 +331,18 @@ export class Profile {
    * how that patching detects an un-patched class. The signature describes the
    * patched function, not this stub.
    */
-  static _hash: (rightsItem?: unknown) => string | false = () => false;
+  /**
+   * Hashes a rights item into the key it is stored under.
+   *
+   * Placeholder on purpose: `profileRepository` replaces it with
+   * `global.kuzzle.hash` at startup, and the `false` returned here is exactly
+   * how that patching detects an un-patched class. The overload signature
+   * describes the patched function; the implementation is the stub.
+   */
+  static _hash(rightsItem?: unknown): string | false;
+  static _hash(): string | false {
+    return false;
+  }
 
   validateRateLimit() {
     if (this.rateLimit === null || this.rateLimit === undefined) {

--- a/lib/types/HttpStream.ts
+++ b/lib/types/HttpStream.ts
@@ -35,7 +35,9 @@ export class HttpStream {
   private _destroyed = false;
 
   private get readableState() {
-    // @ts-ignore
+    // @ts-expect-error -- `_readableState` is Node's internal bookkeeping and
+    // is not declared by @types/node; it is where a destroyed stream's error
+    // lands, and `errored` is the only field read from it.
     return this.stream._readableState;
   }
 


### PR DESCRIPTION
Closes #2707. Found by the post-sprint review of 2026-09-10.

## The problem

ADR-0001 › *Conversion standards* forbids `@ts-ignore`/`@ts-nocheck` "without a comment + ticket". Nothing enforced it, and none of the four ratchets charges for a suppression — it is not `: any`, not `as any`, not `as unknown as`, and it *removes* `TS7xxx` diagnostics. `lib/` held 4, three of them with no stated reason.

## Enforcement

`@typescript-eslint/ban-ts-comment` as an **error** on `.ts`: `@ts-ignore` and `@ts-nocheck` forbidden outright, `@ts-expect-error` allowed only with a ≥ 20-character description. `@ts-expect-error` is the better directive anyway — it fails once the error it suppresses disappears, so it cannot rot silently.

## The three sites, cleared rather than annotated

| Site | Before | After |
|---|---|---|
| `core/shared/sdk/embeddedSdk.ts` | bare `@ts-expect-error` on `request.propagate = …` | `Reflect.set(request, "propagate", …)` — the idiom this same file uses two lines below for `__kuid__` and `__checkRights__`. **No suppression left.** |
| `model/security/profile.ts` | `eslint-disable` + bare `@ts-ignore` on `this.constructor._hash(rightsItem)` | `_hash` declared as what it actually is. **No suppression left.** |
| `types/HttpStream.ts` | bare `@ts-ignore` on `this.stream._readableState` | explained `@ts-expect-error`: Node internals @types/node does not declare, and `errored` is the only field read. |

`model/storage/apiKey.ts`'s existing `@ts-expect-error` already carried its reason and passes the new rule unchanged.

### On `Profile._hash`

Worth flagging, because the suppression was hiding it: `static _hash() { return false; }` never described the real contract. `profileRepository` **replaces** it at startup (`(profile.constructor as any)._hash = (obj) => global.kuzzle.hash(obj)`), using the `false` return as the "not patched yet" probe. It is now declared as the patchable static it is — `(rightsItem?: unknown) => string | false` — and the call site wraps the key in `String()`, which is exactly what a computed property key does implicitly, so the emitted key is unchanged in both the patched and un-patched cases.

The two `as any` casts in `profileRepository.ts` that reach for `_hash` are left alone: removing them lowers the `any` count and belongs in its own PR.

## Validation

- `npx tsc --noEmit` clean · prettier clean · **eslint 0 errors** (373 pre-existing warnings), with the new rule active.
- Ratchets at equality: js 50 · mocha 151 · any 207 · implicit-any 464.
- **Mocha 3026** and **vitest 13 files / 183 tests** green in Docker — including `test/model/security/profile.test.js`, which patches `profile.constructor._hash`.

The register entry (TD-29) is updated in #2708, which owns those docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)