### PR TITLE
chore(td-32): remove tsconfig's dead rootDir key

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,6 @@
       "@cucumber/cucumber"
     ]
   },
-  "rootDir": "lib/",
   "include": [
     // Kuzzle core files
     "lib/**/*.ts",


### PR DESCRIPTION
Closes #2714. Found while deciding #2705.

## The problem

```jsonc
{
  "compilerOptions": { "outDir": "dist", … },
  "rootDir": "lib/",     // <-- top-level: not a tsconfig key, silently ignored
  "include": [ … ]
}
```

tsc ignores unknown top-level keys, so the option has never applied. `dist/` mirrors the repository root, which is what `npm run build`, `main` (`./dist/index.js`) and the `files` list all already rely on.

Harmless at runtime, but misleading: it produced a wrong risk assessment during the #2705 review — the emit path for `bin/` was believed to be at risk of changing, and was not.

## Why delete rather than move it

Moving it into `compilerOptions` **breaks the build**. `index.ts`, `bin/`, `features/`, `features-legacy/`, `test/`, `tests/` and `start-kuzzle-*.ts` all sit outside `lib/`, and each would raise `TS6059: File … is not under 'rootDir'`. The root tsc infers today is the repository root, so the honest fix is to remove the key, not to correct its value.

## Validation

The claim that matters is "the emitted layout does not change", so it was measured rather than argued — inside Docker, `npm run build` then `find dist -type f | sort`, with and without the key:

```
BEFORE files: 1453
AFTER  files: 1453
IDENTICAL LAYOUT
```

- `npx tsc --noEmit` clean; ratchets at equality (js 50 · mocha 151 · any 207 · implicit-any 464); `test:strict` 101/101.
- **Mocha 3026** green.

Note this PR branches from `2-dev`, so it shows `js 50`; [#2713](https://github.com/kuzzleio/kuzzle/pull/2713) takes it to 49 independently — the two do not conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)