### PR TITLE
fix(td-33): gate the functional suite on cluster readiness, not on a handshake

### DIFF
--- a/.github/workflows/pull_request.workflow.yaml
+++ b/.github/workflows/pull_request.workflow.yaml
@@ -208,6 +208,9 @@ jobs:
     name: Functional tests
     needs: [sonarqube, unit-tests]
     strategy:
+      # One flaky variant must not cancel the 29 others: a re-run is otherwise
+      # the only way to learn whether anything else was broken.
+      fail-fast: false
       matrix:
         test-set:
           [

--- a/bin/wait-kuzzle
+++ b/bin/wait-kuzzle
@@ -27,43 +27,125 @@
 
 const { Kuzzle, WebSocket } = require("kuzzle-sdk");
 
+/**
+ * Waits for a Kuzzle node to be able to *process requests*, not merely to
+ * accept a WebSocket handshake.
+ *
+ * Two things this script deliberately does not delegate to the SDK:
+ *
+ *  1. **Readiness.** A successful handshake only says the transport is
+ *     listening. On a cluster, a node stays in the `NOT_ENOUGH_NODES` state
+ *     until it has discovered its peers, and `funnel.throttle()` rejects every
+ *     request with `api.process.not_enough_nodes` until then. So each attempt
+ *     sends a real request and the node counts as up only once that request is
+ *     no longer rejected for that reason.
+ *
+ *  2. **Retrying.** The SDK's auto-reconnect cannot be relied on here: it is
+ *     driven by `clientNetworkError()`, and `WebSocketProtocol.onclose`
+ *     forwards a close to it only `if (this.wasConnected)`. A socket that is
+ *     accepted and then closed before the *first* successful connection —
+ *     exactly what a published Docker port whose container is still booting
+ *     does — therefore takes a path that neither resolves nor rejects
+ *     `connect()` and schedules no retry. The wait then burns its whole budget
+ *     on a single dead attempt. Each attempt below is instead a fresh client
+ *     with `autoReconnect: false`, bounded by its own timeout.
+ */
+
+const NOT_ENOUGH_NODES = "api.process.not_enough_nodes";
+
 const sleep = (seconds) => {
-  return new Promise((resolve) => setTimeout(() => resolve(), seconds * 1000));
+  return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
 };
 
 const kuzzleHost = process.env.KUZZLE_HOST || "localhost";
 const kuzzlePort = process.env.KUZZLE_PORT || 7512;
-const maxTries = process.env.MAX_TRIES || 60;
+const maxTries = Number.parseInt(process.env.MAX_TRIES || "60", 10);
+const attemptTimeout = Number.parseInt(process.env.ATTEMPT_TIMEOUT || "5", 10);
 
-async function waitKuzzle(host, port, timeout) {
-  const spinner = "|/-\\";
-  const protocol = new WebSocket(host, { port });
-  const kuzzle = new Kuzzle(protocol);
-  let connected = false;
-
-  kuzzle.on("connected", () => (connected = true));
-  kuzzle.connect().catch(() => {});
-
-  console.log(
-    `[ℹ] Trying to connect to Kuzzle at "${kuzzleHost}:${kuzzlePort}"`,
+/**
+ * Runs one connection + readiness probe, bounded by `timeout` seconds.
+ *
+ * @returns {Promise<void>} resolves if the node is ready, rejects otherwise
+ */
+async function probe(host, port, timeout) {
+  // `autoReconnect` is a *protocol* option, not a Kuzzle one.
+  const kuzzle = new Kuzzle(
+    new WebSocket(host, { autoReconnect: false, port }),
   );
 
-  for (let seconds = 0; seconds < timeout; seconds++) {
-    const message = `[${spinner.charAt(seconds % spinner.length)}] Still trying to connect to Kuzzle (${seconds}s)...`;
+  let timer;
+  const expire = new Promise((resolve, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`attempt timed out after ${timeout}s`)),
+      timeout * 1000,
+    );
+  });
 
-    if (connected) {
-      console.log(`${" ".repeat(message.length)}\r[✔] Kuzzle is up`);
-      kuzzle.disconnect();
-      return;
+  const attempt = (async () => {
+    await kuzzle.connect();
+
+    try {
+      // Any request goes through `funnel.throttle()`, which is where a
+      // node that has not reached its quorum rejects. `auth:getCurrentUser`
+      // is cheap and open to anonymous; any answer other than
+      // `not_enough_nodes` — an authorization error included — means the
+      // node is processing requests.
+      await kuzzle.query({
+        action: "getCurrentUser",
+        controller: "auth",
+      });
+    } catch (error) {
+      if (error.id === NOT_ENOUGH_NODES) {
+        throw error;
+      }
     }
+  })();
 
-    process.stdout.write(`${message}\r`);
+  // The race below may be won by `expire`, leaving this rejection unobserved.
+  attempt.catch(() => {});
+
+  try {
+    await Promise.race([attempt, expire]);
+  } finally {
+    clearTimeout(timer);
+
+    try {
+      kuzzle.disconnect();
+    } catch {
+      // the client may already be gone: nothing to clean up
+    }
+  }
+}
+
+async function waitKuzzle(host, port, timeout) {
+  console.log(`[ℹ] Trying to connect to Kuzzle at "${host}:${port}"`);
+
+  const deadline = Date.now() + timeout * 1000;
+  let lastError;
+
+  for (let attempt = 0; Date.now() < deadline; attempt++) {
+    const remaining = Math.ceil((deadline - Date.now()) / 1000);
+
+    try {
+      await probe(host, port, Math.min(attemptTimeout, remaining));
+
+      console.log(
+        `[✔] Kuzzle at "${host}:${port}" is up and accepting requests`,
+      );
+      return;
+    } catch (error) {
+      lastError = error;
+
+      console.log(
+        `[-] Kuzzle at "${host}:${port}" is not ready yet (attempt ${attempt + 1}, ${remaining}s left): ${error.message}`,
+      );
+    }
 
     await sleep(1);
   }
 
   console.log(
-    `Timeout after ${timeout}s: cannot connect to Kuzzle at "${host}:${port}"`,
+    `Timeout after ${timeout}s: Kuzzle at "${host}:${port}" never became ready — last error: ${lastError && lastError.message}`,
   );
   process.exit(1);
 }

--- a/docs/adr-001/type-debt-register.md
+++ b/docs/adr-001/type-debt-register.md
@@ -41,7 +41,7 @@
 | [TD-30](#td-30) | 🟡 low | Enforcement | `bin/copy-binaries.js` miscounted as a plugin fixture: the `js` floor is 3, not 4 — [#2705](https://github.com/kuzzleio/kuzzle/issues/2705) | XS | ✅ [#2713](https://github.com/kuzzleio/kuzzle/pull/2713) |
 | [TD-31](#td-31) | 🟡 low | Duplication | TD-23's helpers take loose `methodName`/`action`, which can disagree — [#2706](https://github.com/kuzzleio/kuzzle/issues/2706) | XS | ✅ [#2711](https://github.com/kuzzleio/kuzzle/pull/2711) |
 | [TD-32](#td-32) | 🟡 low | Enforcement | `tsconfig.json`'s `rootDir` sits outside `compilerOptions` and has never applied — [#2714](https://github.com/kuzzleio/kuzzle/issues/2714) | XS | ✅ [#2716](https://github.com/kuzzleio/kuzzle/pull/2716) |
-| [TD-33](#td-33) | 🟠 med | Enforcement | One flaky functional variant blocks unrelated PRs; cluster readiness is not gated — [#2715](https://github.com/kuzzleio/kuzzle/issues/2715) | M | ⬜ |
+| [TD-33](#td-33) | 🟠 med | Enforcement | One flaky functional variant blocks unrelated PRs; cluster readiness is not gated — [#2715](https://github.com/kuzzleio/kuzzle/issues/2715) | M | 🟦 readiness gate + `fail-fast: false` done; the `resetDatabase` visibility race still open |
 | [TD-34](#td-34) | 🟠 med | Correctness | `Profile._hash`'s new overload declared `string \| false`; the patch (`global.kuzzle.hash`) returns a `number`, and `profileRepository` still cast the site to `any` | XS | ✅ |
 | [TD-35](#td-35) | 🟠 med | Enforcement | `npm run build` ran `copy-binaries` through `tsx` (esbuild native binary) and nothing asserted its payload — a broken copy step shipped a `.proto`-less package | XS | ✅ |
 | [TD-36](#td-36) | 🔴 high | Enforcement | TD-35's payload gate never sees the published artifact: `npm publish` re-runs `prepublishOnly` → `build`, which wipes the `dist/` the workflow step verified | XS | ✅ |
@@ -464,9 +464,27 @@ The 30-variant functional matrix is `fail-fast`, so **one flake cancels the othe
 
 Root cause of the common symptom: `run-test-cluster.sh` gates the suite on four `bin/wait-kuzzle` calls, and `wait-kuzzle` resolves on the SDK's **`connected` event** — the WebSocket handshake succeeded. That proves the transport is listening; it proves nothing about the cluster having formed a quorum, which is what the tests actually need. Hence `api.process.not_enough_nodes` in a `Before` hook, 1.7 s into the run.
 
-A second symptom is not explained yet: on #2708 the wait on port 17510 timed out after 60 s while the containers logged `[✔] Kuzzle 2.56.0 is ready` 30 s in. The SDK *does* retry (`Realtime.clientNetworkError` re-calls `connect()` every second, `autoReconnect` on by default), so "it only tried once" is **not** the explanation — recorded as open rather than guessed at.
+A second symptom was recorded as unexplained: on #2708 the wait on port 17510 timed out after 60 s while the containers logged `[✔] Kuzzle 2.56.0 is ready` 30 s in. The SDK *does* retry (`Realtime.clientNetworkError` re-calls `connect()` every second, `autoReconnect` on by default), so "it only tried once" is **not** the explanation.
+
+**✅ Root cause found (2026-09-11) — the retry is real but unreachable.** `clientNetworkError()` is the only thing that schedules a retry, and `WebSocketProtocol.onclose` forwards a close to it *conditionally*:
+
+```js
+if (status === 1000) { this.clientDisconnected(USER_CONNECTION_CLOSED); }
+// do not forward a connection close error if no connection has been previously established
+else if (this.wasConnected) { this.clientNetworkError(error); }
+```
+
+A socket that is **accepted and then closed before the first successful connection** matches neither branch: `wasConnected` is still `false` on the first attempt. Nothing is emitted, no retry is scheduled, and `connect()`'s promise neither resolves nor rejects — `onopen` never fired and `onerror` never fired either. That is exactly what a *published Docker port whose container is still booting* produces: `docker-proxy` accepts the TCP connection, then drops it. The wait then spends its entire 60 s budget on one dead attempt, which is precisely the log on #2708.
+
+So the SDK's auto-reconnect cannot be the retry mechanism for a *first* connection, only for a re-connection — a distinction worth remembering anywhere else the SDK is used as a readiness probe.
 
 - **Reco:** (1) poll `cluster:status` for the 3 expected nodes after the port waits — this is the state the tests depend on; (2) reproduce the `wait-kuzzle` timeout before touching it; (3) consider `fail-fast: false` on the matrix, so one flake stops hiding the other 29 results.
+- **✅ Fixed (2026-09-11)** — all three, in `bin/wait-kuzzle` and the PR workflow:
+  - **(1) readiness, done without `cluster:status`.** `funnel.throttle()` is the single gate *every* request passes, and it is where `NOT_ENOUGH_NODES` rejects. With `minimumNodes=3`, a node that answers a request at all *is* a node in quorum — so each attempt now sends `auth:getCurrentUser` (cheap, open to anonymous) and treats any answer other than `api.process.not_enough_nodes` as ready. No credentials, no extra endpoint, and it works unchanged for the single-node waits in `docker-test.sh`. Polling `cluster:status` would have needed an admin login, since anonymous has no `cluster` rights.
+  - **(2) reproduced by reading the SDK rather than the logs** — see the root cause above. The retry loop is now ours: a fresh client per attempt with `autoReconnect: false`, each bounded by `ATTEMPT_TIMEOUT` (5 s), inside an overall `MAX_TRIES` deadline. A dead attempt now costs 5 s instead of the whole budget.
+  - **(3) `fail-fast: false`** on the functional matrix.
+- **⬜ Still open — the third symptom (`nyc-open-data` already exists) is *not* addressed by this.** That one is inside the cucumber `Before` hook, not in the readiness gate: `admin:resetDatabase` with `refresh: "wait_for"` returns on an Elasticsearch *refresh* acknowledgement, which says nothing about the other cluster nodes. The two share a shape — *a per-node acknowledgement trusted as cluster state* — but not a fix.
+- **The generalisable part:** *a readiness probe must exercise the thing the caller depends on.* Both the handshake gate and `wait_for` are real signals about the wrong layer; the suite needs "this node processes my requests", and only sending a request proves it.
 - **Tracked as [#2715](https://github.com/kuzzleio/kuzzle/issues/2715).**
 - **Trigger:** independent of the migration, but it taxes every PR in it.
 


### PR DESCRIPTION
Closes the two explained symptoms of [#2715](https://github.com/kuzzleio/kuzzle/issues/2715). The issue stays open for the third one (see below).

## The gap

`.ci/scripts/run-test-cluster.sh` gates the whole functional suite on four `bin/wait-kuzzle` calls, and `wait-kuzzle` resolved on the SDK's `connected` event. That proves the transport is listening. It proves nothing about the node being able to process a request.

## Symptom A — `api.process.not_enough_nodes`

The four waits pass in a couple of seconds, cucumber starts, and the first request in a `Before` hook is rejected: the sockets were open, the nodes had not finished discovering each other.

Each attempt now sends a real request and the node counts as up only once that request is no longer rejected for that reason.

**Deliberately not `cluster:status`.** Anonymous has no `cluster` rights, so polling it would have needed an admin login in a CI script. It is also unnecessary: `funnel.throttle()` is the single gate *every* request passes and where `NOT_ENOUGH_NODES` rejects, so with `minimumNodes=3` **a node that answers at all is a node in quorum**. The probe uses `auth:getCurrentUser` (cheap, anonymous-allowed) and treats any answer other than `api.process.not_enough_nodes` as ready — including an authorization error, so it does not break if permissions change. Works unchanged for the single-node waits in `docker-test.sh`.

## Symptom B — the wait times out although Kuzzle is up

On [#2708](https://github.com/kuzzleio/kuzzle/pull/2708) the wait on 17510 gave up after 60 s while the containers logged `[✔] Kuzzle 2.56.0 is ready` 30 s in — ~30 s of budget left. The issue recorded this as unexplained, since the SDK does retry.

**Root cause:** `clientNetworkError()` is the only thing that schedules a retry, and `WebSocketProtocol.onclose` forwards to it *conditionally*:

```js
if (status === 1000) { this.clientDisconnected(USER_CONNECTION_CLOSED); }
// do not forward a connection close error if no connection has been previously established
else if (this.wasConnected) { this.clientNetworkError(error); }
```

A socket **accepted and then closed before the first successful connection** matches neither branch — `wasConnected` is still `false` on attempt #1 — and `onerror` does not fire either. Nothing is emitted, no retry is scheduled, and `connect()` neither resolves nor rejects. That is exactly what a published Docker port whose container is still booting produces: `docker-proxy` accepts the TCP connection, then drops it. The wait burns its whole budget on one dead attempt.

So **the SDK's auto-reconnect is a *re*-connection mechanism, never a first-connection retry.** The retry loop is now ours: a fresh client per attempt with `autoReconnect: false`, each bounded by `ATTEMPT_TIMEOUT` (5 s), inside the overall `MAX_TRIES` deadline. A dead attempt costs 5 s instead of 60.

## `fail-fast: false`

One flaky variant was cancelling the other 29, making a full re-run the only way to learn whether anything else was broken. The cost is runner minutes on a genuinely broken PR; the benefit is that a real failure is never masked by a flaky sibling.

## Not addressed

The occurrence on [#2718](https://github.com/kuzzleio/kuzzle/pull/2718) (`A public index named "nyc-open-data" already exists`, after 41 scenarios had passed) is a **different race**, in the cucumber `Before` hook: `admin:resetDatabase` with `refresh: "wait_for"` returns on an Elasticsearch *refresh* acknowledgement, which says nothing about the other cluster nodes. Same shape — a per-node ack trusted as cluster state — but not the same fix. #2715 stays open for it.

## Validation

- `npx eslint bin/wait-kuzzle` clean, `prettier` clean, `node --check` OK.
- `.ci/scripts/pr-preflight.sh` green (lint, error codes, ratchets, strict 102/102).
- The real proof is this PR's own functional matrix — 30 variants exercising the new gate.

Refs #2715

🤖 Generated with [Claude Code](https://claude.com/claude-code)